### PR TITLE
Add @types/js-yaml to root devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "@types/express": "^4.17.21",
         "@types/express-mongo-sanitize": "^1.3.2",
         "@types/geoip-lite": "^1.4.4",
+        "@types/js-yaml": "^4.0.9",
         "@types/morgan": "^1.9.9",
         "@types/node": "^20.10.6",
         "@types/node-cron": "^3.0.9",
@@ -2223,6 +2224,13 @@
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@types/express": "^4.17.21",
     "@types/express-mongo-sanitize": "^1.3.2",
     "@types/geoip-lite": "^1.4.4",
+    "@types/js-yaml": "^4.0.9",
     "@types/morgan": "^1.9.9",
     "@types/node": "^20.10.6",
     "@types/node-cron": "^3.0.9",


### PR DESCRIPTION
## Summary

- Adds `@types/js-yaml` to root `devDependencies` so `trp-ai-assistant` (and any other plugin using `js-yaml`) can find type declarations during Docker builds.
- `js-yaml` is already a root `dependency`; only the types package was missing at the root level.

## Why

Plugin `node_modules/` directories are excluded by `.dockerignore` (`**/node_modules/`), so plugin-local devDependencies installed by `scripts/setup.sh` never enter the Docker builder stage. Plugins resolve modules via the root `node_modules/` through Node's upward module-resolution walk.

`trp-ai-assistant/package.json` already lists `@types/js-yaml` in its own `devDependencies`, which works for local development and the pre-Docker CI `Build plugins` step, but fails inside the Docker builder where only root deps exist. This is blocking the `prod-publish.yml` workflow:

```
src/backend/template-variables.ts(11,18): error TS7016: Could not find a declaration
file for module 'js-yaml'.
```

Run that failed: https://github.com/delphian/tronrelic-ops/actions/runs/24646871974