### PR TITLE
Remove unimplemented market:update WebSocket event

### DIFF
--- a/apps/backend/src/services/notification.service.ts
+++ b/apps/backend/src/services/notification.service.ts
@@ -224,19 +224,6 @@ export class NotificationService {
 
   private buildNotificationLines(event: TronRelicSocketEvent): string[] | null {
     switch (event.event) {
-      case 'market:update': {
-        const { payload } = event;
-        const price = this.formatNumber(payload.effectivePrice ?? payload.energy.price);
-        const availability = this.formatNumber(payload.energy.available);
-        return [
-          `📊 ${payload.name} market update`,
-          price ? `Effective price: ${price} TRX` : null,
-          availability ? `Available energy: ${availability}` : null,
-          typeof payload.reliability === 'number'
-            ? `Reliability: ${(payload.reliability * 100).toFixed(1)}%`
-            : null
-        ].filter((line): line is string => Boolean(line));
-      }
       case 'transaction:large':
       case 'delegation:new':
       case 'stake:new': {

--- a/apps/backend/src/services/websocket.service.ts
+++ b/apps/backend/src/services/websocket.service.ts
@@ -277,12 +277,6 @@ export class WebSocketService implements IWebSocketService {
     }
 
     switch (event.event) {
-      case 'market:update':
-        this.io.to('markets:all').emit(event.event, event.payload);
-        if (event.payload.guid) {
-          this.io.to(`markets:${event.payload.guid}`).emit(event.event, event.payload);
-        }
-        break;
       case 'transaction:large':
       case 'delegation:new':
       case 'stake:new':

--- a/docs/system/system-api.md
+++ b/docs/system/system-api.md
@@ -271,28 +271,14 @@ socket.on('transaction:large', (tx) => {
 });
 ```
 
-**Subscribe to market updates:**
-
-```javascript
-socket.emit('subscribe', {
-    markets: { all: true }
-});
-
-socket.on('market:update', (market) => {
-    console.log(`${market.name} updated: ${market.pricing['1d']} sun/energy`);
-});
-```
-
 **Multiple subscriptions:**
 
 ```javascript
 socket.emit('subscribe', {
-    markets: { all: true },
     transactions: { minAmount: 1000000 },
     chat: true
 });
 
-socket.on('market:update', handleMarketUpdate);
 socket.on('transaction:large', handleWhaleTransaction);
 socket.on('chat:update', handleChatMessage);
 ```
@@ -781,7 +767,6 @@ socket.on('connect', () => {
 3. **Legacy object format (core subscriptions):**
    ```javascript
    socket.emit('subscribe', {
-       markets: { all: true },
        transactions: { minAmount: 1000000 },
        comments: { resourceId: 'abc123...' },
        chat: true
@@ -795,33 +780,6 @@ socket.emit('unsubscribe', 'plugin-id', 'room-name');
 ```
 
 ### Core Events
-
-#### market:update
-
-Emitted when market data is refreshed for a platform.
-
-**Rooms:** `markets:all`, `markets:{guid}`
-
-**Payload:**
-
-```javascript
-{
-    guid: "tronsave",
-    name: "TronSave",
-    pricing: { "1h": 45.5, "1d": 42.0, "3d": 40.5 },
-    reliability: 95.5,
-    lastFetchedAt: "2025-10-16T14:20:00.000Z"
-}
-```
-
-**Example:**
-
-```javascript
-socket.emit('subscribe', { markets: { all: true } });
-socket.on('market:update', (market) => {
-    console.log(`${market.name}: ${market.pricing['1d']} sun/energy`);
-});
-```
 
 #### transaction:large
 


### PR DESCRIPTION
This removes the market:update WebSocket event that was never actually emitted by any service. All related handling code in notification service and websocket service was dead code. The documentation described behavior that didn't exist in the implementation. This cleanup removes 61 lines of unused code and documentation.