### PR TITLE
Add QR code display for generated addresses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "playwright": "^1.55.1",
         "postcss": "^8.5.6",
         "prom-client": "^15.1.3",
+        "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-redux": "^9.1.2",
@@ -8617,6 +8618,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "playwright": "^1.55.1",
     "postcss": "^8.5.6",
     "prom-client": "^15.1.3",
+    "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-redux": "^9.1.2",

--- a/src/frontend/modules/tools/components/AddressGenerator/AddressGenerator.module.scss
+++ b/src/frontend/modules/tools/components/AddressGenerator/AddressGenerator.module.scss
@@ -236,6 +236,13 @@
     border-radius: var(--radius-sm);
     width: fit-content;
 
+    &__code {
+        background: #ffffff;
+        padding: var(--spacing-4);
+        border-radius: var(--radius-sm);
+        line-height: 0;
+    }
+
     &__label {
         font-size: var(--font-size-xs);
         color: var(--color-text-muted);

--- a/src/frontend/modules/tools/components/AddressGenerator/AddressGenerator.module.scss
+++ b/src/frontend/modules/tools/components/AddressGenerator/AddressGenerator.module.scss
@@ -225,6 +225,48 @@
     }
 }
 
+.qr_panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-3);
+    padding: var(--spacing-5);
+    background: var(--color-surface);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    width: fit-content;
+
+    &__label {
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+        text-transform: uppercase;
+        letter-spacing: var(--letter-spacing-wide);
+    }
+}
+
+.qr_modal {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-5);
+    padding: var(--spacing-5);
+
+    &__address {
+        font-family: var(--font-mono);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+        word-break: break-all;
+        text-align: center;
+    }
+
+    &__hint {
+        font-size: var(--font-size-sm);
+        color: var(--color-text-muted);
+        margin: 0;
+        text-align: center;
+    }
+}
+
 .notice {
     display: flex;
     align-items: flex-start;

--- a/src/frontend/modules/tools/components/AddressGenerator/AddressGenerator.tsx
+++ b/src/frontend/modules/tools/components/AddressGenerator/AddressGenerator.tsx
@@ -9,12 +9,14 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { KeyRound, Search, Square, Copy, Check, Eye, EyeOff, ShieldCheck, TriangleAlert } from 'lucide-react';
+import { KeyRound, Search, Square, Copy, Check, Eye, EyeOff, ShieldCheck, TriangleAlert, QrCode } from 'lucide-react';
+import { QRCodeSVG } from 'qrcode.react';
 import { Page, PageHeader, Stack } from '../../../../components/layout';
 import { Card } from '../../../../components/ui/Card';
 import { Input } from '../../../../components/ui/Input';
 import { Button } from '../../../../components/ui/Button';
 import { Badge } from '../../../../components/ui/Badge';
+import { useModal } from '../../../../components/ui/ModalProvider';
 import styles from './AddressGenerator.module.scss';
 
 /** Valid Base58 characters — excludes 0, O, I, l. */
@@ -113,6 +115,55 @@ function formatNumber(num: number): string {
 }
 
 /**
+ * Inline QR code panel shown below a field when toggled. Renders the value as a
+ * scannable SVG QR code with a label indicating what the code contains.
+ *
+ * @param props - Component props
+ * @param props.value - String to encode in the QR code
+ * @param props.label - Caption shown below the QR code (e.g. "Private Key" or "Recovery Phrase")
+ */
+function InlineQrCode({ value, label }: { value: string; label: string }) {
+    return (
+        <div className={styles.qr_panel}>
+            <QRCodeSVG
+                value={value}
+                size={180}
+                level="M"
+                bgColor="transparent"
+                fgColor="currentColor"
+            />
+            <span className={styles.qr_panel__label}>{label}</span>
+        </div>
+    );
+}
+
+/**
+ * Modal content for displaying a QR code. Used by vanity search rows where
+ * inline display would clutter the table layout.
+ *
+ * @param props - Component props
+ * @param props.address - TRON address shown as a heading
+ * @param props.privateKey - Private key to encode in the QR code
+ */
+function QrModalContent({ address, privateKey }: { address: string; privateKey: string }) {
+    return (
+        <div className={styles.qr_modal}>
+            <QRCodeSVG
+                value={privateKey}
+                size={220}
+                level="M"
+                bgColor="transparent"
+                fgColor="currentColor"
+            />
+            <code className={styles.qr_modal__address}>{address}</code>
+            <p className={styles.qr_modal__hint}>
+                Scan to import private key into a mobile wallet
+            </p>
+        </div>
+    );
+}
+
+/**
  * Display a single generated address with mnemonic and private key, both masked by default.
  *
  * @param props - Component props
@@ -122,6 +173,8 @@ function SingleAddressResult({ entry }: { entry: IGeneratedAddress }) {
     const [revealedMnemonic, setRevealedMnemonic] = useState(false);
     const [revealedKey, setRevealedKey] = useState(false);
     const [copiedField, setCopiedField] = useState<'address' | 'mnemonic' | 'key' | null>(null);
+    const [showMnemonicQr, setShowMnemonicQr] = useState(false);
+    const [showKeyQr, setShowKeyQr] = useState(false);
 
     /** Copy a value to clipboard and show confirmation. */
     const handleCopy = useCallback(async (value: string, field: 'address' | 'mnemonic' | 'key') => {
@@ -187,7 +240,20 @@ function SingleAddressResult({ entry }: { entry: IGeneratedAddress }) {
                             : <Copy size={14} />
                         }
                     </button>
+                    {mnemonic && (
+                        <button
+                            className={styles.icon_button}
+                            onClick={() => setShowMnemonicQr(prev => !prev)}
+                            aria-label={showMnemonicQr ? 'Hide QR code' : 'Show QR code'}
+                            title={showMnemonicQr ? 'Hide QR' : 'Show QR'}
+                        >
+                            <QrCode size={14} />
+                        </button>
+                    )}
                 </div>
+                {showMnemonicQr && mnemonic && (
+                    <InlineQrCode value={mnemonic} label="Recovery Phrase" />
+                )}
             </div>
             <div className={styles.single_result__field}>
                 <span className={styles.single_result__label}>Private Key</span>
@@ -214,7 +280,18 @@ function SingleAddressResult({ entry }: { entry: IGeneratedAddress }) {
                             : <Copy size={14} />
                         }
                     </button>
+                    <button
+                        className={styles.icon_button}
+                        onClick={() => setShowKeyQr(prev => !prev)}
+                        aria-label={showKeyQr ? 'Hide QR code' : 'Show QR code'}
+                        title={showKeyQr ? 'Hide QR' : 'Show QR'}
+                    >
+                        <QrCode size={14} />
+                    </button>
                 </div>
+                {showKeyQr && (
+                    <InlineQrCode value={entry.privateKey} label="Private Key" />
+                )}
             </div>
         </div>
     );
@@ -265,6 +342,7 @@ function AddressRow({ entry, index, pattern, caseSensitive }: {
 }) {
     const [revealed, setRevealed] = useState(false);
     const [copiedField, setCopiedField] = useState<'address' | 'key' | null>(null);
+    const { open: openModal } = useModal();
 
     /** Copy a value to clipboard and show confirmation. */
     const handleCopy = useCallback(async (value: string, field: 'address' | 'key') => {
@@ -323,6 +401,19 @@ function AddressRow({ entry, index, pattern, caseSensitive }: {
                         ? <Check size={12} style={{ color: 'var(--color-success)' }} />
                         : <Copy size={12} />
                     }
+                </button>
+                <button
+                    className={styles.icon_button}
+                    onClick={() => openModal({
+                        title: 'Private Key QR Code',
+                        size: 'sm',
+                        content: <QrModalContent address={entry.address} privateKey={entry.privateKey} />,
+                        dismissible: true,
+                    })}
+                    aria-label="Show QR code"
+                    title="Show QR"
+                >
+                    <QrCode size={12} />
                 </button>
             </td>
         </tr>

--- a/src/frontend/modules/tools/components/AddressGenerator/AddressGenerator.tsx
+++ b/src/frontend/modules/tools/components/AddressGenerator/AddressGenerator.tsx
@@ -125,13 +125,15 @@ function formatNumber(num: number): string {
 function InlineQrCode({ value, label }: { value: string; label: string }) {
     return (
         <div className={styles.qr_panel}>
-            <QRCodeSVG
-                value={value}
-                size={180}
-                level="M"
-                bgColor="transparent"
-                fgColor="currentColor"
-            />
+            <div className={styles.qr_panel__code}>
+                <QRCodeSVG
+                    value={value}
+                    size={180}
+                    level="M"
+                    bgColor="#ffffff"
+                    fgColor="#000000"
+                />
+            </div>
             <span className={styles.qr_panel__label}>{label}</span>
         </div>
     );
@@ -148,13 +150,15 @@ function InlineQrCode({ value, label }: { value: string; label: string }) {
 function QrModalContent({ address, privateKey }: { address: string; privateKey: string }) {
     return (
         <div className={styles.qr_modal}>
-            <QRCodeSVG
-                value={privateKey}
-                size={220}
-                level="M"
-                bgColor="transparent"
-                fgColor="currentColor"
-            />
+            <div className={styles.qr_panel__code}>
+                <QRCodeSVG
+                    value={privateKey}
+                    size={220}
+                    level="M"
+                    bgColor="#ffffff"
+                    fgColor="#000000"
+                />
+            </div>
             <code className={styles.qr_modal__address}>{address}</code>
             <p className={styles.qr_modal__hint}>
                 Scan to import private key into a mobile wallet
@@ -175,6 +179,15 @@ function SingleAddressResult({ entry }: { entry: IGeneratedAddress }) {
     const [copiedField, setCopiedField] = useState<'address' | 'mnemonic' | 'key' | null>(null);
     const [showMnemonicQr, setShowMnemonicQr] = useState(false);
     const [showKeyQr, setShowKeyQr] = useState(false);
+
+    /** Reset all reveal/QR state when the underlying entry changes. */
+    useEffect(() => {
+        setRevealedMnemonic(false);
+        setRevealedKey(false);
+        setCopiedField(null);
+        setShowMnemonicQr(false);
+        setShowKeyQr(false);
+    }, [entry.address, entry.privateKey, entry.mnemonic]);
 
     /** Copy a value to clipboard and show confirmation. */
     const handleCopy = useCallback(async (value: string, field: 'address' | 'mnemonic' | 'key') => {
@@ -223,7 +236,11 @@ function SingleAddressResult({ entry }: { entry: IGeneratedAddress }) {
                     </code>
                     <button
                         className={styles.icon_button}
-                        onClick={() => setRevealedMnemonic(prev => !prev)}
+                        onClick={() => {
+                            const next = !revealedMnemonic;
+                            setRevealedMnemonic(next);
+                            if (!next) setShowMnemonicQr(false);
+                        }}
                         aria-label={revealedMnemonic ? 'Hide recovery phrase' : 'Reveal recovery phrase'}
                         title={revealedMnemonic ? 'Hide' : 'Reveal'}
                     >
@@ -240,7 +257,7 @@ function SingleAddressResult({ entry }: { entry: IGeneratedAddress }) {
                             : <Copy size={14} />
                         }
                     </button>
-                    {mnemonic && (
+                    {mnemonic && revealedMnemonic && (
                         <button
                             className={styles.icon_button}
                             onClick={() => setShowMnemonicQr(prev => !prev)}
@@ -251,7 +268,7 @@ function SingleAddressResult({ entry }: { entry: IGeneratedAddress }) {
                         </button>
                     )}
                 </div>
-                {showMnemonicQr && mnemonic && (
+                {showMnemonicQr && revealedMnemonic && mnemonic && (
                     <InlineQrCode value={mnemonic} label="Recovery Phrase" />
                 )}
             </div>
@@ -263,7 +280,11 @@ function SingleAddressResult({ entry }: { entry: IGeneratedAddress }) {
                     </code>
                     <button
                         className={styles.icon_button}
-                        onClick={() => setRevealedKey(prev => !prev)}
+                        onClick={() => {
+                            const next = !revealedKey;
+                            setRevealedKey(next);
+                            if (!next) setShowKeyQr(false);
+                        }}
                         aria-label={revealedKey ? 'Hide private key' : 'Reveal private key'}
                         title={revealedKey ? 'Hide' : 'Reveal'}
                     >
@@ -280,16 +301,18 @@ function SingleAddressResult({ entry }: { entry: IGeneratedAddress }) {
                             : <Copy size={14} />
                         }
                     </button>
-                    <button
-                        className={styles.icon_button}
-                        onClick={() => setShowKeyQr(prev => !prev)}
-                        aria-label={showKeyQr ? 'Hide QR code' : 'Show QR code'}
-                        title={showKeyQr ? 'Hide QR' : 'Show QR'}
-                    >
-                        <QrCode size={14} />
-                    </button>
+                    {revealedKey && (
+                        <button
+                            className={styles.icon_button}
+                            onClick={() => setShowKeyQr(prev => !prev)}
+                            aria-label={showKeyQr ? 'Hide QR code' : 'Show QR code'}
+                            title={showKeyQr ? 'Hide QR' : 'Show QR'}
+                        >
+                            <QrCode size={14} />
+                        </button>
+                    )}
                 </div>
-                {showKeyQr && (
+                {showKeyQr && revealedKey && (
                     <InlineQrCode value={entry.privateKey} label="Private Key" />
                 )}
             </div>
@@ -404,14 +427,18 @@ function AddressRow({ entry, index, pattern, caseSensitive }: {
                 </button>
                 <button
                     className={styles.icon_button}
-                    onClick={() => openModal({
-                        title: 'Private Key QR Code',
-                        size: 'sm',
-                        content: <QrModalContent address={entry.address} privateKey={entry.privateKey} />,
-                        dismissible: true,
-                    })}
-                    aria-label="Show QR code"
-                    title="Show QR"
+                    onClick={() => {
+                        if (!revealed) return;
+                        openModal({
+                            title: 'Private Key QR Code',
+                            size: 'sm',
+                            content: <QrModalContent address={entry.address} privateKey={entry.privateKey} />,
+                            dismissible: true,
+                        });
+                    }}
+                    disabled={!revealed}
+                    aria-label={revealed ? 'Show QR code' : 'Reveal private key before showing QR code'}
+                    title={revealed ? 'Show QR' : 'Reveal private key first'}
                 >
                     <QrCode size={12} />
                 </button>


### PR DESCRIPTION
## Summary

Adds scannable QR codes to the address generator tool. Single-address mode shows inline toggleable QR codes for recovery phrases and private keys. Vanity search mode opens a modal with the private key QR code to keep the table layout clean. Uses qrcode.react with transparent background and currentColor foreground for theme compatibility.