### PR TITLE
Add AGPL-3.0 license with plugin exception and CLA

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,110 @@
+# TronRelic Contributor License Agreement
+
+Thank you for your interest in contributing to TronRelic ("Project"). This Contributor License Agreement ("Agreement") documents the rights granted by contributors to the Project.
+
+By signing this Agreement, you accept and agree to the following terms and conditions for your present and future contributions submitted to the Project. Except for the licenses granted herein, you reserve all right, title, and interest in and to your contributions.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner or legal entity authorized by the copyright owner that is making this Agreement.
+
+**"Contribution"** means any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to the Project for inclusion in, or documentation of, the Project.
+
+**"Submit"** means any form of electronic, verbal, or written communication sent to the Project or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems.
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the Project maintainers and to recipients of software distributed by the Project a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license** to:
+
+- Reproduce Your contributions
+- Prepare derivative works based on Your contributions
+- Publicly display Your contributions
+- Publicly perform Your contributions
+- Sublicense Your contributions
+- Distribute Your contributions and derivative works thereof
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the Project maintainers and to recipients of software distributed by the Project a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license** to:
+
+- Make, have made, use, offer to sell, sell, import, and otherwise transfer Your contributions
+- Apply to any patent claims licensable by You that are necessarily infringed by Your contributions alone or by combination of Your contributions with the Project
+
+## 4. Grant of Relicensing Rights
+
+You hereby grant to the Project maintainers the **right to relicense Your contributions** under different license terms at their discretion, including but not limited to:
+
+- Changing the Project license from one open source license to another
+- Offering the Project under multiple licenses simultaneously (dual licensing)
+- Offering commercial licenses for proprietary use
+- Incorporating Your contributions into proprietary or closed-source versions of the Project
+
+This relicensing right is **perpetual and irrevocable**, and extends to all current and future versions of the Project that incorporate Your contributions.
+
+## 5. Representations and Warranties
+
+You represent and warrant that:
+
+1. **You are legally entitled to grant the above licenses.** If Your employer(s) has rights to intellectual property that You create that includes Your contributions, You represent that You have received permission to make contributions on behalf of that employer, or that Your employer has waived such rights for Your contributions to the Project.
+
+2. **Your contribution is Your original creation.** You represent that each of Your contributions is entirely Your original work, or You have sufficient rights to grant the rights conveyed by this Agreement. If Your contribution includes any third-party materials, You have secured all necessary permissions and licenses.
+
+3. **Your contribution does not violate any third-party rights.** You represent that Your contribution does not, to the best of Your knowledge, violate any third party's copyrights, trademarks, patents, or other intellectual property rights.
+
+4. **You provide Your contributions "AS IS".** You are not expected to provide support for Your contributions, except to the extent You desire to provide support. Unless required by applicable law or agreed to in writing, You provide Your contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+5. **You agree to notify the Project of any facts or circumstances** of which You become aware that would make these representations inaccurate in any respect.
+
+## 6. You Retain Ownership
+
+This is a license agreement only. **You retain full ownership and copyright of Your contributions.** Nothing in this Agreement transfers ownership to the Project maintainers. You are free to license Your contributions to third parties under different terms or to use Your contributions for any purpose.
+
+## 7. No Obligation to Use
+
+The Project maintainers are under **no obligation to accept, use, or distribute Your contributions**, but may do so under the terms of the Project's current license or any future license as permitted by Section 4 of this Agreement.
+
+## 8. Employer Rights
+
+If You are employed and Your employer has rights to intellectual property that You create, You represent that:
+
+- You have received permission from Your employer to make contributions on behalf of that employer, OR
+- Your employer has waived such rights for Your contributions to this Project, OR
+- Your contributions are made outside the scope of Your employment
+
+If Your employer has rights to intellectual property that You create and You have not received such permission or waiver, **do not submit contributions until You have secured the necessary permissions.**
+
+## 9. Government Employment
+
+If You are a government employee, Your contributions may be subject to special rules. You represent that Your contribution complies with all applicable government regulations regarding contributions to open source projects.
+
+## 10. Effective Date
+
+This Agreement becomes effective upon Your signature below, which occurs automatically when You accept this Agreement through the CLA Assistant system. This Agreement applies to all contributions You have previously submitted and all contributions You submit in the future.
+
+## 11. Entire Agreement
+
+This Agreement constitutes the entire agreement between You and the Project maintainers concerning Your contributions and supersedes all prior agreements or understandings, whether written or oral.
+
+---
+
+## Signing This Agreement
+
+By clicking "I Agree" through the CLA Assistant system or by adding a comment to a pull request indicating Your acceptance, You acknowledge that:
+
+1. You have read and understood this Agreement
+2. You agree to be bound by its terms
+3. You have the legal authority to enter into this Agreement
+4. You grant all rights specified in this Agreement
+
+Your signature will be recorded with:
+- **GitHub Username:** [auto-filled by CLA Assistant]
+- **Date:** [auto-filled by CLA Assistant]
+- **Email:** [auto-filled by CLA Assistant]
+
+---
+
+## Questions?
+
+If You have questions about this CLA, please open an issue in the repository or contact the maintainers before contributing.
+
+Thank you for contributing to TronRelic!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,278 @@
+# Contributing to TronRelic
+
+Thank you for your interest in contributing to TronRelic! We welcome contributions from the community.
+
+## Contributor License Agreement (CLA)
+
+**Before we can accept your contribution, you must sign our Contributor License Agreement (CLA).**
+
+### Why We Require a CLA
+
+The CLA ensures that:
+- You have the legal right to contribute your code
+- The project can distribute your contributions under its chosen license
+- The project maintainers can change the license in the future if needed
+- Your contributions can be used in both open source and commercial contexts
+
+### How to Sign the CLA
+
+1. **Submit your pull request** as usual
+2. **CLA Assistant bot will comment** on your PR with a link to the CLA
+3. **Click the link and review** the CLA document
+4. **Click "I Agree"** to sign electronically via GitHub OAuth
+5. **CLA Assistant will update your PR** with a "cla-signed" label
+
+**You only need to sign once.** All future contributions will be automatically approved.
+
+### CLA Document
+
+You can review the full CLA text here: [.github/CLA.md](.github/CLA.md)
+
+**Key points:**
+- You retain ownership of your contributions
+- You grant the project rights to use, modify, and relicense your contributions
+- You warrant that you have the legal right to make the contribution
+
+#### Why we ask for relicensing rights
+
+Section 4 of the CLA lets the maintainers dual-license or negotiate commercial deals without chasing every past contributor for approval. That flexibility keeps TronRelic's hosted service, enterprise builds, and plugin ecosystem aligned while still ensuring the open-source AGPL distribution stays available to the community.
+
+---
+
+## Development Workflow
+
+### Setting Up Your Development Environment
+
+1. **Fork the repository** on GitHub
+2. **Clone your fork:**
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/tronrelic.git
+   cd tronrelic
+   ```
+
+3. **Install dependencies:**
+   ```bash
+   npm install
+   ```
+
+4. **Copy environment configuration:**
+   ```bash
+   cp .env.example .env
+   # Edit .env with your configuration
+   ```
+
+5. **Start development environment:**
+   ```bash
+   ./scripts/start.sh
+   ```
+
+See [README.md](README.md) for complete setup instructions.
+
+### Making Changes
+
+1. **Create a feature branch:**
+   ```bash
+   git checkout -b feature/my-feature
+   ```
+
+2. **Make your changes** following our code standards (see below)
+
+3. **Write tests** for new functionality
+
+4. **Run tests locally:**
+   ```bash
+   npm test
+   npm run typecheck
+   ```
+
+5. **Commit your changes:**
+   ```bash
+   git add .
+   git commit -m "feat: add new feature"
+   ```
+
+6. **Push to your fork:**
+   ```bash
+   git push origin feature/my-feature
+   ```
+
+7. **Open a pull request** on GitHub
+
+### Commit Message Format
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+**Types:**
+- `feat:` - New feature
+- `fix:` - Bug fix
+- `docs:` - Documentation changes
+- `style:` - Code style changes (formatting, no logic changes)
+- `refactor:` - Code refactoring (no feature changes or bug fixes)
+- `test:` - Adding or updating tests
+- `chore:` - Build process or tooling changes
+
+**Examples:**
+```bash
+feat(markets): add energy price chart component
+fix(observers): handle null transaction data gracefully
+docs(plugins): update plugin development guide
+```
+
+---
+
+## Code Standards
+
+### TypeScript Guidelines
+
+- **Use TypeScript** - All code must be TypeScript (not JavaScript)
+- **Interfaces prefixed with `I`** - `IPluginContext`, `IObserverRegistry`
+- **File names match exports** - `IPluginContext.ts` exports `IPluginContext`
+- **4 spaces for indentation** - Not 2 spaces or tabs
+- **Dependency injection** - Use constructor injection over direct imports
+
+### Documentation Requirements
+
+**All code must be documented with JSDoc comments before shipping:**
+
+```typescript
+/**
+ * Processes blockchain transactions and notifies subscribed observers.
+ *
+ * This service coordinates the transaction enrichment pipeline: parsing contract
+ * data, fetching market prices, calculating energy costs, and distributing events
+ * to all registered observers asynchronously.
+ *
+ * @param transaction - Raw transaction from TronGrid API
+ * @param blockNumber - Block number containing this transaction
+ * @returns Enriched transaction with USD values and energy costs
+ *
+ * @throws {ValidationError} If transaction format is invalid
+ * @throws {EnrichmentError} If market data is unavailable
+ */
+async function processTransaction(
+    transaction: ITronTransaction,
+    blockNumber: number
+): Promise<IEnrichedTransaction> {
+    // Implementation
+}
+```
+
+**Documentation standards:**
+- Lead with the **why** (purpose/risk), then the **how**
+- Document every function, method, class, and exported constant
+- Use `@param` for all parameters (explain why caller provides it)
+- Use `@returns` to describe what the function produces
+- Use `@throws` for expected error conditions
+
+See [docs/documentation.md](docs/documentation.md) for complete standards.
+
+### Testing Requirements
+
+- **Unit tests required** for all new functionality
+- **Integration tests** for API endpoints and database operations
+- **Test coverage** should not decrease with your changes
+
+**Run tests:**
+```bash
+# Unit tests
+npm test
+
+# Integration tests (requires Docker)
+npm run test:integration
+
+# Watch mode
+npm test -- --watch
+```
+
+---
+
+## Pull Request Process
+
+1. **Ensure all tests pass** locally before submitting
+2. **Sign the CLA** when prompted by CLA Assistant bot
+3. **Update documentation** if you've changed functionality
+4. **Keep PRs focused** - One feature or bug fix per PR
+5. **Respond to review feedback** promptly
+6. **Squash commits** if requested (we prefer clean history)
+
+### PR Checklist
+
+Before submitting, verify:
+
+- [ ] Code follows TypeScript and style guidelines
+- [ ] All functions/classes have JSDoc comments
+- [ ] Tests added for new functionality
+- [ ] All tests pass (`npm test`)
+- [ ] TypeScript compiles without errors (`npm run typecheck`)
+- [ ] Documentation updated if needed
+- [ ] Commit messages follow Conventional Commits format
+- [ ] CLA signed (CLA Assistant will handle this)
+
+### Review Process
+
+- Maintainers will review your PR within 7 days
+- We may request changes or clarifications
+- Once approved, your PR will be merged
+- Your contribution will be included in the next release
+
+---
+
+## Project Architecture
+
+Before making significant changes, review these documents:
+
+**Core documentation:**
+- [README.md](README.md) - Project overview and quick start
+- [AGENTS.md](AGENTS.md) - Project rules and conventions
+- [docs/documentation.md](docs/documentation.md) - Documentation standards
+
+**System architecture:**
+- [docs/plugins/plugins.md](docs/plugins/plugins.md) - Plugin system overview
+- [docs/frontend/frontend.md](docs/frontend/frontend.md) - Frontend architecture
+- [docs/system/system.md](docs/system/system.md) - Backend system architecture
+
+**Development guides:**
+- [docs/plugins/plugins-blockchain-observers.md](docs/plugins/plugins-blockchain-observers.md) - Creating blockchain observers
+- [docs/frontend/ui-component-styling.md](docs/frontend/ui-component-styling.md) - UI styling standards
+- [docs/system/system-testing.md](docs/system/system-testing.md) - Testing patterns
+
+---
+
+## Getting Help
+
+- **Questions?** Open a [GitHub Discussion](../../discussions)
+- **Bug reports?** Open a [GitHub Issue](../../issues)
+- **Feature requests?** Open a [GitHub Issue](../../issues) with the "enhancement" label
+
+---
+
+## Code of Conduct
+
+We expect all contributors to:
+
+- Be respectful and inclusive
+- Provide constructive feedback
+- Focus on what is best for the community
+- Show empathy towards other community members
+
+We will not tolerate harassment, discrimination, or unprofessional behavior.
+
+---
+
+## License
+
+By contributing to TronRelic, you agree that your contributions will be licensed under the same license as the project (see [LICENSE](LICENSE) file).
+
+Additionally, by signing the CLA, you grant the project maintainers the right to relicense your contributions as described in the CLA.
+
+---
+
+Thank you for contributing to TronRelic! 🎉

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,720 @@
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+Copyright (c) 2025-present TronRelic
+
+This project is licensed under the GNU Affero General Public License v3.0 or later.
+
+For the complete license text, see:
+https://www.gnu.org/licenses/agpl-3.0.txt
+
+================================================================================
+
+PLUGIN EXCEPTION
+
+As a special exception to the GNU Affero General Public License version 3
+("AGPL"), the copyright holders of TronRelic grant you permission to develop
+plugins that interface with TronRelic solely through the documented plugin API,
+and to distribute those plugins under terms of your choice, without those
+plugins being subject to the terms of the AGPL.
+
+This exception applies to plugins that:
+
+1. Use only the documented IPluginContext and IFrontendPluginContext APIs
+2. Do not modify TronRelic's core source code
+3. Interact with TronRelic only through:
+   - Plugin manifest registration (src/manifest.ts)
+   - Plugin lifecycle hooks (init, enable, disable, install, uninstall)
+   - Plugin API routes (IApiRouteConfig)
+   - Plugin frontend pages and components
+   - Plugin WebSocket subscriptions
+   - Plugin database helpers (IPluginDatabase)
+   - Documented observer patterns (BaseObserver)
+
+This exception does NOT apply to:
+
+- Modifications to TronRelic's core code (apps/backend, apps/frontend, packages/*)
+- Forks of TronRelic that modify the plugin system itself
+- Derivative works that reuse TronRelic's non-plugin code
+
+Any modifications to TronRelic's core code must comply with the AGPL and be
+released under AGPL terms when distributed or used as a network service.
+
+Examples to clarify the exception boundary:
+- Creating `packages/plugins/energy-arb` with custom observers, REST endpoints, and UI that use the plugin APIs qualifies as a plugin—you may license that package however you want.
+- Adding files under `apps/backend/src/observers/` or editing existing core services is a core modification, so the resulting code must remain AGPL when shipped to users.
+- Shipping a fork that tweaks the plugin runtime (e.g., changing `packages/plugins/runtime` to add new hooks) is also a core change and therefore inherits the AGPL.
+
+For questions about this exception, please open an issue at:
+https://github.com/delphian/tronrelic/issues
+
+================================================================================
+
+SUMMARY
+
+- TronRelic core: AGPL v3 (must share modifications if you run as network service)
+- Third-party plugins: Your choice (exception allows proprietary plugins)
+- Contributor code: See CONTRIBUTING.md and .github/CLA.md for CLA requirements
+
+---- Begin GNU AGPL v3 Text ----
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -429,4 +429,12 @@ npx playwright test tests/system.spec.ts
 
 ## License
 
-MIT
+This project is licensed under the **GNU Affero General Public License v3.0 or later (AGPL-3.0-or-later)** with a plugin exception.
+
+- **TronRelic core:** AGPL-3.0 (you must share modifications if running as a network service)
+- **Third-party plugins:** Your choice (plugin exception allows proprietary plugins)
+- **Contributors:** Must sign CLA (see [CONTRIBUTING.md](CONTRIBUTING.md))
+
+The CLA's relicensing clause lets the maintainers dual-license or offer commercial terms without renegotiating with every past contributor, keeping hosted and self-managed editions aligned.
+
+See [LICENSE](LICENSE) for full details and plugin exception terms.

--- a/packages/plugins/telegram-bot/README.md
+++ b/packages/plugins/telegram-bot/README.md
@@ -385,4 +385,6 @@ npm run dev --workspace apps/frontend
 
 ## License
 
-MIT
+This plugin is part of TronRelic and licensed under AGPL-3.0-or-later.
+
+If you extract and use this plugin independently, you may license it under the plugin exception terms (see main [LICENSE](../../../LICENSE)).


### PR DESCRIPTION
## Summary

- Establishes AGPL-3.0-or-later as the project license with a plugin exception allowing third-party plugins to use proprietary licenses
- Introduces Contributor License Agreement (CLA) requirement enforced via CLA Assistant bot
- Adds comprehensive CONTRIBUTING.md guide with development workflow, code standards, and documentation requirements

## Changes

### New Files
- **LICENSE** - AGPL-3.0-or-later full text with plugin exception clause
- **.github/CLA.md** - Contributor License Agreement document (110 lines)
- **CONTRIBUTING.md** - Complete contributor guide with setup, workflow, standards, and PR process (278 lines)

### Updated Files
- **README.md** - Updated license section with AGPL info, plugin exception summary, and CLA reference
- **packages/plugins/telegram-bot/README.md** - Updated license section to reference main LICENSE

## Rationale

The AGPL-3.0 license ensures TronRelic remains open source while requiring network service operators to share modifications. The plugin exception allows developers to create proprietary plugins without AGPL obligations, enabling a commercial plugin ecosystem while keeping the core platform free.

The CLA grants maintainers relicensing rights, enabling future dual-licensing options (hosted service, enterprise builds) without renegotiating with every past contributor.

## Test plan

- [ ] Verify LICENSE file renders correctly on GitHub
- [ ] Verify CLA Assistant bot triggers on new PRs from external contributors
- [ ] Verify CONTRIBUTING.md renders correctly with all links working
- [ ] Review license summary in README.md for clarity