### PR TITLE
Add onKeyDown to Input type in IFrontendPluginContext

### DIFF
--- a/src/types/plugin/IFrontendPluginContext.ts
+++ b/src/types/plugin/IFrontendPluginContext.ts
@@ -156,6 +156,7 @@ export interface IUIComponents {
     Input: ComponentType<{
         value?: string;
         onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+        onKeyDown?: (e: React.KeyboardEvent) => void;
         placeholder?: string;
         disabled?: boolean;
         required?: boolean;


### PR DESCRIPTION
## Summary

The plugin-facing `Input` type in `IUIComponents` was missing the `onKeyDown` prop, causing a TypeScript error in `trp-bazi-fortune` when passing a keyboard handler. The underlying `Input` component already accepts it via `InputHTMLAttributes` spread — this adds the prop to the exposed type definition so plugins can use it without type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)