### PR TITLE
Add curated t-shirt token tier and align UI docs with industry classification

### DIFF
--- a/docs/frontend/frontend.md
+++ b/docs/frontend/frontend.md
@@ -71,10 +71,10 @@ TronRelic uses React with Next.js 14 App Router for building interactive UI comp
 
 ### UI Styling System
 
-  1. Primitives (primitives.scss) — Raw values: --spacing-7: 1rem, --color-primary: #4b8cff
-  2. Semantics (semantic-tokens.scss) — Named purpose, composed of primitives: --card-padding-md: var(--spacing-10)
-  3. Components (.module.scss) — Select which semantic token to use based on context (breakpoints, state)
-  4. Globals (globals.scss) — Utility classes for styling patterns that aren't tied to a specific component (.surface, .btn, .badge)
+  1. Primitives (primitives.scss) — Raw values and value-named scales: `--spacing-7: 1rem`, `--color-blue-500`, `--font-size-xs`. Forbidden in component code.
+  2. Semantics (semantic-tokens.scss) — Use-case-named tokens (`--card-padding-md`, `--font-size-heading-md`) plus curated t-shirt primitives (`--gap-md`, `--padding-md`) that component code may reference.
+  3. Components (.module.scss) — Select tokens by context (breakpoints, state); never redefine them.
+  4. Globals (globals.scss) — Utility classes for styling patterns that aren't tied to a specific component (`.surface`, `.btn`, `.badge`).
 
 TronRelic implements a comprehensive UI styling system with two core architectural layers:
 

--- a/docs/frontend/ui/ui-design-token-layers.md
+++ b/docs/frontend/ui/ui-design-token-layers.md
@@ -47,7 +47,9 @@ Foundation tokens define primitive design values—the raw materials of the desi
 ```
 
 **Usage:**
-Referenced by semantic tokens (Layer 2) and occasionally by CSS Modules for one-off needs. Foundation tokens should rarely appear directly in component code.
+Referenced by semantic tokens (Layer 2). Foundation tokens whose name describes a *value* (`--spacing-*`, raw color palette `--color-blue-500`, raw t-shirt font sizes `--font-size-xs/sm/md/lg/xl/2xl/3xl`) are forbidden in component code — those tokens exist only as the substrate the curated tokens alias. Foundation tokens whose name already describes a *purpose* — design constants like `--border-width-thin`, `--radius-md`, `--shadow-sm`, `--font-weight-bold`, `--line-height-tight`, `--max-width-prose` — *are* acceptable directly in component code; they don't shift between themes, so aliasing them through Layer 2 adds ceremony without value.
+
+**Industry classification of t-shirt-sized tokens.** A category prefix like `gap-`, `space-`, `padding-`, `font-size-` does *not* promote a t-shirt-sized token to semantic status. Spectrum classifies `spacing-100/200` as global. Tailwind v4 classifies `--spacing-2` as primitive. Carbon's `spacing-01...spacing-13` is a raw scale. Atlassian's `space.100/200` is foundation. The W3C DTCG spec deliberately stays out of it — group prefixes "SHOULD NOT be used to infer purpose." Semantic status is earned only when the name encodes a use case (`--card-padding-md`, `--button-gap`). TronRelic follows this convention: t-shirt-sized scales are primitives regardless of where they live in the source files.
 
 ### Layer 2: Semantic Tokens (Alias Tokens)
 
@@ -66,22 +68,27 @@ Semantic tokens compose foundation tokens into meaningful, context-aware variabl
 - Enable theme switching by remapping semantic tokens to different primitives
 - Provide component-specific theming decisions built from Layer 1 primitives
 
-**Examples:**
+**Examples — truly semantic (use-case-named):**
 ```css
-/* Buttons - semantic composition */
+/* Color roles */
+--color-text: var(--color-gray-900);
+--color-danger: var(--color-red-600);
+
+/* Component-scoped semantics */
 --button-bg-primary: var(--color-blue-500);
 --button-padding-md: var(--spacing-3) var(--spacing-7);
---button-border-radius: var(--radius-md);
-
-/* Cards - semantic surface tokens */
 --card-bg: var(--color-white);
---card-border-radius: var(--radius-lg);
 --card-shadow: var(--shadow-md);
 
