### PR TITLE
Copy packages/ before npm ci so workspace symlinks resolve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,10 @@ WORKDIR /app
 # Install necessary build tools
 RUN apk add --no-cache libc6-compat
 
-# Copy package files
+# Copy package files and workspace manifests so npm ci can create the
+# @delphian/* workspace symlinks during install.
 COPY package.json package-lock.json ./
+COPY packages ./packages
 
 # Install all dependencies (needed for building)
 RUN npm ci
@@ -63,8 +65,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy package files
+# Copy package files and workspace manifests so npm ci can create the
+# @delphian/* workspace symlinks in node_modules during install.
 COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/packages ./packages
 
 # Install production dependencies only
 RUN npm ci --only=production
@@ -75,8 +79,8 @@ RUN npx playwright install chromium
 # Copy built backend from builder
 COPY --from=builder /app/dist/backend ./dist/backend
 
-# Copy source files needed at runtime (types, plugins for runtime discovery)
-COPY --from=builder /app/packages/types ./packages/types
+# Copy source files needed at runtime (plugins for runtime discovery).
+# packages/types is already on disk from the workspace install above.
 COPY --from=builder /app/src/shared ./src/shared
 COPY --from=builder /app/src/plugins ./src/plugins
 
@@ -140,8 +144,10 @@ WORKDIR /app
 # Install necessary build tools
 RUN apk add --no-cache libc6-compat
 
-# Copy package files
+# Copy package files and workspace manifests so npm ci can create the
+# @delphian/* workspace symlinks in node_modules during install.
 COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/packages ./packages
 
 # Install production dependencies only
 RUN npm ci --only=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,10 +65,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy package files and workspace manifests so npm ci can create the
-# @delphian/* workspace symlinks in node_modules during install.
+# Copy package files and the prebuilt workspace outputs so npm ci can
+# create the @delphian/* symlinks in node_modules without rebuilding.
+# We only copy the manifest + dist/ (no src/ or tsconfig) to keep the
+# runtime image lean, and strip the "prepare" script so npm does not
+# re-run tsc (devDependency) during the production install.
 COPY --from=builder /app/package*.json ./
-COPY --from=builder /app/packages ./packages
+COPY --from=builder /app/packages/types/package.json ./packages/types/package.json
+COPY --from=builder /app/packages/types/dist ./packages/types/dist
+RUN node -e "const f='packages/types/package.json';const p=require('./'+f);if(p.scripts){delete p.scripts.prepare;delete p.scripts.prepublishOnly;}require('fs').writeFileSync(f, JSON.stringify(p,null,4)+'\n');"
 
 # Install production dependencies only
 RUN npm ci --only=production
@@ -144,10 +149,15 @@ WORKDIR /app
 # Install necessary build tools
 RUN apk add --no-cache libc6-compat
 
-# Copy package files and workspace manifests so npm ci can create the
-# @delphian/* workspace symlinks in node_modules during install.
+# Copy package files and the prebuilt workspace outputs so npm ci can
+# create the @delphian/* symlinks in node_modules without rebuilding.
+# We only copy the manifest + dist/ (no src/ or tsconfig) to keep the
+# runtime image lean, and strip the "prepare" script so npm does not
+# re-run tsc (devDependency) during the production install.
 COPY --from=builder /app/package*.json ./
-COPY --from=builder /app/packages ./packages
+COPY --from=builder /app/packages/types/package.json ./packages/types/package.json
+COPY --from=builder /app/packages/types/dist ./packages/types/dist
+RUN node -e "const f='packages/types/package.json';const p=require('./'+f);if(p.scripts){delete p.scripts.prepare;delete p.scripts.prepublishOnly;}require('fs').writeFileSync(f, JSON.stringify(p,null,4)+'\n');"
 
 # Install production dependencies only
 RUN npm ci --only=production


### PR DESCRIPTION
## Summary

Without `packages/` present at install time, `npm ci` cannot create the `@delphian/*` workspace symlinks in `node_modules`, causing runtime module resolution failures. This change copies workspace manifests alongside `package.json` in each Dockerfile stage, and drops the now-redundant `packages/types` copy in the backend runtime stage since the workspace install already places it on disk.