### PR TITLE
Add IconButton + Switch primitives; extend Button/Badge variants

### DIFF
--- a/docs/frontend/ui/ui-components.md
+++ b/docs/frontend/ui/ui-components.md
@@ -33,14 +33,16 @@ Source: [components/ui/](../../../src/frontend/components/ui/). Each folder expo
 
 | Component | Purpose | Key Props | Source |
 |-----------|---------|-----------|--------|
-| `<Badge>` | Inline status/label pill | `tone="neutral\|success\|warning\|danger"`, `showLiveIndicator` | [Badge](../../../src/frontend/components/ui/Badge/) |
-| `<Button>` | Primary interactive button | `variant="primary\|secondary\|ghost\|danger"`, `size`, `icon`, `loading` | [Button](../../../src/frontend/components/ui/Button/) |
+| `<Badge>` | Inline status/label pill | `tone="neutral\|info\|success\|warning\|danger"`, `showLiveIndicator` | [Badge](../../../src/frontend/components/ui/Badge/) |
+| `<Button>` | Primary interactive button with text label | `variant="primary\|secondary\|ghost\|danger\|warning"`, `size="xs\|sm\|md\|lg"`, `icon`, `loading` | [Button](../../../src/frontend/components/ui/Button/) |
 | `<Card>` | Content surface with padding, elevation, and tone | `padding="sm\|md\|lg"`, `elevated`, `tone`, `noBackgroundImage` | [Card](../../../src/frontend/components/ui/Card/) |
 | `<ClientTime>` | Timezone-safe timestamp renderer; SSR-safe placeholder until hydration | `date`, `format="time\|datetime\|date\|relative\|short"`, `fallback` | [ClientTime](../../../src/frontend/components/ui/ClientTime.tsx) |
 | `<CopyButton>` | Copy-to-clipboard button with `Copy → Check` confirmation and non-secure-context fallback | `value`, `label`, `copiedLabel`, `resetMs`, `ariaLabel` + `ButtonProps` | [CopyButton](../../../src/frontend/components/ui/CopyButton/) |
+| `<IconButton>` | Borderless icon-only button for inline row actions (edit, delete, copy in dense tables/headers). Use when `<Button>` chrome would dominate. | `variant="ghost\|primary\|danger\|success"`, `size="sm\|md\|lg"`, required `aria-label` | [IconButton](../../../src/frontend/components/ui/IconButton/) |
 | `<Input>` | Text input with focus ring | `variant="default\|ghost"` + all `InputHTMLAttributes` | [Input](../../../src/frontend/components/ui/Input/) |
 | `<Pagination>` | Page navigation with sibling-count windowing | `total`, `pageSize`, `currentPage`, `siblingCount`, `onPageChange` | [Pagination](../../../src/frontend/components/ui/Pagination/) |
 | `<Skeleton>` | Shimmer placeholder for loading content | All `HTMLDivAttributes` (style for size) | [Skeleton](../../../src/frontend/components/ui/Skeleton/) |
+| `<Switch>` | Icon-rendered on/off toggle for row-level boolean controls (enable flag, tool on/off). Color + icon are state-driven; `role="switch"` + `aria-checked` set automatically. | `on`, `onChange`, `size="sm\|md\|lg"`, required `aria-label` | [Switch](../../../src/frontend/components/ui/Switch/) |
 | `<Table>` + `Thead` / `Tbody` / `Tr` / `Th` / `Td` | Styled table primitives with `variant="default\|compact"`, `isExpanded`, `hasError` row states, and `width="auto\|shrink\|expand"` cells | | [Table](../../../src/frontend/components/ui/Table/) |
 | `<Tooltip>` | Hover tooltip with `placement="top\|bottom"` | `content`, `placement` | [Tooltip](../../../src/frontend/components/ui/Tooltip/) |
 | `<IconPickerModal>` | Searchable Lucide icon picker rendered inside the ModalProvider | `onSelect`, `onClose`, `initialIcon` | [IconPickerModal](../../../src/frontend/components/ui/IconPickerModal/) |

