### PR TITLE
Expose Table components to plugins via frontend context

### DIFF
--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -203,6 +203,7 @@ export interface IUIComponents {
         children?: React.ReactNode;
         variant?: 'default' | 'compact';
         className?: string;
+        style?: React.CSSProperties;
     }>;
 
     /** Table header section. */
@@ -228,6 +229,7 @@ export interface IUIComponents {
         children?: React.ReactNode;
         hasError?: boolean;
         isExpanded?: boolean;
+        onClick?: () => void;
         className?: string;
     }>;
 
@@ -241,6 +243,8 @@ export interface IUIComponents {
     Th: ComponentType<{
         children?: React.ReactNode;
         width?: 'auto' | 'shrink' | 'expand';
+        colSpan?: number;
+        rowSpan?: number;
         className?: string;
     }>;
 
@@ -253,6 +257,7 @@ export interface IUIComponents {
         children?: React.ReactNode;
         muted?: boolean;
         colSpan?: number;
+        rowSpan?: number;
         className?: string;
     }>;
 }

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -192,6 +192,69 @@ export interface IUIComponents {
         onSelect: (iconName: string) => void;
         onClose: () => void;
     }>;
+
+    /**
+     * Table wrapper matching the core `/system/*` admin tables.
+     *
+     * Compose with `Thead`, `Tbody`, `Tr`, `Th`, `Td` to get the same
+     * visual treatment plugins see on the plugins admin page.
+     */
+    Table: ComponentType<{
+        children?: React.ReactNode;
+        variant?: 'default' | 'compact';
+        className?: string;
+    }>;
+
+    /** Table header section. */
+    Thead: ComponentType<{
+        children?: React.ReactNode;
+        className?: string;
+    }>;
+
+    /** Table body section. */
+    Tbody: ComponentType<{
+        children?: React.ReactNode;
+        className?: string;
+    }>;
+
+    /**
+     * Table row.
+     *
+     * `hasError` applies the error surface tone; `isExpanded` renders the
+     * row with the muted "details drawer" background used by the plugins
+     * admin table for its expanded rows.
+     */
+    Tr: ComponentType<{
+        children?: React.ReactNode;
+        hasError?: boolean;
+        isExpanded?: boolean;
+        className?: string;
+    }>;
+
+    /**
+     * Table header cell.
+     *
+     * `width="shrink"` sizes the column to content (for fixed-width
+     * columns like status badges and action buttons); `width="expand"`
+     * forces the column to fill remaining space.
+     */
+    Th: ComponentType<{
+        children?: React.ReactNode;
+        width?: 'auto' | 'shrink' | 'expand';
+        className?: string;
+    }>;
+
+    /**
+     * Table data cell. `muted` dims the text for secondary metadata;
+     * `colSpan` spans the cell across multiple columns (used by the
+     * expanded details drawer).
+     */
+    Td: ComponentType<{
+        children?: React.ReactNode;
+        muted?: boolean;
+        colSpan?: number;
+        className?: string;
+    }>;
 }
 
 /**

--- a/src/frontend/lib/frontendPluginContext.tsx
+++ b/src/frontend/lib/frontendPluginContext.tsx
@@ -20,6 +20,7 @@ import { Input } from '../components/ui/Input';
 import { ClientTime } from '../components/ui/ClientTime';
 import { Tooltip } from '../components/ui/Tooltip';
 import { LazyIconPickerModal as IconPickerModal } from '../components/ui/IconPickerModal';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../components/ui/Table';
 import { useModal as useModalHook } from '../components/ui/ModalProvider';
 import { useToast as useToastHook } from '../components/ui/ToastProvider';
 import { LineChart } from '../features/charts/components/LineChart';
@@ -425,7 +426,13 @@ export function FrontendPluginContextProvider({ children }: { children: React.Re
             Input,
             ClientTime,
             Tooltip,
-            IconPickerModal
+            IconPickerModal,
+            Table,
+            Thead,
+            Tbody,
+            Tr,
+            Th,
+            Td
         };
 
         const layout: ILayoutComponents = {
@@ -513,7 +520,13 @@ export function createPluginContext(pluginId: string): IFrontendPluginContext {
         Input,
         ClientTime,
         Tooltip,
-        IconPickerModal
+        IconPickerModal,
+        Table,
+        Thead,
+        Tbody,
+        Tr,
+        Th,
+        Td
     };
 
     const layout: ILayoutComponents = {


### PR DESCRIPTION
## Summary
- Adds `Table`, `Thead`, `Tbody`, `Tr`, `Th`, and `Td` to `IUIComponents` with JSDoc covering the admin-table variants (`hasError`, `isExpanded`, `width`, `muted`, `colSpan`).
- Wires the components through `FrontendPluginContextProvider` and `createPluginContext` so plugin pages receive them on `context.ui` without importing from the core workspace.
- Lets plugin-authored admin surfaces match the visual treatment used by the core `/system/*` tables.