### PR TITLE
Add address validation to tools module

### DIFF
--- a/src/backend/modules/tools/services/address.service.ts
+++ b/src/backend/modules/tools/services/address.service.ts
@@ -145,8 +145,9 @@ export class AddressService {
 
         if (HEX_REGEX.test(hex)) {
             try {
-                const base58check = this.tronWeb.address.fromHex(hex.toUpperCase());
-                return { valid: true, format: 'hex', base58check, hex: hex.toUpperCase() };
+                const normalizedHex = hex.toUpperCase();
+                const base58check = this.tronWeb.address.fromHex(normalizedHex);
+                return { valid: true, format: 'hex', base58check, hex: normalizedHex };
             } catch {
                 return { valid: false, format: 'hex', error: 'Invalid hex address' };
             }
@@ -175,7 +176,7 @@ export class AddressService {
         if (hex.length === 40) {
             hex = `41${hex}`;
         }
-        if (!/^41[0-9a-fA-F]{40}$/u.test(hex)) {
+        if (!HEX_REGEX.test(hex)) {
             throw new ValidationError('Invalid Tron hex address', { hex: input });
         }
         return hex.toUpperCase();

--- a/src/backend/modules/tools/services/address.service.ts
+++ b/src/backend/modules/tools/services/address.service.ts
@@ -7,6 +7,7 @@
  */
 
 import type TronWeb from 'tronweb';
+import type { IAddressValidationResult } from '@/types';
 import { ValidationError } from '../../../lib/errors.js';
 
 /**
@@ -16,6 +17,12 @@ export interface IAddressConversionResult {
     hex: string;
     base58check: string;
 }
+
+/** Regex for T-prefixed base58check TRON addresses (34 characters). */
+const BASE58_REGEX = /^T[1-9A-HJ-NP-Za-km-z]{33}$/u;
+
+/** Regex for 41-prefixed hex TRON addresses (42 characters). */
+const HEX_REGEX = /^41[0-9a-fA-F]{40}$/u;
 
 /**
  * Service for converting between TRON hex and base58check address formats.
@@ -94,6 +101,58 @@ export class AddressService {
         } catch (error) {
             throw new ValidationError('Invalid Tron base58Check address', { address, error });
         }
+    }
+
+    /**
+     * Validate whether a string is a well-formed TRON address.
+     *
+     * Detects format (base58 or hex), checks prefix, length, and checksum
+     * via TronWeb round-trip conversion. Never throws — returns a result
+     * object indicating validity.
+     *
+     * @param input - Candidate address string
+     * @returns Validation result with format detection and normalized addresses
+     */
+    validateAddress(input: string): IAddressValidationResult {
+        if (!input || typeof input !== 'string') {
+            return { valid: false, format: null, error: 'Address is required' };
+        }
+
+        const trimmed = input.trim();
+        if (!trimmed) {
+            return { valid: false, format: null, error: 'Address is required' };
+        }
+
+        if (BASE58_REGEX.test(trimmed)) {
+            try {
+                const hex = this.tronWeb.address.toHex(trimmed).toUpperCase();
+                if (!HEX_REGEX.test(hex)) {
+                    return { valid: false, format: 'base58', error: 'Address failed checksum verification' };
+                }
+                return { valid: true, format: 'base58', base58check: trimmed, hex };
+            } catch {
+                return { valid: false, format: 'base58', error: 'Address failed checksum verification' };
+            }
+        }
+
+        let hex = trimmed;
+        if (hex.startsWith('0x') || hex.startsWith('0X')) {
+            hex = hex.slice(2);
+        }
+        if (hex.length === 40) {
+            hex = `41${hex}`;
+        }
+
+        if (HEX_REGEX.test(hex)) {
+            try {
+                const base58check = this.tronWeb.address.fromHex(hex.toUpperCase());
+                return { valid: true, format: 'hex', base58check, hex: hex.toUpperCase() };
+            } catch {
+                return { valid: false, format: 'hex', error: 'Invalid hex address' };
+            }
+        }
+
+        return { valid: false, format: null, error: 'Unrecognized address format' };
     }
 
     /**

--- a/src/backend/modules/tools/services/tools.service.ts
+++ b/src/backend/modules/tools/services/tools.service.ts
@@ -6,7 +6,7 @@
  * IToolsService without importing concrete implementations.
  */
 
-import type { IToolsService, IAddressConversionResult } from '@/types';
+import type { IToolsService, IAddressConversionResult, IAddressValidationResult } from '@/types';
 import type { AddressService } from './address.service.js';
 
 /**
@@ -30,6 +30,20 @@ export class ToolsService implements IToolsService {
      */
     convertAddress(input: { hex?: string; base58Check?: string }): IAddressConversionResult {
         return this.addressService.convertAddress(input);
+    }
+
+    /**
+     * Validate whether a string is a well-formed TRON address.
+     *
+     * Delegates to AddressService for format detection, prefix/length
+     * checking, and TronWeb checksum verification. Never throws on
+     * invalid input — returns a result object instead.
+     *
+     * @param input - Candidate address string in base58 or hex format
+     * @returns Validation result with format detection and normalized addresses
+     */
+    validateAddress(input: string): IAddressValidationResult {
+        return this.addressService.validateAddress(input);
     }
 
     /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,4 +32,4 @@ export type { UserFilterType, BucketInterval, IUser, IWalletLink, IUserPreferenc
 export type { ITronGridService, ITronGridAccountResponse, ITronGridAccountPermission } from './tron-grid/index.js';
 export type { IBlockStats, IBlock, IBlockchainService, ITransactionTimeseriesPoint } from './blockchain/index.js';
 export type { IAddressLabel, IResolvedAddressLabel, AddressCategory, AddressLabelSourceType, ITronAddressMetadata, IAddressLabelService, ICreateAddressLabelInput, IUpdateAddressLabelInput, IAddressLabelFilter, IAddressLabelImportResult, IAddressLabelListResult } from './address-label/index.js';
-export type { IToolsService, IAddressConversionResult } from './tools/index.js';
+export type { IToolsService, IAddressConversionResult, IAddressValidationResult } from './tools/index.js';

--- a/src/types/tools/IToolsService.ts
+++ b/src/types/tools/IToolsService.ts
@@ -6,7 +6,7 @@
  * Registered as 'tools' on the IServiceRegistry during ToolsModule.run().
  */
 
-import type { IAddressConversionResult } from './IToolsTypes.js';
+import type { IAddressConversionResult, IAddressValidationResult } from './IToolsTypes.js';
 
 /**
  * Service interface for TRON address and wallet utilities.
@@ -42,4 +42,16 @@ export interface IToolsService {
      * @throws If the address contains invalid base58 characters
      */
     deriveGender(address: string): 'male' | 'female';
+
+    /**
+     * Validate whether a string is a well-formed TRON address.
+     *
+     * Checks format (base58 or hex), prefix, length, and checksum without
+     * throwing on invalid input. When valid, returns both normalized address
+     * formats for convenience.
+     *
+     * @param input - Candidate address string in base58 or hex format
+     * @returns Validation result with format detection and normalized addresses
+     */
+    validateAddress(input: string): IAddressValidationResult;
 }

--- a/src/types/tools/IToolsTypes.ts
+++ b/src/types/tools/IToolsTypes.ts
@@ -11,3 +11,19 @@ export interface IAddressConversionResult {
     /** T-prefixed base58check address (34 characters). */
     base58check: string;
 }
+
+/**
+ * Address validation result indicating whether a TRON address is well-formed.
+ */
+export interface IAddressValidationResult {
+    /** Whether the address passed all validation checks. */
+    valid: boolean;
+    /** Detected format of the input, or null if unrecognizable. */
+    format: 'base58' | 'hex' | null;
+    /** Normalized base58check address when valid, undefined otherwise. */
+    base58check?: string;
+    /** Normalized hex address when valid, undefined otherwise. */
+    hex?: string;
+    /** Human-readable reason when validation fails. */
+    error?: string;
+}

--- a/src/types/tools/index.ts
+++ b/src/types/tools/index.ts
@@ -3,4 +3,4 @@
  */
 
 export type { IToolsService } from './IToolsService.js';
-export type { IAddressConversionResult } from './IToolsTypes.js';
+export type { IAddressConversionResult, IAddressValidationResult } from './IToolsTypes.js';


### PR DESCRIPTION
## Summary

Adds `validateAddress()` to `AddressService` and `ToolsService` with a new `IAddressValidationResult` type. Detects base58 vs hex format, checks prefix/length, verifies checksum via TronWeb round-trip, and returns normalized addresses when valid. Never throws on invalid input.