### PR TITLE
Add document edit/delete to admin database browser

### DIFF
--- a/docs/frontend/ui/ui-components.md
+++ b/docs/frontend/ui/ui-components.md
@@ -54,7 +54,7 @@ Mounted once in [app/providers.tsx](../../../src/frontend/app/providers.tsx); co
 | Provider | Purpose | Hook | Source |
 |----------|---------|------|--------|
 | `ModalProvider` | Portal-based modal stack with size variants, dismissibility, Redux tracking | `useModal()` → `{ open, close }` | [ModalProvider](../../../src/frontend/components/ui/ModalProvider/) |
-| `ToastProvider` | Viewport toast queue with variants, auto-dismiss, actions | `useToast()` → `{ showToast }` | [ToastProvider](../../../src/frontend/components/ui/ToastProvider/) |
+| `ToastProvider` | Viewport toast queue with variants, auto-dismiss, actions | `useToast()` → `{ push, dismiss }` | [ToastProvider](../../../src/frontend/components/ui/ToastProvider/) |
 | `FrontendPluginContextProvider` | Injects `ui`, `layout`, `api`, `charts`, `websocket` into plugin components | via `IFrontendPluginContext` prop | [lib/frontendPluginContext.tsx](../../../src/frontend/lib/frontendPluginContext.tsx) |
 
 See [react.md](../react/react.md#context-provider-system) for composition order and [plugins-frontend-context.md](../../plugins/plugins-frontend-context.md) for plugin consumption.

--- a/docs/frontend/ui/ui-components.md
+++ b/docs/frontend/ui/ui-components.md
@@ -1,0 +1,87 @@
+# UI Component Reference
+
+A complete catalog of TronRelic's standard React components shipped from `components/layout/` and `components/ui/`. Compose these before reaching for raw HTML — they own the design token wiring, accessibility, and SSR behavior the rest of the app depends on.
+
+## Why This Matters
+
+Without a single inventory, developers reinvent primitives (buttons, modals, copy-to-clipboard) inline, producing drift across pages and plugins. Every duplicate also duplicates its bugs: inconsistent focus rings, off-palette colors, missing ARIA, forgotten hydration guards. This document is the one place to look first. If a component appears here, do not reimplement it — compose it, or extend it in place.
+
+## How To Use This Catalog
+
+Reach for layout components first for page structure, UI primitives next for semantic elements, and SCSS Modules only for component-specific customization on top. Import paths are stable (`'../../../components/layout'` for layout, `'../../../components/ui/<Name>'` for primitives) — do not deep-import internal files. When a primitive almost fits but needs a variant, add the variant to the primitive rather than forking it. When no primitive fits, build a new one inside `components/ui/<Name>/` with a colocated `.module.scss` and add a row to this document in the same PR.
+
+## Layout Primitives
+
+Source: [components/layout/](../../../src/frontend/components/layout/). Export barrel: `index.ts`.
+
+| Component | Purpose | Source |
+|-----------|---------|--------|
+| `<Page>` | Page-level vertical grid with responsive gap and optional background image | [Page](../../../src/frontend/components/layout/Page/) |
+| `<PageHeader>` | Page title + subtitle block with optional actions slot | [PageHeader](../../../src/frontend/components/layout/PageHeader/) |
+| `<Stack>` | Flex container; `gap="sm\|md\|lg"`, `direction="vertical\|horizontal"` | [Stack](../../../src/frontend/components/layout/Stack/) |
+| `<Grid>` | Grid container; `gap`, `columns="2\|3\|responsive"` | [Grid](../../../src/frontend/components/layout/Grid/) |
+| `<Section>` | Content section with internal `gap` spacing | [Section](../../../src/frontend/components/layout/Section/) |
+| `<MainHeader>` | Site header: database-driven `MenuNav`, logo, wallet/theme controls (server component) | [MainHeader](../../../src/frontend/components/layout/MainHeader/) |
+| `MenuNavSSR` / `MenuNavClient` | SSR-first navigation fed by the backend Menu module; hydrates into a client menu with hamburger support | [MenuNav](../../../src/frontend/components/layout/MenuNav/) |
+| `<BlockTicker>` | Compact real-time block ticker; follows SSR + Live Updates with Redux hydration | [BlockTicker](../../../src/frontend/components/layout/BlockTicker/) |
+
+See [ui.md](./ui.md) and [frontend.md](../frontend.md#component-first-layout-architecture) for the decision hierarchy (layout components > utility classes > raw divs).
+
+## UI Primitives
+
+Source: [components/ui/](../../../src/frontend/components/ui/). Each folder exports via its own `index.ts`.
+
+| Component | Purpose | Key Props | Source |
+|-----------|---------|-----------|--------|
+| `<Badge>` | Inline status/label pill | `tone="neutral\|success\|warning\|danger"`, `showLiveIndicator` | [Badge](../../../src/frontend/components/ui/Badge/) |
+| `<Button>` | Primary interactive button | `variant="primary\|secondary\|ghost\|danger"`, `size`, `icon`, `loading` | [Button](../../../src/frontend/components/ui/Button/) |
+| `<Card>` | Content surface with padding, elevation, and tone | `padding="sm\|md\|lg"`, `elevated`, `tone`, `noBackgroundImage` | [Card](../../../src/frontend/components/ui/Card/) |
+| `<ClientTime>` | Timezone-safe timestamp renderer; SSR-safe placeholder until hydration | `date`, `format="time\|datetime\|date\|relative\|short"`, `fallback` | [ClientTime](../../../src/frontend/components/ui/ClientTime.tsx) |
+| `<CopyButton>` | Copy-to-clipboard button with `Copy → Check` confirmation and non-secure-context fallback | `value`, `label`, `copiedLabel`, `resetMs`, `ariaLabel` + `ButtonProps` | [CopyButton](../../../src/frontend/components/ui/CopyButton/) |
+| `<Input>` | Text input with focus ring | `variant="default\|ghost"` + all `InputHTMLAttributes` | [Input](../../../src/frontend/components/ui/Input/) |
+| `<Pagination>` | Page navigation with sibling-count windowing | `total`, `pageSize`, `currentPage`, `siblingCount`, `onPageChange` | [Pagination](../../../src/frontend/components/ui/Pagination/) |
+| `<Skeleton>` | Shimmer placeholder for loading content | All `HTMLDivAttributes` (style for size) | [Skeleton](../../../src/frontend/components/ui/Skeleton/) |
+| `<Table>` + `Thead` / `Tbody` / `Tr` / `Th` / `Td` | Styled table primitives with `variant="default\|compact"`, `isExpanded`, `hasError` row states, and `width="auto\|shrink\|expand"` cells | | [Table](../../../src/frontend/components/ui/Table/) |
+| `<Tooltip>` | Hover tooltip with `placement="top\|bottom"` | `content`, `placement` | [Tooltip](../../../src/frontend/components/ui/Tooltip/) |
+| `<IconPickerModal>` | Searchable Lucide icon picker rendered inside the ModalProvider | `onSelect`, `onClose`, `initialIcon` | [IconPickerModal](../../../src/frontend/components/ui/IconPickerModal/) |
+
+All primitives consume semantic tokens from [semantic-tokens.scss](../../../src/frontend/app/semantic-tokens.scss) and respond to theme changes automatically — see [ui-theme.md](./ui-theme.md).
+
+## Context Providers
+
+Mounted once in [app/providers.tsx](../../../src/frontend/app/providers.tsx); consumed via hooks elsewhere.
+
+| Provider | Purpose | Hook | Source |
+|----------|---------|------|--------|
+| `ModalProvider` | Portal-based modal stack with size variants, dismissibility, Redux tracking | `useModal()` → `{ open, close }` | [ModalProvider](../../../src/frontend/components/ui/ModalProvider/) |
+| `ToastProvider` | Viewport toast queue with variants, auto-dismiss, actions | `useToast()` → `{ showToast }` | [ToastProvider](../../../src/frontend/components/ui/ToastProvider/) |
+| `FrontendPluginContextProvider` | Injects `ui`, `layout`, `api`, `charts`, `websocket` into plugin components | via `IFrontendPluginContext` prop | [lib/frontendPluginContext.tsx](../../../src/frontend/lib/frontendPluginContext.tsx) |
+
+See [react.md](../react/react.md#context-provider-system) for composition order and [plugins-frontend-context.md](../../plugins/plugins-frontend-context.md) for plugin consumption.
+
+## Error and Utility Components
+
+| Component | Purpose | Source |
+|-----------|---------|--------|
+| `<ErrorBoundary>` | Catches render errors in a subtree and renders `ErrorFallback` | [ErrorBoundary](../../../src/frontend/components/ui/ErrorBoundary.tsx) |
+| `<ErrorFallback>` | Default fallback surface for error states | [ErrorFallback](../../../src/frontend/components/ui/ErrorFallback.tsx) |
+
+## Styling Utility Classes (Not Components)
+
+For one-off visual treatments where a component is overkill, use the utility classes defined in [globals.scss](../../../src/frontend/app/globals.scss): `.surface`, `.btn .btn--primary`, `.badge .badge--success`, `.chip`, `.pill`, `.segmented-control`, `.stat-grid`, `.stat-card__*`, `.alert`, `.text-muted`, `.text-subtle`, `.link`, `.live-indicator`, `.table-row--flash`. Prefer the React components above; utility classes exist for legacy call sites and rare compositional needs.
+
+## When To Add A New Component
+
+Add a new primitive under `components/ui/<Name>/` when the same JSX pattern appears in three or more unrelated places, when the pattern carries non-trivial accessibility or SSR concerns, or when a plugin would otherwise need to duplicate core behavior. Update this document in the same PR that introduces the component. If the new component is plugin-specific, put it in the plugin's own frontend folder instead — this catalog is only for shared primitives.
+
+## Further Reading
+
+**Detailed documentation:**
+- [ui.md](./ui.md) — UI system overview and pre-ship checklist
+- [ui-scss-modules.md](./ui-scss-modules.md) — SCSS Module architecture and the component-first decision hierarchy
+- [ui-design-token-layers.md](./ui-design-token-layers.md) — Tokens consumed by every primitive
+- [ui-theme.md](./ui-theme.md) — Themeable components and token overrides
+
+**Related topics:**
+- [react.md](../react/react.md) — SSR + Live Updates pattern, provider composition, server vs client components
+- [plugins-frontend-context.md](../../plugins/plugins-frontend-context.md) — How plugins access these components via `context.ui` / `context.layout`

--- a/docs/frontend/ui/ui.md
+++ b/docs/frontend/ui/ui.md
@@ -80,6 +80,7 @@ All icons from `lucide-react`. Sizes: 14px (inline), 16px (headings), 18px (butt
 ## Further Reading
 
 **Detail documents:**
+- [ui-components.md](./ui-components.md) - Complete catalog of layout primitives, UI primitives, and context providers with prop summaries and source links
 - [ui-scss-modules.md](./ui-scss-modules.md) - SCSS architecture, naming conventions, and component styling workflow
 - [ui-responsive-design.md](./ui-responsive-design.md) - Container queries, breakpoints, and SCSS interpolation
 - [ui-icons-and-feedback.md](./ui-icons-and-feedback.md) - Lucide icons, animations, and state feedback

--- a/src/backend/modules/database/DatabaseModule.ts
+++ b/src/backend/modules/database/DatabaseModule.ts
@@ -342,11 +342,6 @@ export class DatabaseModule implements IModule<IDatabaseModuleDependencies> {
             this.browserController.deleteDocument(req, res)
         );
 
-        // PUT /api/admin/database/collections/:name/documents/:id
-        router.put('/collections/:name/documents/:id', (req, res) =>
-            this.browserController.replaceDocument(req, res)
-        );
-
         return router;
     }
 }

--- a/src/backend/modules/database/DatabaseModule.ts
+++ b/src/backend/modules/database/DatabaseModule.ts
@@ -337,6 +337,16 @@ export class DatabaseModule implements IModule<IDatabaseModuleDependencies> {
             this.browserController.queryDocuments(req, res)
         );
 
+        // DELETE /api/admin/database/collections/:name/documents/:id
+        router.delete('/collections/:name/documents/:id', (req, res) =>
+            this.browserController.deleteDocument(req, res)
+        );
+
+        // PUT /api/admin/database/collections/:name/documents/:id
+        router.put('/collections/:name/documents/:id', (req, res) =>
+            this.browserController.replaceDocument(req, res)
+        );
+
         return router;
     }
 }

