### PR TITLE
Consolidate menu category into single toggle button

### DIFF
--- a/src/frontend/components/layout/MenuNav/MenuNav.module.scss
+++ b/src/frontend/components/layout/MenuNav/MenuNav.module.scss
@@ -83,72 +83,42 @@
     gap: 0;
 }
 
-.categoryLink {
-    padding: var(--spacing-4) var(--spacing-4) var(--spacing-4) var(--spacing-7);
+.categoryButton {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-2);
+    padding: var(--spacing-4) var(--spacing-7);
     background: transparent;
     border: var(--border-width-thin) solid transparent;
-    border-right: none;
-    border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+    border-radius: var(--radius-sm);
     text-transform: capitalize;
-    color: inherit;
-    transition: all var(--transition-base);
-    font-size: var(--font-size-sm);
-    line-height: var(--line-height-normal);
-    white-space: nowrap;
-    text-decoration: none;
-}
-
-.categoryLink:hover {
-    background: var(--color-surface-elevated);
-    border-color: rgba(255, 255, 255, 0.1);
-    color: inherit;
-}
-
-.categoryLink:focus-visible {
-    outline: var(--focus-outline-width) solid var(--color-focus);
-    outline-offset: var(--focus-outline-offset);
-}
-
-.categoryLink.active {
-    background: rgba(255, 255, 255, 0.1);
-    border-color: rgba(255, 255, 255, 0.2);
-    font-weight: var(--font-weight-medium);
-}
-
-.categoryLabel {
-    padding: var(--spacing-4) var(--spacing-4) var(--spacing-4) var(--spacing-7);
-    font-size: var(--font-size-sm);
-    line-height: var(--line-height-normal);
-    white-space: nowrap;
-    color: inherit;
-}
-
-.categoryToggle {
-    padding: var(--spacing-4) var(--spacing-5) var(--spacing-4) var(--spacing-2);
-    background: transparent;
-    border: var(--border-width-thin) solid transparent;
-    border-left: none;
-    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
     color: inherit;
     transition: all var(--transition-base);
     cursor: pointer;
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
-    display: inline-flex;
-    align-items: center;
     font-family: inherit;
-    opacity: 0.6;
+    white-space: nowrap;
 }
 
