### PR TITLE
Replace TronWeb service registry with TronGridClient factory

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -41,7 +41,6 @@ import { ChainParametersService } from './modules/chain-parameters/chain-paramet
 import { UsdtParametersFetcher } from './modules/usdt-parameters/usdt-parameters-fetcher.js';
 import { UsdtParametersService } from './modules/usdt-parameters/usdt-parameters.service.js';
 import { createApiRouter } from './api/routes/index.js';
-import { TronGridClient } from './modules/blockchain/tron-grid.client.js';
 import type { Express } from 'express';
 import type { IDatabaseService, IMenuService, IServiceRegistry } from '@/types';
 import axios from 'axios';

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -41,7 +41,7 @@ import { ChainParametersService } from './modules/chain-parameters/chain-paramet
 import { UsdtParametersFetcher } from './modules/usdt-parameters/usdt-parameters-fetcher.js';
 import { UsdtParametersService } from './modules/usdt-parameters/usdt-parameters.service.js';
 import { createApiRouter } from './api/routes/index.js';
-import TronWeb from 'tronweb';
+import { TronGridClient } from './modules/blockchain/tron-grid.client.js';
 import type { Express } from 'express';
 import type { IDatabaseService, IMenuService, IServiceRegistry } from '@/types';
 import axios from 'axios';
@@ -273,8 +273,6 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     // Register shared infrastructure on the service registry so modules and
     // plugins can discover them via late-binding DI instead of importing
     // concrete classes.
-    const tronWeb = new TronWeb({ fullHost: 'https://api.trongrid.io' });
-    serviceRegistry.register('tronweb', tronWeb);
     serviceRegistry.register('chain-parameters', ChainParametersService.getInstance());
 
     const sharedDeps = { database: coreDatabase, cacheService, menuService, serviceRegistry, app };

--- a/src/backend/loaders/plugins.ts
+++ b/src/backend/loaders/plugins.ts
@@ -21,7 +21,6 @@ import { TronGridClient } from '../modules/blockchain/tron-grid.client.js';
 import { BlockchainService } from '../modules/blockchain/blockchain.service.js';
 import { ClickHouseService } from '../modules/clickhouse/services/clickhouse.service.js';
 import { AddressLabelService } from '../modules/address-labels/services/address-label.service.js';
-import type TronWeb from 'tronweb';
 import { UserService } from '../modules/user/services/user.service.js';
 import { SignatureService } from '../modules/auth/signature.service.js';
 import { getRedisClient } from './redis.js';
