### PR TITLE
Fix live-now filter to require activity within timeout window

### DIFF
--- a/apps/backend/src/modules/user/services/user.service.ts
+++ b/apps/backend/src/modules/user/services/user.service.ts
@@ -1205,15 +1205,19 @@ export class UserService {
 
         switch (filter) {
             // ==================== Real-time ====================
-            case 'live-now':
-                // Users with an active session (endedAt is null)
+            case 'live-now': {
+                // Users with an active session AND recent activity within timeout window
+                // Sessions are closed lazily, so we must also check lastSeen timestamp
+                const timeoutThreshold = new Date(Date.now() - this.SESSION_TIMEOUT_MS);
                 return {
                     'activity.sessions': {
                         $elemMatch: {
                             endedAt: null
                         }
-                    }
+                    },
+                    'activity.lastSeen': { $gte: timeoutThreshold }
                 };
+            }
 
             // ==================== Engagement ====================
             case 'power-users':


### PR DESCRIPTION
## Summary

The live-now filter was displaying users last seen many hours ago. This happened because sessions are closed lazily (only when a user returns with new activity), so users who left and never came back still had open sessions with `endedAt: null`.

The fix adds a `lastSeen` timestamp check alongside the open session check, ensuring only users with activity within the 30-minute timeout window appear in live-now results.