### PR TITLE
Use estimatedDocumentCount for unfiltered DB browser pagination

### DIFF
--- a/src/backend/modules/database/repositories/database-browser.repository.ts
+++ b/src/backend/modules/database/repositories/database-browser.repository.ts
@@ -154,8 +154,8 @@ export class DatabaseBrowserRepository {
             .limit(limit)
             .toArray();
 
-        // Get total count
-        const total = await collection.countDocuments({});
+        // Get total count (estimated — uses collection metadata, avoids full scan on large collections)
+        const total = await collection.estimatedDocumentCount();
 
         // Calculate pagination metadata
         const totalPages = Math.ceil(total / limit);


### PR DESCRIPTION
## Summary

Swaps `countDocuments({})` for `estimatedDocumentCount()` in `DatabaseBrowserRepository.listDocuments()` so paginated browsing of large collections reads the collection metadata instead of scanning every document.

The filtered `queryDocuments()` path still uses `countDocuments(filter)` since `estimatedDocumentCount` does not accept a filter argument.