--- a/docs/frontend/ui/ui-design-token-layers.md
+++ b/docs/frontend/ui/ui-design-token-layers.md
@@ -86,6 +86,9 @@ Semantic tokens compose foundation tokens into meaningful, context-aware variabl
 **Usage:**
 Provide consistent theming for specific UI components. When you need dark mode, you remap semantic tokens (e.g., `--card-bg: var(--color-gray-900)`) without touching foundation tokens.
 
+**Size-variant convention:**
+Component-scoped semantic tokens that vary by density follow the `xs | sm | md | lg` suffix convention across the design system. Buttons expose `--button-padding-xs/sm/md/lg`, `--button-font-size-xs/sm/md/lg`, and `--button-height-xs/sm/md/lg`; cards expose `--card-padding-xs/sm/md/lg`; inputs expose `--input-padding` and `--input-padding-sm` (dense inline variant). When adding a new component-scoped density, extend the same four-step ladder rather than inventing a parallel scale — callers then pick the step that matches the visual weight they need, and responsive rules swap tokens instead of redefining them.
+
 ### Layer 3: Utility Classes (Application Layer)
 
 **File:** `globals.scss`

--- a/docs/frontend/ui/ui.md
+++ b/docs/frontend/ui/ui.md
@@ -39,6 +39,7 @@ Hardcoded values fragment the interface and prevent theming. Global CSS classes 
 | Typography | `--font-size-xs` through `--font-size-3xl`, `--font-weight-normal/medium/semibold/bold` |
 | Borders | `--border-width-thin`, `--radius-sm/md/lg/full` |
 | Shadows | `--shadow-sm/md/lg` |
+| Max Widths | `--max-width-xs` (320px) through `--max-width-xl` (1080px), plus `--max-width-prose` (64ch) |
 | Breakpoints | `$breakpoint-mobile-sm` (360px), `$breakpoint-mobile-md` (480px), `$breakpoint-mobile-lg` (768px), `$breakpoint-tablet` (1024px), `$breakpoint-desktop` (1200px) |
 
 ### SCSS Module Naming
@@ -57,8 +58,8 @@ Use underscores for multi-word identifiers to enable TypeScript dot notation:
 | Pattern | Class |
 |---------|-------|
 | Surface | `.surface`, `.surface--padding-sm/md/lg` |
