### PR TITLE
Polish database browser and use estimated count for totals

### DIFF
--- a/src/backend/modules/database/repositories/database-browser.repository.ts
+++ b/src/backend/modules/database/repositories/database-browser.repository.ts
@@ -154,8 +154,8 @@ export class DatabaseBrowserRepository {
             .limit(limit)
             .toArray();
 
-        // Get total count
-        const total = await collection.countDocuments({});
+        // Get total count (estimated — uses collection metadata, avoids full scan on large collections)
+        const total = await collection.estimatedDocumentCount();
 
         // Calculate pagination metadata
         const totalPages = Math.ceil(total / limit);

--- a/src/frontend/app/(core)/system/database/DatabaseHealthCards.module.css
+++ b/src/frontend/app/(core)/system/database/DatabaseHealthCards.module.css
@@ -8,6 +8,8 @@
  */
 
 .section {
+    container-type: inline-size;
+    container-name: db-health-section;
     background: var(--color-surface);
     border: var(--border-width-thin) solid var(--color-border);
     border-radius: var(--radius-lg);
@@ -135,5 +137,32 @@
 @container health-cards (min-width: 501px) and (max-width: 800px) {
     .cards {
         grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+/* Tighten section spacing below mobile breakpoint (768px) */
+@container db-health-section (max-width: 768px) {
+    .section {
+        padding: var(--spacing-5);
+        margin-bottom: var(--spacing-5);
+        border-radius: var(--radius-md);
+    }
+
+    .section_header {
+        margin-bottom: var(--spacing-5);
+        gap: var(--spacing-3);
+    }
+
+    .cards {
+        gap: var(--spacing-3);
+    }
+
+    .card {
+        padding: var(--spacing-5);
+        gap: var(--spacing-4);
+    }
+
+    .loading {
+        padding: var(--spacing-5);
     }
 }

--- a/src/frontend/app/(core)/system/database/components/CollectionBrowser.module.css
+++ b/src/frontend/app/(core)/system/database/components/CollectionBrowser.module.css
@@ -185,19 +185,66 @@
 }
 
 /* Responsive adjustments */
-@container browser (max-width: 600px) {
+@container browser (max-width: 768px) {
+    .browser {
+        gap: var(--spacing-5);
+    }
+
+    .overview {
+        gap: var(--spacing-4);
+        padding: var(--spacing-3) 0;
+    }
+
+    .overview_subtitle {
+        margin: var(--spacing-1) 0 0;
+    }
+
+    .section_title {
+        margin: 0 0 var(--spacing-5);
+    }
+
     .collection_header {
         flex-wrap: wrap;
+        padding: var(--spacing-4);
+        gap: var(--spacing-3);
     }
 
     .collection_stats {
         width: 100%;
         justify-content: flex-start;
         margin-top: var(--spacing-3);
+        gap: var(--spacing-2);
+    }
+
+    .documents_panel {
+        padding: var(--spacing-4);
     }
 
     .documents_header {
         flex-direction: column;
         align-items: flex-start;
+        margin-bottom: var(--spacing-5);
+        padding-bottom: var(--spacing-3);
+        gap: var(--spacing-3);
+    }
+
+    .pagination {
+        gap: var(--spacing-3);
+    }
+
+    .page_info {
+        padding: 0 var(--spacing-3);
+    }
+
+    .row_actions {
+        gap: var(--spacing-2);
+    }
+
+    .document_json {
+        padding: var(--spacing-3) var(--spacing-4);
+    }
+
+    .loading {
+        padding: var(--spacing-5);
     }
 }

--- a/src/frontend/app/(core)/system/database/page.module.css
+++ b/src/frontend/app/(core)/system/database/page.module.css
@@ -338,44 +338,85 @@
 /* Container Queries for Responsiveness */
 @container (max-width: 768px) {
     .header {
-        gap: var(--spacing-7);
+        gap: var(--spacing-5);
     }
 
     .header_info {
         flex-direction: column;
         align-items: flex-start;
+        gap: var(--spacing-4);
+    }
+
+    .header_subtitle {
+        margin: var(--spacing-2) 0 0;
     }
 
     .header_stats {
         grid-template-columns: repeat(3, 1fr);
+        gap: var(--spacing-4);
     }
 
     .header_actions {
         flex-direction: column;
         width: 100%;
+        gap: var(--spacing-3);
     }
 
     .header_actions > * {
         width: 100%;
     }
 
+    .section_title {
+        margin: 0 0 var(--spacing-5) 0;
+    }
+
+    .empty_state {
+        padding: var(--spacing-7) var(--spacing-4);
+    }
+
+    .empty_icon {
+        margin-bottom: var(--spacing-3);
+    }
+
+    .pending_groups {
+        gap: var(--spacing-5);
+    }
+
+    .group_header {
+        padding: var(--spacing-5) var(--spacing-4);
+    }
+
     .migration_row {
         flex-direction: column;
         align-items: flex-start;
+        gap: var(--spacing-3);
+        padding: var(--spacing-4);
+    }
+
+    .migration_info {
+        gap: var(--spacing-2);
+    }
+
+    .migration_deps {
+        margin-top: var(--spacing-1);
     }
 
     .history_header {
         flex-direction: column;
         align-items: flex-start;
+        gap: var(--spacing-4);
+        margin-bottom: var(--spacing-5);
     }
 
     .filters {
         width: 100%;
         flex-direction: column;
+        gap: var(--spacing-3);
     }
 
     .filter_select {
         width: 100%;
+        padding: var(--spacing-3) var(--spacing-4);
     }
 
     .table {
@@ -384,6 +425,18 @@
 
     .table th,
     .table td {
+        padding: var(--spacing-3);
+    }
+
+    .error_details {
         padding: var(--spacing-4);
+    }
+
+    .error_message {
+        margin: 0 0 var(--spacing-2) 0;
+    }
+
+    .error_stack {
+        padding: var(--spacing-3);
     }
 }


### PR DESCRIPTION
## Summary

- Swaps `countDocuments({})` for `estimatedDocumentCount()` in `DatabaseBrowserRepository` so listing a collection doesn't full-scan on large collections. The total and pagination metadata are the only consumers; both tolerate the small inaccuracy estimated counts can return in exchange for O(1) metadata lookup.
- Styling refresh across the database admin surface: `DatabaseHealthCards`, `CollectionBrowser`, and the database page module.