### PR TITLE
Add use client directive to useBodyScrollLock

### DIFF
--- a/src/frontend/modules/menu/hooks/useBodyScrollLock.ts
+++ b/src/frontend/modules/menu/hooks/useBodyScrollLock.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * useBodyScrollLock Hook
  *


### PR DESCRIPTION
Hook uses browser APIs (document.body) and React hooks (useEffect), requiring the 'use client' directive for Next.js App Router compatibility.