### PR TITLE
Lazy load plugin pages and fix CurrentBlock mirror effect

### DIFF
--- a/apps/frontend/app/page.module.css
+++ b/apps/frontend/app/page.module.css
@@ -7,3 +7,18 @@
 .block_stats_section {
     position: relative;
 }
+
+/**
+ * LCP Optimization: Hide server-rendered placeholder after hydration.
+ *
+ * BlockStatsServer renders immediately for fast LCP paint. Once CurrentBlock
+ * hydrates (indicated by data-hydrated attribute), BlockStatsServer fades out
+ * so only the interactive client component remains visible.
+ *
+ * Uses :has() to detect hydration state and hide the preceding sibling.
+ * The transition provides a smooth visual handoff between components.
+ */
+.block_stats_section:has([data-hydrated="true"]) > [aria-hidden="true"] {
+    opacity: 0;
+    transition: opacity var(--transition-base);
+}

--- a/apps/frontend/features/blockchain/components/CurrentBlock/CurrentBlock.tsx
+++ b/apps/frontend/features/blockchain/components/CurrentBlock/CurrentBlock.tsx
@@ -143,7 +143,7 @@ export function CurrentBlock({ initialBlock }: CurrentBlockProps) {
      */
     if (effectiveStatus === 'idle' || effectiveStatus === 'loading') {
         return (
-            <div className={wrapperClass}>
+            <div className={wrapperClass} data-hydrated={isMounted ? 'true' : undefined}>
                 <Card elevated>
                     <div className={styles['loading-state']}>
                         <h2 className={styles.header__title}>Current Block</h2>
@@ -161,7 +161,7 @@ export function CurrentBlock({ initialBlock }: CurrentBlockProps) {
      */
     if (effectiveStatus === 'error' || !latestBlock) {
         return (
-            <div className={wrapperClass}>
+            <div className={wrapperClass} data-hydrated={isMounted ? 'true' : undefined}>
                 <Card elevated tone="muted">
                     <div className={styles['error-state']}>
                         <h2 className={styles.header__title}>Current Block</h2>
@@ -178,7 +178,7 @@ export function CurrentBlock({ initialBlock }: CurrentBlockProps) {
      * Success state - display full block information.
      */
     return (
-        <div className={wrapperClass}>
+        <div className={wrapperClass} data-hydrated={isMounted ? 'true' : undefined}>
             <Card elevated>
             <div className={styles.container}>
                 {/* Header */}

--- a/packages/plugins/example-dashboard/src/frontend/frontend.ts
+++ b/packages/plugins/example-dashboard/src/frontend/frontend.ts
@@ -1,6 +1,17 @@
+import dynamic from 'next/dynamic';
 import { definePlugin } from '@tronrelic/types';
 import { exampleDashboardManifest } from '../manifest';
-import { ExampleDashboardPage } from './ExampleDashboardPage';
+
+/**
+ * Lazily loaded page components.
+ *
+ * Using next/dynamic ensures CSS modules are code-split and only load when
+ * the page is actually visited. Without this, static imports cause plugin CSS
+ * to be bundled in shared chunks that load on every page (including homepage).
+ */
+const ExampleDashboardPage = dynamic(() =>
+    import('./ExampleDashboardPage').then(m => m.ExampleDashboardPage)
+);
 
 /**
  * Example Dashboard frontend plugin definition.

--- a/packages/plugins/resource-tracking/src/frontend/frontend.ts
+++ b/packages/plugins/resource-tracking/src/frontend/frontend.ts
@@ -1,8 +1,22 @@
+import dynamic from 'next/dynamic';
 import { definePlugin } from '@tronrelic/types';
 import { resourceTrackingManifest } from '../manifest';
-import { ResourceTrackingPage } from './ResourceTrackingPage';
-import { ResourceTrackingSettingsPage } from './ResourceTrackingSettingsPage';
 import './styles.css';
+
+/**
+ * Lazily loaded page components.
+ *
+ * Using next/dynamic ensures CSS modules are code-split and only load when
+ * the page is actually visited. Without this, static imports cause plugin CSS
+ * to be bundled in shared chunks that load on every page (including homepage).
+ */
+const ResourceTrackingPage = dynamic(() =>
+    import('./ResourceTrackingPage').then(m => m.ResourceTrackingPage)
+);
+
+const ResourceTrackingSettingsPage = dynamic(() =>
+    import('./ResourceTrackingSettingsPage').then(m => m.ResourceTrackingSettingsPage)
+);
 
 /**
  * Resource Explorer frontend plugin definition.

--- a/packages/plugins/telegram-bot/src/frontend/frontend.ts
+++ b/packages/plugins/telegram-bot/src/frontend/frontend.ts
@@ -1,6 +1,17 @@
+import dynamic from 'next/dynamic';
 import { definePlugin } from '@tronrelic/types';
 import { telegramBotManifest } from '../manifest';
-import { TelegramBotSettingsPage } from './TelegramBotSettingsPage';
+
+/**
+ * Lazily loaded page components.
+ *
+ * Using next/dynamic ensures CSS modules are code-split and only load when
+ * the page is actually visited. Without this, static imports cause plugin CSS
+ * to be bundled in shared chunks that load on every page (including homepage).
+ */
+const TelegramBotSettingsPage = dynamic(() =>
+    import('./TelegramBotSettingsPage').then(m => m.TelegramBotSettingsPage)
+);
 
 /**
  * Telegram Bot plugin frontend definition.

--- a/packages/plugins/whale-alerts/src/frontend/frontend.ts
+++ b/packages/plugins/whale-alerts/src/frontend/frontend.ts
@@ -1,10 +1,24 @@
+import dynamic from 'next/dynamic';
 import { definePlugin } from '@tronrelic/types';
 import { whaleAlertsManifest } from '../manifest';
 import { WhaleAlertsToastHandler } from './WhaleAlertsToastHandler';
-import { WhaleIntelligencePage } from './WhaleIntelligencePage';
-import { WhaleAdminPage } from './system/pages/WhaleAdminPage';
 import './styles.css';
 import './system/system-styles.css';
+
+/**
+ * Lazily loaded page components.
+ *
+ * Using next/dynamic ensures CSS modules are code-split and only load when
+ * the page is actually visited. Without this, static imports cause plugin CSS
+ * to be bundled in shared chunks that load on every page (including homepage).
+ */
+const WhaleIntelligencePage = dynamic(() =>
+    import('./WhaleIntelligencePage').then(m => m.WhaleIntelligencePage)
+);
+
+const WhaleAdminPage = dynamic(() =>
+    import('./system/pages/WhaleAdminPage').then(m => m.WhaleAdminPage)
+);
 
 /**
  * Expose the whale alerts frontend plugin definition.


### PR DESCRIPTION
## Summary

- Plugin CSS is now code-split using next/dynamic imports, reducing homepage CSS by ~41KB
- Fixed visual duplication in CurrentBlock where server placeholder and hydrated component were both visible

## Changes

- **Plugin frontend.ts files**: Use `next/dynamic` for page component imports so CSS only loads when visiting plugin pages
- **CurrentBlock.tsx**: Added `data-hydrated` attribute to wrapper div when component hydrates
- **page.module.css**: Added CSS rule to hide BlockStatsServer when CurrentBlock is hydrated using `:has()` selector