### PR TITLE
Remove backdrop-filter blur to improve mobile LCP

### DIFF
--- a/apps/frontend/components/layout/BlockTicker/BlockTicker.module.css
+++ b/apps/frontend/components/layout/BlockTicker/BlockTicker.module.css
@@ -9,7 +9,6 @@
     background: var(--color-surface);
     border-top: var(--border-width-thin) solid var(--color-border);
     border-bottom: var(--border-width-thin) solid var(--color-border);
-    backdrop-filter: blur(12px);
     margin-top: var(--spacing-4);
 }
 

--- a/apps/frontend/components/ui/Card/Card.module.css
+++ b/apps/frontend/components/ui/Card/Card.module.css
@@ -20,6 +20,22 @@
     position: relative;
 }
 
+/**
+ * Disable backdrop-filter blur on mobile devices for LCP performance.
+ *
+ * backdrop-filter: blur() is GPU-intensive and delays paint timing on
+ * throttled/mobile devices. PageSpeed tests show 2.7s delay (FCP 1.0s → LCP 3.7s)
+ * due to blur computation on simulated Moto G Power.
+ *
+ * Note: Using @media (not @container) intentionally - targeting device GPU
+ * capability via viewport proxy, not component layout responsiveness.
+ */
+@media (max-width: 768px) {
+    .card {
+        backdrop-filter: none;
+    }
+}
+
 .card:hover {
     border-color: var(--card-border-hover);
     box-shadow: var(--card-shadow-hover);

--- a/apps/frontend/modules/user/components/WalletButton/WalletButton.module.css
+++ b/apps/frontend/modules/user/components/WalletButton/WalletButton.module.css
@@ -27,7 +27,6 @@
     cursor: pointer;
     transition: all var(--transition-base);
     box-shadow: var(--button-primary-shadow);
-    backdrop-filter: blur(var(--spacing-7));
     white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary

PageSpeed showed 3.7s LCP on mobile (Moto G Power simulation) due to GPU-intensive `backdrop-filter: blur()` computations. Three blur effects were rendering simultaneously on initial page load, delaying paint timing.

**Root cause:** `backdrop-filter: blur()` forces separate compositing layers and Gaussian blur computation for each element. On throttled mobile CPUs, this created a 2.7s gap between FCP (1.0s) and LCP (3.7s).

**Changes:**
- Remove blur from BlockTicker and WalletButton entirely (minimal visual impact on small elements)
- Disable Card blur on mobile via `@media (max-width: 768px)` (desktop retains visual polish)

## Test plan

- [ ] Run PageSpeed Insights on mobile - LCP should improve significantly
- [ ] Verify desktop still shows Card blur effect
- [ ] Visual check on mobile - no jarring difference without blur