--- a/src/backend/modules/database/__tests__/database-browser.controller.test.ts
+++ b/src/backend/modules/database/__tests__/database-browser.controller.test.ts
@@ -16,6 +16,7 @@ class MockDatabaseBrowserRepository {
     getDatabaseStats = vi.fn();
     getDocuments = vi.fn();
     queryDocuments = vi.fn();
+    deleteDocument = vi.fn();
 }
 
 /**
@@ -709,6 +710,79 @@ describe('DatabaseBrowserController', () => {
                 page: 5,      // Parsed to number
                 limit: 30,    // Parsed to number
                 sort: { _id: -1 }
+            });
+        });
+    });
+
+    describe('deleteDocument', () => {
+        /**
+         * Test: deleteDocument returns 200 with deletedCount when removed.
+         */
+        it('should return 200 when a document is deleted', async () => {
+            mockRepository.deleteDocument.mockResolvedValue(1);
+
+            const req = createMockRequest({
+                params: { name: 'transactions', id: '507f1f77bcf86cd799439011' }
+            });
+            const res = createMockResponse();
+
+            await controller.deleteDocument(req as Request, res as Response);
+
+            expect(mockRepository.deleteDocument).toHaveBeenCalledWith(
+                'transactions',
+                '507f1f77bcf86cd799439011'
+            );
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith({
+                success: true,
+                data: { deletedCount: 1 }
+            });
+        });
+
+        /**
+         * Test: deleteDocument returns 404 when no document matches.
+         */
+        it('should return 404 when no document matches', async () => {
+            mockRepository.deleteDocument.mockResolvedValue(0);
+
+            const req = createMockRequest({
+                params: { name: 'transactions', id: 'missing-id' }
+            });
+            const res = createMockResponse();
+
+            await controller.deleteDocument(req as Request, res as Response);
+
+            expect(res.status).toHaveBeenCalledWith(404);
+            expect(res.json).toHaveBeenCalledWith({
+                success: false,
+                error: 'Document not found',
+                data: { deletedCount: 0 }
+            });
+        });
+
+        /**
+         * Test: deleteDocument returns 500 on repository failure.
+         */
+        it('should return 500 when the repository throws', async () => {
+            const error = new Error('Mongo unreachable');
+            mockRepository.deleteDocument.mockRejectedValue(error);
+
+            const req = createMockRequest({
+                params: { name: 'transactions', id: 'abc' }
+            });
+            const res = createMockResponse();
+
+            await controller.deleteDocument(req as Request, res as Response);
+
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                { error, params: req.params },
+                'Failed to delete document'
+            );
+            expect(res.status).toHaveBeenCalledWith(500);
+            expect(res.json).toHaveBeenCalledWith({
+                success: false,
+                error: 'Failed to delete document',
+                message: 'Mongo unreachable'
             });
         });
     });