@@ -101,12 +100,10 @@ export async function loadPlugins(database: IDatabaseService, scheduler: ISchedu
         ? ClickHouseService.getInstance()
         : undefined;
 
-    // Resolve TronWeb from the service registry once before the plugin loop
-    // so that every plugin context receives the same configured instance.
-    const tronWebInstance = serviceRegistry.get<TronWeb>('tronweb');
-    if (!tronWebInstance) {
-        throw new Error('TronWeb service not registered — ensure bootstrap registers "tronweb" before loading plugins');
-    }
+    // Create a TronWeb instance for signature verification in plugin contexts.
+    // Uses the TronGridClient factory so the instance has platform defaults
+    // (TronGrid host, API key) baked in without importing them directly.
+    const tronWebInstance = tronGridClient.createTronWeb();
 
     // Create shared HTTP client for all plugins
     const httpClient = axios.create({

--- a/src/backend/modules/auth/signature.service.ts
+++ b/src/backend/modules/auth/signature.service.ts
@@ -2,8 +2,8 @@
  * @fileoverview TRON signature verification and address normalization.
  *
  * Implements ISignatureService using a TronWeb instance received via
- * constructor injection. All consumers should obtain TronWeb from the
- * IServiceRegistry ('tronweb') rather than importing the library directly.
+ * constructor injection. Consumers obtain TronWeb instances from
+ * TronGridClient.createTronWeb() which provides platform defaults.
  */
 
 import type TronWeb from 'tronweb';

--- a/src/backend/modules/blockchain/tron-grid.client.ts
+++ b/src/backend/modules/blockchain/tron-grid.client.ts
@@ -301,6 +301,31 @@ export class TronGridClient {
         TronGridClient.instance = null;
     }
 
+    /**
+     * Create an independent TronWeb instance pre-configured with the platform's
+     * TronGrid host and a rotating API key.
+     *
+     * Each call returns a fresh instance that the caller owns completely. The
+     * caller may set a private key, change the address, or reconfigure the
+     * instance without affecting other consumers or the shared TronGridClient.
+     *
+     * @param options - Optional overrides for the default platform configuration
+     * @param options.privateKey - Private key to enable signing and wallet operations
+     * @param options.fullHost - Override the default TronGrid endpoint
+     * @returns A new, fully independent TronWeb instance
+     */
+    createTronWeb(options?: { privateKey?: string; fullHost?: string }): TronWeb {
+        const instance = new TronWeb({
+            fullHost: options?.fullHost ?? BASE_URL,
+            privateKey: options?.privateKey
+        });
+        const apiKey = getNextApiKey();
+        if (apiKey) {
+            instance.setHeader({ 'TRON-PRO-API-KEY': apiKey });
+        }
+        return instance;
+    }
+
     async getNowBlock(): Promise<TronGridBlock> {
         return retry(() => this.post<TronGridBlock>('/wallet/getnowblock', {}), {
             ...blockchainConfig.retry,

--- a/src/backend/modules/tools/ToolsModule.ts
+++ b/src/backend/modules/tools/ToolsModule.ts
@@ -9,7 +9,6 @@
  * Follows TronRelic's two-phase initialization pattern with dependency injection.
  */
 
-import type TronWeb from 'tronweb';
 import type { Express } from 'express';
 import type { ICacheService, IChainParametersService, IDatabaseService, IMenuService, IModule, IModuleMetadata, IServiceRegistry } from '@/types';
 import { logger } from '../../lib/logger.js';
@@ -120,10 +119,8 @@ export class ToolsModule implements IModule<IToolsModuleDependencies> {
             throw new Error('ChainParametersService not found on service registry. Ensure it is registered as "chain-parameters" before tools module init.');
         }
 
-        const tronWeb = dependencies.serviceRegistry.get<TronWeb>('tronweb');
-        if (!tronWeb) {
-            throw new Error('TronWeb not found on service registry. Ensure it is registered as "tronweb" before tools module init.');
-        }
+        const tronGridClient = TronGridClient.getInstance();
+        const tronWeb = tronGridClient.createTronWeb();
 
         const addressService = new AddressService(tronWeb);
         this.toolsService = new ToolsService(addressService);

--- a/src/backend/modules/tools/__tests__/tools.module.test.ts
+++ b/src/backend/modules/tools/__tests__/tools.module.test.ts
@@ -9,6 +9,27 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/** Mock TronWeb instance with address utilities and signature verification. */
+const mockTronWeb = {
+    address: {
+        toHex: vi.fn((addr: string) => '41' + 'a'.repeat(40)),
+        fromHex: vi.fn((hex: string) => 'T' + 'a'.repeat(33))
+    },
+    trx: {
+        verifyMessageV2: vi.fn().mockResolvedValue(true)
+    },
+    setHeader: vi.fn()
+};
+
+vi.mock('../../blockchain/tron-grid.client.js', () => ({
+    TronGridClient: {
+        getInstance: vi.fn(() => ({
+            createTronWeb: vi.fn(() => mockTronWeb)
+        }))
+    }
+}));
+
 import { ToolsModule } from '../index.js';
 import type { ICacheService, IChainParameters, IChainParametersService, IMenuService, IServiceRegistry } from '@/types';
 import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
@@ -135,20 +156,8 @@ class MockChainParametersService implements IChainParametersService {
  * Pre-loaded with a mock ChainParametersService so the tools module
  * can resolve it during init().
  */
-/** Mock TronWeb instance with address utilities and signature verification. */
-const mockTronWeb = {
-    address: {
-        toHex: vi.fn((addr: string) => '41' + 'a'.repeat(40)),
-        fromHex: vi.fn((hex: string) => 'T' + 'a'.repeat(33))
-    },
-    trx: {
-        verifyMessageV2: vi.fn().mockResolvedValue(true)
-    }
-};
-
 function createMockServiceRegistry(chainParams?: IChainParametersService): IServiceRegistry {
     const services = new Map<string, unknown>();
-    services.set('tronweb', mockTronWeb);
     if (chainParams) {
         services.set('chain-parameters', chainParams);
     }
@@ -268,23 +277,6 @@ describe('ToolsModule', () => {
                 serviceRegistry: emptyRegistry,
                 app: mockApp as any
             })).rejects.toThrow('ChainParametersService not found on service registry');
-        });
-
-        it('should throw if TronWeb is not registered on service registry', async () => {
-            const registryWithoutTronWeb = createMockServiceRegistry(mockChainParams);
-            // Remove tronweb to simulate missing registration
-            (registryWithoutTronWeb.get as ReturnType<typeof vi.fn>).mockImplementation(
-                (name: string) => name === 'chain-parameters' ? mockChainParams : undefined
-            );
-            const module = new ToolsModule();
-
-            await expect(module.init({
-                database: mockDatabase,
-                cacheService: mockCache,
-                menuService: mockMenu,
-                serviceRegistry: registryWithoutTronWeb,
-                app: mockApp as any
-            })).rejects.toThrow('TronWeb not found on service registry');
         });
 
         it('should look up chain-parameters from the service registry', async () => {

--- a/src/backend/modules/user/UserModule.ts
+++ b/src/backend/modules/user/UserModule.ts
@@ -25,6 +25,7 @@
 import type { Express, Router } from 'express';
 import type { ICacheService, IDatabaseService, IMenuService, IModule, IModuleMetadata, ISchedulerService, IServiceRegistry } from '@/types';
 import { logger } from '../../lib/logger.js';
+import { TronGridClient } from '../blockchain/tron-grid.client.js';
 import { UserService } from './services/user.service.js';
 import { GscService } from './services/gsc.service.js';
 import { initGeoIP } from './services/geo.service.js';
@@ -175,11 +176,8 @@ export class UserModule implements IModule<IUserModuleDependencies> {
         // Initialize GeoIP lookup for country detection (non-blocking)
         await initGeoIP();
 
-        // Resolve TronWeb from service registry for signature verification
-        const tronWeb = dependencies.serviceRegistry.get<import('tronweb').default>('tronweb');
-        if (!tronWeb) {
-            throw new Error('TronWeb not found on service registry. Ensure it is registered as "tronweb" before user module init.');
-        }
+        // Create independent TronWeb instance for signature verification
+        const tronWeb = TronGridClient.getInstance().createTronWeb();
 
         // Initialize UserService singleton with dependencies
         UserService.setDependencies(

--- a/src/backend/types/tronweb.d.ts
+++ b/src/backend/types/tronweb.d.ts
@@ -12,7 +12,7 @@ type TronWebUtils = {
 
 declare module 'tronweb' {
   export default class TronWeb {
-    constructor(options: { fullHost: string });
+    constructor(options: { fullHost: string; privateKey?: string });
     static utils: TronWebUtils;
     static address: TronWebAddress;
     utils: TronWebUtils;
@@ -20,5 +20,6 @@ declare module 'tronweb' {
     trx: {
       verifyMessageV2: (message: string, signature: string, address: string) => Promise<boolean>;
     };
+    setHeader: (headers: Record<string, string>) => void;
   }
 }

--- a/src/types/forum/IForumService.ts
+++ b/src/types/forum/IForumService.ts
@@ -3,8 +3,8 @@
  *
  * Exposes forum post CRUD and reaction operations via the service registry
  * so plugins and modules can create, query, and manage forum posts
- * programmatically. Registered as 'forum' on the IServiceRegistry during
- * the forum plugin's init() hook.
+ * programmatically. Intended for registration as 'forum' on the
+ * IServiceRegistry by the forum plugin during its init() hook.
  */
 
 /**
@@ -43,7 +43,7 @@ export interface IForumPost {
  * ```typescript
  * const forum = context.services.get<IForumService>('forum');
  * if (forum) {
- *     const post = await forum.createPost(content, walletAddress, userId, signature);
+ *     const post = await forum.createPost(content, walletAddress, userId, message, signature, timestamp);
  * }
  * ```
  */

--- a/src/types/forum/IForumService.ts
+++ b/src/types/forum/IForumService.ts
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview Forum service interface for cross-component service discovery.
+ *
+ * Exposes forum post CRUD and reaction operations via the service registry
+ * so plugins and modules can create, query, and manage forum posts
+ * programmatically. Registered as 'forum' on the IServiceRegistry during
+ * the forum plugin's init() hook.
+ */
+
+/**
+ * Embedded reaction on a forum post.
+ */
+export interface IForumReaction {
+    walletAddress: string;
+    emoji: string;
+    createdAt: Date;
+}
+
+/**
+ * A single forum post as returned by the service.
+ */
+export interface IForumPost {
+    _id?: string;
+    content: string;
+    walletAddress: string;
+    userId: string;
+    signature: string;
+    posX: number;
+    posY: number;
+    initialWidth: number;
+    initialHeight: number;
+    reactions: IForumReaction[];
+    deleted?: boolean;
+    createdAt: Date;
+}
+
+/**
+ * Service interface for forum post operations.
+ *
+ * Provides full CRUD for forum posts and reaction management.
+ * Consumers retrieve this via the service registry:
+ *
+ * ```typescript
+ * const forum = context.services.get<IForumService>('forum');
+ * if (forum) {
+ *     const post = await forum.createPost(content, walletAddress, userId, signature);
+ * }
+ * ```
+ */
+export interface IForumService {
+    /**
+     * Retrieve active posts from the last 7 days, newest first.
+     *
+     * @param limit - Maximum posts to return (capped at 200)
+     * @returns Array of active forum posts
+     */
+    getActivePosts(limit: number): Promise<IForumPost[]>;
+
+    /**
+     * Retrieve a single post by its database ID.
+     *
+     * @param id - MongoDB ObjectId string
+     * @returns The post or null if not found/deleted
+     */
+    getPostById(id: string): Promise<IForumPost | null>;
+
+    /**
+     * Retrieve all posts by a specific wallet address (no time filter).
+     *
+     * @param walletAddress - TRON wallet address (base58)
+     * @param limit - Maximum posts to return (capped at 50)
+     * @param offset - Number of posts to skip for pagination
+     * @returns Array of posts by the wallet
+     */
+    getPostsByWallet(walletAddress: string, limit: number, offset: number): Promise<IForumPost[]>;
+
+    /**
+     * Create a new forum post with random canvas positioning.
+     *
+     * Content is sanitized and signature is cryptographically verified
+     * against the wallet address before the post is persisted. Every
+     * stored post carries a proven signature — this invariant holds
+     * regardless of entry point (HTTP route or service registry).
+     *
+     * @param content - Post text (1-500 chars)
+     * @param walletAddress - Author's verified TRON address
+     * @param userId - Author's UUID
+     * @param message - The exact message string that was signed
+     * @param signature - TronLink hex-encoded signature
+     * @param timestamp - Epoch ms when the message was signed (must be within 5 minutes)
+     * @returns The created post
+     * @throws If signature verification fails or timestamp is expired
+     */
+    createPost(content: string, walletAddress: string, userId: string, message: string, signature: string, timestamp: number): Promise<IForumPost>;
+
+    /**
+     * Soft-delete a post. Ownership matched by userId.
+     *
+     * @param postId - MongoDB ObjectId string
+     * @param userId - UUID of the requesting user
+     * @returns True if the post was soft-deleted
+     */
+    deletePost(postId: string, userId: string): Promise<boolean>;
+
+    /**
+     * Add or change a reaction on a post (one per wallet).
+     *
+     * @param postId - MongoDB ObjectId string
+     * @param walletAddress - Reacting user's verified wallet
+     * @param emoji - One of the allowed reaction emojis
+     * @returns Updated reactions array
+     */
+    addReaction(postId: string, walletAddress: string, emoji: string): Promise<IForumReaction[]>;
+
+    /**
+     * Remove a wallet's reaction from a post.
+     *
+     * @param postId - MongoDB ObjectId string
+     * @param walletAddress - Reacting user's verified wallet
+     * @returns Updated reactions array
+     */
+    removeReaction(postId: string, walletAddress: string): Promise<IForumReaction[]>;
+}

--- a/src/types/forum/index.ts
+++ b/src/types/forum/index.ts
@@ -1,0 +1,5 @@
+/**
+ * @fileoverview Forum type exports.
+ */
+
+export type { IForumService, IForumPost, IForumReaction } from './IForumService.js';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,3 +33,4 @@ export type { ITronGridService, ITronGridAccountResponse, ITronGridAccountPermis
 export type { IBlockStats, IBlock, IBlockchainService, ITransactionTimeseriesPoint } from './blockchain/index.js';
 export type { IAddressLabel, IResolvedAddressLabel, AddressCategory, AddressLabelSourceType, ITronAddressMetadata, IAddressLabelService, ICreateAddressLabelInput, IUpdateAddressLabelInput, IAddressLabelFilter, IAddressLabelImportResult, IAddressLabelListResult } from './address-label/index.js';
 export type { IToolsService, IAddressConversionResult, IAddressValidationResult } from './tools/index.js';
+export type { IForumService, IForumPost, IForumReaction } from './forum/index.js';

--- a/src/types/tron-grid/ITronGridService.ts
+++ b/src/types/tron-grid/ITronGridService.ts
@@ -50,4 +50,19 @@ export interface ITronGridService {
      * @returns Account response or null if request fails
      */
     getAccount(address: string, visible?: boolean): Promise<ITronGridAccountResponse | null>;
+
+    /**
+     * Create an independent TronWeb instance pre-configured with the platform's
+     * TronGrid host and a rotating API key.
+     *
+     * Each call returns a fresh instance that the caller owns completely. The
+     * caller may set a private key, change the address, or reconfigure the
+     * instance without affecting other consumers or the shared TronGridClient.
+     *
+     * @param options - Optional overrides for the default platform configuration
+     * @param options.privateKey - Private key to enable signing and wallet operations
+     * @param options.fullHost - Override the default TronGrid endpoint
+     * @returns A new, fully independent TronWeb instance
+     */
+    createTronWeb(options?: { privateKey?: string; fullHost?: string }): unknown;
 }

--- a/src/types/tron-grid/ITronGridService.ts
+++ b/src/types/tron-grid/ITronGridService.ts
@@ -64,5 +64,5 @@ export interface ITronGridService {
      * @param options.fullHost - Override the default TronGrid endpoint
      * @returns A new, fully independent TronWeb instance
      */
-    createTronWeb(options?: { privateKey?: string; fullHost?: string }): unknown;
+    createTronWeb(options?: { privateKey?: string; fullHost?: string }): any;
 }


### PR DESCRIPTION
## Summary

Removes the global TronWeb singleton from the service registry and replaces all consumers with `TronGridClient.createTronWeb()`, a factory method that returns fresh instances pre-configured with platform defaults (TronGrid host, rotating API key). Each consumer now owns its own independent instance rather than sharing a mutable singleton.

Also adds `IForumService` types to the shared types package and extends the tronweb type declarations with `privateKey` constructor option and `setHeader` method.