-/* Modals - semantic overlay tokens */
---modal-backdrop-blur: 8px;
---modal-content-bg: var(--color-white);
+/* Type roles */
+--font-size-heading-md: var(--font-size-xl);
+--font-size-body: var(--font-size-base);
+
+/* Layout roles */
+--max-width-prose: 64ch;
 ```
+
+**Note — `semantic-tokens.scss` also hosts curated primitives.** TronRelic places the t-shirt-sized scales `--gap-2xs/xs/sm/md/lg/xl`, `--padding-2xs/xs/sm/md/lg/xl`, and `--avatar-size-*` in `semantic-tokens.scss` even though, by industry definition, they are primitives (the names describe values, not use cases). They live in this file because it serves as the curated chokepoint of *tokens component code may reference* — not as a strict semantic-only collection. Truly semantic spacing tokens would be use-case-named (e.g. `--gap-list-item`, `--gap-page-section`); those don't yet exist as a complete set, so the curated t-shirt tier is the practical fallback. Treat them as primitives when reasoning about classification, even though they share a file with semantics.
 
 **Usage:**
 Provide consistent theming for specific UI components. When you need dark mode, you remap semantic tokens (e.g., `--card-bg: var(--color-gray-900)`) without touching foundation tokens.

--- a/docs/frontend/ui/ui-scss-modules.md
+++ b/docs/frontend/ui/ui-scss-modules.md
@@ -106,17 +106,21 @@ Always use semantic tokens from `semantic-tokens.scss`. Tokens are immutable —
 
 .title {
     color: var(--color-primary);
-    font-size: var(--font-size-lg);
+    font-size: var(--font-size-heading-sm);
     font-weight: var(--font-weight-semibold);
+}
+
+.price {
+    font-size: var(--font-size-heading-lg);
 }
 
 /* CORRECT - select smaller token at narrow width */
 @container market-card (max-width: 300px) {
-    .price { font-size: var(--font-size-xl); }
+    .price { font-size: var(--font-size-heading-md); }
 }
 ```
 
-Never hardcode colors, spacing, fonts, or sizes. Never redefine tokens across breakpoints — this makes names meaningless and debugging impossible.
+Reach for **semantic tokens** — `--font-size-heading-*`, `--gap-md`, `--padding-sm`, `--card-padding-md` — not foundation primitives like `--font-size-lg`, `--spacing-7`. Primitives are raw values; semantics describe purpose, which is what enables theming and global updates. If no semantic token fits, flag the gap so a new one can be added; don't silently fall back to a primitive. Never hardcode colors, spacing, fonts, or sizes. Never redefine tokens across breakpoints — that makes names meaningless and debugging impossible.
 
 ## Complete Example
 
@@ -150,12 +154,12 @@ export function MarketCard({ name, price, availability }: MarketCardProps) {
 
 .card { container-type: inline-size; container-name: market-card; }
 .header { display: flex; align-items: center; justify-content: space-between; }
-.title { font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold); color: var(--color-primary); }
-.price { font-size: var(--font-size-2xl); font-weight: var(--font-weight-bold); color: var(--color-text); }
+.title { font-size: var(--font-size-heading-sm); font-weight: var(--font-weight-semibold); color: var(--color-primary); }
+.price { font-size: var(--font-size-heading-lg); font-weight: var(--font-weight-bold); color: var(--color-text); }
 
 @container market-card (max-width: 300px) {
-    .header { flex-direction: column; align-items: flex-start; gap: var(--spacing-4); }
-    .price { font-size: var(--font-size-xl); }
+    .header { flex-direction: column; align-items: flex-start; gap: var(--gap-sm); }
+    .price { font-size: var(--font-size-heading-md); }
 }
 ```
 

--- a/docs/frontend/ui/ui-scss-modules.md
+++ b/docs/frontend/ui/ui-scss-modules.md
@@ -94,7 +94,7 @@ Use React components for cards, layout, buttons, and badges. Use SCSS Modules fo
 
 ### Step 3: Reference Design Tokens
 
-Always use semantic tokens from `semantic-tokens.scss`. Tokens are immutable — select different tokens at different breakpoints instead of redefining what tokens mean.
+Reach for tokens in `semantic-tokens.scss` first. Tokens are immutable — select different tokens at different breakpoints instead of redefining what tokens mean.
 
 ```scss
 @use '../../../app/breakpoints' as *;