--- a/src/backend/modules/database/__tests__/database-browser.repository.test.ts
+++ b/src/backend/modules/database/__tests__/database-browser.repository.test.ts
@@ -1,0 +1,138 @@
+/// <reference types="vitest" />
+
+/**
+ * Tests for DatabaseBrowserRepository.deleteDocument.
+ *
+ * Focuses on the ObjectId-vs-string _id resolution behavior, which is the
+ * non-trivial logic in the repository: 24-char hex strings are ambiguous
+ * (could be an ObjectId or a literal string _id), so the method tries
+ * ObjectId first and falls back to the raw string when no document matches.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { DatabaseBrowserRepository } from '../repositories/database-browser.repository.js';
+import type { Connection } from 'mongoose';
+import type { ISystemLogService } from '@/types';
+
+class MockLogger {
+    public info = vi.fn();
+    public error = vi.fn();
+    public warn = vi.fn();
+    public debug = vi.fn();
+    public child = vi.fn(() => new MockLogger() as any);
+}
+
+/**
+ * Build a fake mongoose Connection whose db.collection() returns a stub with
+ * a deleteOne spy. The spy uses the matcher to decide what to return so a
+ * single test can simulate "matched as ObjectId", "matched as string", or
+ * "no match either way".
+ */
+function createConnectionWith(
+    deleteOne: (filter: { _id: unknown }) => Promise<{ deletedCount: number }>
+): { connection: Connection; collection: { deleteOne: ReturnType<typeof vi.fn> } } {
+    const collection = {
+        deleteOne: vi.fn().mockImplementation((filter: { _id: unknown }) => deleteOne(filter))
+    };
+    const connection = {
+        db: {
+            collection: vi.fn().mockReturnValue(collection)
+        }
+    } as unknown as Connection;
+    return { connection, collection };
+}
+
+describe('DatabaseBrowserRepository.deleteDocument', () => {
+    const HEX_ID = '507f1f77bcf86cd799439011';
+    const SLUG_ID = 'my-page-slug';
+    let logger: MockLogger;
+
+    beforeEach(() => {
+        logger = new MockLogger();
+    });
+
+    /**
+     * Happy path: 24-hex string parses as ObjectId, matches, returns 1.
+     */
+    it('matches as ObjectId on the first attempt for a 24-hex id', async () => {
+        const { connection, collection } = createConnectionWith(async (filter) => {
+            return filter._id instanceof ObjectId ? { deletedCount: 1 } : { deletedCount: 0 };
+        });
+
+        const repo = new DatabaseBrowserRepository(connection, logger as unknown as ISystemLogService);
+        const deleted = await repo.deleteDocument('transactions', HEX_ID);
+
+        expect(deleted).toBe(1);
+        expect(collection.deleteOne).toHaveBeenCalledTimes(1);
+        const filter = collection.deleteOne.mock.calls[0][0] as { _id: ObjectId };
+        expect(filter._id).toBeInstanceOf(ObjectId);
+        expect(filter._id.toHexString()).toBe(HEX_ID);
+    });
+
+    /**
+     * Fallback path: 24-hex string fails as ObjectId (collection stores it as
+     * a literal string), so the repository retries with the raw string and
+     * returns 1.
+     */
+    it('falls back to string _id when ObjectId match fails for a 24-hex id', async () => {
+        const { connection, collection } = createConnectionWith(async (filter) => {
+            // Collection stores _id as the raw 24-hex string, not as an ObjectId.
+            return filter._id === HEX_ID ? { deletedCount: 1 } : { deletedCount: 0 };
+        });
+
+        const repo = new DatabaseBrowserRepository(connection, logger as unknown as ISystemLogService);
+        const deleted = await repo.deleteDocument('pages', HEX_ID);
+
+        expect(deleted).toBe(1);
+        expect(collection.deleteOne).toHaveBeenCalledTimes(2);
+        // First attempt: ObjectId
+        expect(collection.deleteOne.mock.calls[0][0]._id).toBeInstanceOf(ObjectId);
+        // Second attempt: raw string
+        expect(collection.deleteOne.mock.calls[1][0]._id).toBe(HEX_ID);
+    });
+
+    /**
+     * Non-hex id (slug, UUID, etc.) skips the ObjectId attempt entirely and
+     * goes straight to the string deleteOne.
+     */
+    it('uses string _id directly for non-hex ids', async () => {
+        const { connection, collection } = createConnectionWith(async (filter) => {
+            return filter._id === SLUG_ID ? { deletedCount: 1 } : { deletedCount: 0 };
+        });
+
+        const repo = new DatabaseBrowserRepository(connection, logger as unknown as ISystemLogService);
+        const deleted = await repo.deleteDocument('pages', SLUG_ID);
+
+        expect(deleted).toBe(1);
+        expect(collection.deleteOne).toHaveBeenCalledTimes(1);
+        expect(collection.deleteOne.mock.calls[0][0]._id).toBe(SLUG_ID);
+    });
+
+    /**
+     * Returns 0 when neither the ObjectId attempt nor the string fallback matches.
+     */
+    it('returns 0 when no document matches either as ObjectId or string', async () => {
+        const { connection, collection } = createConnectionWith(async () => ({ deletedCount: 0 }));
+
+        const repo = new DatabaseBrowserRepository(connection, logger as unknown as ISystemLogService);
+        const deleted = await repo.deleteDocument('transactions', HEX_ID);
+
+        expect(deleted).toBe(0);
+        // Both attempts (ObjectId, then string) must run when neither matches.
+        expect(collection.deleteOne).toHaveBeenCalledTimes(2);
+    });
+
+    /**
+     * Connection without a `db` (uninitialized mongoose connection) throws,
+     * surfacing the misconfiguration to the caller instead of silently failing.
+     */
+    it('throws when the connection has no active db', async () => {
+        const connection = { db: undefined } as unknown as Connection;
+        const repo = new DatabaseBrowserRepository(connection, logger as unknown as ISystemLogService);
+
+        await expect(repo.deleteDocument('transactions', HEX_ID)).rejects.toThrow(
+            'Database not connected'
+        );
+    });
+});