-.categoryToggle:hover {
+.categoryButton:hover {
     background: var(--color-surface-elevated);
     border-color: rgba(255, 255, 255, 0.1);
-    opacity: 1;
 }
 
-.categoryToggle:focus-visible {
+.categoryButton:focus-visible {
     outline: var(--focus-outline-width) solid var(--color-focus);
     outline-offset: var(--focus-outline-offset);
+}
+
+.categoryButton.active {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.2);
+    font-weight: var(--font-weight-medium);
+}
+
+.categoryChevron {
+    opacity: 0.6;
 }
 
 .nested {

--- a/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
@@ -257,12 +257,12 @@ export function MenuNavClient({ namespace, items, ariaLabel }: IMenuNavClientPro
     };
 
     /**
-     * Renders a category with link and dropdown chevron.
+     * Renders a category as a toggle button for the dropdown.
      *
-     * The label is a navigable link to the category landing page.
-     * The chevron button toggles the dropdown for quick access to children.
-     * Uses stopPropagation to prevent PriorityNav's "More" dropdown from closing
-     * when the chevron is clicked.
+     * Clicking anywhere on the category opens the dropdown, which shows the
+     * category itself as the first item (acting as the navigable link) followed
+     * by its children. Uses stopPropagation to prevent PriorityNav's "More"
+     * dropdown from closing when the category is clicked.
      */
     const renderCategoryWithLink = (item: IMenuItem): JSX.Element => {
         const isExpanded = expandedCategoryId === item._id;
@@ -272,17 +272,6 @@ export function MenuNavClient({ namespace, items, ariaLabel }: IMenuNavClientPro
 
         return (
             <div key={item._id} className={styles.category}>
-                {item.url ? (
-                    <Link
-                        href={item.url}
-                        className={`${styles.categoryLink} ${isActive ? styles.active : ''}`}
-                        aria-current={isActive ? 'page' : undefined}
-                    >
-                        {item.label}
-                    </Link>
-                ) : (
-                    <span className={styles.categoryLabel}>{item.label}</span>
-                )}
                 <button
                     ref={(el) => {
                         if (el) {
@@ -291,7 +280,7 @@ export function MenuNavClient({ namespace, items, ariaLabel }: IMenuNavClientPro
                             categoryButtonRefs.current.delete(item._id);
                         }
                     }}
-                    className={styles.categoryToggle}
+                    className={`${styles.categoryButton} ${isActive ? styles.active : ''}`}
                     onClick={(e) => {
                         e.stopPropagation();
                         toggleCategory(item._id);
@@ -300,10 +289,11 @@ export function MenuNavClient({ namespace, items, ariaLabel }: IMenuNavClientPro
                     aria-haspopup="true"
                     aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${item.label} submenu`}
                 >
+                    {item.label}
                     {isExpanded ? (
-                        <ChevronDown size={16} />
+                        <ChevronDown size={16} className={styles.categoryChevron} />
                     ) : (
-                        <ChevronRight size={16} />
+                        <ChevronRight size={16} className={styles.categoryChevron} />
                     )}
                 </button>
             </div>
@@ -392,6 +382,14 @@ export function MenuNavClient({ namespace, items, ariaLabel }: IMenuNavClientPro
                         left: position.left
                     }}
                 >
+                    {expandedCategory.url && (
+                        <div
+                            className={styles.categoryDropdownItem}
+                            role="menuitem"
+                        >
+                            {renderLinkItem(expandedCategory, true)}
+                        </div>
+                    )}
                     {expandedCategory.children.map(child => (
                         <div
                             key={child._id}

--- a/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
@@ -242,6 +242,7 @@ export function MenuNavClient({ namespace, items, ariaLabel }: IMenuNavClientPro
                 key={item._id}
                 href={item.url!}
                 className={`${styles.tab} ${isActive ? styles.active : ''} ${isNested ? styles.nested : ''}`}
+                role={isNested ? 'menuitem' : undefined}
                 aria-current={isActive ? 'page' : undefined}
                 onClick={() => {
                     if (isNested) {
@@ -264,7 +265,7 @@ export function MenuNavClient({ namespace, items, ariaLabel }: IMenuNavClientPro
      * by its children. Uses stopPropagation to prevent PriorityNav's "More"
      * dropdown from closing when the category is clicked.
      */
-    const renderCategoryWithLink = (item: IMenuItem): JSX.Element => {
+    const renderCategoryToggle = (item: IMenuItem): JSX.Element => {
         const isExpanded = expandedCategoryId === item._id;
         const isActive = item.url
             ? (item.url === '/' ? pathname === '/' : pathname === item.url || pathname.startsWith(`${item.url}/`))
@@ -273,6 +274,7 @@ export function MenuNavClient({ namespace, items, ariaLabel }: IMenuNavClientPro
         return (
             <div key={item._id} className={styles.category}>
                 <button
+                    type="button"
                     ref={(el) => {
                         if (el) {
                             categoryButtonRefs.current.set(item._id, el);
@@ -308,7 +310,7 @@ export function MenuNavClient({ namespace, items, ariaLabel }: IMenuNavClientPro
 
         // Category node with children - render link + dropdown chevron
         if (hasChildren) {
-            return renderCategoryWithLink(item);
+            return renderCategoryToggle(item);
         }
 
         // Link node - render as navigation link
@@ -385,7 +387,7 @@ export function MenuNavClient({ namespace, items, ariaLabel }: IMenuNavClientPro
                     {expandedCategory.url && (
                         <div
                             className={styles.categoryDropdownItem}
-                            role="menuitem"
+                            role="none"
                         >
                             {renderLinkItem(expandedCategory, true)}
                         </div>
@@ -394,7 +396,7 @@ export function MenuNavClient({ namespace, items, ariaLabel }: IMenuNavClientPro
                         <div
                             key={child._id}
                             className={styles.categoryDropdownItem}
-                            role="menuitem"
+                            role="none"
                         >
                             {renderLinkItem(child, true)}
                         </div>


### PR DESCRIPTION
## Summary

Replaces the split category link + chevron toggle with a single unified button. Clicking the category now opens the dropdown, which shows the category landing page as the first item followed by its children. Simplifies interaction and reduces SCSS complexity.