@@ -120,7 +120,11 @@ Always use semantic tokens from `semantic-tokens.scss`. Tokens are immutable —
 }
 ```
 
-Reach for **semantic tokens** — `--font-size-heading-*`, `--gap-md`, `--padding-sm`, `--card-padding-md` — not foundation primitives like `--font-size-lg`, `--spacing-7`. Primitives are raw values; semantics describe purpose, which is what enables theming and global updates. If no semantic token fits, flag the gap so a new one can be added; don't silently fall back to a primitive. Never hardcode colors, spacing, fonts, or sizes. Never redefine tokens across breakpoints — that makes names meaningless and debugging impossible.
+**Token classification rule.** A token is *semantic* when its name describes a use case (`--card-padding-md`, `--button-gap`, `--font-size-heading-md`, `--max-width-prose`). It is *primitive* when its name describes a value — including category-prefixed t-shirt scales like `--gap-md`, `--padding-md`, `--font-size-xs`. This matches Spectrum, Tailwind v4, Carbon, and Atlassian convention.
+
+**Component code rule.** Prefer use-case-named semantics first (`--card-padding-*`, `--button-gap`, `--font-size-heading-*`, `--font-size-body`). Fall back to curated primitives that live in `semantic-tokens.scss` (`--gap-*`, `--padding-*`, `--avatar-size-*`) for one-off layouts where no use-case-named semantic fits. Design constants from `primitives.scss` (`--border-width-*`, `--radius-*`, `--shadow-*`, `--font-weight-*`, `--line-height-*`, `--max-width-*`) are also acceptable directly. **Never** reach into the foundation scales: `--spacing-*` and the raw t-shirt `--font-size-xs/sm/md/lg/xl/2xl/3xl` are forbidden in component code — those exist as the substrate the curated tokens alias.
+
+If no token in those tiers fits, flag the gap so a new semantic can be added; don't silently drop to a foundation scale. Never hardcode colors, spacing, fonts, or sizes. Never redefine tokens across breakpoints — that makes names meaningless and debugging impossible.
 
 ## Complete Example
 

--- a/docs/frontend/ui/ui.md
+++ b/docs/frontend/ui/ui.md
@@ -32,14 +32,18 @@ Hardcoded values fragment the interface and prevent theming. Global CSS classes 
 
 ### Common Design Tokens
 
-| Category | Tokens |
-|----------|--------|
-| Colors | `--color-text`, `--color-primary`, `--color-surface`, `--color-border`, `--color-success`, `--color-warning`, `--color-danger` |
-| Spacing | `--spacing-1` (0.25rem) through `--spacing-20` (5rem) |
-| Typography | `--font-size-xs` through `--font-size-3xl`, `--font-weight-normal/medium/semibold/bold` |
-| Borders | `--border-width-thin`, `--radius-sm/md/lg/full` |
+**Reach for semantic tokens in component code. Foundation primitives (`--spacing-*`, `--font-size-xs/sm/lg/xl/2xl/3xl`, raw color palette) belong in `primitives.scss` and should rarely appear in `.module.scss` files** — they describe values, not purpose, and so block theming. If no semantic token fits your case, flag the gap so a new one can be added rather than dropping back to a primitive silently.
+
+| Category | Semantic tokens (use these) |
+|----------|------------------------------|
+| Colors | `--color-text`, `--color-text-muted`, `--color-primary`, `--color-surface`, `--color-surface-muted`, `--color-border`, `--color-success`, `--color-warning`, `--color-danger` (plus `--color-*-alpha-*` and `--color-*-text` variants) |
+| Gaps | `--gap-2xs/xs/sm/md/lg/xl` (generic), plus component-scoped `--stack-gap-sm/md/lg`, `--grid-gap-sm/md/lg`, `--button-gap`, `--badge-gap`, `--chip-gap` |
+| Padding | `--padding-2xs/xs/sm/md/lg/xl` (generic), plus component-scoped `--card-padding-xs/sm/md/lg`, `--button-padding-xs/sm/md/lg`, `--alert-padding`, `--input-padding`, `--input-padding-sm` |
+| Typography | `--font-size-caption`, `--font-size-body-sm/body/body-lg`, `--font-size-heading-sm/md/lg/xl`; `--font-weight-normal/medium/semibold/bold`; `--line-height-tight/normal/relaxed` |
+| Borders | `--border-width-thin/medium/thick`, `--radius-xs/sm/md/lg/full` |
 | Shadows | `--shadow-sm/md/lg` |
-| Max Widths | `--max-width-xs` (320px) through `--max-width-xl` (1080px), plus `--max-width-prose` (64ch) |
+| Avatars | `--avatar-size-sm/md/lg` |
+| Max Widths | `--max-width-prose` (64ch), `--max-width-xs/sm/md/lg/xl` (320–1080px) |
 | Breakpoints | `$breakpoint-mobile-sm` (360px), `$breakpoint-mobile-md` (480px), `$breakpoint-mobile-lg` (768px), `$breakpoint-tablet` (1024px), `$breakpoint-desktop` (1200px) |
 
 ### SCSS Module Naming

--- a/docs/frontend/ui/ui.md
+++ b/docs/frontend/ui/ui.md
@@ -32,15 +32,19 @@ Hardcoded values fragment the interface and prevent theming. Global CSS classes 
 
 ### Common Design Tokens
 
-**The ideal:** every value in `.module.scss` is a semantic token — that's what enables theming. **The pragmatic split TronRelic enforces:**
+A token is **semantic** when its name encodes a use case (`--card-padding-md`, `--button-gap`, `--font-size-heading-md`, `--max-width-prose`). It is **primitive** when its name describes a value (`--spacing-7`, `--gap-md`, `--font-size-xs`, `--radius-md`). Industry consensus — Spectrum, Tailwind v4, Carbon, Atlassian — treats t-shirt-sized scales (`xs/sm/md/lg/xl`) as primitives regardless of category prefix. TronRelic follows that classification.
 
-- **Forbidden in component code** — `--spacing-*`, raw color palette, raw t-shirt font sizes (`--font-size-xs/sm/lg/xl/2xl/3xl`). They describe values that *should* vary by theme. Use the semantic equivalents (`--gap-*`, `--padding-*`, `--color-*`, `--font-size-body-*`, `--font-size-heading-*`).
-- **Allowed in component code** — primitives whose name already describes a purpose: `--border-width-thin/medium/thick`, `--radius-xs/sm/md/lg/full`, `--shadow-sm/md/lg`, `--font-weight-*`, `--line-height-*`, `--letter-spacing-*`, `--max-width-*`. These are design constants, not theme variables; aliasing them adds ceremony without value.
+**The rule for component code (`.module.scss`):**
 
-If no token fits, flag the gap so a new semantic can be added — don't silently drop to a forbidden primitive.
+1. **Prefer use-case-named semantic tokens** when one exists — `--color-text`, `--color-danger`, `--card-padding-md`, `--button-gap`, `--stack-gap-md`, `--font-size-heading-md`, `--font-size-body`, `--max-width-prose`.
+2. **Acceptable fallback — curated primitives in `semantic-tokens.scss`** when no use-case-named semantic fits: `--gap-2xs/xs/sm/md/lg/xl`, `--padding-2xs/xs/sm/md/lg/xl`, `--avatar-size-*`. These are primitives by industry definition, but the file curates them as the chokepoint component code may reach for.
+3. **Acceptable fallback — design-constant primitives in `primitives.scss`**: `--border-width-thin/medium/thick`, `--radius-xs/sm/md/lg/full`, `--shadow-sm/md/lg`, `--font-weight-*`, `--line-height-*`, `--letter-spacing-*`, `--max-width-*`. These don't shift between themes; aliasing them adds ceremony.
+4. **Forbidden in component code** — the foundation scales: `--spacing-1`...`--spacing-20`, raw color palette (`--color-blue-500`), raw t-shirt font sizes (`--font-size-xs/sm/md/lg/xl/2xl/3xl`).
 
-| Category | Token to use in component code |
-|----------|--------------------------------|
+If no token in tiers 1–3 fits, flag the gap so a use-case-named semantic can be added — don't silently drop to a forbidden foundation primitive.
+
+| Category | Tokens component code may reference |
+|----------|--------------------------------------|
 | Colors | `--color-text`, `--color-text-muted`, `--color-primary`, `--color-surface`, `--color-surface-muted`, `--color-border`, `--color-success`, `--color-warning`, `--color-danger` (plus `--color-*-alpha-*` and `--color-*-text` variants) |
 | Gaps | `--gap-2xs/xs/sm/md/lg/xl` (generic), plus component-scoped `--stack-gap-sm/md/lg`, `--grid-gap-sm/md/lg`, `--button-gap`, `--badge-gap`, `--chip-gap` |
 | Padding | `--padding-2xs/xs/sm/md/lg/xl` (generic), plus component-scoped `--card-padding-xs/sm/md/lg`, `--button-padding-xs/sm/md/lg`, `--alert-padding`, `--input-padding`, `--input-padding-sm` |

--- a/docs/frontend/ui/ui.md
+++ b/docs/frontend/ui/ui.md
@@ -32,10 +32,15 @@ Hardcoded values fragment the interface and prevent theming. Global CSS classes 
 
 ### Common Design Tokens
 
-**Reach for semantic tokens in component code. Foundation primitives (`--spacing-*`, `--font-size-xs/sm/lg/xl/2xl/3xl`, raw color palette) belong in `primitives.scss` and should rarely appear in `.module.scss` files** — they describe values, not purpose, and so block theming. If no semantic token fits your case, flag the gap so a new one can be added rather than dropping back to a primitive silently.
+**The ideal:** every value in `.module.scss` is a semantic token — that's what enables theming. **The pragmatic split TronRelic enforces:**
 
-| Category | Semantic tokens (use these) |
-|----------|------------------------------|
+- **Forbidden in component code** — `--spacing-*`, raw color palette, raw t-shirt font sizes (`--font-size-xs/sm/lg/xl/2xl/3xl`). They describe values that *should* vary by theme. Use the semantic equivalents (`--gap-*`, `--padding-*`, `--color-*`, `--font-size-body-*`, `--font-size-heading-*`).
+- **Allowed in component code** — primitives whose name already describes a purpose: `--border-width-thin/medium/thick`, `--radius-xs/sm/md/lg/full`, `--shadow-sm/md/lg`, `--font-weight-*`, `--line-height-*`, `--letter-spacing-*`, `--max-width-*`. These are design constants, not theme variables; aliasing them adds ceremony without value.
+
+If no token fits, flag the gap so a new semantic can be added — don't silently drop to a forbidden primitive.
+
+| Category | Token to use in component code |
+|----------|--------------------------------|
 | Colors | `--color-text`, `--color-text-muted`, `--color-primary`, `--color-surface`, `--color-surface-muted`, `--color-border`, `--color-success`, `--color-warning`, `--color-danger` (plus `--color-*-alpha-*` and `--color-*-text` variants) |
 | Gaps | `--gap-2xs/xs/sm/md/lg/xl` (generic), plus component-scoped `--stack-gap-sm/md/lg`, `--grid-gap-sm/md/lg`, `--button-gap`, `--badge-gap`, `--chip-gap` |
 | Padding | `--padding-2xs/xs/sm/md/lg/xl` (generic), plus component-scoped `--card-padding-xs/sm/md/lg`, `--button-padding-xs/sm/md/lg`, `--alert-padding`, `--input-padding`, `--input-padding-sm` |

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -17,6 +17,47 @@
 :root,
 [data-theme="default"] {
     /* ========================================================================
+     * GENERIC LAYOUT & TYPOGRAPHY TOKENS
+     *
+     * Use these in component code instead of reaching for primitives like
+     * --spacing-* or --font-size-xs/sm/lg/xl/2xl/3xl directly. Component-scoped
+     * tokens (e.g. --card-padding-md, --button-gap, --stack-gap-md) remain
+     * preferred where the component fits — these generic tiers cover the
+     * non-component cases (one-off blocks, plugin pages, ad-hoc layouts).
+     * ======================================================================== */
+
+    /* Generic Gaps — for flex/grid contexts that aren't a Stack, Grid, or Card */
+    --gap-2xs: var(--spacing-1);    /* 0.25rem - typographic stacks (label + helper) */
+    --gap-xs:  var(--spacing-2);    /* 0.35rem - dense inline (badge, chip) */
+    --gap-sm:  var(--spacing-4);    /* 0.5rem  - inline gaps, button-icon */
+    --gap-md:  var(--spacing-7);    /* 1rem    - default block gap */
+    --gap-lg:  var(--spacing-10);   /* 1.5rem  - section gap */
+    --gap-xl:  var(--spacing-14);   /* 2.5rem  - page-level gap */
+
+    /* Generic Padding — for any block that isn't a Card, Button, Alert, etc. */
+    --padding-2xs: var(--spacing-1);    /* 0.25rem */
+    --padding-xs:  var(--spacing-2);    /* 0.35rem */
+    --padding-sm:  var(--spacing-4);    /* 0.5rem  */
+    --padding-md:  var(--spacing-7);    /* 1rem    */
+    --padding-lg:  var(--spacing-10);   /* 1.5rem  */
+    --padding-xl:  var(--spacing-14);   /* 2.5rem  */
+
+    /* Typography — purpose-named font sizes */
+    --font-size-caption:    var(--font-size-xs);    /* 0.72rem - labels, table headers, footnotes */
+    --font-size-body-sm:    var(--font-size-sm);    /* 0.85rem - secondary body */
+    --font-size-body:       var(--font-size-base);  /* 0.95rem - default body, buttons */
+    --font-size-body-lg:    var(--font-size-md);    /* 1rem    - emphasized body */
+    --font-size-heading-sm: var(--font-size-lg);    /* 1.05rem - small headings */
+    --font-size-heading-md: var(--font-size-xl);    /* 1.6rem  - default heading, stat values */
+    --font-size-heading-lg: var(--font-size-2xl);   /* 1.8rem  - large heading, page title min */
+    --font-size-heading-xl: var(--font-size-3xl);   /* 2.6rem  - hero heading, page title max */
+
+    /* Avatar Sizes — user / account / profile imagery */
+    --avatar-size-sm: 32px;
+    --avatar-size-md: 48px;
+    --avatar-size-lg: 64px;
+
+    /* ========================================================================
      * BUTTON COMPONENT TOKENS
      * ======================================================================== */
 


### PR DESCRIPTION
## Summary

Adds curated t-shirt-sized tokens — `--gap-2xs/xs/sm/md/lg/xl`, `--padding-2xs/xs/sm/md/lg/xl`, `--font-size-body-*`, `--font-size-heading-*`, `--avatar-size-*` — to `semantic-tokens.scss` so component code has a digestible chokepoint between the 20-tier numeric `--spacing-*` foundation and the use-case-named semantics.

Updates four UI docs (`ui.md`, `ui-scss-modules.md`, `ui-design-token-layers.md`, `frontend.md`) to align with industry classification of t-shirt-sized tokens: Spectrum, Tailwind v4, Carbon, and Atlassian all treat them as primitives even with a category prefix; semantic status is earned only when the name encodes a use case. The docs now state this explicitly and replace the prior simple "semantics vs primitives" framing with a four-tier rule for what component code may reference.

## Why

Component code was reaching directly into `--spacing-*` and the raw t-shirt `--font-size-*` scale, bypassing the chokepoint that makes themes possible. Adding curated t-shirt tokens gives authors a place to land for one-off layouts where no use-case-named semantic exists. Reviewers (gemini, copilot) flagged that the original doc framing called these tokens semantic when several listed alongside them (`--border-width-*`, `--radius-*`, `--shadow-*`, `--max-width-*`) actually live in `primitives.scss`. Researching mainstream design system docs confirmed: t-shirt scales are primitives by industry convention regardless of which file they live in. The docs now reflect that classification honestly while keeping the practical "what component code may use" guidance prominent.

## Four-tier rule for component code

1. **Prefer use-case-named semantics** — `--card-padding-md`, `--button-gap`, `--font-size-heading-md`, `--font-size-body`, `--max-width-prose`, color roles.
2. **Acceptable fallback — curated primitives in `semantic-tokens.scss`** — `--gap-*`, `--padding-*`, `--avatar-size-*`. Primitive by industry definition; live in this file because it's the curated chokepoint.
3. **Acceptable fallback — design-constant primitives in `primitives.scss`** — `--border-width-*`, `--radius-*`, `--shadow-*`, `--font-weight-*`, `--line-height-*`, `--letter-spacing-*`, `--max-width-*`. Don't shift between themes; aliasing them is ceremony.
4. **Forbidden in component code** — `--spacing-*`, raw color palette (`--color-blue-500`), raw t-shirt font sizes (`--font-size-xs/sm/md/lg/xl/2xl/3xl`).

## Out of scope

The 91 `.module.scss` files / 1,151 call sites currently using `--spacing-*` directly are not migrated in this PR. That sweep is tracked separately.