### PR TITLE
Support compiled frontend plugin exports

### DIFF
--- a/docs/plugins/plugins-page-registration.md
+++ b/docs/plugins/plugins-page-registration.md
@@ -139,7 +139,7 @@ export const myFrontendPlugin = definePlugin({
 ```
 
 2. **Generator script picks up the new plugin** at build time:
-   - `generate:plugins` discovers every plugin with a `src/frontend/frontend.ts` entry
+   - `generate:plugins` reads each plugin's `package.json` `exports."./frontend"` field. New plugins ship a compiled entry (`dist/frontend/frontend.js`); legacy plugins still on source mode fall back to `src/frontend/frontend.ts`. See [plugins-system-architecture.md](./plugins-system-architecture.md#frontend-build) for the build pipeline.
    - Emits a static-import line into `src/frontend/components/plugins/plugins.generated.ts`
    - The registry is populated at module load via `pluginRegistry.bootstrap()`
 

--- a/docs/plugins/plugins-system-architecture.md
+++ b/docs/plugins/plugins-system-architecture.md
@@ -404,7 +404,7 @@ Frontend plugins follow TronRelic's foundational SSR + Live Updates pattern: com
 
 ### Build-time Discovery
 
-1. `src/frontend/scripts/generate-frontend-plugin-registry.mjs` runs before `next dev` or `next build`. It scans `src/plugins/**/src/frontend/` directories for plugin components.
+1. `scripts/generate-frontend-plugin-registry.mjs` runs before `next dev` or `next build`. It scans `src/plugins/**/src/frontend/` directories for plugin components.
 2. The generator creates registry files with static imports, enabling components to be available during server-side rendering.
 3. Static imports (not lazy/dynamic) are required for SSR—lazy-loaded components aren't available when the server renders HTML.
 
@@ -567,7 +567,7 @@ Plugins often need secure settings screens without touching core admin code. Giv
 
 ### Frontend infrastructure
 - `src/frontend/app/(core)/system/plugins/page.tsx` – admin UI for plugin management.
-- `src/frontend/scripts/generate-frontend-plugin-registry.mjs` – generator that keeps the lazy import map in sync with the filesystem.
+- `scripts/generate-frontend-plugin-registry.mjs` – generator that keeps the lazy import map in sync with the filesystem.
 - `src/frontend/components/plugins/PluginLoader.tsx` – React component that fetches manifests and mounts frontend plugins.
 
 ### Type definitions

--- a/docs/plugins/plugins-system-architecture.md
+++ b/docs/plugins/plugins-system-architecture.md
@@ -40,8 +40,8 @@ We organize every plugin under `src/plugins/<plugin-id>` so backend and frontend
 
 #### Directory Essentials
 
-- `package.json` declares the workspace package, exposes `dist/backend/backend.js` as the Node entry point, and leaves `./src/frontend/frontend.ts` as the ESM export consumed by Next.js.
-- `tsconfig.json` compiles only backend-facing TypeScript (manifest + backend files) into `dist/` and intentionally excludes React code.
+- `package.json` declares the workspace package and exposes entry points via the `exports` map. Backend ships compiled at `dist/backend/backend.js`. Frontend ships compiled at `dist/frontend/frontend.js` — all new plugins must use this mode, and existing source-mode plugins (raw TSX at `src/frontend/frontend.ts`, transpiled by core's webpack via `transpilePackages`) are being migrated. See [Frontend build](#frontend-build).
+- `tsconfig.json` compiles backend TypeScript into `dist/`. A second `tsconfig.frontend.json` emits frontend output into `dist/frontend/`.
 - `src/manifest.ts` centralizes metadata shared by both runtimes. The manifest sets `backend: true` and/or `frontend: true` so loaders know which surfaces exist.
 - `src/backend/backend.ts` exports the `definePlugin` wrapper that wires `manifest` and `init` together.
 - `src/backend/*.ts` files house the actual observers, queues, and service integration the plugin needs.
@@ -50,8 +50,7 @@ We organize every plugin under `src/plugins/<plugin-id>` so backend and frontend
 - `src/frontend/styles.css` contains plugin-specific styles with scoped class names (e.g., `.whale-dashboard`, `.whale-stat-card`).
 - `src/frontend/public/` (optional) holds plugin-owned static assets that need stable, unfingerprinted public URLs — Open Graph images, manifest icons, favicons. Files are mirrored to `src/frontend/public/plugins/<plugin-id>/` by the registry generator before `next build` runs and are served by Next.js at `/plugins/<plugin-id>/<file>`. See [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md#plugin-owned-og-images) for the convention and bazi-fortune as the canonical example. Distinct from `src/frontend/assets/`, which holds webpack-imported assets that get hashed bundle URLs.
 - `src/shared/` (optional) contains types, constants, and utilities shared between backend and frontend to eliminate duplication and maintain a single source of truth.
-- `dist/` contains everything the backend loader consumes: `manifest.js`, `manifest.d.ts`, `backend/backend.js`, and type maps.
-- `dist/frontend.bundle.js` is produced by the shared esbuild task so we have a browser-friendly artifact for CDN or static hosting scenarios, even though Next currently imports the source file directly.
+- `dist/` contains compiled artifacts both loaders consume: `manifest.js`, `manifest.d.ts`, `backend/backend.js` for the backend loader, and `frontend/*.js` plus mirrored SCSS for the frontend registry. See [Frontend build](#frontend-build) for how the frontend output is produced.
 
 #### Plugin Shared Code Organization
 
@@ -107,6 +106,26 @@ import type { IWhaleTransaction, IWhaleConfig } from '../shared/types';
 - **Portability** – Plugins remain self-contained; extracting a feature to a separate project requires no type reorganization
 - **Clear ownership** – The plugin team owns both the interface and its implementation without coordinating cross-workspace changes
 - **Simple builds** – No cross-workspace TypeScript project references needed; relative imports work immediately
+
+#### Frontend build
+
+New plugins compile their own frontend and ship `dist/frontend/` as the artifact core consumes. The reference implementation is `src/plugins/trp-ai-assistant/`. Source-mode (raw TSX imported by core's webpack via `transpilePackages`) is a legacy state that existing plugins are migrating away from.
+
+**Why this is the direction.** Compiling plugin TSX inside core's Next.js build couples every plugin to core's webpack and blocks per-plugin build isolation. Letting the plugin emit its own `dist/frontend/` makes the plugin a self-contained artifact — backend and frontend both compiled — removes `transpilePackages` as a lever core has to toggle, and makes the plugin typecheckable and buildable standalone. It is also prerequisite to later moves toward runtime-loadable plugins.
+
+**How core selects the mode.** The registry generator (`scripts/generate-frontend-plugin-registry.mjs`) reads each plugin's `package.json` `exports` map. When `exports."./frontend"` points at a `.js`/`.mjs`/`.cjs` artifact, the generator emits a static import at that path and `next.config.mjs` omits the plugin from `transpilePackages`. When the entry still points at `.ts`, core falls back to transpiling the source via `transpilePackages`. The two modes coexist so plugins can be migrated one at a time.
+
+**What stays core-owned even in compiled mode.** Externals (`react`, `next/*`, `lucide-react`, `@delphian/tronrelic-types`, etc.) resolve through core's hoisted `node_modules` so there is one React instance at runtime. SCSS Modules are still compiled by core's webpack via the `/src/plugins/` include extension in `next.config.mjs:113-151` — only the TypeScript compile moves into the plugin. A new plugin version still requires rebuilding the core Docker image because `plugins.generated.ts` imports the plugin entry statically at build time. Compiled mode is a step toward full isolation, not a destination.
+
+**Required plugin files.** Every plugin should include:
+
+1. `tsconfig.frontend.json` as a standalone config (no `extends`) that includes `src/frontend/**/*`, `src/shared/**/*`, `src/manifest.ts`, and `src/global.d.ts`, with `rootDir: ./src` and `outDir: ./dist` so `src/frontend/frontend.ts` compiles to `dist/frontend/frontend.js`. Set `moduleResolution: Bundler` and `declaration: false`. Extending the backend `tsconfig.json` inherits `declarationDir` and triggers TS5069 once declarations are disabled — keep the two configs independent.
+2. `src/global.d.ts` declaring ambient `*.module.scss` and `*.module.css` imports. The declaration is identical across plugins (a two-line module declaration) — copy it from any plugin that already ships one.
+3. `scripts/copy-frontend-assets.mjs` that mirrors `*.scss` and `*.css` files from `src/frontend/` into `dist/frontend/` after tsc emits. Compiled JS references those assets via relative imports, so they must exist next to the JS.
+4. A `build:frontend` script in `package.json`: `tsc -p tsconfig.frontend.json && node scripts/copy-frontend-assets.mjs`. The default `build` script must chain it (`tsc && npm run build:frontend`); otherwise `npm run build` alone does not emit the artifact `exports."./frontend".import` points at, since the backend `tsconfig.json` excludes `src/frontend/**/*`.
+5. `exports."./frontend".import` set to `./dist/frontend/frontend.js` in `package.json`. If the plugin ships widgets, also set `exports."./frontend/widgets"` to `./dist/frontend/widgets/index.js`.
+
+Run `npm run build` inside the plugin before `npm run generate:plugins` at the repo root so the generator finds the compiled artifact.
 
 #### Scaffold Templates
 
@@ -198,7 +217,7 @@ For complete CSS architecture guidance, see [SCSS Modules and Component Styling]
 
 **Development mode**: No manual plugin build required. When you run `npm run dev`, the startup script generates plugin registries that import directly from TypeScript source files. tsx and Next.js compile plugins on-the-fly alongside the rest of the application.
 
-**Production builds**: Running `npm run build` compiles plugins to `dist/`. The `tsc -p tsconfig.json` command produces the backend bundle plus a compiled manifest. The shared `src/plugins/build-frontends.mjs` script emits `dist/frontend.bundle.js` for every plugin whose manifest sets `frontend: true`. Docker images use these pre-compiled artifacts.
+**Production builds**: Running `npm run build` compiles plugins to `dist/`. Each plugin runs `tsc -p tsconfig.json` for the backend (produces `dist/backend/backend.js` plus a compiled manifest) and `npm run build:frontend` for the frontend (produces `dist/frontend/*.js` plus mirrored SCSS, per [Frontend build](#frontend-build)). Docker images bundle these pre-compiled artifacts; `plugins.generated.ts` and `widgets.generated.ts` resolve to the compiled outputs at `next build` time.
 
 ## Quick Checklist / Reference
 
@@ -422,17 +441,17 @@ Frontend plugins should mirror the same discipline:
 `npm run dev` handles everything automatically:
 
 1. The startup script runs `scripts/generate-backend-plugin-registry.mjs` to create static imports for all backend plugins.
-2. The startup script runs `src/frontend/scripts/generate-frontend-plugin-registry.mjs` for frontend plugins.
-3. tsx and Next.js compile plugin TypeScript on-the-fly alongside the rest of the application.
-4. No separate plugin build step is required — just restart `npm run dev` after adding new plugins.
+2. The startup script runs `scripts/generate-frontend-plugin-registry.mjs` for frontend plugins.
+3. For plugins whose frontend is still in source mode, tsx and Next.js compile the TSX on-the-fly via `transpilePackages`. For plugins on compiled mode, run `npm run build:frontend` inside the plugin before the registry generator runs so the compiled artifact exists — core will not transpile the source tree for compiled-mode plugins.
+4. Restart `npm run dev` after adding a new plugin so registries regenerate.
 
 ### Production
 
 Root-level `npm run build` compiles everything for Docker images:
 
-1. Plugin registries are regenerated to ensure all plugins are included.
-2. Each plugin's `tsc -p tsconfig.json` compiles backend code to `dist/`.
-3. `src/plugins/build-frontends.mjs` bundles frontend entries into `dist/frontend.bundle.js`.
+1. Each plugin's `tsc -p tsconfig.json` compiles backend code to `dist/backend/`.
+2. Each plugin's `npm run build:frontend` compiles frontend code to `dist/frontend/` (see [Frontend build](#frontend-build)).
+3. Plugin registries are regenerated so `plugins.generated.ts` and `widgets.generated.ts` import the compiled outputs.
 4. Docker images use pre-compiled artifacts for faster startup.
 
 ## Adding or updating a plugin
@@ -558,4 +577,6 @@ Plugins often need secure settings screens without touching core admin code. Giv
 - `packages/types/src/plugin/definePlugin.ts` – helper for defining plugins.
 
 ### Build tools
-- `src/plugins/build-frontends.mjs` – esbuild task that emits `dist/frontend.bundle.js` for every frontend-enabled plugin.
+- `scripts/generate-frontend-plugin-registry.mjs` – reads each plugin's `package.json` exports map, emits static imports into `src/frontend/components/plugins/plugins.generated.ts` and `src/frontend/components/widgets/widgets.generated.ts`, and mirrors plugin-owned static assets into `src/frontend/public/plugins/`.
+- `src/plugins/trp-ai-assistant/tsconfig.frontend.json` – reference example of the per-plugin frontend tsconfig.
+- `src/plugins/trp-ai-assistant/scripts/copy-frontend-assets.mjs` – reference example of the non-TS asset mirror step.

--- a/docs/plugins/plugins-widget-zones.md
+++ b/docs/plugins/plugins-widget-zones.md
@@ -516,7 +516,7 @@ export const widgetComponents: Record<string, ComponentType<{ data: unknown }>> 
 };
 ```
 
-**Convention:** Export a `widgetComponents` object from `src/frontend/widgets/index.ts`. The generator scans this file at build time.
+**Convention:** Export a `widgetComponents` object from `src/frontend/widgets/index.ts`. The plugin's `build:frontend` pass compiles it to `dist/frontend/widgets/index.js`, and the plugin's `package.json` advertises that path via `exports."./frontend/widgets"`. The registry generator reads the exports map to emit the right static import. See [plugins-system-architecture.md](./plugins-system-architecture.md#frontend-build) for the full build setup.
 
 ### Creating Widget Components
 

--- a/docs/plugins/plugins.md
+++ b/docs/plugins/plugins.md
@@ -172,22 +172,30 @@ Plugins manage custom real-time subscriptions through a namespaced WebSocket man
 src/plugins/{plugin-id}/
 ├── src/
 │   ├── manifest.ts              # Shared metadata (backend + frontend)
+│   ├── global.d.ts              # Ambient *.module.scss / *.module.css types
 │   ├── backend/
-│   │   ├── backend.ts          # Entry point with lifecycle hooks
-│   │   └── *.observer.ts       # Transaction observers
+│   │   ├── backend.ts           # Entry point with lifecycle hooks
+│   │   └── *.observer.ts        # Transaction observers
 │   ├── frontend/
-│   │   ├── frontend.ts         # Entry point with pages/menu items
-│   │   ├── *.tsx               # React components
-│   │   ├── *.module.css        # CSS Modules for scoped styles
-│   │   └── public/             # Stable-URL static assets (OG images, icons) — optional
+│   │   ├── frontend.ts          # Entry point with pages/menu items
+│   │   ├── *.tsx                # React components
+│   │   ├── *.module.scss        # SCSS Modules for scoped styles
+│   │   ├── widgets/             # Widget component registry — optional
+│   │   └── public/              # Stable-URL static assets — optional
 │   └── shared/                  # Types shared between backend/frontend
 │       ├── types/
 │       └── constants.ts
-├── dist/                        # Compiled backend output
+├── scripts/
+│   └── copy-frontend-assets.mjs # Mirrors SCSS into dist/frontend after tsc
+├── dist/                        # Compiled artifacts (both loaders consume)
 │   ├── manifest.js
-│   └── backend/backend.js
-├── package.json                 # Workspace config
-└── tsconfig.json               # TypeScript config
+│   ├── backend/backend.js
+│   └── frontend/                # Compiled TSX + mirrored SCSS
+│       ├── frontend.js
+│       └── widgets/index.js     # If the plugin ships widgets
+├── package.json                 # Workspace config (exports map points at dist/)
+├── tsconfig.json                # Backend TS config
+└── tsconfig.frontend.json       # Frontend TS config (emits dist/frontend/)
 ```
 
 ### Common Plugin Patterns

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "tronrelic",
       "version": "1.0.0",
       "workspaces": [
-        "packages/*"
+        "packages/*",
+        "src/plugins/*/packages/*"
       ],
       "dependencies": {
         "@clickhouse/client": "^1.8.1",
@@ -207,6 +208,46 @@
     },
     "node_modules/@delphian/tronrelic-types": {
       "resolved": "packages/types",
+      "link": true
+    },
+    "node_modules/@delphian/trp-ai-assistant-types": {
+      "resolved": "src/plugins/trp-ai-assistant/packages/types",
+      "link": true
+    },
+    "node_modules/@delphian/trp-bazi-fortune-types": {
+      "resolved": "src/plugins/trp-bazi-fortune/packages/types",
+      "link": true
+    },
+    "node_modules/@delphian/trp-delegation-pools-types": {
+      "resolved": "src/plugins/trp-delegation-pools/packages/types",
+      "link": true
+    },
+    "node_modules/@delphian/trp-dust-tracker-types": {
+      "resolved": "src/plugins/trp-dust-tracker/packages/types",
+      "link": true
+    },
+    "node_modules/@delphian/trp-forum-types": {
+      "resolved": "src/plugins/trp-forum/packages/types",
+      "link": true
+    },
+    "node_modules/@delphian/trp-memo-tracker-types": {
+      "resolved": "src/plugins/trp-memo-tracker/packages/types",
+      "link": true
+    },
+    "node_modules/@delphian/trp-resource-tracker-types": {
+      "resolved": "src/plugins/trp-resource-tracker/packages/types",
+      "link": true
+    },
+    "node_modules/@delphian/trp-telegram-bot-types": {
+      "resolved": "src/plugins/trp-telegram-bot/packages/types",
+      "link": true
+    },
+    "node_modules/@delphian/trp-whale-alerts-types": {
+      "resolved": "src/plugins/trp-whale-alerts/packages/types",
+      "link": true
+    },
+    "node_modules/@delphian/trp-x-poster-types": {
+      "resolved": "src/plugins/trp-x-poster/packages/types",
       "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -12621,6 +12662,87 @@
         "socket.io-client": {
           "optional": true
         }
+      }
+    },
+    "src/plugins/trp-ai-assistant/packages/types": {
+      "name": "@delphian/trp-ai-assistant-types",
+      "version": "1.2.2",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    "src/plugins/trp-bazi-fortune/packages/types": {
+      "name": "@delphian/trp-bazi-fortune-types",
+      "version": "1.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    "src/plugins/trp-delegation-pools/packages/types": {
+      "name": "@delphian/trp-delegation-pools-types",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    "src/plugins/trp-dust-tracker/packages/types": {
+      "name": "@delphian/trp-dust-tracker-types",
+      "version": "1.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    "src/plugins/trp-forum/packages/types": {
+      "name": "@delphian/trp-forum-types",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    "src/plugins/trp-memo-tracker/packages/types": {
+      "name": "@delphian/trp-memo-tracker-types",
+      "version": "1.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    "src/plugins/trp-resource-tracker/packages/types": {
+      "name": "@delphian/trp-resource-tracker-types",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    "src/plugins/trp-telegram-bot/packages/types": {
+      "name": "@delphian/trp-telegram-bot-types",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    "src/plugins/trp-whale-alerts/packages/types": {
+      "name": "@delphian/trp-whale-alerts-types",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    "src/plugins/trp-x-poster/packages/types": {
+      "name": "@delphian/trp-x-poster-types",
+      "version": "1.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.3.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "workspaces": ["packages/*"],
+  "workspaces": ["packages/*", "src/plugins/*/packages/*"],
   "description": "TRON blockchain analytics platform with real-time monitoring, whale tracking, and extensible plugins.",
   "repository": {
     "type": "git",

--- a/scripts/generate-frontend-plugin-registry.mjs
+++ b/scripts/generate-frontend-plugin-registry.mjs
@@ -53,15 +53,15 @@ async function discoverPluginDirectories() {
  * Matches the two shapes the generator supports: a legacy raw TS entry at
  * `src/frontend/frontend.ts`, or a `package.json` that declares a frontend
  * export via the `exports` map.
+ *
+ * Errors from `resolveFrontendEntry` (e.g., declared compiled export missing
+ * its built artifact) propagate intentionally so the operator sees the real
+ * failure instead of silently falling back to a legacy TS entry.
  */
 async function hasFrontendEntry(directory) {
-    try {
-        const entry = await resolveFrontendEntry(directory);
-        if (entry) {
-            return true;
-        }
-    } catch {
-        // fall through to legacy check
+    const entry = await resolveFrontendEntry(directory);
+    if (entry) {
+        return true;
     }
     try {
         await fs.access(join(directory, 'src', 'frontend', 'frontend.ts'));
@@ -78,14 +78,25 @@ async function hasFrontendEntry(directory) {
  * `import` condition (falls through to `default` and `require` for tolerance).
  * Returns null when the subpath isn't declared or the pointed-at file doesn't
  * exist — callers decide whether to fall back to a legacy source path.
+ *
+ * Callers may pass an already-parsed `packageJson` to avoid a redundant read
+ * when the outer loop has already loaded it.
+ *
+ * Fails fast when the declared path has a compiled extension (.js/.mjs/.cjs)
+ * but the file is missing. Silently falling back to a legacy TS entry in that
+ * case is dangerous: `next.config.mjs` classifies compiled-mode purely on the
+ * declared extension, so the generator and Next would disagree and webpack
+ * would choke importing un-transpiled TS. Throwing here surfaces "you forgot
+ * to run the plugin's build" as a clear error instead.
  */
-async function resolveExportEntry(directory, subpath) {
-    const packageJsonPath = join(directory, 'package.json');
-    let packageJson;
-    try {
-        packageJson = await readJson(packageJsonPath);
-    } catch {
-        return null;
+async function resolveExportEntry(directory, subpath, packageJson) {
+    if (!packageJson) {
+        const packageJsonPath = join(directory, 'package.json');
+        try {
+            packageJson = await readJson(packageJsonPath);
+        } catch {
+            return null;
+        }
     }
 
     const exportsField = packageJson.exports;
@@ -107,9 +118,17 @@ async function resolveExportEntry(directory, subpath) {
     }
 
     const absolutePath = join(directory, relativePath);
+    const isCompiled = /\.(js|mjs|cjs)$/.test(relativePath);
     try {
         await fs.access(absolutePath);
     } catch {
+        if (isCompiled) {
+            throw new Error(
+                `Plugin at ${directory} declares compiled export "${subpath}" -> "${relativePath}" ` +
+                `but the file does not exist. Run \`npm run build\` inside the plugin before ` +
+                `\`npm run generate:plugins\`.`
+            );
+        }
         return null;
     }
     return absolutePath;
@@ -122,8 +141,8 @@ async function resolveExportEntry(directory, subpath) {
  * plugins can point at compiled output. Returns null when no exports-based
  * entry is declared; callers fall back to `src/frontend/frontend.ts`.
  */
-async function resolveFrontendEntry(directory) {
-    return resolveExportEntry(directory, './frontend');
+async function resolveFrontendEntry(directory, packageJson) {
+    return resolveExportEntry(directory, './frontend', packageJson);
 }
 
 /**
@@ -133,8 +152,8 @@ async function resolveFrontendEntry(directory) {
  * widget registry via `exports."./frontend/widgets"`; legacy plugins keep
  * shipping raw TS at `src/frontend/widgets/index.ts`.
  */
-async function resolveWidgetsEntry(directory) {
-    return resolveExportEntry(directory, './frontend/widgets');
+async function resolveWidgetsEntry(directory, packageJson) {
+    return resolveExportEntry(directory, './frontend/widgets', packageJson);
 }
 
 /**
@@ -181,10 +200,11 @@ async function collectPluginMetadata() {
     for (const directory of directories) {
         const packageJsonPath = join(directory, 'package.json');
         const manifestPath = join(directory, 'src', 'manifest.ts');
-        const resolvedEntry = await resolveFrontendEntry(directory);
-        const frontendEntry = resolvedEntry || join(directory, 'src', 'frontend', 'frontend.ts');
         const packageJson = await readJson(packageJsonPath);
-        const pluginId = await readPluginId(manifestPath, packageJson.name.split('/').at(-1));
+        const resolvedEntry = await resolveFrontendEntry(directory, packageJson);
+        const frontendEntry = resolvedEntry || join(directory, 'src', 'frontend', 'frontend.ts');
+        const fallbackId = packageJson.name?.split('/').at(-1) || directory.split(/[\\/]/).at(-1);
+        const pluginId = await readPluginId(manifestPath, fallbackId);
         const relativeImportPath = relative(outputDir, frontendEntry).replace(/\\/g, '/');
         const sanitizedImportPath = relativeImportPath.startsWith('.')
             ? relativeImportPath
@@ -371,10 +391,11 @@ async function collectWidgetMetadata() {
     for (const directory of directories) {
         const packageJsonPath = join(directory, 'package.json');
         const manifestPath = join(directory, 'src', 'manifest.ts');
-        const resolvedEntry = await resolveWidgetsEntry(directory);
-        const widgetsEntry = resolvedEntry || join(directory, 'src', 'frontend', 'widgets', 'index.ts');
         const packageJson = await readJson(packageJsonPath);
-        const pluginId = await readPluginId(manifestPath, packageJson.name.split('/').at(-1));
+        const resolvedEntry = await resolveWidgetsEntry(directory, packageJson);
+        const widgetsEntry = resolvedEntry || join(directory, 'src', 'frontend', 'widgets', 'index.ts');
+        const fallbackId = packageJson.name?.split('/').at(-1) || directory.split(/[\\/]/).at(-1);
+        const pluginId = await readPluginId(manifestPath, fallbackId);
         const relativeImportPath = relative(widgetsOutputDir, widgetsEntry).replace(/\\/g, '/');
         const sanitizedImportPath = relativeImportPath.startsWith('.')
             ? relativeImportPath
@@ -382,14 +403,43 @@ async function collectWidgetMetadata() {
         // Strip TS-only extensions. Compiled entries keep their .js/.mjs
         // extension so Node/webpack resolve the artifact as-is.
         const importPathWithoutExtension = sanitizedImportPath.replace(/\.(ts|tsx)$/, '');
+        const isCompiled = /\.(js|mjs|cjs)$/.test(widgetsEntry);
 
         metadata.push({
             id: pluginId,
-            importPath: importPathWithoutExtension
+            importPath: importPathWithoutExtension,
+            absoluteEntry: widgetsEntry,
+            isCompiled
         });
     }
 
     return metadata;
+}
+
+/**
+ * Writes a .d.ts sidecar next to each compiled widget artifact.
+ *
+ * Mirrors `writeCompiledPluginTypes`: the root tsconfig uses
+ * `moduleResolution: "Node"` (legacy) without `allowJs`, so importing a `.js`
+ * widget registry without a sibling `.d.ts` triggers TS2307. Each compiled
+ * widget entry needs a declaration stating that it exports
+ * `widgetComponents: Record<string, WidgetComponent>` — the exact shape
+ * `widgets.generated.ts` imports.
+ *
+ * The plugin's own build intentionally does not emit .d.ts — core's registry
+ * generator owns the declarations because that's the only consumer that needs
+ * them. The sidecar is reproducible from plugin source, so the plugin's
+ * `dist/` stays a build artifact.
+ */
+async function writeCompiledWidgetTypes(metadata) {
+    for (const entry of metadata) {
+        if (!entry.isCompiled) {
+            continue;
+        }
+        const sidecarPath = entry.absoluteEntry.replace(/\.(js|mjs|cjs)$/, '.d.ts');
+        const contents = `/**\n * AUTO-GENERATED FILE. DO NOT EDIT.\n *\n * This declaration file is produced by\n * scripts/generate-frontend-plugin-registry.mjs and gives core's\n * widgets.generated.ts a typed named import for this compiled widget\n * registry. The plugin's own build intentionally skips .d.ts emission —\n * core owns this sidecar because core is the only consumer.\n */\nimport type { WidgetComponent } from '@delphian/tronrelic-types';\n\nexport declare const widgetComponents: Record<string, WidgetComponent>;\n`;
+        await writeIfChanged(sidecarPath, contents);
+    }
 }
 
 /**
@@ -618,6 +668,11 @@ async function run() {
     const widgetMetadata = await collectWidgetMetadata();
     const widgetModuleSource = renderWidgetsModule(widgetMetadata);
     await writeIfChanged(widgetsOutputPath, widgetModuleSource);
+
+    // Emit a typed .d.ts sidecar next to each compiled widget artifact for the
+    // same reason as plugin frontends — the root tsconfig cannot resolve bare
+    // .js imports without allowJs under strict mode.
+    await writeCompiledWidgetTypes(widgetMetadata);
 
     // Mirror plugin-owned static assets into the frontend public folder
     await copyPluginPublicAssets();

--- a/scripts/generate-frontend-plugin-registry.mjs
+++ b/scripts/generate-frontend-plugin-registry.mjs
@@ -15,7 +15,10 @@ const widgetsOutputDir = dirname(widgetsOutputPath);
 /**
  * Discovers plugin directories with frontend entry points.
  *
- * It reads the plugins workspace and keeps directories that expose `src/frontend/frontend.ts`. This ensures the generator only creates loaders for plugins that actually ship frontend code.
+ * Accepts either a raw `src/frontend/frontend.ts` (legacy, core transpiles) or
+ * a `package.json` with an `exports."./frontend"` field that points at a
+ * compiled artifact (self-built plugins). The exports field is checked first
+ * so an opted-in plugin wins even if the raw TS entry still exists.
  */
 async function discoverPluginDirectories() {
     const directories = [];
@@ -36,15 +39,102 @@ async function discoverPluginDirectories() {
             continue;
         }
 
-        try {
-            await fs.access(join(directory, 'src', 'frontend', 'frontend.ts'));
+        if (await hasFrontendEntry(directory)) {
             directories.push(directory);
-        } catch {
-            // Ignore plugins without frontend modules.
         }
     }
 
     return directories;
+}
+
+/**
+ * Returns true if the plugin ships a frontend entry.
+ *
+ * Matches the two shapes the generator supports: a legacy raw TS entry at
+ * `src/frontend/frontend.ts`, or a `package.json` that declares a frontend
+ * export via the `exports` map.
+ */
+async function hasFrontendEntry(directory) {
+    try {
+        const entry = await resolveFrontendEntry(directory);
+        if (entry) {
+            return true;
+        }
+    } catch {
+        // fall through to legacy check
+    }
+    try {
+        await fs.access(join(directory, 'src', 'frontend', 'frontend.ts'));
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Resolves a package export entry to an absolute path on disk.
+ *
+ * Accepts either a string shortcut or a conditions object, preferring the
+ * `import` condition (falls through to `default` and `require` for tolerance).
+ * Returns null when the subpath isn't declared or the pointed-at file doesn't
+ * exist — callers decide whether to fall back to a legacy source path.
+ */
+async function resolveExportEntry(directory, subpath) {
+    const packageJsonPath = join(directory, 'package.json');
+    let packageJson;
+    try {
+        packageJson = await readJson(packageJsonPath);
+    } catch {
+        return null;
+    }
+
+    const exportsField = packageJson.exports;
+    if (!exportsField || typeof exportsField !== 'object') {
+        return null;
+    }
+
+    const entry = exportsField[subpath];
+    if (!entry) {
+        return null;
+    }
+
+    const relativePath = typeof entry === 'string'
+        ? entry
+        : (entry.import || entry.default || entry.require || null);
+
+    if (!relativePath) {
+        return null;
+    }
+
+    const absolutePath = join(directory, relativePath);
+    try {
+        await fs.access(absolutePath);
+    } catch {
+        return null;
+    }
+    return absolutePath;
+}
+
+/**
+ * Resolves the frontend entry the generator should import for a plugin.
+ *
+ * Prefers `exports."./frontend"` from the plugin's package.json so self-built
+ * plugins can point at compiled output. Returns null when no exports-based
+ * entry is declared; callers fall back to `src/frontend/frontend.ts`.
+ */
+async function resolveFrontendEntry(directory) {
+    return resolveExportEntry(directory, './frontend');
+}
+
+/**
+ * Resolves the widgets entry the generator should import for a plugin.
+ *
+ * Mirrors the frontend-entry resolver. Self-built plugins advertise a compiled
+ * widget registry via `exports."./frontend/widgets"`; legacy plugins keep
+ * shipping raw TS at `src/frontend/widgets/index.ts`.
+ */
+async function resolveWidgetsEntry(directory) {
+    return resolveExportEntry(directory, './frontend/widgets');
 }
 
 /**
@@ -79,6 +169,10 @@ async function readPluginId(manifestPath, fallbackId) {
  * Collects plugin metadata for code generation.
  *
  * It merges manifest identifiers with absolute file paths to produce import targets. This avoids redundant filesystem scans when rendering the registry.
+ *
+ * Also classifies each entry as compiled (.js/.mjs/.cjs) or raw TS (.ts/.tsx) so
+ * downstream rendering can emit typed default imports for the former and keep
+ * the legacy namespace-import + runtime-discovery path for the latter.
  */
 async function collectPluginMetadata() {
     const directories = await discoverPluginDirectories();
@@ -87,18 +181,24 @@ async function collectPluginMetadata() {
     for (const directory of directories) {
         const packageJsonPath = join(directory, 'package.json');
         const manifestPath = join(directory, 'src', 'manifest.ts');
-        const frontendEntry = join(directory, 'src', 'frontend', 'frontend.ts');
+        const resolvedEntry = await resolveFrontendEntry(directory);
+        const frontendEntry = resolvedEntry || join(directory, 'src', 'frontend', 'frontend.ts');
         const packageJson = await readJson(packageJsonPath);
         const pluginId = await readPluginId(manifestPath, packageJson.name.split('/').at(-1));
         const relativeImportPath = relative(outputDir, frontendEntry).replace(/\\/g, '/');
         const sanitizedImportPath = relativeImportPath.startsWith('.')
             ? relativeImportPath
             : `./${relativeImportPath}`;
-        const importPathWithoutExtension = sanitizedImportPath.replace(/\.ts$/, '');
+        // Strip TS-only extensions. Compiled entries keep their .js/.mjs
+        // extension so Node/webpack resolve the artifact as-is.
+        const importPathWithoutExtension = sanitizedImportPath.replace(/\.(ts|tsx)$/, '');
+        const isCompiled = /\.(js|mjs|cjs)$/.test(frontendEntry);
 
         metadata.push({
             id: pluginId,
-            importPath: importPathWithoutExtension
+            importPath: importPathWithoutExtension,
+            absoluteEntry: frontendEntry,
+            isCompiled
         });
     }
 
@@ -115,6 +215,14 @@ async function collectPluginMetadata() {
  * instead of polling, so the registry must be populated at module load time on
  * both server and client.
  *
+ * Two import shapes are emitted based on each plugin's entry:
+ *   - Compiled artifact (.js/.mjs/.cjs) → typed default import. The plugin must
+ *     `export default <IPlugin>` from its frontend entry. A sibling .d.ts
+ *     generated in the plugin's dist directory supplies the IPlugin type,
+ *     avoiding TS7016 from noImplicitAny.
+ *   - Raw TS entry → namespace import + runtime discovery. Keeps legacy plugins
+ *     working without forcing a default export until they migrate.
+ *
  * CSS code splitting is preserved because each plugin's frontend.ts uses
  * next/dynamic() to lazy-load its actual page components — the static import
  * here only pulls in the manifest and the dynamic wrappers, not the page CSS.
@@ -129,25 +237,65 @@ function renderModule(metadata) {
         return `${header}${imports}${emptyBody}`;
     }
 
+    const hasLegacy = metadata.some(entry => !entry.isCompiled);
+
     const staticImports = metadata
-        .map(({ id, importPath }) => {
+        .map(({ id, importPath, isCompiled }) => {
             const safeId = id.replace(/[^a-zA-Z0-9_]/g, '_');
+            if (isCompiled) {
+                return `import ${safeId}_plugin from '${importPath}';`;
+            }
             return `import * as ${safeId}_module from '${importPath}';`;
         })
         .join('\n');
 
     const arrayEntries = metadata
-        .map(({ id }) => {
+        .map(({ id, isCompiled }) => {
             const safeId = id.replace(/[^a-zA-Z0-9_]/g, '_');
+            if (isCompiled) {
+                return `    ${safeId}_plugin,`;
+            }
             return `    resolvePluginExport('${id}', ${safeId}_module),`;
         })
         .join('\n');
 
     const arrayDecl = `export const frontendPlugins: IPlugin[] = [\n${arrayEntries}\n];\n`;
 
-    const resolver = `function resolvePluginExport(pluginId: string, module: Record<string, unknown>): IPlugin {\n    const candidate = Object.values(module).find((value): value is IPlugin => {\n        return typeof value === 'object' && value !== null && 'manifest' in value;\n    });\n\n    if (!candidate) {\n        throw new Error(\`Failed to locate plugin export for '\${pluginId}'. Ensure the module exports an IPlugin.\`);\n    }\n\n    return candidate;\n}\n`;
+    const resolver = hasLegacy
+        ? `function resolvePluginExport(pluginId: string, module: Record<string, unknown>): IPlugin {\n    const candidate = Object.values(module).find((value): value is IPlugin => {\n        return typeof value === 'object' && value !== null && 'manifest' in value;\n    });\n\n    if (!candidate) {\n        throw new Error(\`Failed to locate plugin export for '\${pluginId}'. Ensure the module exports an IPlugin.\`);\n    }\n\n    return candidate;\n}\n`
+        : '';
 
-    return `${header}${imports}${staticImports}\n\n${resolver}\n${arrayDecl}`;
+    const body = hasLegacy
+        ? `${staticImports}\n\n${resolver}\n${arrayDecl}`
+        : `${staticImports}\n\n${arrayDecl}`;
+
+    return `${header}${imports}${body}`;
+}
+
+/**
+ * Writes a .d.ts sidecar next to each compiled plugin artifact.
+ *
+ * The root tsconfig uses `moduleResolution: "Node"` (legacy), so it doesn't
+ * honor package `exports.types` conditions and instead looks for `.d.ts` files
+ * sitting next to the imported `.js`. Each compiled plugin frontend therefore
+ * needs a one-line declaration that types the default export as IPlugin.
+ *
+ * The plugin's own build intentionally does not emit .d.ts — core's registry
+ * generator owns the declarations because that's the only consumer that needs
+ * them. The sidecar is reproducible from plugin source, so the plugin's
+ * `dist/` stays a build artifact. We write using the `@delphian/tronrelic-types`
+ * specifier (aliased project-wide in tsconfig.paths) so the sidecar resolves
+ * without needing the plugin's node_modules to contain the types package.
+ */
+async function writeCompiledPluginTypes(metadata) {
+    for (const entry of metadata) {
+        if (!entry.isCompiled) {
+            continue;
+        }
+        const sidecarPath = entry.absoluteEntry.replace(/\.(js|mjs|cjs)$/, '.d.ts');
+        const contents = `/**\n * AUTO-GENERATED FILE. DO NOT EDIT.\n *\n * This declaration file is produced by\n * scripts/generate-frontend-plugin-registry.mjs and gives core's\n * plugins.generated.ts a typed default import for this compiled plugin\n * artifact. The plugin's own build intentionally skips .d.ts emission —\n * core owns this sidecar because core is the only consumer.\n */\nimport type { IPlugin } from '@delphian/tronrelic-types';\n\ndeclare const plugin: IPlugin;\nexport default plugin;\n`;
+        await writeIfChanged(sidecarPath, contents);
+    }
 }
 
 /**
@@ -169,10 +317,12 @@ async function writeIfChanged(filePath, contents) {
 }
 
 /**
- * Discovers plugin directories with widget component exports.
+ * Discovers plugin directories that ship widget components.
  *
- * Scans for plugins that have a src/frontend/widgets/index.ts file exporting
- * widget components for SSR rendering.
+ * Accepts either a legacy raw TS registry at `src/frontend/widgets/index.ts`
+ * or a `package.json` exposing `exports."./frontend/widgets"` for self-built
+ * plugins. The exports field is checked first so an opted-in plugin wins even
+ * when the raw TS file is still present in the source tree.
  */
 async function discoverWidgetDirectories() {
     const directories = [];
@@ -188,6 +338,12 @@ async function discoverWidgetDirectories() {
         try {
             await fs.access(directory);
         } catch {
+            continue;
+        }
+
+        const resolved = await resolveWidgetsEntry(directory);
+        if (resolved) {
+            directories.push(directory);
             continue;
         }
 
@@ -215,14 +371,17 @@ async function collectWidgetMetadata() {
     for (const directory of directories) {
         const packageJsonPath = join(directory, 'package.json');
         const manifestPath = join(directory, 'src', 'manifest.ts');
-        const widgetsEntry = join(directory, 'src', 'frontend', 'widgets', 'index.ts');
+        const resolvedEntry = await resolveWidgetsEntry(directory);
+        const widgetsEntry = resolvedEntry || join(directory, 'src', 'frontend', 'widgets', 'index.ts');
         const packageJson = await readJson(packageJsonPath);
         const pluginId = await readPluginId(manifestPath, packageJson.name.split('/').at(-1));
         const relativeImportPath = relative(widgetsOutputDir, widgetsEntry).replace(/\\/g, '/');
         const sanitizedImportPath = relativeImportPath.startsWith('.')
             ? relativeImportPath
             : `./${relativeImportPath}`;
-        const importPathWithoutExtension = sanitizedImportPath.replace(/\.ts$/, '');
+        // Strip TS-only extensions. Compiled entries keep their .js/.mjs
+        // extension so Node/webpack resolve the artifact as-is.
+        const importPathWithoutExtension = sanitizedImportPath.replace(/\.(ts|tsx)$/, '');
 
         metadata.push({
             id: pluginId,
@@ -449,6 +608,11 @@ async function run() {
     const pluginMetadata = await collectPluginMetadata();
     const pluginModuleSource = renderModule(pluginMetadata);
     await writeIfChanged(outputPath, pluginModuleSource);
+
+    // Emit a typed .d.ts sidecar next to each compiled plugin artifact so the
+    // root tsconfig (moduleResolution: Node, legacy) can type default imports
+    // without each plugin shipping its own declarations.
+    await writeCompiledPluginTypes(pluginMetadata);
 
     // Generate widget component registry (static imports for SSR)
     const widgetMetadata = await collectWidgetMetadata();

--- a/src/frontend/next.config.mjs
+++ b/src/frontend/next.config.mjs
@@ -11,7 +11,11 @@ const pluginsRoot = join(repoRoot, 'src', 'plugins');
 /**
  * Discovers plugin package names for Next.js transpilation.
  *
- * It inspects each plugin directory and reads its package manifest to capture the published package name. This lets Next compile workspace plugins without manually updating the config.
+ * Returns only plugins that still ship raw TS/TSX for their frontend. Plugins
+ * whose `exports."./frontend"` points at a compiled artifact (.js/.mjs) are
+ * omitted so Next doesn't re-transpile them — their build tooling already
+ * produced the bundle core will import. New plugins migrate one at a time by
+ * adding a compiled frontend export.
  */
 function discoverPluginPackages() {
     try {
@@ -27,7 +31,13 @@ function discoverPluginPackages() {
 
                 try {
                     const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-                    return manifest.name ? [manifest.name] : [];
+                    if (!manifest.name) {
+                        return [];
+                    }
+                    if (hasCompiledFrontendExport(manifest)) {
+                        return [];
+                    }
+                    return [manifest.name];
                 } catch {
                     return [];
                 }
@@ -36,6 +46,31 @@ function discoverPluginPackages() {
         console.warn('Failed to read plugin packages for Next.js transpilation.', error);
         return [];
     }
+}
+
+/**
+ * Returns true when the plugin's frontend export resolves to a compiled file.
+ *
+ * Checking the extension (not just presence of exports) lets legacy plugins
+ * keep their existing `exports."./frontend"` pointing at `src/frontend/frontend.ts`
+ * without accidentally opting them out of transpilePackages.
+ */
+function hasCompiledFrontendExport(manifest) {
+    const exportsField = manifest.exports;
+    if (!exportsField || typeof exportsField !== 'object') {
+        return false;
+    }
+    const frontend = exportsField['./frontend'];
+    if (!frontend) {
+        return false;
+    }
+    const resolved = typeof frontend === 'string'
+        ? frontend
+        : (frontend.import || frontend.default || frontend.require || null);
+    if (!resolved) {
+        return false;
+    }
+    return /\.(js|mjs|cjs)$/.test(resolved);
 }
 
 const pluginPackages = discoverPluginPackages();


### PR DESCRIPTION
## Summary

- Registry generator accepts `exports."./frontend"` pointing at a compiled `.js`/`.mjs`/`.cjs` artifact. Compiled entries emit a typed default import plus a `.d.ts` sidecar (core owns the declarations because core is the only consumer). Legacy raw-TS entries keep working via namespace import + runtime discovery.
- `next.config.mjs` omits compiled-mode plugins from `transpilePackages` so webpack doesn't re-transpile pre-built artifacts. Source-mode plugins continue transpiling as before, enabling one-at-a-time migration.
- Root workspaces list extended with `src/plugins/*/packages/*`, and `docs/plugins/plugins-system-architecture.md` documents the new frontend build contract (`tsconfig.frontend.json`, `copy-frontend-assets.mjs`, `build:frontend` script, `exports."./frontend"`).