### PR TITLE
Resolve @delphian/tronrelic-types via tsconfig paths

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -212,43 +212,7 @@ echo ""
 if [[ ${#INSTALL_FAILED[@]} -gt 0 ]]; then
     log_error "Failed to install dependencies: ${INSTALL_FAILED[*]}"
     exit 1
+else
+    log_info "All plugins configured successfully"
+    log_info "Run 'npm install' in the project root to install core dependencies"
 fi
-
-# Replace each plugin's node_modules/@delphian/tronrelic-types with a symlink
-# to packages/types. This deduplicates the types package across plugins —
-# without this, every plugin carries its own copy of @delphian/tronrelic-types
-# downloaded from the registry, producing duplicate type identities that break
-# `tsc --noEmit` (see scripts/reset-generated.mjs for the original workaround).
-#
-# Plugins remain buildable standalone (outside the monorepo) because their
-# package.json still declares the dependency normally; this only rewires
-# resolution inside this checkout.
-log_info "Linking @delphian/tronrelic-types from packages/types into each plugin..."
-LINK_FAILED=()
-
-for target in "${CLONED[@]}"; do
-    plugin_name=$(basename "$target")
-    types_link="$target/node_modules/@delphian/tronrelic-types"
-
-    if [[ ! -e "$target/node_modules/@delphian" ]]; then
-        # Plugin doesn't depend on @delphian/tronrelic-types — skip silently.
-        continue
-    fi
-
-    if rm -rf "$types_link" && \
-       mkdir -p "$(dirname "$types_link")" && \
-       ln -sfn "../../../../../packages/types" "$types_link"; then
-        log_info "Linked types into $plugin_name"
-    else
-        log_error "Failed to link types into $plugin_name"
-        LINK_FAILED+=("$plugin_name")
-    fi
-done
-
-if [[ ${#LINK_FAILED[@]} -gt 0 ]]; then
-    log_error "Failed to link types: ${LINK_FAILED[*]}"
-    exit 1
-fi
-
-log_info "All plugins configured successfully"
-log_info "Run 'npm install' in the project root to install core dependencies"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,8 @@
     "paths": {
       "@/types": ["packages/types/src"],
       "@/types/*": ["packages/types/src/*"],
+      "@delphian/tronrelic-types": ["packages/types/src"],
+      "@delphian/tronrelic-types/*": ["packages/types/src/*"],
       "@/shared": ["src/shared"],
       "@/shared/*": ["src/shared/*"],
       "@/backend/*": ["src/backend/*"],


### PR DESCRIPTION
## Summary

Maps `@delphian/tronrelic-types` to `packages/types/src` in tsconfig `paths` so TypeScript resolves the workspace package directly. Removes the post-install symlink step in `scripts/setup.sh` that rewired each plugin's `node_modules/@delphian/tronrelic-types` to dedupe type identities.

The tsconfig alias achieves the same deduplication statically, so the filesystem surgery in setup.sh is no longer needed.