### PR TITLE
Fix admin nav overflow ellipsis collapse

### DIFF
--- a/src/frontend/app/(core)/system/layout.module.css
+++ b/src/frontend/app/(core)/system/layout.module.css
@@ -67,7 +67,6 @@
     align-items: center;
     justify-content: space-between;
     gap: var(--spacing-5);
-    flex-wrap: wrap;
 }
 
 .layout_section {

--- a/src/frontend/app/(core)/system/layout.module.css
+++ b/src/frontend/app/(core)/system/layout.module.css
@@ -58,6 +58,7 @@
 
 .layout_content {
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     gap: var(--spacing-12);
 }
 


### PR DESCRIPTION
## Summary

`.layout_content` had no explicit `grid-template-columns`, so its implicit track sized to the widest child's `min-content`. On `/system/config` the admin content forces that track to ~1483px — wider than `<main>`'s 1200px cap. The `<nav>` inherits that width via `flex: 1; min-width: 0`, so PriorityNav's IntersectionObserver sees all items fitting and never collapses overflow into the "More" ellipsis.

Setting `grid-template-columns: minmax(0, 1fr)` caps the track at the container width so the nav row can't push wider than `<main>`.

## Why it surfaced now

Latent bug. Commit b79fd60 folded the admin Logout into the nav as a trailing item, pushing total count from 14 to 15 tabs. The nav was already overflowing silently — the ellipsis simply never triggered because the grid kept expanding the nav row to fit all tabs.

## Verified live

Injected the same CSS into running prod at `/system/config`:
- 1366px viewport: 4 items collapse into More menu
- 500px viewport: 11 of 15 items collapse, More button visible