--- a/src/backend/modules/database/api/database-browser.controller.ts
+++ b/src/backend/modules/database/api/database-browser.controller.ts
@@ -230,6 +230,116 @@ export class DatabaseBrowserController {
     }
 
     /**
+     * DELETE /api/admin/database/collections/:name/documents/:id
+     *
+     * Removes a single document from the collection by _id.
+     *
+     * Why this endpoint:
+     * - Admins need to remove bad/stale records without dropping into a shell
+     * - Scoped to a single document — never bulk delete — to keep blast radius small
+     * - Admin-authenticated via the parent router's requireAdmin middleware
+     *
+     * Responses:
+     * - 200 with `{ deletedCount: 1 }` on success
+     * - 404 with `{ deletedCount: 0 }` if the document does not exist
+     * - 500 on unexpected errors
+     *
+     * @param req - Express request with collection name and document id
+     * @param res - Express response
+     */
+    async deleteDocument(req: Request, res: Response): Promise<void> {
+        const { name, id } = req.params;
+
+        try {
+            const deletedCount = await this.repository.deleteDocument(name, id);
+
+            if (deletedCount === 0) {
+                res.status(404).json({
+                    success: false,
+                    error: 'Document not found',
+                    data: { deletedCount: 0 }
+                });
+                return;
+            }
+
+            this.logger.info({ collection: name, id, deletedCount }, 'Deleted document');
+            res.status(200).json({
+                success: true,
+                data: { deletedCount }
+            });
+        } catch (error) {
+            this.logger.error({ error, params: req.params }, 'Failed to delete document');
+
+            res.status(500).json({
+                success: false,
+                error: 'Failed to delete document',
+                message: error instanceof Error ? error.message : 'Unknown error'
+            });
+        }
+    }
+
+    /**
+     * PUT /api/admin/database/collections/:name/documents/:id
+     *
+     * Replaces a single document's contents by _id.
+     *
+     * Request body:
+     * - `document`: object with the new contents (any _id field is ignored; original is preserved)
+     *
+     * Responses:
+     * - 200 on successful replacement
+     * - 400 when the body is missing or `document` is not a plain object
+     * - 404 when no document matches the given _id
+     * - 500 on unexpected errors
+     *
+     * Why full replacement:
+     * - Admin JSON editor works on the raw document blob — "save what I see"
+     * - Avoids ambiguous merge semantics for nested fields and arrays
+     *
+     * @param req - Express request with collection name, document id, and body
+     * @param res - Express response
+     */
+    async replaceDocument(req: Request, res: Response): Promise<void> {
+        const { name, id } = req.params;
+        const { document } = req.body ?? {};
+
+        if (document === null || typeof document !== 'object' || Array.isArray(document)) {
+            res.status(400).json({
+                success: false,
+                error: 'Invalid document',
+                message: 'Request body must include a `document` object'
+            });
+            return;
+        }
+
+        try {
+            const matched = await this.repository.replaceDocument(name, id, document);
+
+            if (!matched) {
+                res.status(404).json({
+                    success: false,
+                    error: 'Document not found'
+                });
+                return;
+            }
+
+            this.logger.info({ collection: name, id }, 'Replaced document');
+            res.status(200).json({
+                success: true,
+                data: { matched: true }
+            });
+        } catch (error) {
+            this.logger.error({ error, params: req.params }, 'Failed to replace document');
+
+            res.status(500).json({
+                success: false,
+                error: 'Failed to replace document',
+                message: error instanceof Error ? error.message : 'Unknown error'
+            });
+        }
+    }
+
+    /**
      * Parses sort parameter string into MongoDB sort object.
      *
      * Supports prefixed notation for direction:

--- a/src/backend/modules/database/api/database-browser.controller.ts
+++ b/src/backend/modules/database/api/database-browser.controller.ts
@@ -240,9 +240,10 @@ export class DatabaseBrowserController {
      * - Admin-authenticated via the parent router's requireAdmin middleware
      *
      * Responses:
-     * - 200 with `{ deletedCount: 1 }` on success
-     * - 404 with `{ deletedCount: 0 }` if the document does not exist
-     * - 500 on unexpected errors
+     * - 200 with `{ success: true, data: { deletedCount: 1 } }` on success
+     * - 404 with `{ success: false, error: 'Document not found', data: { deletedCount: 0 } }`
+     *   if the document does not exist
+     * - 500 with `{ success: false, error, message }` on unexpected errors
      *
      * @param req - Express request with collection name and document id
      * @param res - Express response
@@ -273,67 +274,6 @@ export class DatabaseBrowserController {
             res.status(500).json({
                 success: false,
                 error: 'Failed to delete document',
-                message: error instanceof Error ? error.message : 'Unknown error'
-            });
-        }
-    }
-
-    /**
-     * PUT /api/admin/database/collections/:name/documents/:id
-     *
-     * Replaces a single document's contents by _id.
-     *
-     * Request body:
-     * - `document`: object with the new contents (any _id field is ignored; original is preserved)
-     *
-     * Responses:
-     * - 200 on successful replacement
-     * - 400 when the body is missing or `document` is not a plain object
-     * - 404 when no document matches the given _id
-     * - 500 on unexpected errors
-     *
-     * Why full replacement:
-     * - Admin JSON editor works on the raw document blob — "save what I see"
-     * - Avoids ambiguous merge semantics for nested fields and arrays
-     *
-     * @param req - Express request with collection name, document id, and body
-     * @param res - Express response
-     */
-    async replaceDocument(req: Request, res: Response): Promise<void> {
-        const { name, id } = req.params;
-        const { document } = req.body ?? {};
-
-        if (document === null || typeof document !== 'object' || Array.isArray(document)) {
-            res.status(400).json({
-                success: false,
-                error: 'Invalid document',
-                message: 'Request body must include a `document` object'
-            });
-            return;
-        }
-
-        try {
-            const matched = await this.repository.replaceDocument(name, id, document);
-
-            if (!matched) {
-                res.status(404).json({
-                    success: false,
-                    error: 'Document not found'
-                });
-                return;
-            }
-
-            this.logger.info({ collection: name, id }, 'Replaced document');
-            res.status(200).json({
-                success: true,
-                data: { matched: true }
-            });
-        } catch (error) {
-            this.logger.error({ error, params: req.params }, 'Failed to replace document');
-
-            res.status(500).json({
-                success: false,
-                error: 'Failed to replace document',
                 message: error instanceof Error ? error.message : 'Unknown error'
             });
         }

--- a/src/backend/modules/database/repositories/database-browser.repository.ts
+++ b/src/backend/modules/database/repositories/database-browser.repository.ts
@@ -14,6 +14,7 @@
  */
 
 import type { Connection } from 'mongoose';
+import { ObjectId } from 'mongodb';
 import type { ISystemLogService } from '@/types';
 import type {
     ICollectionStat,
@@ -249,6 +250,89 @@ export class DatabaseBrowserRepository {
             hasNextPage,
             hasPrevPage
         };
+    }
+
+    /**
+     * Deletes a single document from a collection by its _id.
+     *
+     * Why _id-based deletion:
+     * - Stable, unambiguous identifier for any document shape
+     * - Matches the admin UI's expand-on-row model where each row owns a document
+     * - Parses ObjectId when possible; falls back to raw string _id for non-ObjectId keys
+     *
+     * Security posture:
+     * - Admin-gated via requireAdmin on the parent router
+     * - express-mongo-sanitize already strips $ and . from the :id path parameter
+     * - Only acts on the single document; never a blanket deleteMany
+     *
+     * @param collectionName - Name of the collection
+     * @param id - Document _id as a string (ObjectId hex or plain string key)
+     * @returns Number of documents actually removed (0 or 1)
+     */
+    async deleteDocument(collectionName: string, id: string): Promise<number> {
+        this.logger.debug({ collectionName, id }, 'Deleting document');
+
+        const db = this.connection.db;
+        if (!db) {
+            throw new Error('Database not connected');
+        }
+
+        const collection = db.collection(collectionName);
+
+        // Parse as ObjectId when the string matches the ObjectId hex shape;
+        // otherwise treat _id as a plain string (some collections use slugs or UUIDs).
+        const filterId: ObjectId | string = ObjectId.isValid(id) && /^[a-f0-9]{24}$/i.test(id)
+            ? new ObjectId(id)
+            : id;
+
+        const result = await collection.deleteOne({ _id: filterId } as Record<string, unknown>);
+        return result.deletedCount ?? 0;
+    }
+
+    /**
+     * Replaces a single document's contents by _id.
+     *
+     * Why full replacement instead of PATCH/$set:
+     * - Admin editor works on the raw JSON blob, so "save what I see" is the expected semantic
+     * - Avoids per-field merge ambiguity for nested objects and arrays
+     * - The document's _id is preserved by stripping it from the replacement payload
+     *
+     * Security posture:
+     * - Admin-gated via requireAdmin on the parent router
+     * - express-mongo-sanitize already strips $ and . from body keys at the router level,
+     *   preventing operator injection at the cost of mangling legitimate keys containing those
+     *   characters (acceptable tradeoff for an admin JSON editor)
+     * - Only acts on the single matching document; never bulk
+     *
+     * @param collectionName - Name of the collection
+     * @param id - Document _id as a string (ObjectId hex or plain string key)
+     * @param replacement - New document contents; any _id field is ignored
+     * @returns True if the document was found and replaced, false if no match
+     */
+    async replaceDocument(
+        collectionName: string,
+        id: string,
+        replacement: Record<string, unknown>
+    ): Promise<boolean> {
+        this.logger.debug({ collectionName, id }, 'Replacing document');
+
+        const db = this.connection.db;
+        if (!db) {
+            throw new Error('Database not connected');
+        }
+
+        const collection = db.collection(collectionName);
+
+        const filterId: ObjectId | string = ObjectId.isValid(id) && /^[a-f0-9]{24}$/i.test(id)
+            ? new ObjectId(id)
+            : id;
+
+        // _id is immutable; drop any value the caller sent for it.
+        const { _id: _discardedId, ...body } = replacement;
+        void _discardedId;
+
+        const result = await collection.replaceOne({ _id: filterId } as Record<string, unknown>, body);
+        return (result.matchedCount ?? 0) > 0;
     }
 
     /**

--- a/src/backend/modules/database/repositories/database-browser.repository.ts
+++ b/src/backend/modules/database/repositories/database-browser.repository.ts
@@ -258,11 +258,17 @@ export class DatabaseBrowserRepository {
      * Why _id-based deletion:
      * - Stable, unambiguous identifier for any document shape
      * - Matches the admin UI's expand-on-row model where each row owns a document
-     * - Parses ObjectId when possible; falls back to raw string _id for non-ObjectId keys
+     *
+     * Why try ObjectId then string fallback:
+     * - The URL parameter is always a string; the actual _id may be an ObjectId or a
+     *   plain string (slug/UUID). A 24-char hex string is ambiguous — it parses as
+     *   ObjectId, but the collection may store it as a literal string. Trying ObjectId
+     *   first matches the common case; falling back to string covers collections that
+     *   use 24-hex strings as keys.
      *
      * Security posture:
      * - Admin-gated via requireAdmin on the parent router
-     * - express-mongo-sanitize already strips $ and . from the :id path parameter
+     * - express-mongo-sanitize replaces $ and . with _ in the :id path parameter
      * - Only acts on the single document; never a blanket deleteMany
      *
      * @param collectionName - Name of the collection
@@ -278,61 +284,23 @@ export class DatabaseBrowserRepository {
         }
 
         const collection = db.collection(collectionName);
+        const looksLikeObjectId = ObjectId.isValid(id) && /^[a-f0-9]{24}$/i.test(id);
 
-        // Parse as ObjectId when the string matches the ObjectId hex shape;
-        // otherwise treat _id as a plain string (some collections use slugs or UUIDs).
-        const filterId: ObjectId | string = ObjectId.isValid(id) && /^[a-f0-9]{24}$/i.test(id)
-            ? new ObjectId(id)
-            : id;
-
-        const result = await collection.deleteOne({ _id: filterId } as Record<string, unknown>);
-        return result.deletedCount ?? 0;
-    }
-
-    /**
-     * Replaces a single document's contents by _id.
-     *
-     * Why full replacement instead of PATCH/$set:
-     * - Admin editor works on the raw JSON blob, so "save what I see" is the expected semantic
-     * - Avoids per-field merge ambiguity for nested objects and arrays
-     * - The document's _id is preserved by stripping it from the replacement payload
-     *
-     * Security posture:
-     * - Admin-gated via requireAdmin on the parent router
-     * - express-mongo-sanitize already strips $ and . from body keys at the router level,
-     *   preventing operator injection at the cost of mangling legitimate keys containing those
-     *   characters (acceptable tradeoff for an admin JSON editor)
-     * - Only acts on the single matching document; never bulk
-     *
-     * @param collectionName - Name of the collection
-     * @param id - Document _id as a string (ObjectId hex or plain string key)
-     * @param replacement - New document contents; any _id field is ignored
-     * @returns True if the document was found and replaced, false if no match
-     */
-    async replaceDocument(
-        collectionName: string,
-        id: string,
-        replacement: Record<string, unknown>
-    ): Promise<boolean> {
-        this.logger.debug({ collectionName, id }, 'Replacing document');
-
-        const db = this.connection.db;
-        if (!db) {
-            throw new Error('Database not connected');
+        // Try ObjectId first when the shape matches; fall back to string _id if no match.
+        // Collections that store 24-hex strings as _id would otherwise return false 404s.
+        if (looksLikeObjectId) {
+            const objectIdResult = await collection.deleteOne(
+                { _id: new ObjectId(id) } as Record<string, unknown>
+            );
+            if ((objectIdResult.deletedCount ?? 0) > 0) {
+                return objectIdResult.deletedCount ?? 0;
+            }
         }
 
-        const collection = db.collection(collectionName);
-
-        const filterId: ObjectId | string = ObjectId.isValid(id) && /^[a-f0-9]{24}$/i.test(id)
-            ? new ObjectId(id)
-            : id;
-
-        // _id is immutable; drop any value the caller sent for it.
-        const { _id: _discardedId, ...body } = replacement;
-        void _discardedId;
-
-        const result = await collection.replaceOne({ _id: filterId } as Record<string, unknown>, body);
-        return (result.matchedCount ?? 0) > 0;
+        const stringResult = await collection.deleteOne(
+            { _id: id } as Record<string, unknown>
+        );
+        return stringResult.deletedCount ?? 0;
     }
 
     /**

--- a/src/frontend/app/(core)/system/database/components/CollectionBrowser.module.css
+++ b/src/frontend/app/(core)/system/database/components/CollectionBrowser.module.css
@@ -163,38 +163,6 @@
     background: var(--color-surface-muted);
 }
 
-.document_editor {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-4);
-}
-
-.document_textarea {
-    width: 100%;
-    min-height: 240px;
-    padding: var(--spacing-5) var(--spacing-6);
-    background: var(--color-surface);
-    color: var(--color-text);
-    border: var(--border-width-thin) solid var(--color-border);
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
-    line-height: var(--line-height-relaxed);
-    resize: vertical;
-}
-
-.document_textarea:focus {
-    outline: none;
-    border-color: var(--input-border-focus);
-    box-shadow: var(--input-shadow-focus);
-}
-
-.document_editor_toolbar {
-    display: flex;
-    justify-content: flex-end;
-    gap: var(--spacing-4);
-}
-
 .document_json {
     margin: 0;
     padding: var(--spacing-5) var(--spacing-6);

--- a/src/frontend/app/(core)/system/database/components/CollectionBrowser.module.css
+++ b/src/frontend/app/(core)/system/database/components/CollectionBrowser.module.css
@@ -138,41 +138,69 @@
 }
 
 .documents_list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-4);
     max-height: 500px;
     overflow-y: auto;
 }
 
-.document {
+.document_row {
+    cursor: pointer;
+}
+
+.row_actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-3);
+    justify-content: flex-end;
+}
+
+.document_id {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--color-text);
+}
+
+.document_detail_row {
+    background: var(--color-surface-muted);
+}
+
+.document_editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-4);
+}
+
+.document_textarea {
+    width: 100%;
+    min-height: 240px;
+    padding: var(--spacing-5) var(--spacing-6);
+    background: var(--color-surface);
+    color: var(--color-text);
     border: var(--border-width-thin) solid var(--color-border);
     border-radius: var(--radius-sm);
-    background: var(--color-surface-elevated);
-    overflow: hidden;
-}
-
-.document_summary {
-    cursor: pointer;
-    user-select: none;
-    color: var(--color-text);
     font-family: var(--font-mono);
-    font-size: var(--font-size-sm);
-    padding: var(--spacing-5) var(--spacing-6);
-    display: block;
-    transition: background-color var(--transition-fast);
+    font-size: var(--font-size-xs);
+    line-height: var(--line-height-relaxed);
+    resize: vertical;
 }
 
-.document_summary:hover {
-    color: var(--color-primary);
-    background: var(--color-surface-elevated);
+.document_textarea:focus {
+    outline: none;
+    border-color: var(--input-border-focus);
+    box-shadow: var(--input-shadow-focus);
+}
+
+.document_editor_toolbar {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--spacing-4);
 }
 
 .document_json {
     margin: 0;
-    padding: var(--spacing-6);
+    padding: var(--spacing-5) var(--spacing-6);
     background: var(--color-surface);
-    border-top: var(--border-width-thin) solid var(--color-border);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-sm);
     font-family: var(--font-mono);
     font-size: var(--font-size-xs);
     color: var(--color-text);

--- a/src/frontend/app/(core)/system/database/components/CollectionBrowser.tsx
+++ b/src/frontend/app/(core)/system/database/components/CollectionBrowser.tsx
@@ -12,11 +12,15 @@
  * - Document viewing enables quick debugging and data verification
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, Fragment } from 'react';
 import { Card } from '../../../../../components/ui/Card';
 import { Button } from '../../../../../components/ui/Button';
 import { Badge } from '../../../../../components/ui/Badge';
-import { Database, ChevronDown, ChevronRight, FileText } from 'lucide-react';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
+import { ClientTime } from '../../../../../components/ui/ClientTime';
+import { CopyButton } from '../../../../../components/ui/CopyButton';
+import { useToast } from '../../../../../components/ui/ToastProvider/ToastProvider';
+import { Database, ChevronDown, ChevronRight, FileText, Trash2, Pencil, Save, X } from 'lucide-react';
 import styles from './CollectionBrowser.module.css';
 
 interface ICollectionStat {
@@ -54,6 +58,12 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
     const [expandedCollection, setExpandedCollection] = useState<string | null>(null);
     const [documents, setDocuments] = useState<IPaginatedDocuments | null>(null);
     const [loadingDocuments, setLoadingDocuments] = useState(false);
+    const [expandedDocumentId, setExpandedDocumentId] = useState<string | null>(null);
+    const [deletingDocumentId, setDeletingDocumentId] = useState<string | null>(null);
+    const [editingDocumentId, setEditingDocumentId] = useState<string | null>(null);
+    const [editDraft, setEditDraft] = useState<string>('');
+    const [savingDocument, setSavingDocument] = useState(false);
+    const { push: pushToast } = useToast();
 
     const fetchStats = useCallback(async () => {
         if (!token) return;
@@ -114,6 +124,9 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
     }, [fetchStats]);
 
     const toggleCollection = (collectionName: string) => {
+        setExpandedDocumentId(null);
+        setEditingDocumentId(null);
+        setEditDraft('');
         if (expandedCollection === collectionName) {
             setExpandedCollection(null);
             setDocuments(null);
@@ -122,6 +135,152 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
             void fetchDocuments(collectionName);
         }
     };
+
+    const toggleDocument = (documentId: string) => {
+        setExpandedDocumentId(prev => {
+            if (prev === documentId) {
+                // Collapsing: drop any in-progress edit for this row.
+                if (editingDocumentId === documentId) {
+                    setEditingDocumentId(null);
+                    setEditDraft('');
+                }
+                return null;
+            }
+            return documentId;
+        });
+    };
+
+    const startEditingDocument = useCallback((doc: any, documentId: string) => {
+        setEditingDocumentId(documentId);
+        setEditDraft(JSON.stringify(doc, null, 2));
+        setExpandedDocumentId(documentId);
+    }, []);
+
+    const cancelEditingDocument = useCallback(() => {
+        setEditingDocumentId(null);
+        setEditDraft('');
+    }, []);
+
+    const saveDocumentEdit = useCallback(async (collectionName: string, documentId: string) => {
+        if (!token) return;
+
+        let parsed: any;
+        try {
+            parsed = JSON.parse(editDraft);
+        } catch (err) {
+            pushToast({
+                tone: 'danger',
+                title: 'Invalid JSON',
+                description: err instanceof Error ? err.message : 'Document must be valid JSON'
+            });
+            return;
+        }
+
+        if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            pushToast({
+                tone: 'danger',
+                title: 'Invalid JSON',
+                description: 'Document must be a JSON object'
+            });
+            return;
+        }
+
+        setSavingDocument(true);
+        try {
+            const response = await fetch(
+                `/api/admin/database/collections/${collectionName}/documents/${encodeURIComponent(documentId)}`,
+                {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'x-admin-token': token
+                    },
+                    body: JSON.stringify({ document: parsed })
+                }
+            );
+
+            if (!response.ok) {
+                const body = await response.json().catch(() => ({}));
+                throw new Error(body?.message || body?.error || `Save failed: ${response.statusText}`);
+            }
+
+            pushToast({
+                tone: 'success',
+                title: 'Document saved',
+                description: `Updated ${documentId} in ${collectionName}`
+            });
+
+            setEditingDocumentId(null);
+            setEditDraft('');
+
+            const currentPage = documents?.page ?? 1;
+            await Promise.all([
+                fetchDocuments(collectionName, currentPage),
+                fetchStats()
+            ]);
+        } catch (err) {
+            pushToast({
+                tone: 'danger',
+                title: 'Save failed',
+                description: err instanceof Error ? err.message : 'Unknown error'
+            });
+        } finally {
+            setSavingDocument(false);
+        }
+    }, [token, editDraft, pushToast, documents?.page, fetchDocuments, fetchStats]);
+
+    const deleteDocument = useCallback(async (collectionName: string, documentId: string) => {
+        if (!token) return;
+
+        const confirmed = typeof window !== 'undefined'
+            ? window.confirm(
+                `Delete document ${documentId} from "${collectionName}"?\n\nThis cannot be undone.`
+            )
+            : false;
+        if (!confirmed) return;
+
+        setDeletingDocumentId(documentId);
+        try {
+            const response = await fetch(
+                `/api/admin/database/collections/${collectionName}/documents/${encodeURIComponent(documentId)}`,
+                {
+                    method: 'DELETE',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'x-admin-token': token
+                    }
+                }
+            );
+
+            if (!response.ok) {
+                const body = await response.json().catch(() => ({}));
+                throw new Error(body?.message || body?.error || `Delete failed: ${response.statusText}`);
+            }
+
+            pushToast({
+                tone: 'success',
+                title: 'Document deleted',
+                description: `Removed ${documentId} from ${collectionName}`
+            });
+
+            if (expandedDocumentId === documentId) setExpandedDocumentId(null);
+
+            // Refresh the current page of documents and the top-level counts.
+            const currentPage = documents?.page ?? 1;
+            await Promise.all([
+                fetchDocuments(collectionName, currentPage),
+                fetchStats()
+            ]);
+        } catch (err) {
+            pushToast({
+                tone: 'danger',
+                title: 'Delete failed',
+                description: err instanceof Error ? err.message : 'Unknown error'
+            });
+        } finally {
+            setDeletingDocumentId(null);
+        }
+    }, [token, pushToast, expandedDocumentId, documents?.page, fetchDocuments, fetchStats]);
 
     const formatBytes = (bytes: number): string => {
         if (bytes === 0) return '0 B';
@@ -174,7 +333,7 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
             <Card padding="lg">
                 <h3 className={styles.section_title}>Collections</h3>
                 <div className={styles.collections}>
-                    {stats.collections.map(collection => (
+                    {[...stats.collections].sort((a, b) => a.name.localeCompare(b.name)).map(collection => (
                         <div key={collection.name} className={styles.collection_item}>
                             <button
                                 className={styles.collection_header}
@@ -228,16 +387,117 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
                                                 </div>
                                             </div>
                                             <div className={styles.documents_list}>
-                                                {documents.documents.map((doc, index) => (
-                                                    <details key={doc._id || index} className={styles.document}>
-                                                        <summary className={styles.document_summary}>
-                                                            <code>_id: {String(doc._id)}</code>
-                                                        </summary>
-                                                        <pre className={styles.document_json}>
-                                                            {JSON.stringify(doc, null, 2)}
-                                                        </pre>
-                                                    </details>
-                                                ))}
+                                                <Table variant="compact">
+                                                    <Thead>
+                                                        <Tr>
+                                                            <Th width="shrink" aria-label="Expand" />
+                                                            <Th>_id</Th>
+                                                            <Th>createdAt</Th>
+                                                            <Th>updatedAt</Th>
+                                                            <Th width="shrink" aria-label="Actions" />
+                                                        </Tr>
+                                                    </Thead>
+                                                    <Tbody>
+                                                        {documents.documents.map((doc, index) => {
+                                                            const docId = String(doc._id ?? index);
+                                                            const isOpen = expandedDocumentId === docId;
+                                                            return (
+                                                                <Fragment key={docId}>
+                                                                    <Tr
+                                                                        isExpanded={isOpen}
+                                                                        onClick={() => toggleDocument(docId)}
+                                                                        className={styles.document_row}
+                                                                    >
+                                                                        <Td muted>
+                                                                            {isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                                                                        </Td>
+                                                                        <Td>
+                                                                            <code className={styles.document_id}>{String(doc._id)}</code>
+                                                                        </Td>
+                                                                        <Td muted>
+                                                                            {doc.createdAt
+                                                                                ? <ClientTime date={doc.createdAt} format="short" />
+                                                                                : '—'}
+                                                                        </Td>
+                                                                        <Td muted>
+                                                                            {doc.updatedAt
+                                                                                ? <ClientTime date={doc.updatedAt} format="short" />
+                                                                                : '—'}
+                                                                        </Td>
+                                                                        <Td>
+                                                                            <div className={styles.row_actions} onClick={(e) => e.stopPropagation()}>
+                                                                                <CopyButton
+                                                                                    value={JSON.stringify(doc, null, 2)}
+                                                                                    ariaLabel="Copy document JSON"
+                                                                                />
+                                                                                <Button
+                                                                                    variant="ghost"
+                                                                                    size="sm"
+                                                                                    icon={<Pencil size={16} />}
+                                                                                    aria-label="Edit document"
+                                                                                    onClick={() => startEditingDocument(doc, docId)}
+                                                                                />
+                                                                                <Button
+                                                                                    variant="ghost"
+                                                                                    size="sm"
+                                                                                    icon={<Trash2 size={16} />}
+                                                                                    aria-label="Delete document"
+                                                                                    loading={deletingDocumentId === docId}
+                                                                                    onClick={() => void deleteDocument(collection.name, docId)}
+                                                                                />
+                                                                            </div>
+                                                                        </Td>
+                                                                    </Tr>
+                                                                    {isOpen && (
+                                                                        <Tr className={styles.document_detail_row}>
+                                                                            <Td colSpan={5}>
+                                                                                {editingDocumentId === docId ? (
+                                                                                    <div
+                                                                                        className={styles.document_editor}
+                                                                                        onClick={(e) => e.stopPropagation()}
+                                                                                    >
+                                                                                        <textarea
+                                                                                            className={styles.document_textarea}
+                                                                                            value={editDraft}
+                                                                                            onChange={(e) => setEditDraft(e.target.value)}
+                                                                                            spellCheck={false}
+                                                                                            aria-label="Edit document JSON"
+                                                                                            rows={16}
+                                                                                        />
+                                                                                        <div className={styles.document_editor_toolbar}>
+                                                                                            <Button
+                                                                                                variant="ghost"
+                                                                                                size="sm"
+                                                                                                icon={<X size={16} />}
+                                                                                                onClick={cancelEditingDocument}
+                                                                                                disabled={savingDocument}
+                                                                                            >
+                                                                                                Cancel
+                                                                                            </Button>
+                                                                                            <Button
+                                                                                                variant="primary"
+                                                                                                size="sm"
+                                                                                                icon={<Save size={16} />}
+                                                                                                loading={savingDocument}
+                                                                                                onClick={() => void saveDocumentEdit(collection.name, docId)}
+                                                                                            >
+                                                                                                Save
+                                                                                            </Button>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                ) : (
+                                                                                    <pre className={styles.document_json}>
+                                                                                        {JSON.stringify(doc, null, 2)}
+                                                                                    </pre>
+                                                                                )}
+                                                                            </Td>
+                                                                        </Tr>
+                                                                    )}
+                                                                </Fragment>
+                                                            );
+                                                        })}
+                                                    </Tbody>
+                                                </Table>
                                             </div>
                                         </>
                                     ) : (

--- a/src/frontend/app/(core)/system/database/components/CollectionBrowser.tsx
+++ b/src/frontend/app/(core)/system/database/components/CollectionBrowser.tsx
@@ -12,7 +12,7 @@
  * - Document viewing enables quick debugging and data verification
  */
 
-import { useState, useEffect, useCallback, Fragment } from 'react';
+import { useState, useEffect, useCallback, useMemo, Fragment } from 'react';
 import { Card } from '../../../../../components/ui/Card';
 import { Button } from '../../../../../components/ui/Button';
 import { Badge } from '../../../../../components/ui/Badge';
@@ -20,7 +20,7 @@ import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Ta
 import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { CopyButton } from '../../../../../components/ui/CopyButton';
 import { useToast } from '../../../../../components/ui/ToastProvider/ToastProvider';
-import { Database, ChevronDown, ChevronRight, FileText, Trash2, Pencil, Save, X } from 'lucide-react';
+import { Database, ChevronDown, ChevronRight, FileText, Trash2 } from 'lucide-react';
 import styles from './CollectionBrowser.module.css';
 
 interface ICollectionStat {
@@ -60,9 +60,6 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
     const [loadingDocuments, setLoadingDocuments] = useState(false);
     const [expandedDocumentId, setExpandedDocumentId] = useState<string | null>(null);
     const [deletingDocumentId, setDeletingDocumentId] = useState<string | null>(null);
-    const [editingDocumentId, setEditingDocumentId] = useState<string | null>(null);
-    const [editDraft, setEditDraft] = useState<string>('');
-    const [savingDocument, setSavingDocument] = useState(false);
     const { push: pushToast } = useToast();
 
     const fetchStats = useCallback(async () => {
@@ -125,8 +122,6 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
 
     const toggleCollection = (collectionName: string) => {
         setExpandedDocumentId(null);
-        setEditingDocumentId(null);
-        setEditDraft('');
         if (expandedCollection === collectionName) {
             setExpandedCollection(null);
             setDocuments(null);
@@ -137,97 +132,8 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
     };
 
     const toggleDocument = (documentId: string) => {
-        setExpandedDocumentId(prev => {
-            if (prev === documentId) {
-                // Collapsing: drop any in-progress edit for this row.
-                if (editingDocumentId === documentId) {
-                    setEditingDocumentId(null);
-                    setEditDraft('');
-                }
-                return null;
-            }
-            return documentId;
-        });
+        setExpandedDocumentId(prev => (prev === documentId ? null : documentId));
     };
-
-    const startEditingDocument = useCallback((doc: any, documentId: string) => {
-        setEditingDocumentId(documentId);
-        setEditDraft(JSON.stringify(doc, null, 2));
-        setExpandedDocumentId(documentId);
-    }, []);
-
-    const cancelEditingDocument = useCallback(() => {
-        setEditingDocumentId(null);
-        setEditDraft('');
-    }, []);
-
-    const saveDocumentEdit = useCallback(async (collectionName: string, documentId: string) => {
-        if (!token) return;
-
-        let parsed: any;
-        try {
-            parsed = JSON.parse(editDraft);
-        } catch (err) {
-            pushToast({
-                tone: 'danger',
-                title: 'Invalid JSON',
-                description: err instanceof Error ? err.message : 'Document must be valid JSON'
-            });
-            return;
-        }
-
-        if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-            pushToast({
-                tone: 'danger',
-                title: 'Invalid JSON',
-                description: 'Document must be a JSON object'
-            });
-            return;
-        }
-
-        setSavingDocument(true);
-        try {
-            const response = await fetch(
-                `/api/admin/database/collections/${collectionName}/documents/${encodeURIComponent(documentId)}`,
-                {
-                    method: 'PUT',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'x-admin-token': token
-                    },
-                    body: JSON.stringify({ document: parsed })
-                }
-            );
-
-            if (!response.ok) {
-                const body = await response.json().catch(() => ({}));
-                throw new Error(body?.message || body?.error || `Save failed: ${response.statusText}`);
-            }
-
-            pushToast({
-                tone: 'success',
-                title: 'Document saved',
-                description: `Updated ${documentId} in ${collectionName}`
-            });
-
-            setEditingDocumentId(null);
-            setEditDraft('');
-
-            const currentPage = documents?.page ?? 1;
-            await Promise.all([
-                fetchDocuments(collectionName, currentPage),
-                fetchStats()
-            ]);
-        } catch (err) {
-            pushToast({
-                tone: 'danger',
-                title: 'Save failed',
-                description: err instanceof Error ? err.message : 'Unknown error'
-            });
-        } finally {
-            setSavingDocument(false);
-        }
-    }, [token, editDraft, pushToast, documents?.page, fetchDocuments, fetchStats]);
 
     const deleteDocument = useCallback(async (collectionName: string, documentId: string) => {
         if (!token) return;
@@ -290,6 +196,11 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
         return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
     };
 
+    const sortedCollections = useMemo(
+        () => [...(stats?.collections ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
+        [stats?.collections]
+    );
+
     if (loading) {
         return (
             <Card>
@@ -333,7 +244,7 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
             <Card padding="lg">
                 <h3 className={styles.section_title}>Collections</h3>
                 <div className={styles.collections}>
-                    {[...stats.collections].sort((a, b) => a.name.localeCompare(b.name)).map(collection => (
+                    {sortedCollections.map(collection => (
                         <div key={collection.name} className={styles.collection_item}>
                             <button
                                 className={styles.collection_header}
@@ -399,20 +310,23 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
                                                     </Thead>
                                                     <Tbody>
                                                         {documents.documents.map((doc, index) => {
-                                                            const docId = String(doc._id ?? index);
-                                                            const isOpen = expandedDocumentId === docId;
+                                                            // Only documents with a real _id can be addressed by the API.
+                                                            // Rows without _id render view-only with delete disabled.
+                                                            const docId = doc._id != null ? String(doc._id) : null;
+                                                            const rowKey = docId ?? `__row_${index}`;
+                                                            const isOpen = expandedDocumentId === rowKey;
                                                             return (
-                                                                <Fragment key={docId}>
+                                                                <Fragment key={rowKey}>
                                                                     <Tr
                                                                         isExpanded={isOpen}
-                                                                        onClick={() => toggleDocument(docId)}
+                                                                        onClick={() => toggleDocument(rowKey)}
                                                                         className={styles.document_row}
                                                                     >
                                                                         <Td muted>
                                                                             {isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
                                                                         </Td>
                                                                         <Td>
-                                                                            <code className={styles.document_id}>{String(doc._id)}</code>
+                                                                            <code className={styles.document_id}>{docId ?? '—'}</code>
                                                                         </Td>
                                                                         <Td muted>
                                                                             {doc.createdAt
@@ -433,17 +347,11 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
                                                                                 <Button
                                                                                     variant="ghost"
                                                                                     size="sm"
-                                                                                    icon={<Pencil size={16} />}
-                                                                                    aria-label="Edit document"
-                                                                                    onClick={() => startEditingDocument(doc, docId)}
-                                                                                />
-                                                                                <Button
-                                                                                    variant="ghost"
-                                                                                    size="sm"
                                                                                     icon={<Trash2 size={16} />}
-                                                                                    aria-label="Delete document"
-                                                                                    loading={deletingDocumentId === docId}
-                                                                                    onClick={() => void deleteDocument(collection.name, docId)}
+                                                                                    aria-label={docId ? 'Delete document' : 'Delete unavailable: document has no _id'}
+                                                                                    disabled={!docId}
+                                                                                    loading={docId !== null && deletingDocumentId === docId}
+                                                                                    onClick={() => docId && void deleteDocument(collection.name, docId)}
                                                                                 />
                                                                             </div>
                                                                         </Td>
@@ -451,45 +359,9 @@ export function CollectionBrowser({ token }: CollectionBrowserProps) {
                                                                     {isOpen && (
                                                                         <Tr className={styles.document_detail_row}>
                                                                             <Td colSpan={5}>
-                                                                                {editingDocumentId === docId ? (
-                                                                                    <div
-                                                                                        className={styles.document_editor}
-                                                                                        onClick={(e) => e.stopPropagation()}
-                                                                                    >
-                                                                                        <textarea
-                                                                                            className={styles.document_textarea}
-                                                                                            value={editDraft}
-                                                                                            onChange={(e) => setEditDraft(e.target.value)}
-                                                                                            spellCheck={false}
-                                                                                            aria-label="Edit document JSON"
-                                                                                            rows={16}
-                                                                                        />
-                                                                                        <div className={styles.document_editor_toolbar}>
-                                                                                            <Button
-                                                                                                variant="ghost"
-                                                                                                size="sm"
-                                                                                                icon={<X size={16} />}
-                                                                                                onClick={cancelEditingDocument}
-                                                                                                disabled={savingDocument}
-                                                                                            >
-                                                                                                Cancel
-                                                                                            </Button>
-                                                                                            <Button
-                                                                                                variant="primary"
-                                                                                                size="sm"
-                                                                                                icon={<Save size={16} />}
-                                                                                                loading={savingDocument}
-                                                                                                onClick={() => void saveDocumentEdit(collection.name, docId)}
-                                                                                            >
-                                                                                                Save
-                                                                                            </Button>
-                                                                                        </div>
-                                                                                    </div>
-                                                                                ) : (
-                                                                                    <pre className={styles.document_json}>
-                                                                                        {JSON.stringify(doc, null, 2)}
-                                                                                    </pre>
-                                                                                )}
+                                                                                <pre className={styles.document_json}>
+                                                                                    {JSON.stringify(doc, null, 2)}
+                                                                                </pre>
                                                                             </Td>
                                                                         </Tr>
                                                                     )}

--- a/src/frontend/components/ui/CopyButton/CopyButton.tsx
+++ b/src/frontend/components/ui/CopyButton/CopyButton.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+import { Button, type ButtonProps } from '../Button/Button';
+
+interface CopyButtonProps extends Omit<ButtonProps, 'icon' | 'onClick' | 'children' | 'loading'> {
+    /**
+     * The string value placed on the system clipboard when clicked.
+     */
+    value: string;
+    /**
+     * Label shown next to the icon. When omitted, only the icon renders.
+     */
+    label?: string;
+    /**
+     * Label shown during the brief confirmation window after a successful copy.
+     * @default 'Copied'
+     */
+    copiedLabel?: string;
+    /**
+     * How long the confirmation state persists before reverting, in milliseconds.
+     * @default 1500
+     */
+    resetMs?: number;
+    /**
+     * Accessible label when no visible text is shown.
+     * @default 'Copy to clipboard'
+     */
+    ariaLabel?: string;
+}
+
+/**
+ * CopyButton writes its `value` to the system clipboard on click and swaps
+ * its icon/label to a confirmation state for a brief window. Falls back to
+ * a textarea-based execCommand path when the async clipboard API is
+ * unavailable (older browsers / non-secure contexts).
+ */
+export function CopyButton({
+    value,
+    label,
+    copiedLabel = 'Copied',
+    resetMs = 1500,
+    ariaLabel = 'Copy to clipboard',
+    variant = 'ghost',
+    size = 'sm',
+    ...rest
+}: CopyButtonProps) {
+    const [copied, setCopied] = useState(false);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => () => {
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    }, []);
+
+    const handleCopy = useCallback(async (event: React.MouseEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+        try {
+            if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+                await navigator.clipboard.writeText(value);
+            } else {
+                const textarea = document.createElement('textarea');
+                textarea.value = value;
+                textarea.setAttribute('readonly', '');
+                textarea.style.position = 'absolute';
+                textarea.style.left = '-9999px';
+                document.body.appendChild(textarea);
+                textarea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textarea);
+            }
+            setCopied(true);
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+            timeoutRef.current = setTimeout(() => setCopied(false), resetMs);
+        } catch {
+            setCopied(false);
+        }
+    }, [value, resetMs]);
+
+    const iconSize = size === 'lg' ? 18 : 16;
+    const icon = copied ? <Check size={iconSize} /> : <Copy size={iconSize} />;
+    const visibleLabel = label !== undefined ? (copied ? copiedLabel : label) : undefined;
+    const resolvedAriaLabel = label !== undefined ? undefined : (copied ? copiedLabel : ariaLabel);
+
+    return (
+        <Button
+            variant={variant}
+            size={size}
+            icon={icon}
+            onClick={handleCopy}
+            aria-label={resolvedAriaLabel}
+            {...rest}
+        >
+            {visibleLabel ?? ''}
+        </Button>
+    );
+}

--- a/src/frontend/components/ui/CopyButton/CopyButton.tsx
+++ b/src/frontend/components/ui/CopyButton/CopyButton.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react';
 import { Check, Copy } from 'lucide-react';
-import { Button, type ButtonProps } from '../Button/Button';
+import { Button, type ButtonProps } from '../Button';
 
 interface CopyButtonProps extends Omit<ButtonProps, 'icon' | 'onClick' | 'children' | 'loading'> {
     /**
@@ -53,7 +53,7 @@ export function CopyButton({
         if (timeoutRef.current) clearTimeout(timeoutRef.current);
     }, []);
 
-    const handleCopy = useCallback(async (event: React.MouseEvent<HTMLButtonElement>) => {
+    const handleCopy = useCallback(async (event: MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
         try {
             if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {

--- a/src/frontend/components/ui/CopyButton/index.ts
+++ b/src/frontend/components/ui/CopyButton/index.ts
@@ -1,0 +1,1 @@
+export { CopyButton } from './CopyButton';


### PR DESCRIPTION
## Summary
- Add `DELETE` and `PUT` endpoints under `/api/admin/database/collections/:name/documents/:id` (admin-authenticated, single-document scope)
- Wire `CollectionBrowser` to edit a document via a JSON editor and delete it with confirmation
- Introduce shared `CopyButton` component and index the new `ui-components` doc