### PR TITLE
Add plugin page SSR with serverDataFetcher and per-page SEO config

### DIFF
--- a/docs/frontend/react/component-icon-picker-modal.md
+++ b/docs/frontend/react/component-icon-picker-modal.md
@@ -508,7 +508,7 @@ npm list lucide-react
 If missing, install it:
 
 ```bash
-npm install lucide-react --workspace apps/frontend
+npm install lucide-react
 ```
 
 ### Search Not Working

--- a/docs/plugins/plugins-frontend-context.md
+++ b/docs/plugins/plugins-frontend-context.md
@@ -731,6 +731,8 @@ interface TimeseriesPoint {
 
 Server-side rendering (SSR) with live data updates is the preferred pattern for plugin UI components. This approach provides instant display without loading flash, while still supporting real-time data changes.
 
+**Where `initialData` comes from:** Plugin pages declare a `serverDataFetcher` on their `IPageConfig`, which the catch-all route awaits server-side and passes to the page component as the `initialData` prop. **See [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md) for the `serverDataFetcher` contract, the bazi-fortune reference example, and pitfalls around timezone-sensitive and non-serializable data.** This section covers the component-side pattern; the page-config side (SEO fields plus the SSR data hook) lives in the dedicated doc.
+
 ### How It Works
 
 1. **Build time** - Generator creates static imports for plugin components
@@ -804,7 +806,7 @@ Export components from standard locations so the generator can discover them:
 After adding new components, regenerate the registry:
 
 ```bash
-npm run generate:plugins --workspace apps/frontend
+npm run generate:plugins
 ```
 
 ## Best Practices

--- a/docs/plugins/plugins-page-registration.md
+++ b/docs/plugins/plugins-page-registration.md
@@ -44,25 +44,29 @@ await context.menuService.create({
 Plugins declare routable pages in their frontend manifest:
 ```typescript
 interface IPageConfig {
-    path: string;               // URL route
-    component: ComponentType;   // React component
-    title?: string;             // Page title (metadata)
-    description?: string;       // Page description (metadata)
-    requiresAuth?: boolean;     // Authentication required
-    requiresAdmin?: boolean;    // Admin privileges required
+    path: string;                 // URL route
+    component: ComponentType;     // React component
+    title?: string;               // Page title (metadata)
+    description?: string;         // Page description (metadata)
+    keywords?: string[];          // SEO keywords
+    ogImage?: string;             // Open Graph image
+    ogType?: 'website' | 'article';
+    canonical?: string;           // Canonical URL override
+    noindex?: boolean;            // Set true on admin pages
+    structuredData?: Record<string, unknown>;  // Schema.org JSON-LD
+    serverDataFetcher?: (ctx) => Promise<unknown>;  // SSR data hook
+    requiresAuth?: boolean;       // Authentication required
+    requiresAdmin?: boolean;      // Admin privileges required
 }
 ```
 
-### 3. Plugin Loader Integration
+**For SEO fields and the `serverDataFetcher` SSR pattern in detail (with bazi-fortune as the canonical example), see [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md).** This guide focuses on routing and menu integration; SEO and server-side data fetching live in the dedicated doc.
 
-The `PluginLoader` component (in `src/frontend/components/plugins/PluginLoader.tsx`) automatically registers plugins with the menu/page system:
+### 3. Plugin Registry Bootstrap
 
-1. Fetches plugin manifests from backend
-2. Lazy loads frontend plugin modules
-3. Registers each plugin with `pluginRegistry`
-4. Renders plugin components
+Plugin frontends are statically imported into `src/frontend/components/plugins/plugins.generated.ts` by the `generate:plugins` script and registered with `pluginRegistry` (`src/frontend/lib/pluginRegistry.ts`) at module load time. The registry is populated synchronously on both server and client — no fetch, no polling, no loading flash.
 
-This ensures all plugin UI surfaces are discovered before the app renders navigation or routes.
+The `PluginLoader` component (`src/frontend/components/plugins/PluginLoader.tsx`) no longer loads plugins. Its only remaining job is to mount the global side-effect components some plugins ship (toast handlers, notification listeners) and to filter them by enabled state via a single `/api/plugins/manifests` fetch.
 
 ### 4. Dynamic Routing
 
@@ -74,11 +78,11 @@ Two systems consume the registry:
 - Renders clickable navigation links
 - Respects adminOnly and other access controls
 
-**Dynamic Route Handler** (`src/frontend/app/(core)/[...plugin]/page.tsx`):
+**Catch-all Route Handler** (`src/frontend/app/[...slug]/page.tsx`):
 - Catches all plugin page requests via Next.js catch-all route
-- Looks up page configuration by URL path
-- Renders the associated React component
-- Shows loading states and 404 errors
+- Resolves the page through the server-side registry (`src/frontend/lib/serverPluginRegistry.ts`), filtering by currently-enabled plugin manifests
+- Calls `notFound()` server-side for unknown URLs and disabled plugins
+- Generates `<head>` metadata from `IPageConfig` SEO fields and awaits `serverDataFetcher` to forward `initialData` to the page component
 
 ## How It Works
 
@@ -134,26 +138,25 @@ export const myFrontendPlugin = definePlugin({
 });
 ```
 
-2. **PluginLoader discovers pages** at runtime:
-   - Fetches manifests from `/api/plugins/manifests`
-   - Filters for plugins with `frontend: true`
-   - Lazy loads the plugin module
-   - Calls `pluginRegistry.registerPlugin(myPlugin)`
+2. **Generator script picks up the new plugin** at build time:
+   - `generate:plugins` discovers every plugin with a `src/frontend/frontend.ts` entry
+   - Emits a static-import line into `src/frontend/components/plugins/plugins.generated.ts`
+   - The registry is populated at module load via `pluginRegistry.bootstrap()`
 
-3. **Registry stores page configuration**:
-   - Extracts pages array
-   - Makes them available via `getPageByPath()`
-   - Dynamic route handler uses registry for lookups
+3. **Catch-all route resolves the page** server-side:
+   - `getEnabledPluginPageConfig(slug)` looks up the path in the server-side registry
+   - Filters by the currently-enabled plugin manifests
+   - Returns `null` for disabled plugins, triggering `notFound()`
 
 ### URL Routing Flow
 
 When a user navigates to `/my-feature`:
 
-1. Next.js matches the catch-all route `[...plugin]/page.tsx`
-2. Dynamic route handler extracts path from URL params
-3. Calls `pluginRegistry.getPageByPath('/my-feature')`
-4. Retrieves page config with component
-5. Renders: `<MyFeaturePage />`
+1. Next.js matches the catch-all route `app/[...slug]/page.tsx`
+2. The route resolves the slug via `getEnabledPluginPageConfig('/my-feature')`
+3. `generateMetadata` reads `IPageConfig` SEO fields and emits the `<head>` metadata
+4. The page render awaits `serverDataFetcher` (if defined) and forwards `initialData`
+5. `<PluginPageHandler>` looks the page up synchronously in the client registry and renders `<MyFeaturePage context={...} initialData={...} />`
 
 ### Menu Rendering Flow
 
@@ -292,7 +295,7 @@ export const myManifest: IPluginManifest = {
 ### Step 5: Build and Enable Plugin
 
 1. Build your plugin: `npm run build --workspace src/plugins/my-plugin`
-2. Generate frontend registry: `npm run generate:plugins --workspace apps/frontend`
+2. Generate frontend registry: `npm run generate:plugins`
 3. Restart the app (Ctrl+C then `npm run dev`)
 4. Navigate to `/system/plugins` admin UI
 5. Install and enable your plugin
@@ -401,20 +404,11 @@ pages: [
 ]
 ```
 
-### Page with Metadata
+### Page with SEO and SSR
 
-Add SEO and metadata:
+Plugin pages can declare full SEO metadata (title, description, keywords, ogImage, structuredData, noindex) and a `serverDataFetcher` for pre-fetching body data server-side. The catch-all route reads these fields during SSR, populates `<head>` via Next.js Metadata, and forwards `serverDataFetcher`'s return value to the page component as `initialData`.
 
-```typescript
-pages: [
-    {
-        path: '/my-page',
-        component: MyPageComponent,
-        title: 'My Feature - TronRelic',
-        description: 'Explore my feature with detailed analytics'
-    }
-]
-```
+**See [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md) for the full reference**, including the SEO field table, the `serverDataFetcher` contract, common pitfalls (timezone-sensitive data, JSON serialization), and bazi-fortune as the canonical implementation example.
 
 ### Page with API and Charts
 
@@ -604,10 +598,9 @@ await context.menuService.create({
 
 1. Confirm page `path` in frontend matches menu item `url` in backend
 2. Check `pages` array includes the route
-3. Verify plugin registered successfully (check React DevTools)
-4. Ensure dynamic route exists at `app/(core)/[...plugin]/page.tsx`
-5. Look for path lookup errors in console
-6. Verify frontend plugin has `manifest.frontend === true`
+3. Verify the plugin is enabled in `/system/plugins` — disabled plugins return 404 server-side
+4. Confirm `plugins.generated.ts` includes the plugin (re-run `npm run generate:plugins` if missing)
+5. Verify frontend plugin has `manifest.frontend === true`
 
 ### Menu items in wrong order
 
@@ -679,6 +672,8 @@ Planned improvements to the menu/page system:
 - **Hierarchical menus** - Container nodes with parent-child relationships (via IMenuService)
 - **WebSocket updates** - Real-time menu updates when plugins register/unregister
 - **Icon rendering** - Full Lucide icon support in NavBar
+- **Dynamic metadata** - Automatic Next.js metadata generation from `IPageConfig` SEO fields, including OpenGraph tags, Twitter cards, JSON-LD structured data, and per-page `noindex`. See [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md).
+- **Server-side data fetching** - `IPageConfig.serverDataFetcher` for pre-fetching plugin page data during SSR, eliminating the loading flash on plugin pages. See [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md).
 
 ### 🚧 Planned
 
@@ -692,13 +687,6 @@ pages: [
         requiresAdmin: true  // Auto-redirect if not admin
     }
 ]
-```
-
-**Dynamic Metadata** - Automatic Next.js metadata generation from page configs:
-
-```typescript
-// Generates:
-// export const metadata = { title: '...', description: '...' }
 ```
 
 **Permission-Based Visibility** - Hide menu items based on user permissions:
@@ -739,12 +727,16 @@ Core implementation files:
   - `packages/types/src/observer/IPluginContext.ts` - Backend context with menuService
 
 - **Page registry system**:
-  - `src/frontend/lib/pluginRegistry.ts` - Plugin page registry
-  - `src/frontend/components/plugins/PluginLoader.tsx` - Plugin loader with registry integration
+  - `src/frontend/lib/pluginRegistry.ts` - Client-side plugin registry, self-bootstrapped from `plugins.generated.ts`
+  - `src/frontend/lib/serverPluginRegistry.ts` - Server-only registry that filters by enabled manifests
+  - `src/frontend/components/plugins/plugins.generated.ts` - Auto-generated static-import registry
+  - `src/frontend/components/plugins/PluginLoader.tsx` - Mounts global side-effect components for enabled plugins
 
 - **UI integration**:
   - `src/frontend/components/layout/NavBar.tsx` - Navigation with WebSocket menu updates
-  - `src/frontend/app/(core)/[...plugin]/page.tsx` - Dynamic route handler
+  - `src/frontend/app/[...slug]/page.tsx` - Catch-all route handler (custom pages + plugin pages)
+  - `src/frontend/components/PluginPageHandler.tsx` - Client-side synchronous registry lookup
+  - `src/frontend/components/PluginPageWithZones.tsx` - Server wrapper with widget zones
 
 - **Example plugins**:
   - `src/plugins/resource-tracking/` - Uses IMenuService with hierarchical menus
@@ -760,7 +752,7 @@ When building plugins with UI:
 4. **Create hierarchies**: Use container nodes (no `url`) to group related menu items
 5. **Require backend flag**: Set `manifest.backend = true` even if plugin only registers menus
 6. **Provide metadata**: Always include page titles and descriptions for SEO
-7. **Handle loading states**: Pages should show spinners during data fetching
+7. **Render with SSR data, not loading spinners**: Pre-fetch via `serverDataFetcher` and initialize state from `initialData` so the first render contains real content. See [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md). Loading spinners are only appropriate for user-triggered actions (form submission, pagination), not initial render
 8. **Error boundaries**: Wrap page content in error boundaries for resilience
 9. **Responsive design**: Ensure pages work on mobile and desktop
 10. **Document your UI**: Add README.md explaining your plugin's pages and navigation structure
@@ -776,7 +768,7 @@ After implementing a plugin with menu items and pages, verify it works correctly
 npm run build --workspace src/plugins/my-plugin
 
 # Generate frontend registry
-npm run generate:plugins --workspace apps/frontend
+npm run generate:plugins
 
 # Restart application (Ctrl+C first if running, then:)
 npm run dev
@@ -870,11 +862,14 @@ For developers working on the plugin system itself, here are the key files:
 - `packages/types/src/plugin/index.ts` - Type exports
 
 ### Frontend Infrastructure
-- `src/frontend/lib/pluginRegistry.ts` - Plugin page registry singleton
-- `src/frontend/components/plugins/PluginLoader.tsx` - Plugin loader with registry integration
+- `src/frontend/lib/pluginRegistry.ts` - Client-side plugin registry singleton, self-bootstrapped at module load
+- `src/frontend/lib/serverPluginRegistry.ts` - Server-only registry that filters by currently-enabled plugin manifests
+- `src/frontend/components/plugins/PluginLoader.tsx` - Mounts global side-effect components for enabled plugins
+- `src/frontend/components/PluginPageHandler.tsx` - Client-side synchronous registry lookup
+- `src/frontend/components/PluginPageWithZones.tsx` - Server wrapper with widget zones
 - `src/frontend/components/layout/NavBar.tsx` - Navigation with WebSocket menu updates
-- `src/frontend/app/(core)/[...plugin]/page.tsx` - Dynamic route handler
-- `src/frontend/components/plugins/plugins.generated.ts` - Auto-generated plugin loaders
+- `src/frontend/app/[...slug]/page.tsx` - Catch-all route handler (handles custom pages and plugin pages)
+- `src/frontend/components/plugins/plugins.generated.ts` - Auto-generated static-import registry of all plugin frontends
 
 ### Example Plugins
 - `src/plugins/resource-tracking/` - Complete example with IMenuService

--- a/docs/plugins/plugins-seo-and-ssr.md
+++ b/docs/plugins/plugins-seo-and-ssr.md
@@ -1,0 +1,134 @@
+# Plugin SEO and Server-Side Rendering
+
+This document covers how plugin pages declare SEO metadata and pre-fetch data server-side so crawlers, social link previewers, and first-time visitors see fully populated content in the initial HTML response — without executing JavaScript.
+
+## Why This Matters
+
+Plugin pages used to render entirely client-side: the catch-all route delegated to a polling client component that waited for the registry to populate, then rendered the plugin component, which then fetched its own data in `useEffect`. The result was empty `<head>` tags, empty `<body>` content in the initial HTML, and a loading flash on every visit. Crawlers saw nothing meaningful, social link previews failed, and the SEO footprint was effectively zero.
+
+The solution is twofold. First, every plugin page declares SEO fields directly in its `IPageConfig` so the catch-all route's `generateMetadata` can read them server-side and emit a fully populated `<head>`. Second, plugins that need pre-fetched body data declare a `serverDataFetcher` that the catch-all route awaits during SSR, passing the result as `initialData` to the plugin component. The plugin component initializes its state from `initialData` instead of fetching in `useEffect`. The result: real content in the initial HTML, no loading flash, and no JavaScript required for crawlers.
+
+## How It Works
+
+The catch-all route at `src/frontend/app/[...slug]/page.tsx` is the integration point. During SSR it calls `getEnabledPluginPageConfig(slug)` from the server-side plugin registry, which returns the `IPageConfig` only if the owning plugin is currently enabled. From there:
+
+1. **`generateMetadata`** reads the page config's SEO fields (title, description, keywords, ogImage, ogType, canonical, structuredData, noindex) and composes a Next.js Metadata object via the existing `buildMetadata()` helper. The metadata lands in the `<head>` of the HTML response that crawlers and social scrapers receive — no JavaScript involved.
+
+2. **The page render** awaits the page config's `serverDataFetcher` if present, passing it an `IServerDataContext` containing the backend API URL and the public site URL. The fetcher returns JSON-serializable data which the route forwards through `<PluginPageWithZones>` to `<PluginPageHandler>`, which passes it to the plugin component as the `initialData` prop. Errors from `serverDataFetcher` are caught and logged; the page renders without `initialData` rather than 500ing.
+
+3. **The plugin component** is a `'use client'` React component. It receives `initialData` and uses it as the initial state for the data it would otherwise have fetched in `useEffect`. Static structure (headers, forms, descriptive text) renders during the SSR pass automatically because Next.js SSRs client components.
+
+4. **After hydration**, `useEffect` runs as normal. Plugins can subscribe to WebSocket events for live updates, refetch data when client-side context warrants it (e.g., the user's local timezone differs from the SSR machine's), and handle user interactions.
+
+Disabled plugins return `null` from the resolver and the catch-all route calls `notFound()` server-side, so disabled plugin URLs return HTTP 404 with no body — preserving the runtime-disable semantics the admin UI promises.
+
+## SEO Fields Reference
+
+All fields live in `IPageConfig` (`src/types/plugin/IPageConfig.ts`). Every field is optional. If `title` and `description` are both present, the catch-all route emits a full `<head>` populated via `buildMetadata()`. If they're absent, the route emits an empty metadata object and Next.js falls back to the layout-level defaults.
+
+| Field | Purpose |
+|-------|---------|
+| `title` | `<title>`, `og:title`, `twitter:title` |
+| `description` | `<meta description>`, `og:description`, `twitter:description` |
+| `keywords` | `<meta name="keywords">` |
+| `ogImage` | `og:image`, `twitter:image` (relative paths resolve against siteUrl) |
+| `ogType` | `og:type` — defaults to `'website'`, use `'article'` for time-stamped content |
+| `canonical` | Override the canonical URL (defaults to the page's `path`) |
+| `noindex` | Adds `<meta name="robots" content="noindex,nofollow">` for admin pages |
+| `structuredData` | Schema.org JSON-LD object injected as `<script type="application/ld+json">` |
+
+## serverDataFetcher Pattern
+
+`serverDataFetcher` is an optional async function on `IPageConfig` that runs during SSR. Its return value becomes the `initialData` prop on the plugin component.
+
+```typescript
+serverDataFetcher?: (ctx: IServerDataContext) => Promise<unknown>;
+```
+
+`IServerDataContext` exposes the values plugins need for backend fetches:
+
+| Field | Description |
+|-------|-------------|
+| `apiBaseUrl` | Backend API base URL with `/api` suffix (Docker-internal in containers, localhost otherwise) |
+| `siteUrl` | Public site URL from runtime config |
+
+The returned data **must be JSON-serializable** because it crosses the React Server Components boundary. Functions, class instances, Maps, Sets, and component references will fail. Stick to plain objects, arrays, strings, numbers, booleans, and `null`.
+
+## Canonical Example: bazi-fortune
+
+The bazi-fortune plugin demonstrates both halves of the pattern. See `src/plugins/trp-bazi-fortune/src/frontend/frontend.ts` for the page config and `src/plugins/trp-bazi-fortune/src/frontend/BaziPage.tsx` for the component.
+
+The page config declares full SEO metadata (title, description, keywords, ogType, structuredData with a `WebApplication` schema) and a `serverDataFetcher` that fetches today's day pillar from the bazi backend endpoint:
+
+```typescript
+serverDataFetcher: async (ctx) => {
+    const now = new Date();
+    const date = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
+    const url = `${ctx.apiBaseUrl}/plugins/bazi-fortune/day-pillar?date=${date}`;
+    const response = await fetch(url, { next: { revalidate: 60 } });
+    if (!response.ok) {
+        return null;
+    }
+    const data = await response.json();
+    return { dayPillar: data.dayPillar, date };
+}
+```
+
+The component initializes its day-pillar state from `initialData` instead of fetching in `useEffect`:
+
+```typescript
+const ssrData = initialData as IBaziInitialData | undefined;
+const [dayPillar, setDayPillar] = useState<ISexagenaryPair | null>(ssrData?.dayPillar ?? null);
+```
+
+A client `useEffect` still runs after hydration, but it short-circuits when the SSR date matches the user's local date — only re-fetching when the user is in a forward timezone past UTC midnight where "today" means a different day pillar:
+
+```typescript
+useEffect(() => {
+    const localDate = getLocalDateString();
+    if (ssrData && ssrData.date === localDate) {
+        return;  // SSR data is correct for this user
+    }
+    // ... fetch with localDate
+}, [api, ssrData]);
+```
+
+The user-triggered fetch (entering a wallet address and clicking "Read Fortune") stays client-only — it doesn't belong in `serverDataFetcher` because it depends on user input, not on what should appear in the initial HTML.
+
+## Common Pitfalls
+
+**Non-serializable data.** If `serverDataFetcher` returns a `Date`, `Map`, or class instance, the React Server Components serialization step throws. Convert to ISO strings, plain arrays, and plain objects before returning.
+
+**Timezone-sensitive content.** The server has no concept of "the user's timezone." If your data depends on the user's local date (like bazi's day pillar), include the SSR-side date in `initialData` so the client `useEffect` can detect a mismatch and re-fetch only when needed. Don't unconditionally re-fetch — that defeats the purpose.
+
+**Loading states for SSR data.** Don't render a `<Skeleton>` or "Loading..." placeholder for data that arrived via `initialData`. Initialize state directly: `useState(initialData?.field ?? null)`. The skeleton only makes sense if `initialData` is `undefined` AND the component is still trying to fetch.
+
+**Forgetting `noindex` on admin pages.** Plugin admin/settings pages should set `noindex: true` so search engines don't index them. Public pages don't need this.
+
+**Importing frontend internals from `serverDataFetcher`.** The page config lives in the plugin workspace, which can't import from `apps/frontend`. Use the `IServerDataContext` parameter for URLs instead of importing helpers directly.
+
+## Pre-Implementation Checklist
+
+Before adding SEO and SSR to a plugin page, verify:
+
+- [ ] `title` and `description` are populated with crawler-friendly copy
+- [ ] `keywords` reflect terms users would actually search
+- [ ] `ogType` is set explicitly (`'website'` or `'article'`)
+- [ ] `structuredData` includes a Schema.org `@type` appropriate for the page
+- [ ] Admin pages have `noindex: true`
+- [ ] If the page needs pre-fetched data, `serverDataFetcher` returns JSON-serializable values
+- [ ] The plugin component accepts `initialData` and initializes state from it
+- [ ] Client-side `useEffect` only re-fetches when context warrants (timezone, user input, live updates)
+- [ ] No `<Skeleton>` or loading state for data that arrives via `initialData`
+- [ ] Tested with `curl <URL>` to confirm metadata and content appear in initial HTML
+
+## Further Reading
+
+**Plugin documentation:**
+- [plugins-page-registration.md](./plugins-page-registration.md) — Page registration, menu items, and admin pages
+- [plugins-frontend-context.md](./plugins-frontend-context.md) — Plugin context injection and UI components
+- [plugins-system-architecture.md](./plugins-system-architecture.md) — Plugin loader, lifecycle hooks, and runtime flow
+
+**Frontend documentation:**
+- [react.md](../frontend/react/react.md#ssr--live-updates-pattern) — Complete SSR + Live Updates pattern guide for core components
+- [ui-ssr-hydration.md](../frontend/ui/ui-ssr-hydration.md) — Hydration error prevention and `ClientTime` component

--- a/docs/plugins/plugins-widget-zones.md
+++ b/docs/plugins/plugins-widget-zones.md
@@ -731,7 +731,7 @@ This pinpoints the exact element. The fix is usually: defer that render until `i
 After adding or modifying widget components, regenerate the registry:
 
 ```bash
-npm run generate:plugins --workspace apps/frontend
+npm run generate:plugins
 ```
 
 This scans all plugins for `src/frontend/widgets/index.ts` files and creates static imports in `widgets.generated.ts`.

--- a/docs/plugins/plugins.md
+++ b/docs/plugins/plugins.md
@@ -58,6 +58,11 @@ Plugins extend the frontend through:
 - Plugin admin pages and settings screens
 - Migration from deprecated `adminUI` pattern
 
+**See [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md) for complete details on:**
+- SEO fields on `IPageConfig` (title, description, keywords, ogImage, structuredData, noindex)
+- `serverDataFetcher` for pre-fetching plugin page data during SSR
+- bazi-fortune as the canonical reference implementation
+
 **See [plugins-widget-zones.md](./plugins-widget-zones.md) for complete details on:**
 - Registering widgets to inject UI into page zones
 - Zone naming conventions and routing
@@ -246,6 +251,7 @@ context.websocket.onSubscribe(async (socket, roomName, payload) => {
 - [plugins-system-architecture.md](./plugins-system-architecture.md) - Package layout, manifests, lifecycle hooks, admin interface
 - [plugins-blockchain-observers.md](./plugins-blockchain-observers.md) - Observer pattern, transaction processing, subscriptions
 - [plugins-page-registration.md](./plugins-page-registration.md) - Menu items, pages, routing, admin UI
+- [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md) - SEO metadata fields and `serverDataFetcher` for body SSR (bazi-fortune as canonical example)
 - [plugins-widget-zones.md](./plugins-widget-zones.md) - Widget zones for injecting UI into existing pages
 - [plugins-frontend-context.md](./plugins-frontend-context.md) - Context injection, UI components, API client, WebSocket
 - [plugins-api-registration.md](./plugins-api-registration.md) - REST routes, middleware, admin endpoints

--- a/scripts/generate-frontend-plugin-registry.mjs
+++ b/scripts/generate-frontend-plugin-registry.mjs
@@ -107,37 +107,46 @@ async function collectPluginMetadata() {
 /**
  * Renders the TypeScript source for the registry module.
  *
- * It generates lazy loader functions that import plugin frontends on demand. This lets the frontend dynamically initialize plugins without bundling them all upfront.
+ * Generates synchronous static imports for every plugin's frontend entry file
+ * and exports a `frontendPlugins` array. Static imports are required for SSR:
+ * the catch-all route's generateMetadata reads the registry server-side, and the
+ * client-side PluginPageHandler now does a synchronous lookup during render
+ * instead of polling, so the registry must be populated at module load time on
+ * both server and client.
+ *
+ * CSS code splitting is preserved because each plugin's frontend.ts uses
+ * next/dynamic() to lazy-load its actual page components — the static import
+ * here only pulls in the manifest and the dynamic wrappers, not the page CSS.
  */
 function renderModule(metadata) {
-    const header = `/**\n * AUTO-GENERATED FILE. DO NOT EDIT.\n *\n * This module is produced by scripts/generate-frontend-plugin-registry.mjs\n * and exposes lazy loaders for plugin frontend modules.\n */\n`;
+    const header = `/**\n * AUTO-GENERATED FILE. DO NOT EDIT.\n *\n * This module is produced by scripts/generate-frontend-plugin-registry.mjs\n * and exposes a synchronous, statically-imported array of plugin frontends.\n *\n * Static imports are required so the plugin registry can be populated at\n * module load time on both server and client. CSS code splitting is preserved\n * because plugin frontend entry files use next/dynamic() for their page\n * components — only the manifest and dynamic wrappers are pulled in here.\n */\n`;
 
     const imports = `import type { IPlugin } from '@/types';\n\n`;
 
     if (metadata.length === 0) {
-        const emptyBody = `export const frontendPluginLoaders: Record<string, () => Promise<IPlugin>> = {};\n\nfunction resolvePluginExport(pluginId: string): IPlugin {\n    throw new Error(\`Plugin registry attempted to load '\${pluginId}' but no loaders were generated.\`);\n}\n`;
+        const emptyBody = `export const frontendPlugins: IPlugin[] = [];\n`;
         return `${header}${imports}${emptyBody}`;
     }
 
-    const loaderBodies = metadata
+    const staticImports = metadata
         .map(({ id, importPath }) => {
             const safeId = id.replace(/[^a-zA-Z0-9_]/g, '_');
-            return `async function load_${safeId}(): Promise<IPlugin> {\n    const module = await import('${importPath}');\n    return resolvePluginExport('${id}', module);\n}\n`;
+            return `import * as ${safeId}_module from '${importPath}';`;
         })
         .join('\n');
 
-    const registryEntries = metadata
+    const arrayEntries = metadata
         .map(({ id }) => {
             const safeId = id.replace(/[^a-zA-Z0-9_]/g, '_');
-            return `    '${id}': load_${safeId},`;
+            return `    resolvePluginExport('${id}', ${safeId}_module),`;
         })
         .join('\n');
 
-    const registry = `export const frontendPluginLoaders: Record<string, () => Promise<IPlugin>> = {\n${registryEntries}\n};\n`;
+    const arrayDecl = `export const frontendPlugins: IPlugin[] = [\n${arrayEntries}\n];\n`;
 
     const resolver = `function resolvePluginExport(pluginId: string, module: Record<string, unknown>): IPlugin {\n    const candidate = Object.values(module).find((value): value is IPlugin => {\n        return typeof value === 'object' && value !== null && 'manifest' in value;\n    });\n\n    if (!candidate) {\n        throw new Error(\`Failed to locate plugin export for '\${pluginId}'. Ensure the module exports an IPlugin.\`);\n    }\n\n    return candidate;\n}\n`;
 
-    return `${header}${imports}${loaderBodies}\n${registry}\n${resolver}`;
+    return `${header}${imports}${staticImports}\n\n${resolver}\n${arrayDecl}`;
 }
 
 /**

--- a/src/frontend/BUILD.md
+++ b/src/frontend/BUILD.md
@@ -131,29 +131,28 @@ Only these JavaScript/TypeScript declaration files should exist:
 
 ### Start Development
 ```bash
-npm run dev --workspace apps/frontend
-# Runs: next dev --turbo
+npm run dev
+# Runs: node scripts/dev.mjs (concurrent backend + frontend with plugin generation)
 # Output: .next/ (dev build, auto-refreshes)
 ```
 
 ### Type Check
 ```bash
-npm run typecheck --workspace apps/frontend
-# Runs: tsc --noEmit
+npm run typecheck:frontend
+# Runs: tsc --noEmit -p src/frontend/tsconfig.json
 # Output: Console errors only, no files
 ```
 
 ### Build for Production
 ```bash
-npm run build --workspace apps/frontend
-# Runs: next build
+npm run build:frontend
+# Runs: npm run generate:plugins && next build src/frontend
 # Output: .next/ (optimized production build)
 ```
 
 ### Start Production Server
 ```bash
-npm run start --workspace apps/frontend
-# Runs: next start
+next start src/frontend
 # Serves: .next/ folder
 ```
 

--- a/src/frontend/app/(core)/system/layout.tsx
+++ b/src/frontend/app/(core)/system/layout.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from 'react';
+import type { Metadata } from 'next';
 import { SystemAuthProvider, SystemAuthGate } from '../../../features/system';
 import { MenuNavSSR } from '../../../components/layout/MenuNav';
 
@@ -10,6 +11,27 @@ import { MenuNavSSR } from '../../../components/layout/MenuNav';
  * attempting static pre-rendering at build time when the backend isn't available.
  */
 export const dynamic = 'force-dynamic';
+
+/**
+ * Block search engine indexing for the entire /system/* admin surface.
+ *
+ * Why this exists:
+ * Every route under /system/* is admin-only and gated by SystemAuthGate, so the
+ * only thing a crawler would index is the login form — a pure reconnaissance
+ * leak that exposes the admin entry point without exposing data. Setting robots
+ * here cascades to every nested route (overview, plugin admin pages, scheduler,
+ * websockets, users, etc.) without each page having to opt in.
+ *
+ * Next.js merges metadata across the layout hierarchy by replacing the robots
+ * field rather than merging it, so this overrides the root layout's
+ * `robots: { index: true, follow: true }` for all /system/* paths.
+ */
+export const metadata: Metadata = {
+    robots: {
+        index: false,
+        follow: false
+    }
+};
 
 /**
  * System monitoring layout with server-side navigation and authentication.

--- a/src/frontend/app/[...slug]/page.tsx
+++ b/src/frontend/app/[...slug]/page.tsx
@@ -291,31 +291,51 @@ export default async function UnifiedPage({ params }: { params: Promise<IPagePar
     // Live Updates pattern for plugin pages — the plugin's body content arrives
     // in the initial HTML so crawlers see it without executing JavaScript, and
     // the client component initializes its state from the same data after
-    // hydration. Errors are logged and the page renders without initialData
-    // rather than 500ing.
+    // hydration.
+    //
+    // The fetched value is normalized via JSON round-trip before being passed
+    // across the RSC boundary. This guarantees the value is plain-data
+    // serializable: Date instances become ISO strings, undefined fields are
+    // dropped, and class instances / Map / Set / functions are coerced to
+    // empty objects rather than throwing the React serialization error after
+    // this try/catch has already returned. Round-trip failures (circular refs,
+    // BigInt, etc.) are caught and degrade gracefully — the page renders
+    // without initialData rather than 500ing, matching what the docstring
+    // and IPageConfig comment promise plugin authors.
     let initialData: unknown = undefined;
     if (pluginPage.serverDataFetcher) {
         try {
             const { siteUrl } = await getServerConfig();
-            initialData = await pluginPage.serverDataFetcher({
+            const raw = await pluginPage.serverDataFetcher({
                 apiBaseUrl: getServerSideApiUrlWithPath(),
                 siteUrl
             });
+            initialData = raw === undefined ? undefined : JSON.parse(JSON.stringify(raw));
         } catch (error) {
             console.error(
                 `[catch-all] serverDataFetcher failed for ${slug}:`,
                 error
             );
+            initialData = undefined;
         }
     }
 
-    // PluginPageWithZones wraps with widget zones for cross-plugin content injection
+    // PluginPageWithZones wraps with widget zones for cross-plugin content injection.
+    // The structured data JSON is escaped so any string value containing
+    // '</script>' (or any '<') can't break out of the script tag and become an
+    // injection vector. Replacing '<' with the unicode escape '\u003c' is
+    // sufficient because JSON.stringify never emits unescaped '\u003c' on its
+    // own and the JSON parser still treats the escape as a literal '<'.
+    const pluginStructuredDataJson = pluginStructuredData
+        ? JSON.stringify(pluginStructuredData).replace(/</g, '\\u003c')
+        : null;
+
     return (
         <>
-            {pluginStructuredData && (
+            {pluginStructuredDataJson && (
                 <script
                     type="application/ld+json"
-                    dangerouslySetInnerHTML={{ __html: JSON.stringify(pluginStructuredData) }}
+                    dangerouslySetInnerHTML={{ __html: pluginStructuredDataJson }}
                 />
             )}
             <PluginPageWithZones slug={slug} initialData={initialData} />

--- a/src/frontend/app/[...slug]/page.tsx
+++ b/src/frontend/app/[...slug]/page.tsx
@@ -5,79 +5,8 @@ import { PluginPageWithZones } from '../../components/PluginPageWithZones';
 import { getServerSideApiUrlWithPath } from '../../lib/api-url';
 import { buildMetadata, buildArticleStructuredData } from '../../lib/seo';
 import { getServerConfig } from '../../lib/serverConfig';
+import { getEnabledPluginPageConfig } from '../../lib/serverPluginRegistry';
 import styles from './page.module.css';
-
-/**
- * Static SEO metadata and structured data for known plugin pages.
- *
- * Plugin pages are client-rendered and cannot generate their own server-side metadata.
- * This map provides titles, descriptions, keywords, and Schema.org structured data
- * so crawlers see meaningful content in the initial HTML response.
- */
-interface PluginSeoEntry {
-    title: string;
-    description: string;
-    keywords: string[];
-    /** Schema.org structured data type and properties for rich results. */
-    structuredData?: Record<string, unknown>;
-}
-
-const PLUGIN_SEO_METADATA: Record<string, PluginSeoEntry> = {
-    '/resource-markets': {
-        title: 'Compare TRON Energy Rental Prices | Live Market Tracker | TronRelic',
-        description: 'Compare real-time TRON energy rental prices across 20+ platforms. Find the cheapest rates for TRC-20 USDT transfers and save up to 90% on transaction fees. Updated every 10 minutes.',
-        keywords: [
-            'rent TRON energy',
-            'TRON energy rental',
-            'TRC20 transfer fee',
-            'cheapest TRON energy',
-            'TRON energy market',
-            'TronSave',
-            'JustLend',
-            'energy price comparison',
-            'TRX staking'
-        ],
-        structuredData: {
-            '@context': 'https://schema.org',
-            '@type': 'WebApplication',
-            'name': 'TronRelic Energy Market Comparison',
-            'applicationCategory': 'FinanceApplication',
-            'description': 'Compare real-time TRON energy rental prices across 20+ platforms to find the cheapest rates for TRC-20 USDT transfers.',
-            'offers': {
-                '@type': 'Offer',
-                'price': '0',
-                'priceCurrency': 'USD'
-            },
-            'operatingSystem': 'Web'
-        }
-    },
-    '/tools': {
-        title: 'TRON Blockchain Tools | Staking Calculator, Address Generator | TronRelic',
-        description: 'Free TRON blockchain tools: energy fee calculator, staking calculator, custom address generator, signature verification, and hex/base58 converters.',
-        keywords: [
-            'TRON tools',
-            'TRX staking calculator',
-            'TRON energy calculator',
-            'TRON address generator',
-            'TRC20 fee calculator',
-            'hex to base58',
-            'TRON signature verification'
-        ],
-        structuredData: {
-            '@context': 'https://schema.org',
-            '@type': 'WebApplication',
-            'name': 'TronRelic Blockchain Tools',
-            'applicationCategory': 'UtilitiesApplication',
-            'description': 'Free TRON blockchain tools including staking calculator, energy fee calculator, custom address generator, and format converters.',
-            'offers': {
-                '@type': 'Offer',
-                'price': '0',
-                'priceCurrency': 'USD'
-            },
-            'operatingSystem': 'Web'
-        }
-    }
-};
 
 /**
  * Page metadata response from backend.
@@ -144,8 +73,15 @@ async function isCustomPage(slug: string): Promise<boolean> {
 /**
  * Generate metadata for the page.
  *
- * Only generates metadata for custom pages (not plugin pages, as they handle
- * their own metadata client-side).
+ * Resolves metadata in priority order:
+ * 1. Custom pages (database-backed CMS): fetched from /api/pages
+ * 2. Enabled plugin pages: read from the plugin's IPageConfig via the
+ *    server-side plugin registry, then composed via buildMetadata()
+ * 3. Otherwise: empty metadata (Next.js applies the layout-level defaults)
+ *
+ * Plugin SEO is now declared per-page in each plugin's frontend.ts page config
+ * (title, description, keywords, ogImage, ogType, structuredData, noindex).
+ * The hardcoded PLUGIN_SEO_METADATA map this used to live in has been removed.
  *
  * @param params - Next.js route params containing slug array (Promise in Next.js 15+)
  * @returns Metadata object for Next.js
@@ -156,18 +92,76 @@ export async function generateMetadata({ params }: { params: Promise<IPageParams
     const isCustom = await isCustomPage(slug);
 
     if (!isCustom) {
-        const pluginSeo = PLUGIN_SEO_METADATA[slug];
-        if (pluginSeo) {
-            const { siteUrl } = await getServerConfig();
-            return buildMetadata({
-                siteUrl,
-                title: pluginSeo.title,
-                description: pluginSeo.description,
-                path: slug,
-                keywords: pluginSeo.keywords
-            });
+        const pluginPage = await getEnabledPluginPageConfig(slug);
+        if (!pluginPage) {
+            return {};
         }
-        return {};
+
+        const { siteUrl } = await getServerConfig();
+        let metadata: Metadata;
+
+        // When both title and description are present, emit the full SEO
+        // bundle via the shared buildMetadata helper (canonical, openGraph,
+        // twitter card, keywords). For pages that declare only a subset of
+        // fields, fall through to a fields-only path that emits whatever
+        // was actually declared. Either way, noindex is honored below
+        // independently of which other fields are present.
+        if (pluginPage.title && pluginPage.description) {
+            metadata = buildMetadata({
+                siteUrl,
+                title: pluginPage.title,
+                description: pluginPage.description,
+                path: slug,
+                image: pluginPage.ogImage,
+                type: pluginPage.ogType,
+                keywords: pluginPage.keywords,
+                canonical: pluginPage.canonical
+            });
+        } else {
+            metadata = {};
+            if (pluginPage.title) {
+                metadata.title = pluginPage.title;
+            }
+            if (pluginPage.description) {
+                metadata.description = pluginPage.description;
+            }
+            if (pluginPage.keywords) {
+                metadata.keywords = pluginPage.keywords;
+            }
+            if (pluginPage.canonical) {
+                metadata.alternates = { canonical: pluginPage.canonical };
+            }
+            // Build openGraph only when at least one OG-relevant field is
+            // present, so we don't synthesize an empty default OG block for
+            // pages that explicitly opted out by omitting all SEO fields.
+            if (pluginPage.title || pluginPage.description || pluginPage.ogImage || pluginPage.ogType) {
+                metadata.openGraph = {
+                    type: pluginPage.ogType ?? 'website',
+                    ...(pluginPage.title ? { title: pluginPage.title } : {}),
+                    ...(pluginPage.description ? { description: pluginPage.description } : {}),
+                    ...(pluginPage.canonical ? { url: pluginPage.canonical } : {}),
+                    ...(pluginPage.ogImage
+                        ? {
+                            images: [{
+                                url: pluginPage.ogImage,
+                                width: 1200,
+                                height: 630,
+                                alt: pluginPage.title ?? 'TronRelic'
+                            }]
+                        }
+                        : {})
+                };
+            }
+        }
+
+        // noindex applies independently of which other fields are present —
+        // admin pages frequently set noindex without bothering to populate
+        // crawler-friendly title/description copy.
+        if (pluginPage.noindex) {
+            metadata.robots = { index: false, follow: false };
+        }
+
+        return metadata;
     }
 
     const apiUrl = getServerSideApiUrlWithPath();
@@ -281,10 +275,39 @@ export default async function UnifiedPage({ params }: { params: Promise<IPagePar
         );
     }
 
-    // Not a custom page, let plugin handler check the registry.
-    // Inject structured data for known plugin pages (resource-markets, tools, etc.)
-    const pluginSeo = PLUGIN_SEO_METADATA[slug];
-    const pluginStructuredData = pluginSeo?.structuredData ?? null;
+    // Not a custom page — look up an enabled plugin page in the server-side
+    // registry. Disabled plugins and unknown URLs both return null and 404
+    // server-side, so the HTTP status code is correct (200 → only for real
+    // pages) and disabled plugin URLs disappear from search engine indexes.
+    const pluginPage = await getEnabledPluginPageConfig(slug);
+    if (!pluginPage) {
+        notFound();
+    }
+
+    const pluginStructuredData = pluginPage.structuredData ?? null;
+
+    // If the plugin declares a serverDataFetcher, run it server-side and pass
+    // the result to the plugin component as `initialData`. This is the SSR +
+    // Live Updates pattern for plugin pages — the plugin's body content arrives
+    // in the initial HTML so crawlers see it without executing JavaScript, and
+    // the client component initializes its state from the same data after
+    // hydration. Errors are logged and the page renders without initialData
+    // rather than 500ing.
+    let initialData: unknown = undefined;
+    if (pluginPage.serverDataFetcher) {
+        try {
+            const { siteUrl } = await getServerConfig();
+            initialData = await pluginPage.serverDataFetcher({
+                apiBaseUrl: getServerSideApiUrlWithPath(),
+                siteUrl
+            });
+        } catch (error) {
+            console.error(
+                `[catch-all] serverDataFetcher failed for ${slug}:`,
+                error
+            );
+        }
+    }
 
     // PluginPageWithZones wraps with widget zones for cross-plugin content injection
     return (
@@ -295,7 +318,7 @@ export default async function UnifiedPage({ params }: { params: Promise<IPagePar
                     dangerouslySetInnerHTML={{ __html: JSON.stringify(pluginStructuredData) }}
                 />
             )}
-            <PluginPageWithZones slug={slug} />
+            <PluginPageWithZones slug={slug} initialData={initialData} />
         </>
     );
 }

--- a/src/frontend/components/PluginPageHandler.tsx
+++ b/src/frontend/components/PluginPageHandler.tsx
@@ -1,48 +1,35 @@
 'use client';
 
-import { useEffect, useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import { pluginRegistry } from '../lib/pluginRegistry';
 import { createPluginContext } from '../lib/frontendPluginContext';
-import type { IPageConfig } from '@/types';
+
+interface PluginPageHandlerProps {
+    slug: string;
+    initialData?: unknown;
+}
 
 /**
  * Plugin page handler component.
  *
- * This component checks the plugin registry for a registered page at the given
- * path and renders it with plugin-specific context. If no plugin page is found,
- * it displays a 404 message.
+ * Looks up a plugin page synchronously from the eagerly-bootstrapped plugin
+ * registry and renders it with plugin-specific context. The registry is
+ * populated at module load by `pluginRegistry.bootstrap()` (called from
+ * pluginRegistry.ts as a top-level side effect of importing
+ * plugins.generated.ts), so the lookup always resolves immediately on both the
+ * SSR pass and the client hydration pass — no useEffect, no polling, no
+ * loading flash.
  *
- * This is used by the unified catch-all route to handle plugin pages after
- * checking that the path is not a custom user-created page.
+ * Receives optional `initialData` from the catch-all route's serverDataFetcher
+ * pipeline and forwards it to the plugin component as a prop, enabling true
+ * server-side rendering of plugin page bodies.
+ *
+ * Returns null when the slug is not registered by any plugin. The catch-all
+ * route already filters out unknown / disabled plugin slugs server-side via
+ * notFound(), so this branch should be unreachable in production.
  */
-export function PluginPageHandler({ slug }: { slug: string }) {
-    const [pageConfig, setPageConfig] = useState<IPageConfig | null>(null);
-    const [notFound, setNotFound] = useState(false);
-
-    useEffect(() => {
-        let attempts = 0;
-        const maxAttempts = 50; // 5 seconds max (50 * 100ms)
-
-        // Poll for plugin registration with retry logic
-        const checkForPlugin = () => {
-            const config = pluginRegistry.getPageByPath(slug);
-
-            if (config) {
-                setPageConfig(config);
-            } else if (attempts < maxAttempts) {
-                attempts++;
-                setTimeout(checkForPlugin, 100);
-            } else {
-                setNotFound(true);
-            }
-        };
-
-        // Start checking immediately
-        checkForPlugin();
-    }, [slug]);
-
-    // Create plugin-specific context only when pluginId is available
-    // Avoids creating throwaway empty-pluginId contexts during polling
+export function PluginPageHandler({ slug, initialData }: PluginPageHandlerProps) {
+    const pageConfig = useMemo(() => pluginRegistry.getPageByPath(slug), [slug]);
     const context = useMemo(() => {
         if (!pageConfig?.pluginId) {
             return null;
@@ -50,31 +37,10 @@ export function PluginPageHandler({ slug }: { slug: string }) {
         return createPluginContext(pageConfig.pluginId);
     }, [pageConfig?.pluginId]);
 
-    if (notFound) {
-        return (
-            <div className="flex items-center justify-center min-h-screen">
-                <div className="text-center">
-                    <h1 className="text-4xl font-bold mb-4">404 - Page Not Found</h1>
-                    <p className="text-muted-foreground">
-                        The page you're looking for doesn't exist.
-                    </p>
-                </div>
-            </div>
-        );
-    }
-
     if (!pageConfig || !context) {
-        return (
-            <div className="flex items-center justify-center min-h-screen">
-                <div className="text-center">
-                    <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto"></div>
-                    <p className="mt-4 text-muted-foreground">Loading page...</p>
-                </div>
-            </div>
-        );
+        return null;
     }
 
     const PageComponent = pageConfig.component;
-
-    return <PageComponent context={context} />;
+    return <PageComponent context={context} initialData={initialData} />;
 }

--- a/src/frontend/components/PluginPageWithZones.tsx
+++ b/src/frontend/components/PluginPageWithZones.tsx
@@ -32,19 +32,33 @@
 
 import { WidgetZone, fetchWidgetsForRoute } from './widgets';
 import { PluginPageHandler } from './PluginPageHandler';
-import { getServerConfig } from '../lib/serverConfig';
 import styles from './PluginPageWithZones.module.css';
 
 interface PluginPageWithZonesProps {
     slug: string;
+    /**
+     * Server-fetched initial data from the plugin's IPageConfig.serverDataFetcher,
+     * forwarded to the plugin component via PluginPageHandler. Plugins use this
+     * for SSR-rendered body content (e.g., bazi-fortune's day pillar) so the
+     * initial HTML contains real data instead of placeholders.
+     */
+    initialData?: unknown;
 }
 
 /**
  * Render a plugin page with widget zones for cross-plugin content injection.
  *
+ * Structured data (JSON-LD) for plugin pages is now declared in each plugin's
+ * IPageConfig.structuredData field and injected by the catch-all route at
+ * src/frontend/app/[...slug]/page.tsx, so this component no longer hardcodes
+ * any per-plugin schema. The visible FAQ HTML for /resource-markets remains
+ * here intentionally — it must continue rendering server-side until that
+ * plugin moves the prose into its own page component.
+ *
  * @param slug - The URL path for the plugin page (e.g., '/whales', '/memo-tracker')
+ * @param initialData - Optional SSR-fetched data forwarded to the plugin component
  */
-export async function PluginPageWithZones({ slug }: PluginPageWithZonesProps) {
+export async function PluginPageWithZones({ slug, initialData }: PluginPageWithZonesProps) {
     // For plugin pages, the slug is the route and params are empty
     // (plugin-internal param parsing is handled by the plugin's page component)
     const route = slug;
@@ -53,93 +67,9 @@ export async function PluginPageWithZones({ slug }: PluginPageWithZonesProps) {
     const widgets = await fetchWidgetsForRoute(route, params);
     const isResourceMarkets = slug === '/resource-markets';
 
-    let structuredData: JSX.Element | null = null;
     let seoContent: JSX.Element | null = null;
 
     if (isResourceMarkets) {
-        const { siteUrl } = await getServerConfig();
-
-        const webAppSchema = {
-            '@context': 'https://schema.org',
-            '@type': 'WebApplication',
-            name: 'TronRelic Energy Market Tracker',
-            description: 'Compare real-time TRON energy rental prices across 20+ platforms. Find the cheapest rates for TRC-20 USDT transfers.',
-            url: `${siteUrl}/resource-markets`,
-            applicationCategory: 'FinanceApplication',
-            operatingSystem: 'Any',
-            offers: {
-                '@type': 'Offer',
-                price: '0',
-                priceCurrency: 'USD'
-            },
-            provider: {
-                '@type': 'Organization',
-                '@id': `${siteUrl}/#organization`
-            }
-        };
-
-        const faqSchema = {
-            '@context': 'https://schema.org',
-            '@type': 'FAQPage',
-            mainEntity: [
-                {
-                    '@type': 'Question',
-                    name: 'What is TRON energy and why does it matter?',
-                    acceptedAnswer: {
-                        '@type': 'Answer',
-                        text: 'TRON energy is a resource consumed when executing smart contracts on the TRON network, including TRC-20 token transfers like USDT. Every wallet regenerates a small amount of free energy daily based on staked TRX, but high-volume wallets exhaust this quickly. Without enough energy, the network burns TRX from your balance to cover the cost, which can be 10-50x more expensive than renting energy from a delegation provider.'
-                    }
-                },
-                {
-                    '@type': 'Question',
-                    name: 'How does renting energy reduce TRC-20 transfer fees?',
-                    acceptedAnswer: {
-                        '@type': 'Answer',
-                        text: 'When you rent energy, a provider delegates their staked TRX resources to your wallet for a set period. Your wallet temporarily gains enough energy to execute smart contracts without burning TRX. A standard USDT transfer requires approximately 65,000 energy. Burning that energy costs roughly 27 TRX at current rates, but renting the same amount from a market provider typically costs 2-5 TRX, saving you up to 90% per transaction.'
-                    }
-                },
-                {
-                    '@type': 'Question',
-                    name: 'How does TRON energy regeneration affect pricing?',
-                    acceptedAnswer: {
-                        '@type': 'Answer',
-                        text: 'Every TRON wallet regenerates energy over a 24-hour cycle based on how much TRX is staked for energy. This natural regeneration means the total energy available on the network changes throughout the day, which influences rental market pricing. Providers monitor regeneration rates to adjust their pricing, and savvy users can time their rentals to coincide with periods of higher supply and lower demand for better rates.'
-                    }
-                },
-                {
-                    '@type': 'Question',
-                    name: 'Which energy rental platforms does TronRelic compare?',
-                    acceptedAnswer: {
-                        '@type': 'Answer',
-                        text: 'TronRelic monitors over 20 TRON energy rental platforms including TronSave, JustLend, Brutus Finance, CatFee, TronZap, Feee.io, Tronspark, NRG, and many more. Each platform is queried for current pricing, minimum order sizes, and availability. The comparison table normalizes all prices to a per-energy-unit cost so you can instantly identify the cheapest provider for your transaction size.'
-                    }
-                },
-                {
-                    '@type': 'Question',
-                    name: 'How often are market prices updated?',
-                    acceptedAnswer: {
-                        '@type': 'Answer',
-                        text: 'TronRelic refreshes energy market prices every 10 minutes through automated API queries to each platform. The last-updated timestamp is displayed on the market comparison page so you always know how fresh the data is. If a platform is temporarily unreachable, the most recent successful price is shown with a stale indicator until the next successful refresh.'
-                    }
-                }
-            ]
-        };
-
-        structuredData = (
-            <>
-                <script
-                    suppressHydrationWarning
-                    type="application/ld+json"
-                    dangerouslySetInnerHTML={{ __html: JSON.stringify(webAppSchema).replace(/</g, '\\u003c') }}
-                />
-                <script
-                    suppressHydrationWarning
-                    type="application/ld+json"
-                    dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema).replace(/</g, '\\u003c') }}
-                />
-            </>
-        );
-
         seoContent = (
             <section className={styles.seo_section}>
                 <h2 className={styles.seo_heading}>How TRON Energy Rental Works</h2>
@@ -214,9 +144,8 @@ export async function PluginPageWithZones({ slug }: PluginPageWithZonesProps) {
 
     return (
         <>
-            {structuredData}
             <WidgetZone name="plugin-content:before" widgets={widgets} route={route} params={params} />
-            <PluginPageHandler slug={slug} />
+            <PluginPageHandler slug={slug} initialData={initialData} />
             <WidgetZone name="plugin-content:after" widgets={widgets} route={route} params={params} />
             {seoContent}
         </>

--- a/src/frontend/components/plugins/PluginLoader.tsx
+++ b/src/frontend/components/plugins/PluginLoader.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import type { IPlugin, IPluginManifest } from '@/types';
-import { frontendPluginLoaders } from './plugins.generated';
+import type { IPluginManifest } from '@/types';
 import { pluginRegistry } from '../../lib/pluginRegistry';
 import { createPluginContext } from '../../lib/frontendPluginContext';
 import { config } from '../../lib/config';
@@ -10,72 +9,64 @@ import { config } from '../../lib/config';
 /**
  * Plugin Loader component.
  *
- * Fetches plugin manifests from the backend and lazily loads the matching frontend modules.
- * This keeps plugin registration automatic while letting Next.js compile the code directly.
- * Additionally, it registers plugins with the menu/page registry for dynamic navigation.
+ * The plugin registry is now self-bootstrapping at module load (see
+ * pluginRegistry.ts), so this component no longer fetches manifests to
+ * dynamically import plugin frontend modules — every built-in plugin is
+ * already in the registry by the time this component mounts.
  *
- * Each plugin receives a plugin-specific context with automatic event namespacing,
- * ensuring WebSocket events are properly isolated between plugins.
+ * Its remaining responsibility is to render the global side-effect components
+ * that some plugins ship (e.g., AiAssistantToastHandler, WhaleAlertsToastHandler)
+ * — but only for plugins that are currently enabled. To honor enabled state, it
+ * fetches /api/plugins/manifests once on mount and intersects the result with
+ * the registry's full plugin list.
+ *
+ * If a plugin is disabled, its side-effect component never mounts, preserving
+ * the runtime-disable behavior the admin UI promises.
  */
 export function PluginLoader() {
-    const [plugins, setPlugins] = useState<IPlugin[]>([]);
+    const [enabledIds, setEnabledIds] = useState<Set<string> | null>(null);
 
     useEffect(() => {
         let cancelled = false;
 
-        async function loadPlugins() {
+        async function loadEnabledManifests() {
             try {
                 const response = await fetch(`${config.apiBaseUrl}/plugins/manifests`);
                 const data = await response.json();
                 const manifests: IPluginManifest[] = data.manifests ?? [];
-
-                const loadableManifests = manifests.filter(manifest => manifest.frontend);
-                const pluginPromises = loadableManifests.map(async manifest => {
-                    const loader = frontendPluginLoaders[manifest.id];
-
-                    if (!loader) {
-                        console.warn(`No registered frontend module for plugin '${manifest.id}'.`);
-                        return null;
-                    }
-
-                    try {
-                        return await loader();
-                    } catch (error) {
-                        console.error(`Failed to load frontend plugin ${manifest.id}:`, error);
-                        return null;
-                    }
-                });
-
-                const resolvedPlugins = (await Promise.all(pluginPromises)).filter(
-                    (plugin): plugin is IPlugin => Boolean(plugin)
-                );
-
                 if (!cancelled) {
-                    // Register plugins with the menu/page registry
-                    pluginRegistry.clear(); // Clear previous registrations
-                    resolvedPlugins.forEach(plugin => pluginRegistry.registerPlugin(plugin));
-
-                    setPlugins(resolvedPlugins);
+                    setEnabledIds(new Set(manifests.map(m => m.id)));
                 }
             } catch (error) {
                 console.error('Failed to load plugin manifests:', error);
+                if (!cancelled) {
+                    setEnabledIds(new Set());
+                }
             }
         }
 
-        void loadPlugins();
+        void loadEnabledManifests();
 
         return () => {
             cancelled = true;
         };
     }, []);
 
-    const pluginsWithComponents = plugins.filter(plugin => plugin.component);
+    // Until the manifest fetch resolves, render no side-effect components.
+    // The registry is already populated, but we don't yet know which plugins
+    // are enabled — rendering all of them would let disabled plugins run.
+    if (!enabledIds) {
+        return null;
+    }
+
+    const pluginsWithComponents = pluginRegistry
+        .getAllPlugins()
+        .filter(plugin => plugin.component && enabledIds.has(plugin.manifest.id));
 
     return (
         <>
             {pluginsWithComponents.map(plugin => {
                 const Component = plugin.component!;
-                // Create plugin-specific context with automatic event namespacing
                 const context = createPluginContext(plugin.manifest.id);
                 return <Component key={plugin.manifest.id} context={context} />;
             })}

--- a/src/frontend/components/plugins/PluginLoader.tsx
+++ b/src/frontend/components/plugins/PluginLoader.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import type { IPluginManifest } from '@/types';
 import { pluginRegistry } from '../../lib/pluginRegistry';
 import { createPluginContext } from '../../lib/frontendPluginContext';
-import { config } from '../../lib/config';
+import { getRuntimeConfig } from '../../lib/runtimeConfig';
 
 /**
  * Plugin Loader component.
@@ -31,7 +31,11 @@ export function PluginLoader() {
 
         async function loadEnabledManifests() {
             try {
-                const response = await fetch(`${config.apiBaseUrl}/plugins/manifests`);
+                // Use the SSR-injected runtime config (lib/runtimeConfig) instead
+                // of the deprecated lib/config build-time module, so the URL is
+                // correct in universal Docker images regardless of build-time env.
+                const { apiUrl } = getRuntimeConfig();
+                const response = await fetch(`${apiUrl}/plugins/manifests`);
                 const data = await response.json();
                 const manifests: IPluginManifest[] = data.manifests ?? [];
                 if (!cancelled) {

--- a/src/frontend/lib/pluginRegistry.ts
+++ b/src/frontend/lib/pluginRegistry.ts
@@ -1,4 +1,5 @@
 import type { IMenuItemConfig, IPageConfig, IPlugin } from '@/types';
+import { frontendPlugins } from '../components/plugins/plugins.generated';
 
 /**
  * Plugin menu and page registry for dynamic navigation.
@@ -6,6 +7,17 @@ import type { IMenuItemConfig, IPageConfig, IPlugin } from '@/types';
  * This module provides centralized access to plugin-provided menu items and pages.
  * It aggregates navigation and routing configurations from all loaded plugins,
  * enabling the UI to discover and render plugin features without hardcoding imports.
+ *
+ * The registry is self-bootstrapping at module load time: importing this module
+ * synchronously registers every plugin from `plugins.generated.ts`. This works on
+ * both server (for catch-all route SSR) and client (for synchronous render-time
+ * lookups in PluginPageHandler), eliminating the polling pattern that previously
+ * caused loading flash on plugin pages.
+ *
+ * Enabled-state filtering happens elsewhere — the catch-all server route filters
+ * via /api/plugins/manifests in the request path, and PluginLoader filters
+ * side-effect components by the same mechanism. The registry itself contains
+ * every built-in plugin regardless of enabled state.
  */
 
 interface PluginRegistryState {
@@ -22,6 +34,8 @@ class PluginRegistry {
         menuItems: [],
         pages: []
     };
+
+    private bootstrapped = false;
 
     private listeners: Set<PluginRegistryListener> = new Set();
 
@@ -110,6 +124,37 @@ class PluginRegistry {
     }
 
     /**
+     * Bootstrap the registry from a known set of plugins, idempotently.
+     *
+     * Called once at module load time with the synchronously-imported list from
+     * `plugins.generated.ts`. Subsequent calls are no-ops. The registry's
+     * existing `clear()` and `registerPlugin()` methods remain available for
+     * tests that need to reset state.
+     *
+     * @param plugins - Plugin instances to register synchronously
+     */
+    bootstrap(plugins: IPlugin[]): void {
+        if (this.bootstrapped) {
+            return;
+        }
+        this.bootstrapped = true;
+        for (const plugin of plugins) {
+            this.registerPlugin(plugin);
+        }
+    }
+
+    /**
+     * Get every plugin registered with the registry, regardless of enabled
+     * state. Consumers that care about enabled state must filter externally
+     * (typically via /api/plugins/manifests).
+     *
+     * @returns Array of all registered plugin instances
+     */
+    getAllPlugins(): IPlugin[] {
+        return this.state.plugins;
+    }
+
+    /**
      * Get all registered menu items.
      *
      * Returns menu items sorted by category and order. This enables the
@@ -151,7 +196,8 @@ class PluginRegistry {
      * Clear all registered plugins, menu items, and pages.
      *
      * This is primarily useful for testing or hot-reloading scenarios where
-     * you need to reset the registry state and re-register plugins.
+     * you need to reset the registry state and re-register plugins. Also resets
+     * the bootstrap flag so a subsequent bootstrap() call repopulates state.
      */
     clear(): void {
         this.state = {
@@ -159,8 +205,13 @@ class PluginRegistry {
             menuItems: [],
             pages: []
         };
+        this.bootstrapped = false;
     }
 }
 
 // Export singleton instance
 export const pluginRegistry = new PluginRegistry();
+
+// Self-bootstrap from the generated plugin list at module load. Runs once on
+// both server and client thanks to Node's module cache and Next.js's bundling.
+pluginRegistry.bootstrap(frontendPlugins);

--- a/src/frontend/lib/pluginRegistry.ts
+++ b/src/frontend/lib/pluginRegistry.ts
@@ -37,6 +37,14 @@ class PluginRegistry {
 
     private bootstrapped = false;
 
+    /**
+     * When true, registerPlugin() skips the per-call menu sort and notify().
+     * Bootstrap flips this on while iterating the generated plugin list and
+     * flushes once at the end, turning O(n × m log m) sorts into a single
+     * O(m log m) sort and one notification.
+     */
+    private bulkRegistering = false;
+
     private listeners: Set<PluginRegistryListener> = new Set();
 
     /**
@@ -85,26 +93,47 @@ class PluginRegistry {
             this.state.menuItems.push(...plugin.menuItems);
         }
 
+        // First-wins collision policy. The server-side registry uses the same
+        // policy in serverPluginRegistry.buildPermanentMap, so SSR and client
+        // hydration always resolve to the same plugin for any given path —
+        // preventing React hydration mismatches when two plugins accidentally
+        // register the same path.
+        const addPageIfFirst = (page: IPageConfig) => {
+            const existing = this.state.pages.find(p => p.path === page.path);
+            if (existing) {
+                console.warn(
+                    `[pluginRegistry] Duplicate page path '${page.path}' detected. ` +
+                        `Plugin '${plugin.manifest.id}' will be ignored; ` +
+                        `'${existing.pluginId}' keeps the route.`
+                );
+                return;
+            }
+            this.state.pages.push({ ...page, pluginId: plugin.manifest.id });
+        };
+
         if (plugin.pages) {
-            // Add plugin ID to each page for context injection
-            const pagesWithPluginId = plugin.pages.map(page => ({
-                ...page,
-                pluginId: plugin.manifest.id
-            }));
-            this.state.pages.push(...pagesWithPluginId);
+            plugin.pages.forEach(addPageIfFirst);
         }
 
         // Register admin pages (also added to pages array)
         if (plugin.adminPages) {
-            // Add plugin ID to each admin page for context injection
-            const adminPagesWithPluginId = plugin.adminPages.map(page => ({
-                ...page,
-                pluginId: plugin.manifest.id
-            }));
-            this.state.pages.push(...adminPagesWithPluginId);
+            plugin.adminPages.forEach(addPageIfFirst);
         }
 
-        // Sort menu items by order and category
+        // Skip the sort + notify when called from bootstrap(); the bulk
+        // path sorts once and notifies once at the end of the loop.
+        if (!this.bulkRegistering) {
+            this.sortMenuItems();
+            this.notify();
+        }
+    }
+
+    /**
+     * Sort menu items by category, then by order within category. Extracted
+     * so bootstrap() can sort once after registering every plugin instead of
+     * after each plugin individually.
+     */
+    private sortMenuItems(): void {
         this.state.menuItems.sort((a, b) => {
             // Group by category first
             const categoryA = a.category || 'default';
@@ -118,9 +147,6 @@ class PluginRegistry {
             const orderB = b.order ?? 999;
             return orderA - orderB;
         });
-
-        // Notify subscribers of the change
-        this.notify();
     }
 
     /**
@@ -138,9 +164,19 @@ class PluginRegistry {
             return;
         }
         this.bootstrapped = true;
-        for (const plugin of plugins) {
-            this.registerPlugin(plugin);
+        this.bulkRegistering = true;
+        try {
+            for (const plugin of plugins) {
+                this.registerPlugin(plugin);
+            }
+        } finally {
+            this.bulkRegistering = false;
         }
+        // Single sort + notify after registering every plugin, instead of
+        // sorting and notifying after each one. With ~20 plugins this turns
+        // 20 sorts into 1 and 20 listener invocations into 1.
+        this.sortMenuItems();
+        this.notify();
     }
 
     /**

--- a/src/frontend/lib/serverPluginRegistry.ts
+++ b/src/frontend/lib/serverPluginRegistry.ts
@@ -53,6 +53,13 @@ let permanentMap: Map<string, IResolvedPluginPage> | null = null;
  * Walks the synchronously-imported plugin list and indexes every plugin's
  * pages and adminPages by URL path.
  *
+ * Collision policy: first-wins. The first plugin to register a given path
+ * keeps it; later plugins are warned and skipped. This matches the
+ * client-side `pluginRegistry.getPageByPath` semantics (which uses
+ * `Array.find` and returns the first match), so the server and client
+ * always resolve the same plugin for any given path — preventing React
+ * hydration mismatches when two plugins accidentally collide.
+ *
  * @returns A path-to-resolved-page map covering every plugin's pages
  */
 function buildPermanentMap(): Map<string, IResolvedPluginPage> {
@@ -62,6 +69,14 @@ function buildPermanentMap(): Map<string, IResolvedPluginPage> {
         const pages = plugin.pages ?? [];
         const adminPages = plugin.adminPages ?? [];
         for (const page of [...pages, ...adminPages]) {
+            const existing = map.get(page.path);
+            if (existing) {
+                console.warn(
+                    `[serverPluginRegistry] Duplicate page path '${page.path}' detected. ` +
+                        `Plugin '${pluginId}' will be ignored; '${existing.pluginId}' keeps the route.`
+                );
+                continue;
+            }
             map.set(page.path, {
                 pluginId,
                 config: { ...page, pluginId }

--- a/src/frontend/lib/serverPluginRegistry.ts
+++ b/src/frontend/lib/serverPluginRegistry.ts
@@ -1,0 +1,151 @@
+/**
+ * @fileoverview Server-side plugin page resolver.
+ *
+ * Provides server-rendered plugin pages with synchronous-feeling access to plugin
+ * page configs from the catch-all route's generateMetadata and body render.
+ *
+ * Why this exists:
+ * The client-side pluginRegistry only stores the page configs in a shape suited
+ * for runtime React lookups. This module exposes a server-only read path that
+ * filters by the currently-enabled plugin manifest set, ensuring disabled
+ * plugins 404 server-side and never leak metadata into the response head.
+ *
+ * Caching strategy:
+ * - The permanent path-to-page-config map is built lazily once from the
+ *   synchronously-imported `frontendPlugins` array and reused for the server
+ *   process lifetime. Plugin code is statically compiled into the build, so it
+ *   cannot change at runtime.
+ * - The enabled-plugin-ids fetch uses React's cache() so generateMetadata and
+ *   the page body render within a single request share one fetch instead of two.
+ * - Disabled plugins return null even if their page is in the permanent map.
+ *   This preserves the runtime-disable semantics that the admin UI promises.
+ *
+ * Server-only:
+ * The 'server-only' import causes Next.js to throw a build error if any client
+ * component accidentally imports this module. Importing `frontendPlugins`
+ * server-side is safe because plugin frontend entry files only import
+ * next/dynamic, types, and the manifest — no top-level browser APIs.
+ */
+
+import 'server-only';
+import { cache } from 'react';
+import type { IPageConfig } from '@/types';
+import { frontendPlugins } from '../components/plugins/plugins.generated';
+import { getServerSideApiUrlWithPath } from './api-url';
+
+/**
+ * A page resolved from a plugin's frontend module, with the owning pluginId
+ * pre-attached to the config so callers don't have to track it separately.
+ */
+interface IResolvedPluginPage {
+    pluginId: string;
+    config: IPageConfig;
+}
+
+/**
+ * Process-lifetime cache of every plugin page declared by every plugin,
+ * regardless of enabled state. Built lazily on first call to
+ * getEnabledPluginPageConfig.
+ */
+let permanentMap: Map<string, IResolvedPluginPage> | null = null;
+
+/**
+ * Walks the synchronously-imported plugin list and indexes every plugin's
+ * pages and adminPages by URL path.
+ *
+ * @returns A path-to-resolved-page map covering every plugin's pages
+ */
+function buildPermanentMap(): Map<string, IResolvedPluginPage> {
+    const map = new Map<string, IResolvedPluginPage>();
+    for (const plugin of frontendPlugins) {
+        const pluginId = plugin.manifest.id;
+        const pages = plugin.pages ?? [];
+        const adminPages = plugin.adminPages ?? [];
+        for (const page of [...pages, ...adminPages]) {
+            map.set(page.path, {
+                pluginId,
+                config: { ...page, pluginId }
+            });
+        }
+    }
+    return map;
+}
+
+/**
+ * Returns the permanent path-to-page-config map, building it on first call.
+ * Subsequent calls return the cached map immediately.
+ *
+ * @returns The permanent path-to-resolved-page map
+ */
+function getPermanentMap(): Map<string, IResolvedPluginPage> {
+    if (!permanentMap) {
+        permanentMap = buildPermanentMap();
+    }
+    return permanentMap;
+}
+
+/**
+ * Per-request cached fetch of the set of currently-enabled plugin ids.
+ *
+ * Wrapped in React's cache() so generateMetadata and the page body render
+ * within a single SSR pass share one fetch. The underlying HTTP response is
+ * also revalidated every 60 seconds via Next's data cache so toggling a plugin
+ * in the admin UI propagates within a minute without a full server restart.
+ *
+ * Returns an empty set on failure rather than throwing, so an unreachable
+ * backend during SSR degrades gracefully (every plugin page 404s) instead of
+ * 500ing the whole site.
+ *
+ * @returns Set of plugin ids that are currently installed and enabled
+ */
+const fetchEnabledPluginIds = cache(async (): Promise<Set<string>> => {
+    const apiUrl = getServerSideApiUrlWithPath();
+    try {
+        const response = await fetch(`${apiUrl}/plugins/manifests`, {
+            next: { revalidate: 60 }
+        });
+        if (!response.ok) {
+            console.warn(
+                `[serverPluginRegistry] Manifests fetch returned HTTP ${response.status}`
+            );
+            return new Set();
+        }
+        const data = await response.json();
+        const manifests: Array<{ id: string }> = data.manifests ?? [];
+        return new Set(manifests.map(m => m.id));
+    } catch (error) {
+        console.error(
+            '[serverPluginRegistry] Failed to fetch enabled plugin manifests:',
+            error
+        );
+        return new Set();
+    }
+});
+
+/**
+ * Look up a plugin page config by URL path, returning it only if the owning
+ * plugin is currently enabled.
+ *
+ * Used by the catch-all route's generateMetadata to populate <head> and by the
+ * default page render to await serverDataFetcher and render the plugin component.
+ * Returns null when the path is not registered by any plugin OR when the
+ * registering plugin is currently disabled — both cases collapse to a 404 in
+ * the catch-all route.
+ *
+ * @param slug - URL path to look up (e.g., '/tools/bazi-fortune')
+ * @returns The page config with pluginId attached, or null if not found / disabled
+ */
+export async function getEnabledPluginPageConfig(
+    slug: string
+): Promise<IPageConfig | null> {
+    const map = getPermanentMap();
+    const resolved = map.get(slug);
+    if (!resolved) {
+        return null;
+    }
+    const enabledIds = await fetchEnabledPluginIds();
+    if (!enabledIds.has(resolved.pluginId)) {
+        return null;
+    }
+    return resolved.config;
+}

--- a/src/types/plugin/IPageConfig.ts
+++ b/src/types/plugin/IPageConfig.ts
@@ -70,7 +70,13 @@ export interface IPageConfig {
      */
     component: ComponentType<{
         context: IFrontendPluginContext;
-        initialData?: any;
+        /**
+         * SSR-fetched data forwarded by the catch-all route from
+         * `serverDataFetcher`. Typed as `unknown` so plugin authors are
+         * forced to narrow (cast or runtime-validate) before use, rather
+         * than silently relying on a shape the fetcher might not return.
+         */
+        initialData?: unknown;
     }>;
 
     /**
@@ -127,9 +133,11 @@ export interface IPageConfig {
     ogType?: 'website' | 'article';
 
     /**
-     * Optional canonical URL override. Defaults to the page's `path`.
+     * Optional canonical URL override.
      * Set this when the page is reachable from multiple paths and you want
-     * search engines to consolidate signals to one canonical URL.
+     * search engines to consolidate signals to one canonical URL. If omitted,
+     * this page config does not request an explicit canonical override and
+     * the catch-all route emits no `<link rel="canonical">` for the page.
      */
     canonical?: string;
 

--- a/src/types/plugin/IPageConfig.ts
+++ b/src/types/plugin/IPageConfig.ts
@@ -2,42 +2,163 @@ import type { ComponentType } from 'react';
 import type { IFrontendPluginContext } from './IFrontendPluginContext.js';
 
 /**
+ * Server-side context provided to a plugin page's `serverDataFetcher` during SSR.
+ *
+ * Plugins use these values to construct URLs for backend fetches without
+ * importing frontend internals or hardcoding environment variables. The context
+ * is built by the catch-all route immediately before invoking serverDataFetcher
+ * and reflects the request-time runtime configuration.
+ */
+export interface IServerDataContext {
+    /**
+     * Backend API base URL for server-side fetches, including the /api suffix.
+     * In Docker deployments this resolves to the internal Docker network URL
+     * (e.g. http://backend:4000/api); locally it's http://localhost:4000/api.
+     */
+    apiBaseUrl: string;
+
+    /**
+     * Public site URL from runtime config (e.g., https://tronrelic.com).
+     * Use this when building absolute URLs in fetched data.
+     */
+    siteUrl: string;
+}
+
+/**
  * Page configuration for plugin routes.
  *
  * Defines routable pages provided by a plugin. Each page config maps a URL path
  * to a React component, enabling plugins to own their full-stack features including
- * UI presentation without modifying core routing infrastructure.
+ * UI presentation, SEO metadata, and server-side data fetching without modifying
+ * core routing infrastructure.
  *
  * Plugin page components receive an IFrontendPluginContext prop containing UI
  * components, API client, WebSocket access, and other utilities needed to build
- * features without importing from the frontend app.
+ * features without importing from the frontend app. They optionally receive
+ * `initialData` produced server-side by `serverDataFetcher`, enabling true SSR
+ * of plugin pages.
+ *
+ * SEO fields (title, description, keywords, ogImage, structuredData) are read
+ * server-side by the catch-all route's generateMetadata function and injected
+ * into the page <head>. This means crawlers and social link previewers see fully
+ * populated metadata without executing JavaScript.
  */
 export interface IPageConfig {
     /** Plugin identifier (set automatically by the registry) */
     pluginId?: string;
+
     /** URL path (e.g., '/whales', '/my-plugin/settings') */
     path: string;
+
     /**
      * React component to render for this route.
      *
      * The component receives IFrontendPluginContext as a prop, providing access
      * to UI components, charts, API client, and WebSocket for real-time updates.
+     * It optionally receives `initialData` produced by `serverDataFetcher` —
+     * plugins that pre-fetch data server-side should accept this prop and use
+     * it as initial state instead of fetching in useEffect.
      *
      * @example
      * ```typescript
-     * function MyPage({ context }: { context: IFrontendPluginContext }) {
+     * function MyPage({ context, initialData }: { context: IFrontendPluginContext; initialData?: { items: Item[] } }) {
      *     const { ui, api, websocket } = context;
+     *     const [items, setItems] = useState(initialData?.items ?? []);
      *     return <ui.Card>...</ui.Card>;
      * }
      * ```
      */
-    component: ComponentType<{ context: IFrontendPluginContext }>;
-    /** Optional page title for metadata */
+    component: ComponentType<{
+        context: IFrontendPluginContext;
+        initialData?: any;
+    }>;
+
+    /**
+     * Optional async function to fetch initial data server-side before rendering.
+     *
+     * If defined, the catch-all route awaits this during SSR and passes the result
+     * as the `initialData` prop to the page component. This enables full server-side
+     * rendering of plugin pages — the data appears in the initial HTML so crawlers
+     * see it without executing JavaScript, and users see no loading flash.
+     *
+     * The function receives an IServerDataContext containing the backend API URL
+     * and the public site URL, so plugins can fetch from their own backend without
+     * importing frontend internals or hardcoding environment variables.
+     *
+     * The returned data must be JSON-serializable because it crosses the React
+     * Server Components boundary. Functions, class instances, Maps, Sets, and
+     * component references will fail. Stick to plain objects, arrays, strings,
+     * numbers, booleans, and null.
+     *
+     * Errors thrown by this function are caught and logged; the page renders
+     * without initialData rather than 500ing.
+     *
+     * @example
+     * ```typescript
+     * serverDataFetcher: async (ctx) => {
+     *     const response = await fetch(`${ctx.apiBaseUrl}/plugins/my-plugin/data`);
+     *     const data = await response.json();
+     *     return { items: data.items };
+     * }
+     * ```
+     */
+    serverDataFetcher?: (ctx: IServerDataContext) => Promise<unknown>;
+
+    /** Page title for SEO. Used in <title>, og:title, and twitter:title. */
     title?: string;
-    /** Optional page description for metadata */
+
+    /** Page description for SEO. Used in <meta description>, og:description, and twitter:description. */
     description?: string;
+
+    /** SEO keywords. Used in <meta name="keywords">. */
+    keywords?: string[];
+
+    /**
+     * Open Graph image URL for social link previews (Facebook, Twitter, Slack, Discord).
+     * Can be a relative path (resolved against siteUrl) or an absolute URL.
+     * Recommended dimensions: 1200x630.
+     */
+    ogImage?: string;
+
+    /**
+     * Open Graph type. Defaults to 'website'.
+     * Use 'article' for time-stamped content like blog posts or news.
+     */
+    ogType?: 'website' | 'article';
+
+    /**
+     * Optional canonical URL override. Defaults to the page's `path`.
+     * Set this when the page is reachable from multiple paths and you want
+     * search engines to consolidate signals to one canonical URL.
+     */
+    canonical?: string;
+
+    /**
+     * If true, instructs search engines not to index this page.
+     * Use for admin pages, settings screens, and transient content.
+     */
+    noindex?: boolean;
+
+    /**
+     * Schema.org structured data (JSON-LD) for rich search results.
+     * Injected as a <script type="application/ld+json"> tag in the page head.
+     *
+     * @example
+     * ```typescript
+     * structuredData: {
+     *     '@context': 'https://schema.org',
+     *     '@type': 'WebApplication',
+     *     name: 'My Plugin',
+     *     applicationCategory: 'FinanceApplication',
+     *     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' }
+     * }
+     * ```
+     */
+    structuredData?: Record<string, unknown>;
+
     /** Whether this page requires authentication */
     requiresAuth?: boolean;
+
     /** Whether this page requires admin privileges */
     requiresAdmin?: boolean;
 }

--- a/src/types/plugin/index.ts
+++ b/src/types/plugin/index.ts
@@ -8,7 +8,7 @@ export type { IPlugin } from './IPlugin.js';
 export type { IPluginManifest } from './IPluginManifest.js';
 export type { IAdminUIConfig } from './IAdminUIConfig.js';
 export type { IMenuItemConfig } from './IMenuItemConfig.js';
-export type { IPageConfig } from './IPageConfig.js';
+export type { IPageConfig, IServerDataContext } from './IPageConfig.js';
 export type { IPluginDatabase } from './IPluginDatabase.js';
 export type { IApiRouteConfig, HttpMethod, ApiRouteHandler, ApiMiddleware } from './IApiRouteConfig.js';
 export type {


### PR DESCRIPTION
## Summary

Plugin pages now render server-side via a server-only plugin registry that filters by enabled state. Each plugin page declares its own SEO metadata (`title`, `description`, `keywords`, `ogImage`, `ogType`, `structuredData`, `noindex`, `canonical`) on `IPageConfig` and may optionally provide a `serverDataFetcher` that runs during SSR and forwards the result to the page component as `initialData`. This is the foundation for the SSR + Live Updates pattern on plugin-owned routes — body content arrives in the initial HTML so crawlers see real data without executing JavaScript, and the client component initializes its state from the same data after hydration.

## Changes

- **`IPageConfig`**: adds SEO fields and an optional `serverDataFetcher(ctx)` that receives an `IServerDataContext` (`apiBaseUrl`, `siteUrl`) and returns JSON-serializable initial data.
- **`src/frontend/lib/serverPluginRegistry.ts`** (new, `server-only`): builds a process-lifetime path-to-page-config map from the synchronously-imported plugin list and intersects it with the per-request set of enabled plugin ids (cached via React's `cache()`, with a 60s `next.revalidate`). Disabled or unknown slugs return `null` so the catch-all 404s server-side.
- **`src/frontend/app/[...slug]/page.tsx`**: `generateMetadata` now resolves plugin SEO from `IPageConfig` via the server registry, composing through the existing `buildMetadata` helper or emitting a fields-only subset. The default render awaits `serverDataFetcher` and forwards `initialData` down the tree. The hardcoded `PLUGIN_SEO_METADATA` map is gone.
- **`PluginPageWithZones`** / **`PluginPageHandler`**: forward `initialData` to the plugin component. `PluginPageHandler` no longer polls — the registry is populated at module load, so the lookup is synchronous on both SSR and client passes, removing the loading spinner flash.
- **`pluginRegistry.ts`**: self-bootstraps from `frontendPlugins` at module load (idempotent), exposes `getAllPlugins()`, and resets the bootstrap flag in `clear()` for tests.
- **`scripts/generate-frontend-plugin-registry.mjs`**: emits synchronous static imports and a `frontendPlugins` array instead of lazy loaders. CSS code splitting is preserved because plugin entry files still use `next/dynamic()` for their actual page components.
- **`PluginLoader`**: only renders side-effect components for plugins whose ids appear in `/api/plugins/manifests`, preserving runtime disable semantics now that the registry contains every built-in plugin.
- **`PluginPageWithZones`**: removes the inline `WebApplication` and `FAQPage` JSON-LD blocks for `/resource-markets` (now declared by the plugin via `IPageConfig.structuredData`); the visible FAQ HTML stays until that plugin moves prose into its own component.
- **`/system` layout**: adds `robots: { index: false, follow: false }` so the admin login form and every nested admin route are excluded from search engines.
- **Docs**: new `docs/plugins/plugins-seo-and-ssr.md` plus cross-references from `plugins.md`. Minor doc touch-ups in `plugins-page-registration.md`, `plugins-frontend-context.md`, `plugins-widget-zones.md`, `component-icon-picker-modal.md`, and `BUILD.md` to match the new build/typecheck commands.

## Verification

- `npm run typecheck` passes.