### PR TITLE
Add title prop to Badge in plugin context

### DIFF
--- a/src/types/plugin/IFrontendPluginContext.ts
+++ b/src/types/plugin/IFrontendPluginContext.ts
@@ -128,6 +128,7 @@ export interface IUIComponents {
     Badge: ComponentType<{
         children?: React.ReactNode;
         tone?: 'neutral' | 'success' | 'warning' | 'danger';
+        title?: string;
         className?: string;
     }>;
 


### PR DESCRIPTION
## Summary

Adds an optional `title` prop to the `Badge` component type in `IFrontendPluginContext`, enabling plugins to set native HTML tooltip text on badges.