### PR TITLE
Add test enforcement to workflows and replace hardcoded theme colors

### DIFF
--- a/apps/frontend/features/blockchain/components/CurrentBlock/CurrentBlock.module.css
+++ b/apps/frontend/features/blockchain/components/CurrentBlock/CurrentBlock.module.css
@@ -73,13 +73,13 @@
 }
 
 .stat-card--accent {
-    background: rgba(59, 130, 246, 0.1);
-    border: var(--border-width-thin) solid rgba(59, 130, 246, 0.3);
+    background: var(--color-primary-alpha-10);
+    border: var(--border-width-thin) solid var(--color-primary-alpha-30);
 }
 
 .stat-card--accent.stat-card--clickable:hover {
-    background: rgba(59, 130, 246, 0.15);
-    border-color: rgba(59, 130, 246, 0.4);
+    background: var(--color-primary-alpha-15);
+    border-color: var(--color-primary-alpha-38);
 }
 
 .stat-card__label {
@@ -198,12 +198,12 @@
 }
 
 .period-button--active {
-    background: rgba(124, 155, 255, 0.2);
-    color: rgb(124, 155, 255);
+    background: var(--color-primary-alpha-15);
+    color: var(--color-primary);
 }
 
 .period-button--active:hover {
-    background: rgba(124, 155, 255, 0.3);
+    background: var(--color-primary-alpha-30);
 }
 
 .graph-content {

--- a/apps/frontend/features/blockchain/components/CurrentBlock/CurrentBlock.tsx
+++ b/apps/frontend/features/blockchain/components/CurrentBlock/CurrentBlock.tsx
@@ -69,8 +69,18 @@ export function CurrentBlock() {
     const chartLoading = isLiveMode ? false : timeseriesLoading;
     const chartError = isLiveMode ? null : timeseriesError;
 
+    // Get primary color from CSS variables for chart
+    const [primaryColor, setPrimaryColor] = useState('#7C9BFF');
+
     useEffect(() => {
         setIsMounted(true);
+        // Read primary color from CSS variables
+        if (typeof window !== 'undefined') {
+            const color = getComputedStyle(document.documentElement).getPropertyValue('--color-primary').trim();
+            if (color) {
+                setPrimaryColor(color);
+            }
+        }
     }, []);
 
     // Track when we receive live WebSocket updates
@@ -236,7 +246,7 @@ export function CurrentBlock() {
                                                 date: point.date,
                                                 value: point.transactions
                                             })),
-                                            color: '#7C9BFF'
+                                            color: primaryColor
                                         }
                                     ]}
                                     yAxisFormatter={(value) => formatLargeNumber(value)}


### PR DESCRIPTION
This PR adds required test jobs to deployment workflows ensuring tests pass before provisioning droplets and eliminates duplicate test executions. It replaces Let's Encrypt with self-signed SSL certificates for ephemeral dev environments to avoid rate limits on frequent provisioning. The CurrentBlock component now uses theme-aware CSS variables instead of hardcoded blue colors for accent elements. Custom themes like Thanksgiving will now properly style the block number card, period selector buttons, and transaction chart with their primary colors.