-| Button | `.btn .btn--primary/secondary/ghost/danger .btn--sm/md/lg` |
-| Badge | `.badge .badge--neutral/success/warning/danger` |
+| Button | `.btn .btn--primary/secondary/ghost/danger/warning .btn--xs/sm/md/lg` |
+| Badge | `.badge .badge--neutral/info/success/warning/danger` |
 | Muted text | `.text-muted` |
 
 ### Icons

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -164,7 +164,14 @@ export interface IUIComponents {
      */
     IconButton: ComponentType<{
         children?: React.ReactNode;
-        onClick?: () => void;
+        /**
+         * Click handler with full event access. The event parameter is
+         * preserved (rather than narrowed to `() => void`) because this
+         * primitive is designed for inline row actions where plugin code
+         * commonly needs `event.stopPropagation()` to avoid firing an
+         * enclosing row's click handler.
+         */
+        onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
         disabled?: boolean;
         variant?: 'ghost' | 'primary' | 'danger' | 'success';
         size?: 'sm' | 'md' | 'lg';
@@ -184,10 +191,18 @@ export interface IUIComponents {
     Switch: ComponentType<{
         on: boolean;
         onChange: (next: boolean) => void;
+        /**
+         * Optional raw click handler. Runs before `onChange`; calling
+         * `event.preventDefault()` vetoes the toggle, and
+         * `event.stopPropagation()` keeps the click from reaching an
+         * enclosing row handler.
+         */
+        onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
         disabled?: boolean;
         size?: 'sm' | 'md' | 'lg';
         className?: string;
         title?: string;
+        type?: 'button' | 'submit' | 'reset';
         'aria-label': string;
     }>;
 

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -127,7 +127,7 @@ export interface IUIComponents {
     /** Badge component for labels and status indicators */
     Badge: ComponentType<{
         children?: React.ReactNode;
-        tone?: 'neutral' | 'success' | 'warning' | 'danger';
+        tone?: 'neutral' | 'info' | 'success' | 'warning' | 'danger';
         title?: string;
         className?: string;
     }>;
@@ -146,11 +146,49 @@ export interface IUIComponents {
         onClick?: () => void;
         disabled?: boolean;
         loading?: boolean;
-        variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
-        size?: 'sm' | 'md' | 'lg';
+        variant?: 'primary' | 'secondary' | 'ghost' | 'danger' | 'warning';
+        size?: 'xs' | 'sm' | 'md' | 'lg';
         icon?: React.ReactNode;
         className?: string;
         type?: 'button' | 'submit' | 'reset';
+        'aria-label'?: string;
+    }>;
+
+    /**
+     * IconButton — borderless icon-only button for inline row actions.
+     *
+     * Use when a bordered `<Button>` with an icon would visually dominate
+     * a dense row (table actions, response header copy, etc.). The hover
+     * color follows `variant`. `aria-label` is required because no visible
+     * text describes the action.
+     */
+    IconButton: ComponentType<{
+        children?: React.ReactNode;
+        onClick?: () => void;
+        disabled?: boolean;
+        variant?: 'ghost' | 'primary' | 'danger' | 'success';
+        size?: 'sm' | 'md' | 'lg';
+        className?: string;
+        title?: string;
+        type?: 'button' | 'submit' | 'reset';
+        'aria-label': string;
+    }>;
+
+    /**
+     * Switch — icon-rendered on/off toggle. Flips `on` state on click; the
+     * color + icon reflect current state (right+success when on, left+muted
+     * when off). Use for row-level boolean controls (tool enable/disable,
+     * feature flag, notification on/off). Carries `role="switch"` +
+     * `aria-checked` so assistive tech reads it as a toggle.
+     */
+    Switch: ComponentType<{
+        on: boolean;
+        onChange: (next: boolean) => void;
+        disabled?: boolean;
+        size?: 'sm' | 'md' | 'lg';
+        className?: string;
+        title?: string;
+        'aria-label': string;
     }>;
 
     /** Input component for form fields */

--- a/src/frontend/app/primitives.scss
+++ b/src/frontend/app/primitives.scss
@@ -153,6 +153,7 @@
 
     /* Max Width Tokens (for layout containers) */
     --max-width-prose: 64ch;     /* Readable text width */
+    --max-width-xs: 320px;       /* Narrow hint copy, empty-state labels */
     --max-width-sm: 420px;       /* Small modal */
     --max-width-md: 640px;       /* Medium modal */
     --max-width-lg: 820px;       /* Large modal */

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -32,6 +32,10 @@
                          border-color var(--transition-base);
 
     /* Button - Size Variants */
+    --button-height-xs: 26px;
+    --button-padding-xs: var(--spacing-1) var(--spacing-3);  /* 0.25rem 0.4rem */
+    --button-font-size-xs: var(--font-size-xs);              /* 0.72rem */
+
     --button-height-sm: 34px;
     --button-padding-sm: var(--spacing-3) var(--spacing-6);  /* 0.4rem 0.85rem */
     --button-font-size-sm: var(--font-size-sm);              /* 0.85rem */
@@ -69,6 +73,12 @@
     --button-danger-color: #ffb3bb;
     --button-danger-border: rgba(255, 111, 125, 0.5);
 
+    /* Button - Warning Variant (caution actions short of destructive) */
+    --button-warning-background: rgba(255, 200, 87, 0.12);
+    --button-warning-background-hover: rgba(255, 200, 87, 0.2);
+    --button-warning-color: #ffe2a6;
+    --button-warning-border: rgba(255, 200, 87, 0.5);
+
     /* Button - State Modifiers */
     --button-loading-opacity: var(--opacity-75);
     --button-disabled-opacity: var(--opacity-55);
@@ -94,6 +104,36 @@
     --icon-button-border-radius: var(--radius-md);
     --icon-button-color: var(--color-text-muted);
     --icon-button-color-hover: var(--color-text);
+
+    /*
+     * Icon Button Bare — borderless, transparent icon-only button used for
+     * inline row actions (edit, delete, copy) where an outlined icon button
+     * would visually dominate. Color of the icon flips on hover based on the
+     * semantic tone of the action (primary / danger / success / text).
+     */
+    --icon-button-bare-padding-sm: calc(var(--spacing-1) * 0.5);
+    --icon-button-bare-padding-md: var(--spacing-1);
+    --icon-button-bare-padding-lg: var(--spacing-2);
+    --icon-button-bare-border-radius: var(--radius-sm);
+    --icon-button-bare-color: var(--color-text-muted);
+    --icon-button-bare-color-ghost-hover: var(--color-text);
+    --icon-button-bare-color-primary-hover: var(--color-primary);
+    --icon-button-bare-color-danger-hover: var(--color-danger);
+    --icon-button-bare-color-success-hover: var(--color-success);
+
+    /* ========================================================================
+     * SWITCH COMPONENT TOKENS
+     * Icon-rendered toggle for on/off state (tool enable, flag flip, etc.).
+     * Base color is state-driven (on = success, off = muted); the component
+     * deliberately has no hover-color change because the click flips state.
+     * ======================================================================== */
+
+    --switch-padding-sm: calc(var(--spacing-1) * 0.5);
+    --switch-padding-md: var(--spacing-1);
+    --switch-padding-lg: var(--spacing-2);
+    --switch-border-radius: var(--radius-sm);
+    --switch-on-color: var(--color-success);
+    --switch-off-color: var(--color-text-muted);
 
     /* ========================================================================
      * CARD COMPONENT TOKENS
@@ -162,6 +202,11 @@
     --badge-danger-color: #ffc1c8;
     --badge-danger-border: rgba(255, 111, 125, 0.45);
 
+    /* Badge - Info Variant (primary-tinted for active/in-progress status) */
+    --badge-info-background: rgba(79, 140, 255, 0.15);
+    --badge-info-color: #bcd7ff;
+    --badge-info-border: rgba(79, 140, 255, 0.4);
+
     /* ========================================================================
      * INPUT COMPONENT TOKENS
      * ======================================================================== */
@@ -171,6 +216,7 @@
     --input-border: var(--border-width-thin) solid rgba(110, 160, 255, 0.18);
     --input-border-radius: var(--radius-sm);
     --input-padding: var(--spacing-5) var(--spacing-7); /* 0.75rem 1rem */
+    --input-padding-sm: var(--spacing-1) var(--spacing-2); /* 0.25rem 0.35rem — dense filter/search/inline inputs */
     --input-font-size: 0.98rem;
     --input-transition: border-color var(--transition-base),
                         box-shadow var(--transition-base);

--- a/src/frontend/components/ui/Badge/Badge.module.css
+++ b/src/frontend/components/ui/Badge/Badge.module.css
@@ -52,6 +52,12 @@
     border-color: var(--badge-neutral-border);
 }
 
+.badge--info {
+    background: var(--badge-info-background);
+    color: var(--badge-info-color);
+    border-color: var(--badge-info-border);
+}
+
 .badge--success {
     background: var(--badge-success-background);
     color: var(--badge-success-color);

--- a/src/frontend/components/ui/Badge/Badge.tsx
+++ b/src/frontend/components/ui/Badge/Badge.tsx
@@ -13,7 +13,7 @@ interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
      * Visual tone variant for status indication
      * @default 'neutral'
      */
-    tone?: 'neutral' | 'success' | 'warning' | 'danger';
+    tone?: 'neutral' | 'info' | 'success' | 'warning' | 'danger';
 
     /**
      * Whether to display a pulsing red recording indicator dot before the badge content.
@@ -29,6 +29,7 @@ interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
  */
 const toneClass: Record<NonNullable<BadgeProps['tone']>, string> = {
     neutral: `${styles.badge} ${styles['badge--neutral']}`,
+    info: `${styles.badge} ${styles['badge--info']}`,
     success: `${styles.badge} ${styles['badge--success']}`,
     warning: `${styles.badge} ${styles['badge--warning']}`,
     danger: `${styles.badge} ${styles['badge--danger']}`

--- a/src/frontend/components/ui/Button/Button.module.css
+++ b/src/frontend/components/ui/Button/Button.module.css
@@ -61,6 +61,16 @@
     background: var(--button-danger-background-hover);
 }
 
+.btn--warning {
+    background: var(--button-warning-background);
+    color: var(--button-warning-color);
+    border-color: var(--button-warning-border);
+}
+
+.btn--warning:hover {
+    background: var(--button-warning-background-hover);
+}
+
 /* Focus State */
 .btn:focus-visible {
     outline: var(--focus-outline-width) solid var(--focus-outline-color);
@@ -69,6 +79,12 @@
 }
 
 /* Size Variants */
+.btn--xs {
+    min-height: var(--button-height-xs);
+    padding: var(--button-padding-xs);
+    font-size: var(--button-font-size-xs);
+}
+
 .btn--sm {
     min-height: var(--button-height-sm);
     padding: var(--button-padding-sm);

--- a/src/frontend/components/ui/Button/Button.tsx
+++ b/src/frontend/components/ui/Button/Button.tsx
@@ -4,8 +4,8 @@ import type { ButtonHTMLAttributes, PropsWithChildren, ReactNode } from 'react';
 import { cn } from '../../../lib/cn';
 import styles from './Button.module.css';
 
-type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
-type ButtonSize = 'sm' | 'md' | 'lg';
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'warning';
+type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 
 /**
  * ButtonProps interface defines the properties available for the Button component.
@@ -43,7 +43,8 @@ const variantClass: Record<ButtonVariant, string> = {
     primary: `${styles.btn} ${styles['btn--primary']}`,
     secondary: `${styles.btn} ${styles['btn--secondary']}`,
     ghost: `${styles.btn} ${styles['btn--ghost']}`,
-    danger: `${styles.btn} ${styles['btn--danger']}`
+    danger: `${styles.btn} ${styles['btn--danger']}`,
+    warning: `${styles.btn} ${styles['btn--warning']}`
 };
 
 /**
@@ -51,6 +52,7 @@ const variantClass: Record<ButtonVariant, string> = {
  * Controls the padding, height, and font size of the button.
  */
 const sizeClass: Record<ButtonSize, string> = {
+    xs: styles['btn--xs'],
     sm: styles['btn--sm'],
     md: styles['btn--md'],
     lg: styles['btn--lg']

--- a/src/frontend/components/ui/IconButton/IconButton.module.css
+++ b/src/frontend/components/ui/IconButton/IconButton.module.css
@@ -1,0 +1,61 @@
+/**
+ * IconButton Component CSS Module
+ *
+ * Bare icon-only button styling. Consumes semantic tokens so theme overrides
+ * cascade automatically.
+ */
+
+.icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--icon-button-bare-padding-md);
+    background: none;
+    border: none;
+    border-radius: var(--icon-button-bare-border-radius);
+    color: var(--icon-button-bare-color);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: color var(--transition-base);
+}
+
+.icon-btn:disabled {
+    opacity: var(--opacity-50);
+    cursor: not-allowed;
+}
+
+.icon-btn:focus-visible {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: var(--focus-outline-offset);
+    box-shadow: var(--focus-shadow);
+}
+
+/* Size Variants (padding only; caller controls icon size) */
+.icon-btn--sm {
+    padding: var(--icon-button-bare-padding-sm);
+}
+
+.icon-btn--md {
+    padding: var(--icon-button-bare-padding-md);
+}
+
+.icon-btn--lg {
+    padding: var(--icon-button-bare-padding-lg);
+}
+
+/* Hover color variants */
+.icon-btn--ghost:hover:not(:disabled) {
+    color: var(--icon-button-bare-color-ghost-hover);
+}
+
+.icon-btn--primary:hover:not(:disabled) {
+    color: var(--icon-button-bare-color-primary-hover);
+}
+
+.icon-btn--danger:hover:not(:disabled) {
+    color: var(--icon-button-bare-color-danger-hover);
+}
+
+.icon-btn--success:hover:not(:disabled) {
+    color: var(--icon-button-bare-color-success-hover);
+}

--- a/src/frontend/components/ui/IconButton/IconButton.tsx
+++ b/src/frontend/components/ui/IconButton/IconButton.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import type { ButtonHTMLAttributes, PropsWithChildren } from 'react';
+import { cn } from '../../../lib/cn';
+import styles from './IconButton.module.css';
+
+type IconButtonVariant = 'ghost' | 'primary' | 'danger' | 'success';
+type IconButtonSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Icon-only button primitive for inline row actions (edit, delete, copy) where
+ * a bordered `<Button>` would visually dominate. Renders with no background
+ * and no border by default; the icon color flips on hover according to the
+ * chosen tone.
+ *
+ * `aria-label` is required because there is no visible text to describe the
+ * action to assistive technology. Pass a Lucide icon (or any ReactNode) as
+ * the single child; the component handles padding and focus state.
+ */
+export interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    /**
+     * Hover-color intent.
+     * - ghost (default): muted text → text color on hover (neutral action)
+     * - primary: muted text → primary color on hover (affirmative/edit/copy)
+     * - danger: muted text → danger color on hover (destructive)
+     * - success: muted text → success color on hover (confirm)
+     */
+    variant?: IconButtonVariant;
+    /** Tap-target size — adjusts outer padding; the icon size is the caller's responsibility. */
+    size?: IconButtonSize;
+    /** Required accessible label describing the action. */
+    'aria-label': string;
+}
+
+const variantClass: Record<IconButtonVariant, string> = {
+    ghost: styles['icon-btn--ghost'],
+    primary: styles['icon-btn--primary'],
+    danger: styles['icon-btn--danger'],
+    success: styles['icon-btn--success']
+};
+
+const sizeClass: Record<IconButtonSize, string> = {
+    sm: styles['icon-btn--sm'],
+    md: styles['icon-btn--md'],
+    lg: styles['icon-btn--lg']
+};
+
+/**
+ * @param props - IconButton props (variant, size, standard button attributes)
+ * @returns A borderless, transparent icon-only button.
+ */
+export function IconButton({
+    children,
+    className,
+    variant = 'ghost',
+    size = 'md',
+    type = 'button',
+    ...props
+}: PropsWithChildren<IconButtonProps>) {
+    return (
+        <button
+            type={type}
+            className={cn(styles['icon-btn'], variantClass[variant], sizeClass[size], className)}
+            {...props}
+        >
+            {children}
+        </button>
+    );
+}

--- a/src/frontend/components/ui/IconButton/index.ts
+++ b/src/frontend/components/ui/IconButton/index.ts
@@ -1,0 +1,2 @@
+export { IconButton } from './IconButton';
+export type { IconButtonProps } from './IconButton';

--- a/src/frontend/components/ui/Switch/Switch.module.css
+++ b/src/frontend/components/ui/Switch/Switch.module.css
@@ -28,7 +28,7 @@
     box-shadow: var(--focus-shadow);
 }
 
-/* Size Variants (padding scales with size; icon size is the caller's responsibility) */
+/* Size Variants (padding scales with size; icon sizing is handled by the component's `size` prop) */
 .switch--sm {
     padding: var(--switch-padding-sm);
 }

--- a/src/frontend/components/ui/Switch/Switch.module.css
+++ b/src/frontend/components/ui/Switch/Switch.module.css
@@ -1,0 +1,51 @@
+/**
+ * Switch Component CSS Module
+ *
+ * State-colored icon toggle. No hover color change by design — the click
+ * action flips state, so the color already reflects the upcoming state.
+ */
+
+.switch {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    border-radius: var(--switch-border-radius);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: color var(--transition-base);
+}
+
+.switch:disabled {
+    opacity: var(--opacity-50);
+    cursor: not-allowed;
+}
+
+.switch:focus-visible {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: var(--focus-outline-offset);
+    box-shadow: var(--focus-shadow);
+}
+
+/* Size Variants (padding scales with size; icon size is the caller's responsibility) */
+.switch--sm {
+    padding: var(--switch-padding-sm);
+}
+
+.switch--md {
+    padding: var(--switch-padding-md);
+}
+
+.switch--lg {
+    padding: var(--switch-padding-lg);
+}
+
+/* State Variants (color only — no hover change) */
+.switch--on {
+    color: var(--switch-on-color);
+}
+
+.switch--off {
+    color: var(--switch-off-color);
+}

--- a/src/frontend/components/ui/Switch/Switch.tsx
+++ b/src/frontend/components/ui/Switch/Switch.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import type { ButtonHTMLAttributes } from 'react';
+import { ToggleLeft, ToggleRight } from 'lucide-react';
+import { cn } from '../../../lib/cn';
+import styles from './Switch.module.css';
+
+type SwitchSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Icon-rendered on/off toggle. Flips `on` state on click; the icon and color
+ * reflect current state (right+success when on, left+muted when off). Use
+ * when a row-level control represents a boolean state (tool enable/disable,
+ * feature flag, notification on/off).
+ *
+ * Unlike `<IconButton>`, color is state-driven (not hover-driven) and the
+ * icon itself swaps — so hover has no visual effect by design. The button
+ * carries `role="switch"` + `aria-checked` so assistive tech reads it as a
+ * toggle rather than a generic button.
+ */
+export interface SwitchProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange' | 'role' | 'aria-checked'> {
+    /** Current on/off state. */
+    on: boolean;
+    /** Called with the new state when the user toggles. */
+    onChange: (next: boolean) => void;
+    /** Tap-target size; also scales the rendered icon. @default 'md' */
+    size?: SwitchSize;
+    /** Required accessible label describing what is being toggled. */
+    'aria-label': string;
+}
+
+const sizeClass: Record<SwitchSize, string> = {
+    sm: styles['switch--sm'],
+    md: styles['switch--md'],
+    lg: styles['switch--lg']
+};
+
+const iconSize: Record<SwitchSize, number> = {
+    sm: 20,
+    md: 24,
+    lg: 32
+};
+
+/**
+ * @param props - Switch props (on/onChange required; size; standard button attributes)
+ * @returns A role="switch" button rendering ToggleRight/ToggleLeft based on state.
+ */
+export function Switch({
+    on,
+    onChange,
+    size = 'md',
+    disabled,
+    className,
+    type = 'button',
+    onClick,
+    ...props
+}: SwitchProps) {
+    const Icon = on ? ToggleRight : ToggleLeft;
+    return (
+        <button
+            type={type}
+            role="switch"
+            aria-checked={on}
+            disabled={disabled}
+            className={cn(
+                styles.switch,
+                sizeClass[size],
+                on ? styles['switch--on'] : styles['switch--off'],
+                className
+            )}
+            onClick={(event) => {
+                onClick?.(event);
+                if (!event.defaultPrevented) {
+                    onChange(!on);
+                }
+            }}
+            {...props}
+        >
+            <Icon size={iconSize[size]} />
+        </button>
+    );
+}

--- a/src/frontend/components/ui/Switch/Switch.tsx
+++ b/src/frontend/components/ui/Switch/Switch.tsx
@@ -35,10 +35,15 @@ const sizeClass: Record<SwitchSize, string> = {
     lg: styles['switch--lg']
 };
 
+/**
+ * Icon pixel sizes aligned to the design-system `--icon-size-*` ladder in
+ * primitives.scss (sm=18, md=20, lg=24). Hardcoded here because CSS custom
+ * properties can't be read synchronously by the lucide-react `size` prop.
+ */
 const iconSize: Record<SwitchSize, number> = {
-    sm: 20,
-    md: 24,
-    lg: 32
+    sm: 18,
+    md: 20,
+    lg: 24
 };
 
 /**
@@ -58,6 +63,7 @@ export function Switch({
     const Icon = on ? ToggleRight : ToggleLeft;
     return (
         <button
+            {...props}
             type={type}
             role="switch"
             aria-checked={on}
@@ -74,7 +80,6 @@ export function Switch({
                     onChange(!on);
                 }
             }}
-            {...props}
         >
             <Icon size={iconSize[size]} />
         </button>

--- a/src/frontend/components/ui/Switch/index.ts
+++ b/src/frontend/components/ui/Switch/index.ts
@@ -1,0 +1,2 @@
+export { Switch } from './Switch';
+export type { SwitchProps } from './Switch';

--- a/src/frontend/lib/frontendPluginContext.tsx
+++ b/src/frontend/lib/frontendPluginContext.tsx
@@ -16,6 +16,8 @@ import { Card } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { Skeleton } from '../components/ui/Skeleton';
 import { Button } from '../components/ui/Button';
+import { IconButton } from '../components/ui/IconButton';
+import { Switch } from '../components/ui/Switch';
 import { Input } from '../components/ui/Input';
 import { ClientTime } from '../components/ui/ClientTime';
 import { Tooltip } from '../components/ui/Tooltip';
@@ -423,6 +425,8 @@ export function FrontendPluginContextProvider({ children }: { children: React.Re
             Badge,
             Skeleton,
             Button,
+            IconButton,
+            Switch,
             Input,
             ClientTime,
             Tooltip,
@@ -517,6 +521,8 @@ export function createPluginContext(pluginId: string): IFrontendPluginContext {
         Badge,
         Skeleton,
         Button,
+        IconButton,
+        Switch,
         Input,
         ClientTime,
         Tooltip,


### PR DESCRIPTION
## Summary

- New `<IconButton>` primitive — borderless transparent icon-only button for inline row actions (edit, delete, copy in dense tables/headers). Variants `ghost|primary|danger|success` drive hover color. Consumes a new `--icon-button-bare-*` semantic token set.
- New `<Switch>` primitive — `role="switch"` + `aria-checked` icon-rendered on/off toggle for row-level boolean state (tool enable/disable, feature flag, notification on/off). Icons + color are state-driven; no hover-color change. Consumes a new `--switch-*` token set.
- `<Button>` gains a `warning` variant (amber-tinted, between `ghost` and `danger`) and an `xs` size for compact controls. Button CSS pulls from a new `--button-warning-*` set plus the xs tier of the existing `--button-padding-*` / `--button-font-size-*` / `--button-height-*` ladder.
- `<Badge>` gains an `info` tone (primary-tinted) for active/in-progress status indicators. Uses a new `--badge-info-*` set.
- `--input-padding-sm` added for dense inline inputs (filter fields, inline number inputs, cron inputs). `--max-width-xs: 320px` added as a foundation primitive for narrow hint copy.
- Both new primitives are wired through `IFrontendPluginContext` and both factory paths in `frontendPluginContext.tsx`, so plugins get them for free via `context.ui`.
- Docs updated: `ui-components.md` lists Switch + IconButton and the new Badge/Button rows; `ui.md` gains a Max Widths row and updated utility-class lines; `ui-design-token-layers.md` documents the `xs|sm|md|lg` size-variant convention under Layer 2.