### PR TITLE
Replace menu requiredRole with per-user identity, group, and admin gating

### DIFF
--- a/docs/plugins/plugins-api-registration.md
+++ b/docs/plugins/plugins-api-registration.md
@@ -27,6 +27,8 @@ Every route entry uses the `IApiRouteConfig` contract. Focus on these fields:
 
 Remember: `req.params`, `req.query`, `req.body`, and `req.ip` are plain objects; `res.status()`, `res.json()`, `res.send()`, and `res.setHeader()` mirror familiar Express methods but stay framework-agnostic.
 
+**`requiresAdmin` is a shared-token gate, not a per-user check.** When set, the platform applies the `requireAdmin` middleware which compares the request's `x-admin-token` header against `ADMIN_API_TOKEN`. It is for operators, scripts, and CI tooling — there is no user identity involved. To gate a route on whether the cookie-identified *visitor* is an admin (a human-facing admin SPA, for example), look up `IUserGroupService` from the service registry and call `isAdmin(req.userId)` inside the handler. The two checks coexist and often combine: protect the route with `requiresAdmin: true` so only token-bearing callers reach it, then use `isAdmin(req.userId)` inside the handler to vary the response shape per user. See [plugins.md → Cross-Component Service Sharing](./plugins.md#cross-component-service-sharing) and the [User Module README](../../src/backend/modules/user/README.md#user-groups-and-admin-status) for the canonical pattern.
+
 **User context is automatically available.** Middleware populates `req.userId` (from the `tronrelic_uid` cookie) and `req.user` (the resolved user record) before your handler runs. For feature gating, check wallet states:
 - `req.user?.wallets?.length > 0` — user has linked a wallet (may be unverified)
 - `req.user?.wallets?.some(w => w.verified)` — user has a verified wallet (recommended for feature gating)

--- a/docs/plugins/plugins-page-registration.md
+++ b/docs/plugins/plugins-page-registration.md
@@ -676,6 +676,21 @@ Planned improvements to the menu/page system:
 - **Dynamic metadata** - Automatic Next.js metadata generation from `IPageConfig` SEO fields, including OpenGraph tags, Twitter cards, JSON-LD structured data, and per-page `noindex`. See [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md).
 - **Server-side data fetching** - `IPageConfig.serverDataFetcher` for pre-fetching plugin page data during SSR, eliminating the loading flash on plugin pages. See [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md).
 
+### ✅ Implemented (cont.)
+
+**Per-user menu visibility gating** — Menu nodes carry three optional
+gating fields that the backend evaluates against the cookie-resolved
+visitor at read time: `allowedIdentityStates: UserIdentityState[]` (allow-list
+of `'anonymous' | 'registered' | 'verified'`), `requiresGroups: string[]`
+(OR-of-membership across admin-defined groups), and `requiresAdmin: boolean`
+(routes through `IUserGroupService.isAdmin`). The filter is in
+`MenuService.getTreeForUser`; the admin UI surfaces the fields as a
+checkbox/multi-select fieldset on `/system/menu`. See the
+[Menu Module README → Visibility Gating](../../src/backend/modules/menu/README.md#visibility-gating)
+for the full contract and the distinction between `requiresAdmin` (per-user,
+cookie identity) and the `requireAdmin` middleware (shared-token gate, see
+[plugins-api-registration.md](./plugins-api-registration.md)).
+
 ### 🚧 Planned
 
 **Route Guards** - Automatic enforcement of `requiresAuth` and `requiresAdmin`:
@@ -690,18 +705,34 @@ pages: [
 ]
 ```
 
-**Permission-Based Visibility** - Hide menu items based on user permissions:
+Plugin-registered menu nodes can use the same gating fields documented in
+the [Menu Module README → Visibility Gating](../../src/backend/modules/menu/README.md#visibility-gating).
+Pass `allowedIdentityStates`, `requiresGroups`, and/or `requiresAdmin`
+directly to `context.menuService.create()`:
 
 ```typescript
+// Hidden from anonymous and registered visitors
 await context.menuService.create({
     namespace: 'main',
-    label: 'Admin Panel',
-    url: '/admin',
-    icon: 'Shield',
+    label: 'Premium Tools',
+    url: '/plugins/my-plugin/premium',
+    icon: 'Sparkles',
     order: 200,
     parent: null,
     enabled: true,
-    requiresAdmin: true  // Completely hidden if not admin
+    allowedIdentityStates: [UserIdentityState.Verified]
+});
+
+// Visible only to admins (per-user check via IUserGroupService.isAdmin)
+await context.menuService.create({
+    namespace: 'main',
+    label: 'Plugin Admin',
+    url: '/plugins/my-plugin/admin',
+    icon: 'Shield',
+    order: 250,
+    parent: null,
+    enabled: true,
+    requiresAdmin: true
 });
 ```
 

--- a/docs/plugins/plugins.md
+++ b/docs/plugins/plugins.md
@@ -172,6 +172,19 @@ disable: async (context: IPluginContext) => {
 
 `watch()` is state-oriented, not event-oriented: the registry models "does this capability exist right now?" as a continuous truth, and `watch()` subscribes the caller to that truth. Three rules for handlers: **keep `onAvailable` idempotent** (the registry fires it again on every re-registration), **treat `onUnavailable` as past tense** (the provider's instance is already gone — don't call into it), and **always dispose in `disable()`** (the disposer returned from `watch()` prevents the registry from retaining closures that point at torn-down plugin state).
 
+**Platform-provided services on the registry — the `user-groups` example.** Modules also publish on the registry, and `IUserGroupService` (registered as `'user-groups'` by the user module) is the canonical entry point for plugin permission gating. It exposes membership reads and writes (`isMember`, `getUserGroups`, `addMember`, `removeMember`) plus a special `isAdmin(userId)` predicate that resolves through any system-flagged group whose id matches the reserved-admin pattern. The service contract ships with the platform via `@/types`, so consumers don't need a sibling types package — the import below resolves like any other framework type:
+
+```typescript
+import type { IUserGroupService } from '@/types';
+
+const groups = context.services.get<IUserGroupService>('user-groups');
+if (groups && req.userId && await groups.isAdmin(req.userId)) {
+    // Render admin-only UI for the cookie-identified visitor
+}
+```
+
+`isAdmin(userId)` is a per-user predicate keyed off the visitor's UUID — use it whenever a request handler runs in cookie-identified context and the question is "should this person see admin UI?" Do not conflate it with the `requiresAdmin: true` flag on `IApiRouteConfig` or with the `requireAdmin` middleware: those are *shared-token* gates that match the request's `x-admin-token` header against `ADMIN_API_TOKEN` and exist for operators, scripts, and CI tooling — they don't know who the user is. A typical admin SPA combines both: the route is protected by `requireAdmin` (token), and the page logic uses `groups.isAdmin(req.userId)` to decide what to render to the human behind the request. Plugins that want per-user admin gating must call `IUserGroupService.isAdmin` rather than rolling their own scheme — the JSDoc on the interface explicitly warns against parallel permission models. See the [User Module README](../../src/backend/modules/user/README.md#user-groups-and-admin-status) for the full method table, reserved-admin slug rules, and cache-invalidation semantics.
+
 **Architectural direction:** The registry exists so that features providing shared capabilities — AI analysis, notification dispatch, data enrichment — can remain plugins rather than requiring promotion to modules. A plugin that exposes a shared service is still a plugin if the application functions without it. Consumers must handle the service being unavailable, which enforces graceful degradation by design. See [modules.md](../system/modules/modules.md#module-vs-plugin-decision-matrix) for how this changes the module vs plugin decision.
 
 ### WebSocket Real-Time Events

--- a/packages/types/src/menu/IMenuNode.ts
+++ b/packages/types/src/menu/IMenuNode.ts
@@ -1,3 +1,5 @@
+import type { UserIdentityState } from '../user/IUserIdentityState.js';
+
 /**
  * Menu node interface representing a single item in the menu tree.
  *
@@ -89,11 +91,45 @@ export interface IMenuNode {
     enabled: boolean;
 
     /**
-     * Optional access control role or permission requirement.
-     * Frontend can check this before rendering or enabling navigation.
-     * Examples: 'admin', 'user', 'premium'
+     * Allow-list of identity states that may see the node.
+     *
+     * Backend filters menu reads by checking that the cookie-resolved user's
+     * `identityState` is in this set. `undefined` means the node has no
+     * identity-state gate (visible to anonymous, registered, and verified
+     * visitors alike). An empty array is rejected at write time — that would
+     * hide the node from every visitor, which is what `enabled: false`
+     * already expresses cleanly.
+     *
+     * Examples:
+     * - `['anonymous']` — visible only to UUID-only visitors (e.g. signup CTA)
+     * - `['registered', 'verified']` — visible only after a wallet is linked
+     * - `['anonymous', 'verified']` — visible to UUID-only and signed visitors,
+     *   hidden from the unsigned-wallet middle state
      */
-    requiredRole?: string;
+    allowedIdentityStates?: UserIdentityState[];
+
+    /**
+     * Required group memberships for visibility (OR-of-membership).
+     *
+     * The user must be a member of at least one listed group for the node to
+     * be visible. Group ids reference rows in the `module_user_groups`
+     * collection managed by the user module. `undefined` or `[]` means no
+     * group requirement. The set of available groups is admin-defined and
+     * fetched via `GET /api/admin/users/groups`.
+     */
+    requiresGroups?: string[];
+
+    /**
+     * Restrict the node to admin users.
+     *
+     * When true, the node is only visible to users for whom
+     * `IUserGroupService.isAdmin(userId)` returns true — i.e. members of any
+     * system-flagged group whose id matches the reserved-admin pattern. This
+     * is a separate flag from `requiresGroups` so that future seeded admin
+     * tiers (e.g. `super-admin`) automatically grant access without rewriting
+     * gated nodes.
+     */
+    requiresAdmin?: boolean;
 
     /**
      * Timestamp when the node was created.

--- a/packages/types/src/menu/IMenuService.ts
+++ b/packages/types/src/menu/IMenuService.ts
@@ -2,6 +2,7 @@ import type { IMenuNode } from './IMenuNode.js';
 import type { IMenuTree } from './IMenuTree.js';
 import type { MenuEventType, MenuEventSubscriber } from './IMenuEvent.js';
 import type { IMenuNamespaceConfig } from './IMenuNamespaceConfig.js';
+import type { IUser } from '../user/IUser.js';
 
 /**
  * Service interface for managing the hierarchical menu system.
@@ -230,6 +231,32 @@ export interface IMenuService {
      * ```
      */
     getTree(namespace?: string): IMenuTree;
+
+    /**
+     * Get the menu tree filtered to nodes the given user is permitted to see.
+     *
+     * Applies the gating rules declared on each node (`allowedIdentityStates`,
+     * `requiresGroups`, `requiresAdmin`) using the cookie-resolved user. An
+     * `undefined` user is treated as an anonymous visitor with no group
+     * memberships, so only nodes with no gates (or with `'anonymous'` in their
+     * `allowedIdentityStates`) appear.
+     *
+     * The admin predicate (`requiresAdmin: true`) resolves through
+     * `IUserGroupService.isAdmin`, looked up lazily from the service registry.
+     *
+     * @param namespace - Menu namespace (defaults to 'main')
+     * @param user - Cookie-resolved user, or undefined for anonymous
+     * @returns Filtered tree containing only nodes the user may see
+     */
+    getTreeForUser(namespace: string | undefined, user: IUser | undefined): Promise<IMenuTree>;
+
+    /**
+     * Get the children of `parentId` filtered to those the given user may see.
+     *
+     * Same gating rules as {@link getTreeForUser}; returns user-filtered
+     * children sorted by order.
+     */
+    getChildrenForUser(parentId: string | null, namespace: string | undefined, user: IUser | undefined): Promise<IMenuNode[]>;
 
     /**
      * Get child nodes of a specific parent within a namespace.

--- a/src/backend/modules/menu/MenuModule.ts
+++ b/src/backend/modules/menu/MenuModule.ts
@@ -150,7 +150,8 @@ export class MenuModule implements IModule<IMenuModuleDependencies> {
 
         // Initialize MenuService singleton with database + registry dependencies.
         // The registry is used at read time to look up `'user-groups'` for the
-        // admin-predicate gating filter (see MenuService.applyGatingFilter).
+        // admin-predicate gating filter (see MenuService.passesGate, called
+        // from getTreeForUser / getChildrenForUser).
         MenuService.setDependencies(this.database, this.serviceRegistry);
         this.menuService = MenuService.getInstance();
 

--- a/src/backend/modules/menu/MenuModule.ts
+++ b/src/backend/modules/menu/MenuModule.ts
@@ -18,6 +18,7 @@ import { MenuService } from './services/menu.service.js';
 import { MenuController } from './api/menu.controller.js';
 import { Router as ExpressRouter } from 'express';
 import { requireAdmin } from '../../api/middleware/admin-auth.js';
+import { userContextMiddleware } from '../../api/middleware/user-context.js';
 
 /**
  * Menu module dependencies for initialization.
@@ -147,8 +148,10 @@ export class MenuModule implements IModule<IMenuModuleDependencies> {
         this.serviceRegistry = dependencies.serviceRegistry;
         this.app = dependencies.app;
 
-        // Initialize MenuService singleton with database dependency
-        MenuService.setDatabase(this.database);
+        // Initialize MenuService singleton with database + registry dependencies.
+        // The registry is used at read time to look up `'user-groups'` for the
+        // admin-predicate gating filter (see MenuService.applyGatingFilter).
+        MenuService.setDependencies(this.database, this.serviceRegistry);
         this.menuService = MenuService.getInstance();
 
         // Initialize MenuService (loads menu tree from database)
@@ -229,11 +232,15 @@ export class MenuModule implements IModule<IMenuModuleDependencies> {
     private createRouter(): Router {
         const router = ExpressRouter();
 
-        // Public routes (no auth required for reading navigation structure)
-        router.get('/resolve', this.controller.resolve);
+        // Public routes (no auth required for reading navigation structure).
+        // userContextMiddleware resolves the tronrelic_uid cookie to req.user
+        // so the controller can apply per-user gating on `getTree` and
+        // `resolve`. The middleware is identity-only; it does not enforce
+        // authentication and is safe to apply to public reads.
+        router.get('/resolve', userContextMiddleware, this.controller.resolve);
         router.get('/namespaces', this.controller.getNamespaces);
         router.get('/namespace/:namespace/config', this.controller.getNamespaceConfig);
-        router.get('/', this.controller.getTree);
+        router.get('/', userContextMiddleware, this.controller.getTree);
 
         // Admin-only routes (mutating operations require authentication)
         router.post('/', requireAdmin, this.controller.create);

--- a/src/backend/modules/menu/README.md
+++ b/src/backend/modules/menu/README.md
@@ -203,7 +203,11 @@ Read endpoints are public so the frontend can render navigation without an admin
 
 ## WebSocket Real-Time Updates
 
-The menu service broadcasts `menu:update` events whenever nodes are created, updated, or deleted.
+The menu service broadcasts `menu:update` refetch signals whenever nodes are
+created, updated, or deleted. Per-user gating means the server cannot ship a
+single tree shape that fits every connected client — receivers re-request
+`GET /api/menu?namespace=...` with their own cookie and the gating filter
+returns their personalized view.
 
 **Event payload:**
 ```typescript
@@ -211,9 +215,9 @@ The menu service broadcasts `menu:update` events whenever nodes are created, upd
     type: 'menu:update',
     payload: {
         event: 'after:create' | 'after:update' | 'after:delete',
-        node: IMenuNode,
-        tree: IMenuTree,
-        timestamp: Date
+        namespace: string,
+        nodeId: string,
+        timestamp: string
     }
 }
 ```
@@ -221,10 +225,14 @@ The menu service broadcasts `menu:update` events whenever nodes are created, upd
 **Frontend subscription:**
 ```typescript
 socket.on('menu:update', (payload) => {
-    console.log(`Menu ${payload.event}:`, payload.node.label);
-    setMenuTree(payload.tree);
+    // Refetch via the user's cookie context; the signal carries no tree body
+    fetch(`/api/menu?namespace=${payload.namespace}`, { credentials: 'include' })
+        .then(r => r.json())
+        .then(({ tree }) => setMenuTree(tree));
 });
 ```
+
+**Admin namespaces are suppressed.** Mutations to `system` / `admin-sidebar` skip the broadcast entirely so the existence of admin-only URLs doesn't leak to anonymous visitors. Admin UIs reload via authenticated fetch after each mutation, so the suppression is invisible to operators.
 
 **Note:** Lifecycle events (init, ready, loaded) are NOT broadcast via WebSocket because clients are not connected during backend startup.
 

--- a/src/backend/modules/menu/README.md
+++ b/src/backend/modules/menu/README.md
@@ -123,6 +123,50 @@ if (menu) {
 
 **Delete:** Emits `before:delete` (can halt), removes from MongoDB if `persist=true`, removes from in-memory tree, emits `after:delete`, broadcasts WebSocket event. **Delete does NOT cascade by default** - subscribers must implement cascade logic.
 
+## Visibility Gating
+
+Menu nodes can be gated on three independent fields, ANDed together. The
+backend filters menu reads at request time using the cookie-resolved
+`req.user`; admin token holders bypass the filter so the admin UI can render
+and edit gated nodes.
+
+| Field | Shape | Semantics |
+|-------|-------|-----------|
+| `allowedIdentityStates` | `UserIdentityState[]?` | Visible only to users whose `identityState` is in the set. `undefined` means no gate. Empty array is rejected at write time. |
+| `requiresGroups` | `string[]?` | Visible if the user is a member of *any* listed group id (OR-of-membership). Group ids reference `module_user_groups` rows managed by the user module. |
+| `requiresAdmin` | `boolean?` | Visible only when `IUserGroupService.isAdmin(req.userId)` returns true. Routes through the user-groups service registry entry so future seeded admin tiers (e.g. `super-admin`) automatically qualify. |
+
+The filter lives in `MenuService.getTreeForUser(namespace, user?)` and
+`getChildrenForUser(parentId, namespace, user?)`. Both are called by the
+public read endpoints (`GET /api/menu`, `GET /api/menu/resolve`) after
+`userContextMiddleware` has populated `req.user`. Anonymous visitors pass
+`undefined` and only see nodes with no gates (or with `'anonymous'` in the
+allow-list).
+
+The admin predicate looks up `'user-groups'` from the service registry
+lazily — the user module registers the service in its `run()` phase, so by
+the time anyone calls `GET /api/menu` it's available. If the registry entry
+is missing (tests, or a deployment where the user module hasn't initialized
+yet), `requiresAdmin: true` nodes are hidden from everyone except the
+shared-admin-token holder.
+
+`requiresAdmin` is **not** the same as the `requireAdmin` middleware. The
+middleware is a shared-token gate (`x-admin-token` against
+`ADMIN_API_TOKEN`) for operators and CI tooling. `requiresAdmin` is a
+per-user check keyed off cookie identity. They coexist: operators creating
+admin-only menu items typically want both — `requiresAdmin: true` on the
+node so cookie-identified visitors are filtered out, and admin-namespace
+isolation (`system`, `admin-sidebar`) for the shared-token gate around
+mutating endpoints.
+
+### Real-time updates
+
+`menu:update` WebSocket events no longer ship the full tree — per-user
+gating means there is no single shape that fits every connected client.
+The event is now a refetch signal carrying `{ event, namespace, nodeId,
+timestamp }`; clients re-request `GET /api/menu` with their own cookie and
+the server returns the filtered view.
+
 ## REST API Reference
 
 Read endpoints are public so the frontend can render navigation without an admin token; mutating endpoints require `ADMIN_API_TOKEN` via `x-admin-token` or `Authorization: Bearer`. See [system-api.md](../../../../docs/system/system-api.md) for complete authentication patterns.
@@ -140,7 +184,7 @@ Read endpoints are public so the frontend can render navigation without an admin
 
 | Endpoint | Method | Purpose | Key Fields |
 |----------|--------|---------|------------|
-| `/api/menu` | POST | Create persisted menu node | Body: `label` (required), `description`, `url`, `icon`, `order`, `parent`, `enabled`, `requiredRole` |
+| `/api/menu` | POST | Create persisted menu node | Body: `label` (required), `description`, `url`, `icon`, `order`, `parent`, `enabled`, `allowedIdentityStates`, `requiresGroups`, `requiresAdmin` |
 | `/api/menu/:id` | PATCH | Update menu node | Body: any fields to update |
 | `/api/menu/:id` | DELETE | Delete menu node | Does **not** cascade — children become orphans unless a `before:delete` subscriber handles them |
 | `/api/menu/namespace/:namespace/config` | PUT | Replace namespace configuration | Body: `overflow`, `icons`, `layout`, `styling` |

--- a/src/backend/modules/menu/__tests__/menu.service.gating.test.ts
+++ b/src/backend/modules/menu/__tests__/menu.service.gating.test.ts
@@ -1,0 +1,254 @@
+/// <reference types="vitest" />
+
+/**
+ * MenuService gating filter tests.
+ *
+ * Covers `getTreeForUser` and `getChildrenForUser`: identity-state allow-list,
+ * group OR-membership, admin predicate via the user-groups service registry
+ * entry, and combinations. The mock `IUserGroupService` only stubs the
+ * methods the filter actually calls (`isAdmin`, `isMember`); the registry is
+ * a minimal in-memory implementation.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ObjectId } from 'mongodb';
+import type {
+    IDatabaseService,
+    IServiceRegistry,
+    IServiceWatchHandlers,
+    ServiceWatchDisposer,
+    IUser,
+    IUserGroupService,
+    UserIdentityState as UserIdentityStateType
+} from '@/types';
+import { UserIdentityState } from '@/types';
+
+vi.mock('../../../../services/websocket.service.js', () => ({
+    WebSocketService: {
+        getInstance: vi.fn(() => ({ emit: vi.fn() }))
+    }
+}));
+
+import { MenuService } from '../services/menu.service.js';
+
+// Minimal in-memory database mock — enough surface for MenuService.initialize
+// and the create() path used to seed gated nodes.
+function createDatabase(): IDatabaseService {
+    const collections = new Map<string, any[]>();
+
+    const buildCollection = (name: string) => {
+        if (!collections.has(name)) collections.set(name, []);
+        const data = collections.get(name)!;
+        return {
+            find: () => ({ toArray: async () => data }),
+            findOne: async (filter: any) => data.find((d) => Object.entries(filter).every(([k, v]) => (k === '_id' && v instanceof ObjectId ? d._id.equals(v) : d[k] === v))) ?? null,
+            insertOne: async (doc: any) => {
+                const id = new ObjectId();
+                data.push({ ...doc, _id: id });
+                return { insertedId: id, acknowledged: true };
+            },
+            updateOne: async () => ({ modifiedCount: 0, acknowledged: true }),
+            deleteOne: async () => ({ deletedCount: 0, acknowledged: true }),
+            createIndex: async () => 'idx',
+            deleteMany: async () => ({ deletedCount: 0, acknowledged: true }),
+            updateMany: async () => ({ modifiedCount: 0, acknowledged: true }),
+            countDocuments: async () => data.length
+        };
+    };
+
+    return {
+        registerModel: () => undefined,
+        getModel: () => undefined,
+        initializeMigrations: async () => undefined,
+        getMigrationsPending: async () => [],
+        getMigrationsCompleted: async () => [],
+        executeMigration: async () => undefined,
+        executeMigrationsAll: async () => undefined,
+        isMigrationRunning: () => false,
+        getCollection: <T>(name: string) => buildCollection(name) as any,
+        get: async () => undefined,
+        set: async () => undefined,
+        delete: async () => false,
+        createIndex: async () => undefined,
+        count: async () => 0,
+        find: async () => [],
+        findOne: async () => null,
+        insertOne: async () => new ObjectId() as any,
+        updateMany: async () => 0,
+        deleteMany: async () => 0
+    } as unknown as IDatabaseService;
+}
+
+// In-memory IServiceRegistry. The MenuService only calls `get`, but a full
+// implementation lets test setup wire services in the standard way.
+function createRegistry(): IServiceRegistry {
+    const services = new Map<string, unknown>();
+    return {
+        register: <T,>(name: string, service: T) => {
+            services.set(name, service);
+        },
+        unregister: (name: string) => services.delete(name),
+        get: <T,>(name: string) => services.get(name) as T | undefined,
+        has: (name: string) => services.has(name),
+        getNames: () => Array.from(services.keys()),
+        watch: <T,>(name: string, handlers: IServiceWatchHandlers<T>): ServiceWatchDisposer => {
+            const svc = services.get(name) as T | undefined;
+            if (svc !== undefined && handlers.onAvailable) void handlers.onAvailable(svc);
+            return () => undefined;
+        }
+    };
+}
+
+// Stub IUserGroupService implementing only what the menu filter calls. The
+// admin predicate uses the user's `groups[]` array as an allow-list, since the
+// MenuService never asks the service for membership directly — group-membership
+// checks read off the user object in-memory.
+function createGroupsService(adminUserIds: Set<string>): IUserGroupService {
+    return {
+        listGroups: async () => [],
+        getGroup: async () => null,
+        createGroup: async () => { throw new Error('not used'); },
+        updateGroup: async () => { throw new Error('not used'); },
+        deleteGroup: async () => undefined,
+        getUserGroups: async (userId: string) => [],
+        isMember: async (userId: string, groupId: string) => false,
+        addMember: async () => undefined,
+        removeMember: async () => undefined,
+        isAdmin: async (userId: string) => adminUserIds.has(userId)
+    } as IUserGroupService;
+}
+
+function makeUser(overrides: Partial<IUser> = {}): IUser {
+    return {
+        id: 'u-1',
+        isLoggedIn: true,
+        identityState: UserIdentityState.Verified,
+        wallets: [],
+        preferences: {} as IUser['preferences'],
+        activity: { firstSeen: new Date(), lastSeen: new Date(), pageViews: 0 } as IUser['activity'],
+        groups: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...overrides
+    };
+}
+
+describe('MenuService gating filter', () => {
+    let db: IDatabaseService;
+    let registry: IServiceRegistry;
+    let svc: MenuService;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        db = createDatabase();
+        registry = createRegistry();
+        MenuService.__resetForTests();
+        MenuService.setDependencies(db, registry);
+        svc = MenuService.getInstance();
+        await svc.initialize();
+    });
+
+    it('treats a missing user as anonymous and shows only ungated or anonymous-allowed nodes', async () => {
+        await svc.create({ namespace: 'main', label: 'Public', url: '/p', order: 1, parent: null, enabled: true });
+        await svc.create({ namespace: 'main', label: 'Anon-only', url: '/a', order: 2, parent: null, enabled: true, allowedIdentityStates: [UserIdentityState.Anonymous] });
+        await svc.create({ namespace: 'main', label: 'Verified-only', url: '/v', order: 3, parent: null, enabled: true, allowedIdentityStates: [UserIdentityState.Verified] });
+
+        const tree = await svc.getTreeForUser('main', undefined);
+        const labels = tree.all.map((n) => n.label).sort();
+        // Default Home is auto-created on empty initialize — include it.
+        expect(labels).toEqual(['Anon-only', 'Home', 'Public']);
+    });
+
+    it('hides anonymous-only nodes from a verified user and shows verified-only nodes', async () => {
+        await svc.create({ namespace: 'main', label: 'Anon-only', url: '/a', order: 1, parent: null, enabled: true, allowedIdentityStates: [UserIdentityState.Anonymous] });
+        await svc.create({ namespace: 'main', label: 'Verified-only', url: '/v', order: 2, parent: null, enabled: true, allowedIdentityStates: [UserIdentityState.Verified] });
+
+        const verified = makeUser({ id: 'u-verified', identityState: UserIdentityState.Verified });
+        const tree = await svc.getTreeForUser('main', verified);
+        const labels = tree.all.map((n) => n.label).sort();
+        expect(labels).toEqual(['Home', 'Verified-only']);
+    });
+
+    it('honors the "verified or anonymous" combination', async () => {
+        await svc.create({ namespace: 'main', label: 'Mixed', url: '/m', order: 1, parent: null, enabled: true, allowedIdentityStates: [UserIdentityState.Anonymous, UserIdentityState.Verified] });
+
+        const anon = await svc.getTreeForUser('main', undefined);
+        expect(anon.all.some((n) => n.label === 'Mixed')).toBe(true);
+
+        const verified = await svc.getTreeForUser('main', makeUser({ id: 'u-verified', identityState: UserIdentityState.Verified }));
+        expect(verified.all.some((n) => n.label === 'Mixed')).toBe(true);
+
+        const registered = await svc.getTreeForUser('main', makeUser({ id: 'u-reg', identityState: UserIdentityState.Registered }));
+        expect(registered.all.some((n) => n.label === 'Mixed')).toBe(false);
+    });
+
+    it('shows group-gated nodes only to users in any required group', async () => {
+        await svc.create({ namespace: 'main', label: 'VIP', url: '/vip', order: 1, parent: null, enabled: true, requiresGroups: ['vip-traders', 'whales'] });
+
+        const outsider = await svc.getTreeForUser('main', makeUser({ id: 'u-out', groups: [] }));
+        expect(outsider.all.some((n) => n.label === 'VIP')).toBe(false);
+
+        const insider = await svc.getTreeForUser('main', makeUser({ id: 'u-in', groups: ['whales'] }));
+        expect(insider.all.some((n) => n.label === 'VIP')).toBe(true);
+    });
+
+    it('treats missing user-groups service as "no admin" — admin-gated nodes hidden from everyone', async () => {
+        await svc.create({ namespace: 'main', label: 'Admin', url: '/admin', order: 1, parent: null, enabled: true, requiresAdmin: true });
+
+        const tree = await svc.getTreeForUser('main', makeUser({ id: 'u-1', groups: ['admin'] }));
+        // No user-groups service registered yet — isAdmin always returns false.
+        expect(tree.all.some((n) => n.label === 'Admin')).toBe(false);
+    });
+
+    it('shows admin-gated nodes when the user is an admin per the registered service', async () => {
+        registry.register('user-groups', createGroupsService(new Set(['u-admin'])));
+
+        await svc.create({ namespace: 'main', label: 'Admin', url: '/admin', order: 1, parent: null, enabled: true, requiresAdmin: true });
+
+        const admin = await svc.getTreeForUser('main', makeUser({ id: 'u-admin' }));
+        expect(admin.all.some((n) => n.label === 'Admin')).toBe(true);
+
+        const peasant = await svc.getTreeForUser('main', makeUser({ id: 'u-peasant' }));
+        expect(peasant.all.some((n) => n.label === 'Admin')).toBe(false);
+    });
+
+    it('ANDs identity-state, group, and admin predicates together', async () => {
+        registry.register('user-groups', createGroupsService(new Set(['u-admin'])));
+
+        await svc.create({
+            namespace: 'main',
+            label: 'AdminAndVerifiedAndVip',
+            url: '/x',
+            order: 1,
+            parent: null,
+            enabled: true,
+            allowedIdentityStates: [UserIdentityState.Verified],
+            requiresGroups: ['vip-traders'],
+            requiresAdmin: true
+        });
+
+        // Wrong on every axis
+        const noFit = await svc.getTreeForUser('main', makeUser({ id: 'u-1', identityState: UserIdentityState.Anonymous, groups: [] }));
+        expect(noFit.all.some((n) => n.label === 'AdminAndVerifiedAndVip')).toBe(false);
+
+        // Verified but missing group + not admin
+        const verifiedOnly = await svc.getTreeForUser('main', makeUser({ id: 'u-2', identityState: UserIdentityState.Verified, groups: [] }));
+        expect(verifiedOnly.all.some((n) => n.label === 'AdminAndVerifiedAndVip')).toBe(false);
+
+        // Hits all three predicates
+        const allFit = await svc.getTreeForUser('main', makeUser({ id: 'u-admin', identityState: UserIdentityState.Verified, groups: ['vip-traders'] }));
+        expect(allFit.all.some((n) => n.label === 'AdminAndVerifiedAndVip')).toBe(true);
+    });
+
+    it('getChildrenForUser applies the same gating to direct children', async () => {
+        const parent = await svc.create({ namespace: 'main', label: 'Tools', url: '/tools', order: 1, parent: null, enabled: true });
+        await svc.create({ namespace: 'main', label: 'Public-tool', url: '/tools/p', order: 1, parent: parent._id!, enabled: true });
+        await svc.create({ namespace: 'main', label: 'Verified-tool', url: '/tools/v', order: 2, parent: parent._id!, enabled: true, allowedIdentityStates: [UserIdentityState.Verified] });
+
+        const anonChildren = await svc.getChildrenForUser(parent._id!, 'main', undefined);
+        expect(anonChildren.map((n) => n.label).sort()).toEqual(['Public-tool']);
+
+        const verifiedChildren = await svc.getChildrenForUser(parent._id!, 'main', makeUser({ id: 'u-v', identityState: UserIdentityState.Verified }));
+        expect(verifiedChildren.map((n) => n.label).sort()).toEqual(['Public-tool', 'Verified-tool']);
+    });
+});

--- a/src/backend/modules/menu/api/menu.controller.ts
+++ b/src/backend/modules/menu/api/menu.controller.ts
@@ -66,19 +66,22 @@ function emptyStringAsUndefined<T extends z.ZodTypeAny>(schema: T) {
 
 /**
  * Group ids written to `requiresGroups` must match the slug shape enforced by
- * `IUserGroupService.createGroup`. Validating client-side prevents bad input
- * from being persisted and propagating to filter checks at read time.
+ * `UserGroupService.createGroup` (see `services/user-group.service.ts`).
+ * The canonical pattern requires a letter start, allows internal hyphens,
+ * and rejects trailing hyphens — letting the menu API persist a slug the
+ * user-groups service would never accept guarantees an unfindable group at
+ * read time.
  */
-const GROUP_ID_REGEX = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const GROUP_ID_REGEX = /^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$/;
 
 /**
- * Allow-list of identity states. Must be non-empty when present — an empty
- * array would hide the node from every visitor, which is what `enabled: false`
- * already expresses cleanly.
+ * Allow-list of identity states. An empty array is accepted and treated as
+ * "no gate" — the service persists empty arrays via `$unset` so the database
+ * stays clean. Sending `[]` from a PATCH is the only way to clear a gate
+ * that was previously set, since omitting the field means "leave unchanged".
  */
 const allowedIdentityStatesField = z
     .array(z.nativeEnum(UserIdentityState))
-    .min(1, 'allowedIdentityStates must contain at least one state, or be omitted entirely')
     .max(3)
     .optional();
 

--- a/src/backend/modules/menu/api/menu.controller.ts
+++ b/src/backend/modules/menu/api/menu.controller.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 import { MenuService } from '../services/menu.service.js';
 import { ADMIN_NAMESPACES } from '../constants.js';
 import { isAdmin } from '../../../api/middleware/admin-auth.js';
-import type { IMenuNodeWithChildren, IMenuTree } from '@/types';
+import type { IMenuNodeWithChildren, IMenuTree, IUser } from '@/types';
+import { UserIdentityState } from '@/types';
 
 /**
  * Acceptable namespace identifiers. Lowercase ASCII, hyphens allowed,
@@ -62,6 +63,29 @@ const objectIdField = z
 function emptyStringAsUndefined<T extends z.ZodTypeAny>(schema: T) {
     return z.preprocess((val) => (typeof val === 'string' && val.length === 0 ? undefined : val), schema);
 }
+
+/**
+ * Group ids written to `requiresGroups` must match the slug shape enforced by
+ * `IUserGroupService.createGroup`. Validating client-side prevents bad input
+ * from being persisted and propagating to filter checks at read time.
+ */
+const GROUP_ID_REGEX = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+/**
+ * Allow-list of identity states. Must be non-empty when present — an empty
+ * array would hide the node from every visitor, which is what `enabled: false`
+ * already expresses cleanly.
+ */
+const allowedIdentityStatesField = z
+    .array(z.nativeEnum(UserIdentityState))
+    .min(1, 'allowedIdentityStates must contain at least one state, or be omitted entirely')
+    .max(3)
+    .optional();
+
+const requiresGroupsField = z
+    .array(z.string().regex(GROUP_ID_REGEX, 'Group ids must be lowercase kebab-case slugs'))
+    .max(64)
+    .optional();
 
 /**
  * Zod schema for creating a new menu node.
@@ -136,15 +160,19 @@ const createNodeSchema = z.object({
     enabled: z.boolean().optional(),
 
     /**
-     * Optional access control role or permission requirement.
+     * Allow-list of identity states that may see the node.
      */
-    requiredRole: emptyStringAsUndefined(
-        z
-            .string()
-            .max(64)
-            .regex(/^[a-zA-Z0-9_-]+$/, 'Required role must be alphanumeric')
-            .optional()
-    )
+    allowedIdentityStates: allowedIdentityStatesField,
+
+    /**
+     * Required group memberships (OR-of-membership).
+     */
+    requiresGroups: requiresGroupsField,
+
+    /**
+     * Restrict the node to admin users — see IMenuNode.requiresAdmin.
+     */
+    requiresAdmin: z.boolean().optional()
 });
 
 /**
@@ -182,13 +210,9 @@ const updateNodeSchema = z.object({
     order: z.number().int().min(0).max(100_000).optional(),
     parent: objectIdField.nullable().optional(),
     enabled: z.boolean().optional(),
-    requiredRole: emptyStringAsUndefined(
-        z
-            .string()
-            .max(64)
-            .regex(/^[a-zA-Z0-9_-]+$/, 'Required role must be alphanumeric')
-            .optional()
-    )
+    allowedIdentityStates: allowedIdentityStatesField,
+    requiresGroups: requiresGroupsField,
+    requiresAdmin: z.boolean().optional()
 });
 
 /**
@@ -348,11 +372,18 @@ export class MenuController {
 
             if (denyIfAdminNamespace(req, res, namespace)) return;
 
-            const tree = this.service.getTree(namespace);
-            // Anonymous callers see only enabled nodes; admins see everything
-            // so the admin UI can render and toggle disabled items.
-            const view = isAdmin(req) ? tree : publicTreeView(tree);
-            res.json({ success: true, tree: view });
+            // Admin token holders see the full unfiltered tree (including
+            // disabled nodes and gated entries) so the admin UI can render
+            // and edit them. Regular visitors get the per-user filtered
+            // view: enabled-only AND gating-aware.
+            if (isAdmin(req)) {
+                res.json({ success: true, tree: this.service.getTree(namespace) });
+                return;
+            }
+
+            const user = (req as Request & { user?: IUser }).user;
+            const filtered = await this.service.getTreeForUser(namespace, user);
+            res.json({ success: true, tree: publicTreeView(filtered) });
         } catch (error) {
             const message = error instanceof Error ? error.message : 'Failed to get menu tree';
             res.status(500).json({ success: false, error: message });
@@ -844,7 +875,14 @@ export class MenuController {
             }
             if (denyIfAdminNamespace(req, res, namespace)) return;
 
-            const tree = this.service.getTree(namespace);
+            // Admin token holders bypass the per-user filter so they can
+            // resolve any URL regardless of gating; regular visitors see only
+            // the URLs (and children) their identity qualifies for.
+            const callerIsAdmin = isAdmin(req);
+            const user = (req as Request & { user?: IUser }).user;
+            const tree = callerIsAdmin
+                ? this.service.getTree(namespace)
+                : await this.service.getTreeForUser(namespace, user);
 
             // Find node matching the URL
             const node = tree.all.find(n => n.url === url && n.enabled);
@@ -853,9 +891,12 @@ export class MenuController {
                 return;
             }
 
-            // Get enabled children with URLs sorted by order
-            const children = this.service.getChildren(node._id!, namespace)
-                .filter(c => c.enabled && c.url);
+            // Get enabled children with URLs sorted by order, gated to the
+            // calling visitor unless the caller is admin.
+            const children = (callerIsAdmin
+                ? this.service.getChildren(node._id!, namespace)
+                : await this.service.getChildrenForUser(node._id!, namespace, user)
+            ).filter(c => c.enabled && c.url);
 
             if (children.length === 0) {
                 res.status(404).json({ success: false, error: 'No children found for category node' });

--- a/src/backend/modules/menu/database/IMenuNodeDocument.ts
+++ b/src/backend/modules/menu/database/IMenuNodeDocument.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from 'mongodb';
+import type { UserIdentityState } from '@/types';
 
 /**
  * MongoDB document interface for menu nodes.
@@ -26,7 +27,21 @@ export interface IMenuNodeDocument {
     order: number;
     parent: ObjectId | null;
     enabled: boolean;
-    requiredRole?: string;
+    /**
+     * Allow-list of identity states that may see the node. See
+     * `IMenuNode.allowedIdentityStates` for semantics.
+     */
+    allowedIdentityStates?: UserIdentityState[];
+    /**
+     * Required group memberships (OR-of-membership). See
+     * `IMenuNode.requiresGroups` for semantics.
+     */
+    requiresGroups?: string[];
+    /**
+     * Admin-only flag, evaluated through `IUserGroupService.isAdmin`. See
+     * `IMenuNode.requiresAdmin` for semantics.
+     */
+    requiresAdmin?: boolean;
     createdAt?: Date;
     updatedAt?: Date;
 }

--- a/src/backend/modules/menu/migrations/003_replace_required_role_with_gating_fields.ts
+++ b/src/backend/modules/menu/migrations/003_replace_required_role_with_gating_fields.ts
@@ -1,0 +1,93 @@
+import type { IMigration, IMigrationContext } from '@/types';
+
+/**
+ * Replace the legacy `requiredRole` string field on menu nodes with the
+ * structured gating shape (`allowedIdentityStates`, `requiresGroups`,
+ * `requiresAdmin`) introduced alongside the user-groups permission system.
+ *
+ * **Why this migration exists:**
+ * `requiredRole` was a free-form string that nothing in the codebase actually
+ * enforced — the JSDoc punted the check to the frontend, and no consumer ever
+ * filtered on it. The new gating shape is enforced server-side at read time
+ * by `MenuService.getTreeForUser`, which uses cookie-resolved user identity
+ * plus `IUserGroupService.isAdmin/isMember` to decide visibility. Keeping the
+ * legacy field around alongside the new fields would invite drift and make
+ * the operator UI ambiguous.
+ *
+ * **Mapping rules:**
+ * - `requiredRole === 'admin'` → `requiresAdmin: true`. The new admin
+ *   predicate routes through `IUserGroupService.isAdmin`, which evaluates any
+ *   system-flagged group whose id matches the reserved-admin pattern. This
+ *   keeps existing admin-gated menu items working for future seeded admin
+ *   tiers (e.g. `super-admin`) without rewriting them.
+ * - `requiredRole === <other-non-empty-string>` → `requiresGroups: [value]`.
+ *   The string is reused as the literal group id. Operators should review
+ *   the resulting groups and either create matching rows in
+ *   `module_user_groups` or update the menu item to point at an existing
+ *   group.
+ * - `requiredRole` empty/missing → no migration needed; the field is dropped
+ *   either way as a final cleanup step.
+ *
+ * **Idempotency:**
+ * Each pass runs `$exists: true` filters and only writes to documents that
+ * still carry `requiredRole`. Re-running after a successful pass is a no-op.
+ *
+ * **Rollback:**
+ * Not provided. The mapping is lossy (group-id form is a guess for non-'admin'
+ * values) and the legacy field had no enforced semantics. Operators recover
+ * by editing menu items via the admin UI.
+ */
+export const migration: IMigration = {
+    id: '003_replace_required_role_with_gating_fields',
+    description: 'Migrate menu_nodes.requiredRole to allowedIdentityStates/requiresGroups/requiresAdmin gating fields and drop the legacy field.',
+    dependencies: [],
+
+    async up(context: IMigrationContext): Promise<void> {
+        const collection = context.database.getCollection('menu_nodes');
+
+        // Pass 1: requiredRole === 'admin' becomes requiresAdmin: true.
+        const adminResult = await collection.updateMany(
+            { requiredRole: 'admin' },
+            { $set: { requiresAdmin: true }, $unset: { requiredRole: '' } }
+        );
+        console.log(`[Migration] Mapped ${adminResult.modifiedCount} admin-gated menu nodes to requiresAdmin: true`);
+
+        // Pass 2: any other non-empty requiredRole becomes a single-element
+        // requiresGroups array. We can't pre-create the matching group rows
+        // here — the user module owns that collection and operators may want
+        // to consolidate ids — so the migration trusts the literal value.
+        // Operators see the result in the admin UI's group multi-select and
+        // can fix up entries that reference unknown group ids.
+        const remaining = await collection.find({
+            requiredRole: { $exists: true, $nin: [null, ''] }
+        }).toArray();
+
+        let groupMappedCount = 0;
+        for (const doc of remaining) {
+            const role = (doc as { requiredRole?: string }).requiredRole;
+            if (typeof role !== 'string' || role.length === 0) continue;
+
+            await collection.updateOne(
+                { _id: doc._id },
+                {
+                    $set: { requiresGroups: [role] },
+                    $unset: { requiredRole: '' }
+                }
+            );
+            groupMappedCount++;
+        }
+        console.log(`[Migration] Mapped ${groupMappedCount} role-gated menu nodes to requiresGroups arrays`);
+
+        // Pass 3: clear the legacy field on every remaining document. Catches
+        // empty strings and stragglers that the typed passes above skipped.
+        const cleanupResult = await collection.updateMany(
+            { requiredRole: { $exists: true } },
+            { $unset: { requiredRole: '' } }
+        );
+        if (cleanupResult.modifiedCount > 0) {
+            console.log(`[Migration] Cleared legacy requiredRole field from ${cleanupResult.modifiedCount} additional documents`);
+        }
+
+        console.log('[Migration] Menu node gating migration complete');
+    }
+};

--- a/src/backend/modules/menu/services/menu.service.ts
+++ b/src/backend/modules/menu/services/menu.service.ts
@@ -8,8 +8,13 @@ import type {
     MenuEventType,
     MenuEventSubscriber,
     IDatabaseService,
-    IMenuNamespaceConfig
+    IMenuNamespaceConfig,
+    IServiceRegistry,
+    IUserGroupService,
+    IUser,
+    UserIdentityState as UserIdentityStateType
 } from '@/types';
+import { UserIdentityState } from '@/types';
 import { logger } from '../../../lib/logger.js';
 import { WebSocketService } from '../../../services/websocket.service.js';
 import { ObjectId } from 'mongodb';
@@ -68,6 +73,7 @@ export class MenuService implements IMenuService {
     private subscribers: Map<MenuEventType, MenuEventSubscriber[]> = new Map();
     private initialized = false;
     private database: IDatabaseService;
+    private serviceRegistry: IServiceRegistry;
     private readonly DEFAULT_NAMESPACE = 'main';
     private readonly OVERRIDES_COLLECTION = 'menu_node_overrides';
     private persistedNodeIds = new Set<string>();
@@ -81,26 +87,49 @@ export class MenuService implements IMenuService {
     /**
      * Private constructor enforcing singleton pattern with dependency injection.
      *
-     * Accepts database dependency to decouple from Mongoose and enable testability.
-     * Use getInstance() to access the service after calling setDatabase().
-     *
      * @param database - Database service for menu node storage
+     * @param serviceRegistry - Service registry for late-binding lookup of
+     *                          `IUserGroupService` (used by the gating filter to
+     *                          evaluate `requiresAdmin`)
      */
-    private constructor(database: IDatabaseService) {
+    private constructor(database: IDatabaseService, serviceRegistry: IServiceRegistry) {
         this.database = database;
+        this.serviceRegistry = serviceRegistry;
     }
 
     /**
-     * Set the database instance for the singleton.
+     * Configure the singleton with its dependencies.
      *
      * Must be called once during application bootstrap before getInstance().
-     * This enables dependency injection while maintaining the singleton pattern.
+     * The service registry is held for lazy `IUserGroupService` lookup at read
+     * time — by the time anyone calls `getTree()` with a user, the user module
+     * has registered `'user-groups'`.
      *
      * @param database - Database service for menu node storage
+     * @param serviceRegistry - Service registry for late-binding service lookup
+     */
+    public static setDependencies(database: IDatabaseService, serviceRegistry: IServiceRegistry): void {
+        if (!MenuService.instance) {
+            MenuService.instance = new MenuService(database, serviceRegistry);
+        }
+    }
+
+    /**
+     * @deprecated Use `setDependencies(database, serviceRegistry)` instead. Retained for
+     * tests and external callers that haven't migrated; throws at read time if a node
+     * uses `requiresAdmin` because the registry is unavailable.
      */
     public static setDatabase(database: IDatabaseService): void {
         if (!MenuService.instance) {
-            MenuService.instance = new MenuService(database);
+            const stub: IServiceRegistry = {
+                register: () => { /* no-op stub */ },
+                unregister: () => false,
+                get: () => undefined,
+                has: () => false,
+                getNames: () => [],
+                watch: () => () => { /* no-op disposer */ }
+            };
+            MenuService.instance = new MenuService(database, stub);
         }
     }
 
@@ -111,13 +140,23 @@ export class MenuService implements IMenuService {
      * subsequent calls, ensuring a single source of truth for menu state.
      *
      * @returns The singleton MenuService instance
-     * @throws Error if setDatabase() was not called first
+     * @throws Error if setDependencies() was not called first
      */
     public static getInstance(): MenuService {
         if (!MenuService.instance) {
-            throw new Error('MenuService.setDatabase() must be called before getInstance()');
+            throw new Error('MenuService.setDependencies() must be called before getInstance()');
         }
         return MenuService.instance;
+    }
+
+    /**
+     * Reset the singleton (test-only).
+     *
+     * @internal
+     */
+    public static __resetForTests(): void {
+        // Used by Vitest suites to swap in a fresh instance with mock deps.
+        MenuService.instance = undefined as unknown as MenuService;
     }
 
     /**
@@ -316,7 +355,9 @@ export class MenuService implements IMenuService {
             order: nodeData.order ?? 0,
             parent: nodeData.parent ?? null,
             enabled: nodeData.enabled ?? true,
-            requiredRole: nodeData.requiredRole
+            allowedIdentityStates: nodeData.allowedIdentityStates,
+            requiresGroups: nodeData.requiresGroups,
+            requiresAdmin: nodeData.requiresAdmin
         };
 
         // Reject duplicate URLs within the same namespace. Without this,
@@ -356,7 +397,9 @@ export class MenuService implements IMenuService {
                 order: node.order,
                 parent: node.parent ? new ObjectId(node.parent) : null,
                 enabled: node.enabled,
-                requiredRole: node.requiredRole,
+                allowedIdentityStates: node.allowedIdentityStates,
+                requiresGroups: node.requiresGroups,
+                requiresAdmin: node.requiresAdmin,
                 createdAt: now,
                 updatedAt: now
             };
@@ -385,7 +428,9 @@ export class MenuService implements IMenuService {
                 order: override?.order ?? node.order,
                 parent: node.parent,
                 enabled: override?.enabled ?? node.enabled,
-                requiredRole: node.requiredRole,
+                allowedIdentityStates: node.allowedIdentityStates,
+                requiresGroups: node.requiresGroups,
+                requiresAdmin: node.requiresAdmin,
                 createdAt: new Date(),
                 updatedAt: new Date()
             };
@@ -516,7 +561,9 @@ export class MenuService implements IMenuService {
                     ...(updates.order !== undefined && { order: updates.order }),
                     ...(updates.parent !== undefined && { parent: updates.parent ? new ObjectId(updates.parent) : null }),
                     ...(updates.enabled !== undefined && { enabled: updates.enabled }),
-                    ...(updates.requiredRole !== undefined && { requiredRole: updates.requiredRole }),
+                    ...(updates.allowedIdentityStates !== undefined && { allowedIdentityStates: updates.allowedIdentityStates }),
+                    ...(updates.requiresGroups !== undefined && { requiresGroups: updates.requiresGroups }),
+                    ...(updates.requiresAdmin !== undefined && { requiresAdmin: updates.requiresAdmin }),
                     updatedAt: new Date()
                 };
 
@@ -670,6 +717,88 @@ export class MenuService implements IMenuService {
             all,
             generatedAt: new Date()
         };
+    }
+
+    /**
+     * Get the menu tree filtered to nodes the given user is permitted to see.
+     *
+     * Applies the gating rules declared on each node (`allowedIdentityStates`,
+     * `requiresGroups`, `requiresAdmin`) using the cookie-resolved user. An
+     * `undefined` user is treated as an anonymous visitor with no group
+     * memberships, so only nodes with no gates (or with `'anonymous'` in their
+     * `allowedIdentityStates`) appear.
+     *
+     * The admin predicate (`requiresAdmin: true`) resolves through
+     * `IUserGroupService.isAdmin`, looked up lazily from the service registry.
+     * If the user-groups service is not registered, admin-gated nodes are
+     * hidden from non-admin token holders by default.
+     *
+     * @param namespace - Menu namespace (defaults to 'main')
+     * @param user - Cookie-resolved user, or undefined for anonymous
+     * @returns Filtered tree containing only nodes the user may see
+     */
+    public async getTreeForUser(namespace: string | undefined, user: IUser | undefined): Promise<IMenuTree> {
+        const tree = this.getTree(namespace);
+        const groupsService = this.serviceRegistry.get<IUserGroupService>('user-groups');
+        const isUserAdmin = user && groupsService ? await groupsService.isAdmin(user.id) : false;
+
+        const visible = tree.all.filter((node) => this.passesGate(node, user, isUserAdmin));
+        return {
+            roots: this.buildTree(visible),
+            all: visible,
+            generatedAt: tree.generatedAt
+        };
+    }
+
+    /**
+     * Get a single child of the named parent that the given user may see.
+     *
+     * Same gating rules as {@link getTreeForUser}; returns the user-filtered
+     * children sorted by order.
+     */
+    public async getChildrenForUser(
+        parentId: string | null,
+        namespace: string | undefined,
+        user: IUser | undefined
+    ): Promise<IMenuNode[]> {
+        const groupsService = this.serviceRegistry.get<IUserGroupService>('user-groups');
+        const isUserAdmin = user && groupsService ? await groupsService.isAdmin(user.id) : false;
+        return this.getChildren(parentId, namespace).filter((node) => this.passesGate(node, user, isUserAdmin));
+    }
+
+    /**
+     * Decide whether a single node is visible to the given user.
+     *
+     * The three gating fields are ANDed together — a missing field is
+     * tautologically true. The order of checks is intentional: cheap
+     * in-memory predicates first, then the precomputed admin flag.
+     *
+     * @param node - The node under consideration
+     * @param user - Cookie-resolved user, or undefined for anonymous
+     * @param isUserAdmin - Result of `groups.isAdmin(user.id)`, precomputed
+     *                      so a tree filter can amortize one DB round-trip
+     *                      across hundreds of nodes
+     */
+    private passesGate(node: IMenuNode, user: IUser | undefined, isUserAdmin: boolean): boolean {
+        const identityState: UserIdentityStateType = user?.identityState ?? UserIdentityState.Anonymous;
+        const userGroups: string[] = user?.groups ?? [];
+
+        // Identity-state allow-list: if set, the user's state must be in it.
+        if (node.allowedIdentityStates && node.allowedIdentityStates.length > 0) {
+            if (!node.allowedIdentityStates.includes(identityState)) return false;
+        }
+
+        // Required groups: if set, the user must be in at least one.
+        if (node.requiresGroups && node.requiresGroups.length > 0) {
+            const hasAny = node.requiresGroups.some((gid) => userGroups.includes(gid));
+            if (!hasAny) return false;
+        }
+
+        // Admin predicate: routes through IUserGroupService.isAdmin so future
+        // seeded admin tiers (e.g. super-admin) automatically qualify.
+        if (node.requiresAdmin && !isUserAdmin) return false;
+
+        return true;
     }
 
     /**
@@ -967,9 +1096,9 @@ export class MenuService implements IMenuService {
         try {
             const ns = node.namespace || this.DEFAULT_NAMESPACE;
 
-            // Admin namespaces never broadcast publicly. WebSocketService.emit
-            // sends `menu:update` to every connected socket via `io.emit`, so
-            // any system-namespace mutation would otherwise leak admin URLs to
+            // Admin namespaces never broadcast publicly. The signal goes to
+            // every connected socket via `io.emit`, so any system-namespace
+            // mutation would otherwise leak the existence of admin URLs to
             // anonymous visitors. Admin UIs reload via authenticated fetch
             // after each mutation, so the suppression is invisible to them.
             if (ADMIN_NAMESPACES.has(ns)) {
@@ -977,56 +1106,29 @@ export class MenuService implements IMenuService {
                 return;
             }
 
-            // The broadcast goes to every client, so strip disabled nodes —
-            // an admin toggling `enabled: false` should remove the item from
-            // public view immediately rather than push it disabled-but-visible.
-            const fullTree = this.getTree(ns);
-            const tree: IMenuTree = {
-                roots: this.filterEnabledTree(fullTree.roots),
-                all: fullTree.all.filter((n) => n.enabled),
-                generatedAt: fullTree.generatedAt
-            };
-
-            // The broadcast reaches every connected socket. Sending the full
-            // node would leak label/url/icon/requiredRole at the moment a node
-            // is disabled or deleted — even though the redacted tree above
-            // already removes those fields from public view. Emit only the
-            // identifiers clients need to invalidate cached entries; the tree
-            // is the authoritative public surface.
-            const redactedNode = {
-                _id: node._id,
-                namespace: ns,
-                enabled: node.enabled
-            };
+            // Per-user gating (allowedIdentityStates / requiresGroups /
+            // requiresAdmin) means there is no single tree shape that fits
+            // every connected client. Send a refetch signal instead — each
+            // client re-requests `GET /api/menu` with its own cookie and the
+            // server returns the filtered view. Identifiers are kept in the
+            // payload so clients can scope cache invalidation to one
+            // namespace, but no node body is shipped.
             const wsService = WebSocketService.getInstance();
             wsService.emit({
                 event: 'menu:update',
                 payload: {
                     event: eventType,
-                    node: redactedNode,
-                    tree,
+                    namespace: ns,
+                    nodeId: node._id,
                     timestamp: new Date()
                 }
             });
 
-            logger.debug({ eventType, nodeId: node._id, namespace: ns }, 'Menu tree update broadcast via WebSocket');
+            logger.debug({ eventType, nodeId: node._id, namespace: ns }, 'Menu refetch signal broadcast via WebSocket');
         } catch (error) {
-            logger.error({ error }, 'Failed to broadcast menu tree update');
+            logger.error({ error }, 'Failed to broadcast menu refetch signal');
             // Don't throw - WebSocket failure shouldn't break menu operations
         }
-    }
-
-    /**
-     * Recursively strip disabled nodes from a hierarchical tree view.
-     * Returns fresh objects so the in-memory tree is not mutated.
-     */
-    private filterEnabledTree(roots: IMenuNodeWithChildren[]): IMenuNodeWithChildren[] {
-        return roots
-            .filter((node) => node.enabled)
-            .map((node) => ({
-                ...node,
-                children: this.filterEnabledTree(node.children)
-            }));
     }
 
     /**
@@ -1164,7 +1266,9 @@ export class MenuService implements IMenuService {
             order: doc.order ?? 0,
             parent: doc.parent ? doc.parent.toString() : null,
             enabled: doc.enabled ?? true,
-            requiredRole: doc.requiredRole,
+            allowedIdentityStates: doc.allowedIdentityStates,
+            requiresGroups: doc.requiresGroups,
+            requiresAdmin: doc.requiresAdmin,
             createdAt: doc.createdAt,
             updatedAt: doc.updatedAt
         };

--- a/src/backend/modules/menu/services/menu.service.ts
+++ b/src/backend/modules/menu/services/menu.service.ts
@@ -116,8 +116,11 @@ export class MenuService implements IMenuService {
 
     /**
      * @deprecated Use `setDependencies(database, serviceRegistry)` instead. Retained for
-     * tests and external callers that haven't migrated; throws at read time if a node
-     * uses `requiresAdmin` because the registry is unavailable.
+     * tests and external callers that haven't migrated. Without a real registry the stub
+     * returns no service for `'user-groups'`, so `requiresAdmin: true` nodes are simply
+     * hidden from any cookie-identified caller — there is no shared-token bypass at the
+     * gating layer (admins still see everything because the controller short-circuits
+     * filtering for admin-token requests, not because the gate trusts them).
      */
     public static setDatabase(database: IDatabaseService): void {
         if (!MenuService.instance) {
@@ -501,7 +504,22 @@ export class MenuService implements IMenuService {
             throw new Error(`Menu node not found: ${id}`);
         }
 
-        const updated: IMenuNode = { ...existing, ...updates, _id: id };
+        // Empty gating arrays and `requiresAdmin: false` are treated as
+        // "clear this gate" — the only way to remove a previously-set gate
+        // through PATCH is to send the cleared value explicitly. Normalize
+        // here so the in-memory tree carries `undefined`, not `[]` / `false`.
+        const normalizedUpdates: Partial<IMenuNode> = { ...updates };
+        if (Array.isArray(normalizedUpdates.allowedIdentityStates) && normalizedUpdates.allowedIdentityStates.length === 0) {
+            normalizedUpdates.allowedIdentityStates = undefined;
+        }
+        if (Array.isArray(normalizedUpdates.requiresGroups) && normalizedUpdates.requiresGroups.length === 0) {
+            normalizedUpdates.requiresGroups = undefined;
+        }
+        if (normalizedUpdates.requiresAdmin === false) {
+            normalizedUpdates.requiresAdmin = undefined;
+        }
+
+        const updated: IMenuNode = { ...existing, ...normalizedUpdates, _id: id };
         const newNamespace = updated.namespace || existingNamespace;
 
         // If the URL or namespace is changing, refuse to clobber an existing
@@ -552,22 +570,38 @@ export class MenuService implements IMenuService {
             if (this.persistedNodeIds.has(id)) {
                 // Node exists in menu_nodes — update it directly
                 const collection = this.database.getCollection<IMenuNodeDocument>('menu_nodes');
-                const updateDoc: Partial<IMenuNodeDocument> = {
-                    ...(updates.namespace !== undefined && { namespace: updates.namespace }),
-                    ...(updates.label !== undefined && { label: updates.label }),
-                    ...(updates.description !== undefined && { description: updates.description }),
-                    ...(updates.url !== undefined && { url: updates.url }),
-                    ...(updates.icon !== undefined && { icon: updates.icon }),
-                    ...(updates.order !== undefined && { order: updates.order }),
-                    ...(updates.parent !== undefined && { parent: updates.parent ? new ObjectId(updates.parent) : null }),
-                    ...(updates.enabled !== undefined && { enabled: updates.enabled }),
-                    ...(updates.allowedIdentityStates !== undefined && { allowedIdentityStates: updates.allowedIdentityStates }),
-                    ...(updates.requiresGroups !== undefined && { requiresGroups: updates.requiresGroups }),
-                    ...(updates.requiresAdmin !== undefined && { requiresAdmin: updates.requiresAdmin }),
+                const setDoc: Partial<IMenuNodeDocument> = {
+                    ...(normalizedUpdates.namespace !== undefined && { namespace: normalizedUpdates.namespace }),
+                    ...(normalizedUpdates.label !== undefined && { label: normalizedUpdates.label }),
+                    ...(normalizedUpdates.description !== undefined && { description: normalizedUpdates.description }),
+                    ...(normalizedUpdates.url !== undefined && { url: normalizedUpdates.url }),
+                    ...(normalizedUpdates.icon !== undefined && { icon: normalizedUpdates.icon }),
+                    ...(normalizedUpdates.order !== undefined && { order: normalizedUpdates.order }),
+                    ...(normalizedUpdates.parent !== undefined && { parent: normalizedUpdates.parent ? new ObjectId(normalizedUpdates.parent) : null }),
+                    ...(normalizedUpdates.enabled !== undefined && { enabled: normalizedUpdates.enabled }),
+                    ...(normalizedUpdates.allowedIdentityStates !== undefined && { allowedIdentityStates: normalizedUpdates.allowedIdentityStates }),
+                    ...(normalizedUpdates.requiresGroups !== undefined && { requiresGroups: normalizedUpdates.requiresGroups }),
+                    ...(normalizedUpdates.requiresAdmin !== undefined && { requiresAdmin: normalizedUpdates.requiresAdmin }),
                     updatedAt: new Date()
                 };
 
-                await collection.updateOne({ _id: new ObjectId(id) }, { $set: updateDoc });
+                // A field present in `updates` but normalized away is an
+                // explicit clear-the-gate signal — use $unset so the doc
+                // doesn't carry stale empty arrays / `false` flags.
+                const unsetDoc: Record<string, ''> = {};
+                if (updates.allowedIdentityStates !== undefined && normalizedUpdates.allowedIdentityStates === undefined) {
+                    unsetDoc.allowedIdentityStates = '';
+                }
+                if (updates.requiresGroups !== undefined && normalizedUpdates.requiresGroups === undefined) {
+                    unsetDoc.requiresGroups = '';
+                }
+                if (updates.requiresAdmin !== undefined && normalizedUpdates.requiresAdmin === undefined) {
+                    unsetDoc.requiresAdmin = '';
+                }
+
+                const op: { $set: typeof setDoc; $unset?: typeof unsetDoc } = { $set: setDoc };
+                if (Object.keys(unsetDoc).length > 0) op.$unset = unsetDoc;
+                await collection.updateOne({ _id: new ObjectId(id) }, op);
             } else if (existing.url) {
                 // Memory-only node with a URL — save overrides so changes survive restarts
                 await this.saveOverride(existing.namespace || this.DEFAULT_NAMESPACE, existing.url, updates);
@@ -742,7 +776,7 @@ export class MenuService implements IMenuService {
         const groupsService = this.serviceRegistry.get<IUserGroupService>('user-groups');
         const isUserAdmin = user && groupsService ? await groupsService.isAdmin(user.id) : false;
 
-        const visible = tree.all.filter((node) => this.passesGate(node, user, isUserAdmin));
+        const visible = this.filterVisibleSubtree(tree.all, user, isUserAdmin);
         return {
             roots: this.buildTree(visible),
             all: visible,
@@ -754,7 +788,9 @@ export class MenuService implements IMenuService {
      * Get a single child of the named parent that the given user may see.
      *
      * Same gating rules as {@link getTreeForUser}; returns the user-filtered
-     * children sorted by order.
+     * children sorted by order. If the parent itself (or any ancestor of the
+     * parent) fails its gate, returns empty — there is no way to surface a
+     * child whose parent the caller cannot see.
      */
     public async getChildrenForUser(
         parentId: string | null,
@@ -763,7 +799,56 @@ export class MenuService implements IMenuService {
     ): Promise<IMenuNode[]> {
         const groupsService = this.serviceRegistry.get<IUserGroupService>('user-groups');
         const isUserAdmin = user && groupsService ? await groupsService.isAdmin(user.id) : false;
+
+        if (parentId) {
+            // Walk the parent chain through the namespace's flat node list and
+            // refuse to surface descendants of a hidden ancestor.
+            const all = this.getTree(namespace).all;
+            const byId = new Map<string, IMenuNode>(all.map((n) => [n._id!, n]));
+            let cursor: IMenuNode | undefined = byId.get(parentId);
+            while (cursor) {
+                if (!this.passesGate(cursor, user, isUserAdmin)) return [];
+                cursor = cursor.parent ? byId.get(cursor.parent) : undefined;
+            }
+        }
+
         return this.getChildren(parentId, namespace).filter((node) => this.passesGate(node, user, isUserAdmin));
+    }
+
+    /**
+     * Filter a flat node list down to nodes whose entire ancestor chain passes
+     * the gate. Without this, `buildTree` treats children of a filtered-out
+     * parent as orphans and promotes them to roots — silently exposing nested
+     * items the operator just hid by gating their parent.
+     */
+    private filterVisibleSubtree(nodes: IMenuNode[], user: IUser | undefined, isUserAdmin: boolean): IMenuNode[] {
+        const byId = new Map(nodes.map((n) => [n._id!, n]));
+        const cache = new Map<string, boolean>();
+
+        const isVisible = (node: IMenuNode): boolean => {
+            const id = node._id!;
+            const cached = cache.get(id);
+            if (cached !== undefined) return cached;
+
+            if (!this.passesGate(node, user, isUserAdmin)) {
+                cache.set(id, false);
+                return false;
+            }
+            if (node.parent) {
+                const parent = byId.get(node.parent);
+                // Parent missing from the namespace is treated as visible —
+                // matches `buildTree`'s orphan-as-root fallback so we don't
+                // hide otherwise-valid nodes because of a stale parent ref.
+                if (parent && !isVisible(parent)) {
+                    cache.set(id, false);
+                    return false;
+                }
+            }
+            cache.set(id, true);
+            return true;
+        };
+
+        return nodes.filter(isVisible);
     }
 
     /**

--- a/src/backend/modules/pages/__tests__/pages.module.test.ts
+++ b/src/backend/modules/pages/__tests__/pages.module.test.ts
@@ -43,7 +43,9 @@ class MockMenuService implements IMenuService {
     delete = vi.fn();
     getNode = vi.fn();
     getTree = vi.fn(() => ({ all: [], roots: [], generatedAt: new Date() }));
+    getTreeForUser = vi.fn(async () => ({ all: [], roots: [], generatedAt: new Date() }));
     getChildren = vi.fn(() => []);
+    getChildrenForUser = vi.fn(async () => []);
     getNamespaces = vi.fn(() => []);
     initialize = vi.fn();
     subscribe = vi.fn();

--- a/src/backend/modules/tools/__tests__/tools.module.test.ts
+++ b/src/backend/modules/tools/__tests__/tools.module.test.ts
@@ -74,7 +74,9 @@ class MockMenuService implements IMenuService {
     delete = vi.fn();
     getNode = vi.fn();
     getTree = vi.fn(() => ({ all: [], roots: [], generatedAt: new Date() }));
+    getTreeForUser = vi.fn(async () => ({ all: [], roots: [], generatedAt: new Date() }));
     getChildren = vi.fn(() => []);
+    getChildrenForUser = vi.fn(async () => []);
     getNamespaces = vi.fn(() => []);
     initialize = vi.fn();
     subscribe = vi.fn();

--- a/src/backend/modules/user/README.md
+++ b/src/backend/modules/user/README.md
@@ -120,6 +120,37 @@ const user = await context.userService.getByWallet('TXyz...');
 
 The `IUser` interface includes `id`, `wallets`, `preferences`, `activity`, and timestamps. The summary return types (`IUserActivitySummary`, `IUserWalletSummary`, `IUserRetentionSummary`, `IUserPreferencesSummary`) are defined in `@/types`. The internal `IUserDocument` (with MongoDB-specific fields) stays in the module.
 
+## User Groups and Admin Status
+
+User groups are lightweight named tags admins attach to users so plugins can gate features on group membership without inventing their own permission models. The user module owns the namespace; plugins own the policy. Group definitions live in MongoDB, are managed through the Groups tab on `/system/users`, and are read by plugins through `IUserGroupService`. A reserved-admin slug pattern (`admin`, `admins`, `administrator(s)`, `super-admin(s)`, `sub-admin(s)`, `superadmin(s)`, `root(s)`) is platform-only — operators cannot create or rename rows matching it, and the seeded `admin` row is flagged `system: true` so the admin UI treats it as read-only.
+
+`UserGroupService` is registered on the service registry as `'user-groups'`. Plugins discover it via `context.services.get<IUserGroupService>('user-groups')` for one-shot reads, or `context.services.watch(...)` when their behavior depends on the service being present over time. The service is platform-provided and always available once the user module has run, so the `undefined` branch of `get()` is a defensive nicety rather than a real degradation path.
+
+```typescript
+import type { IUserGroupService } from '@/types';
+
+const groups = context.services.get<IUserGroupService>('user-groups');
+if (groups && req.userId && await groups.isAdmin(req.userId)) {
+    // Render admin-only UI for the cookie-identified visitor
+}
+```
+
+**Membership API for plugins:**
+
+| Method | Purpose |
+|--------|---------|
+| `getUserGroups(userId)` | Return the array of group ids the user belongs to. Empty array for unknown users. |
+| `isMember(userId, groupId)` | Test membership. Never throws on missing user or group — returns `false`. |
+| `addMember(userId, groupId)` | Idempotent. Throws when the group does not exist (treat as deployment mistake). |
+| `removeMember(userId, groupId)` | Idempotent. Removing a non-member is a no-op. |
+| `isAdmin(userId)` | True when the user belongs to any system-flagged group whose id matches the reserved-admin pattern. Use this — never compare group ids directly. |
+
+Definition CRUD (`listGroups`, `getGroup`, `createGroup`, `updateGroup`, `deleteGroup`) is operator-facing and exposed via `/api/admin/users/groups`. Membership is read by plugins and mutated programmatically — there is no public HTTP endpoint for `addMember` or `removeMember`. Plugins that need to grant or revoke groups call the service directly from request handlers.
+
+**Two distinct admin checks coexist — do not conflate them.** `IUserGroupService.isAdmin(userId)` is a per-user predicate keyed off the visitor's UUID. Use it from plugin code that runs in a request context (cookie identity is present) when the question is "should this person see admin UI?" The `requireAdmin` middleware in `src/backend/api/middleware/admin-auth.ts` (and the `requiresAdmin: true` flag on `IApiRouteConfig`) is a shared-token gate — the caller must present `x-admin-token` matching `ADMIN_API_TOKEN`. It is for operators, scripts, and CI tooling; there is no user identity involved. A typical admin SPA page combines both: the route handler is protected by `requireAdmin` (token), and the page component uses `groups.isAdmin(req.userId)` to decide which controls to render to a cookie-identified human. Plugins that want per-user admin gating must use `IUserGroupService.isAdmin` — rolling a parallel scheme is the path the JSDoc on the interface explicitly warns against.
+
+**Cache and identity-merge semantics.** Membership writes invalidate the `user:${userId}` cache tag, so `/api/user/:id` reflects group changes immediately rather than waiting on the 1-hour TTL. Every membership method (`isAdmin`, `isMember`, `getUserGroups`, `addMember`, `removeMember`) resolves `mergedInto` pointers, so post-merge lookups hit the canonical user instead of the loser tombstone.
+
 ## Architecture Overview
 
 The module follows TronRelic's layered architecture with cookie-based authentication for public endpoints and admin token authentication for admin endpoints.
@@ -443,38 +474,26 @@ The module stores data in a single MongoDB collection with indexes for efficient
 interface IUserDocument {
     _id: ObjectId;
     id: string;                          // UUID v4 primary identifier
+    identityState: UserIdentityState;    // Stored taxonomy: anonymous | registered | verified
     wallets: IWalletLink[];              // Linked TRON wallets
-    preferences: IUserPreferences;        // User settings
-    activity: IUserActivity;              // Tracking data
+    preferences: IUserPreferences;       // User settings
+    activity: IUserActivity;             // Tracking data
+    groups: string[];                    // Admin-defined group memberships (group ids)
+    mergedInto?: string;                 // Tombstone pointer to canonical UUID after reconciliation
     createdAt: Date;
     updatedAt: Date;
 }
-
-interface IWalletLink {
-    address: string;                     // TRON address (T...)
-    linkedAt: Date;                      // When wallet was linked
-    isPrimary: boolean;                  // Whether this is primary wallet
-    label?: string;                      // Optional user-assigned label
-}
-
-interface IUserPreferences {
-    theme?: 'light' | 'dark' | 'system';
-    notifications?: boolean;
-    timezone?: string;
-    language?: string;
-}
-
-interface IUserActivity {
-    lastSeen: Date;
-    pageViews: number;
-    firstSeen: Date;
-}
 ```
+
+`identityState` is stored, not derived — UserService recomputes it on every wallet mutation so all consumers read the field directly. `groups` holds group ids from the `module_user_groups` collection and is mutated only via `IUserGroupService`. Migrations 006 and 007 backfill `identityState` and `groups` on legacy documents.
 
 **Indexes:**
 - `id` (unique) - Fast lookup by UUID, prevents duplicates
 - `wallets.address` - Find users by linked wallet address
 - `activity.lastSeen` - Sort by recency for admin queries
+- `identityState` - Filter users by canonical taxonomy in admin queries
+- `groups` - Fast membership lookups for `isMember` / `isAdmin`
+- `mergedInto` (sparse) - Pointer-chain flattening during identity reconciliation
 
 **Validation rules:**
 - UUID must be valid v4 format (enforced in service layer)
@@ -482,20 +501,44 @@ interface IUserActivity {
 - Wallet signature must verify against address (using SignatureService)
 - Only one wallet can be primary per user
 
+### module_user_groups Collection
+
+Stores admin-defined group definitions. Managed by `UserGroupService`; consumed by plugins via the `'user-groups'` service registry entry. See [User Groups and Admin Status](#user-groups-and-admin-status) for the full API.
+
+**Schema:**
+```typescript
+interface IUserGroupDocument {
+    _id: ObjectId;
+    id: string;          // Stable kebab-case slug used by plugins
+    name: string;        // Human-readable label
+    description: string; // Optional admin description
+    system: boolean;     // True for platform-seeded rows (read-only in admin UI)
+    createdAt: Date;
+    updatedAt: Date;
+}
+```
+
+**Indexes:**
+- `id` (unique) - Slug-based lookup; enforces uniqueness across admin-defined and seeded groups
+
+**Seeded rows:** the user module seeds the `admin` row (with `system: true`) on every boot. The reserved-admin slug pattern (`admin`, `admins`, `super-admin(s)`, `administrator(s)`, `sub-admin(s)`, `superadmin(s)`, `root(s)`) blocks operators from creating or renaming rows matching it — only the platform may seed them.
+
 ## Module Lifecycle
 
 The user module implements the `IModule` interface with two-phase initialization:
 
 **Phase 1: init()** - Prepare module without activation
-- Store injected dependencies (database, cache, menu service, app)
-- Initialize UserService singleton with `setDependencies()`
-- Create database indexes
-- Create controller with service reference
+- Store injected dependencies (database, cache, menu service, app, scheduler, service registry, system config)
+- Initialize UserService singleton with `setDependencies()` and create its indexes
+- Initialize UserGroupService singleton, create its indexes, and seed system groups (the reserved `admin` row)
+- Create user and user-group controllers with their service references
 
 **Phase 2: run()** - Activate and integrate with application
-- Register UserService on the service registry as `'user'` for late-binding plugin discovery
 - Register menu item in `system` namespace at `/system/users`
+- Register UserService on the service registry as `'user'` for late-binding plugin discovery
+- Register UserGroupService on the service registry as `'user-groups'` for plugin permission gating
 - Mount public router at `/api/user` (cookie validation on `:id` routes)
+- Mount admin user-groups router at `/api/admin/users/groups` with `requireAdmin` middleware (mounted before the user admin router so its specific paths win over `/:id`)
 - Mount admin router at `/api/admin/users` with `requireAdmin` middleware
 
 **Module metadata:**

--- a/src/frontend/app/(core)/system/menu/page.tsx
+++ b/src/frontend/app/(core)/system/menu/page.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useState, type FormEvent, type ReactNode } from 'react';
 import { AlertTriangle, ChevronRight, Pencil, Plus, Trash2 } from 'lucide-react';
-import type { IMenuNamespaceConfig, IMenuNode, IMenuTree } from '@/types';
+import type { IMenuNamespaceConfig, IMenuNode, IMenuTree, IUserGroup } from '@/types';
+import { UserIdentityState } from '@/types';
 
 import { Page, PageHeader, Stack } from '../../../../components/layout';
 import { Badge } from '../../../../components/ui/Badge';
@@ -102,6 +103,10 @@ export default function MenuAdminPage() {
     const [loading, setLoading] = useState(false);
     const [savingConfig, setSavingConfig] = useState(false);
     const [busyNodeId, setBusyNodeId] = useState<string | null>(null);
+    // Admin-defined groups for the gating fieldset multi-select. Populated
+    // once on mount; group definition changes are infrequent enough that we
+    // don't subscribe to live updates here.
+    const [availableGroups, setAvailableGroups] = useState<IUserGroup[]>([]);
 
     const authHeaders = useMemo<HeadersInit>(
         () => ({ 'X-Admin-Token': token || '' }),
@@ -171,6 +176,28 @@ export default function MenuAdminPage() {
             cancelled = true;
         };
     }, [authHeaders, notifyError]); // intentionally omits activeNamespace
+
+    /* Available groups for the gating multi-select. Fetched once; group
+     * definition changes are operator-driven and infrequent. Errors are
+     * surfaced as a toast but don't block the page — operators can still
+     * edit nodes whose gating fields don't depend on group selection. */
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const res = await fetch('/api/admin/users/groups', { headers: authHeaders });
+                if (!res.ok) throw new Error('Failed to load user groups');
+                const data = await res.json();
+                if (cancelled) return;
+                setAvailableGroups((data.groups ?? []) as IUserGroup[]);
+            } catch (err) {
+                if (!cancelled) notifyError('Could not load user groups', err);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [authHeaders, notifyError]);
 
     /* Tree + config for the active namespace. */
     useEffect(() => {
@@ -277,6 +304,7 @@ export default function MenuAdminPage() {
                         mode={mode}
                         initial={node}
                         availableParents={(menuTree?.all ?? []).filter((n) => n._id !== node?._id)}
+                        availableGroups={availableGroups}
                         onCancel={() => closeModal(id)}
                         onSubmit={async (data) => {
                             try {
@@ -300,7 +328,7 @@ export default function MenuAdminPage() {
                 )
             });
         },
-        [closeModal, handleCreate, handleUpdate, menuTree?.all, notifyError, notifySuccess, openModal, reloadTree]
+        [availableGroups, closeModal, handleCreate, handleUpdate, menuTree?.all, notifyError, notifySuccess, openModal, reloadTree]
     );
 
     const openDeleteModal = useCallback(
@@ -823,11 +851,24 @@ interface MenuNodeFormProps {
     mode: 'create' | 'edit';
     initial?: IMenuNode;
     availableParents: IMenuNode[];
+    availableGroups: IUserGroup[];
     onSubmit: (data: Partial<IMenuNode>) => Promise<void>;
     onCancel: () => void;
 }
 
-function MenuNodeForm({ mode, initial, availableParents, onSubmit, onCancel }: MenuNodeFormProps) {
+const ALL_IDENTITY_STATES: UserIdentityState[] = [
+    UserIdentityState.Anonymous,
+    UserIdentityState.Registered,
+    UserIdentityState.Verified
+];
+
+const IDENTITY_STATE_LABELS: Record<UserIdentityState, string> = {
+    [UserIdentityState.Anonymous]: 'Anonymous',
+    [UserIdentityState.Registered]: 'Registered',
+    [UserIdentityState.Verified]: 'Verified'
+};
+
+function MenuNodeForm({ mode, initial, availableParents, availableGroups, onSubmit, onCancel }: MenuNodeFormProps) {
     const { open: openInnerModal, close: closeInnerModal } = useModal();
     const [data, setData] = useState<Partial<IMenuNode>>({
         label: initial?.label ?? '',
@@ -836,7 +877,9 @@ function MenuNodeForm({ mode, initial, availableParents, onSubmit, onCancel }: M
         order: initial?.order ?? 0,
         parent: initial?.parent ?? null,
         enabled: initial?.enabled ?? true,
-        requiredRole: initial?.requiredRole ?? ''
+        allowedIdentityStates: initial?.allowedIdentityStates,
+        requiresGroups: initial?.requiresGroups,
+        requiresAdmin: initial?.requiresAdmin ?? false
     });
     const [saving, setSaving] = useState(false);
 
@@ -850,17 +893,56 @@ function MenuNodeForm({ mode, initial, availableParents, onSubmit, onCancel }: M
             // serialize as omitted rather than failing validation.
             const blankToUndefined = (v: unknown) =>
                 typeof v === 'string' ? (v.trim() || undefined) : v;
+
+            // Identity-state allow-list normalization: empty selection or all
+            // three checked both mean "no gate" — store as undefined so the
+            // database doesn't carry tautological arrays. Backend rejects an
+            // empty array explicitly, so we never send one.
+            const states = data.allowedIdentityStates ?? [];
+            const normalizedStates =
+                states.length === 0 || states.length === ALL_IDENTITY_STATES.length
+                    ? undefined
+                    : states;
+
+            // Group selection normalization: empty array becomes undefined for
+            // the same "no gate" reason. The backend treats `undefined` and
+            // missing field identically.
+            const groups = data.requiresGroups ?? [];
+            const normalizedGroups = groups.length === 0 ? undefined : groups;
+
             const normalized: Partial<IMenuNode> = {
                 ...data,
                 label: typeof data.label === 'string' ? data.label.trim() : data.label,
                 url: blankToUndefined(data.url) as string | undefined,
                 icon: blankToUndefined(data.icon) as string | undefined,
-                requiredRole: blankToUndefined(data.requiredRole) as string | undefined
+                allowedIdentityStates: normalizedStates,
+                requiresGroups: normalizedGroups,
+                requiresAdmin: data.requiresAdmin || undefined
             };
             await onSubmit(normalized);
         } finally {
             setSaving(false);
         }
+    };
+
+    const toggleIdentityState = (state: UserIdentityState) => {
+        setData((prev) => {
+            const current = prev.allowedIdentityStates ?? [];
+            const next = current.includes(state)
+                ? current.filter((s) => s !== state)
+                : [...current, state];
+            return { ...prev, allowedIdentityStates: next };
+        });
+    };
+
+    const toggleGroup = (groupId: string) => {
+        setData((prev) => {
+            const current = prev.requiresGroups ?? [];
+            const next = current.includes(groupId)
+                ? current.filter((g) => g !== groupId)
+                : [...current, groupId];
+            return { ...prev, requiresGroups: next };
+        });
     };
 
     const openIconPicker = () => {
@@ -954,16 +1036,69 @@ function MenuNodeForm({ mode, initial, availableParents, onSubmit, onCancel }: M
                 </select>
             </div>
 
-            <div className={styles.field}>
-                <label htmlFor="mn-role">Required role</label>
-                <Input
-                    id="mn-role"
-                    value={data.requiredRole ?? ''}
-                    onChange={(e) => setData({ ...data, requiredRole: e.target.value })}
-                    placeholder="(none)"
-                    disabled={saving}
-                />
-            </div>
+            <fieldset className={styles.field} disabled={saving}>
+                <legend className={styles.field_label}>Visibility</legend>
+
+                <div className={styles.field}>
+                    <span className={styles.field_label}>Identity states</span>
+                    {ALL_IDENTITY_STATES.map((state) => {
+                        const checked = (data.allowedIdentityStates ?? []).includes(state);
+                        const inputId = `mn-state-${state}`;
+                        return (
+                            <label key={state} htmlFor={inputId} className={styles.inline_toggle}>
+                                <input
+                                    id={inputId}
+                                    type="checkbox"
+                                    checked={checked}
+                                    onChange={() => toggleIdentityState(state)}
+                                />
+                                <span>{IDENTITY_STATE_LABELS[state]}</span>
+                            </label>
+                        );
+                    })}
+                    <p className={styles.field_hint}>
+                        Leave all unchecked or all checked for "no restriction" — both
+                        normalize to no gate at save time.
+                    </p>
+                </div>
+
+                <div className={styles.field}>
+                    <span className={styles.field_label}>Required groups</span>
+                    {availableGroups.length === 0 ? (
+                        <p className={styles.field_hint}>No groups defined yet.</p>
+                    ) : (
+                        availableGroups.map((group) => {
+                            const checked = (data.requiresGroups ?? []).includes(group.id);
+                            const inputId = `mn-group-${group.id}`;
+                            return (
+                                <label key={group.id} htmlFor={inputId} className={styles.inline_toggle}>
+                                    <input
+                                        id={inputId}
+                                        type="checkbox"
+                                        checked={checked}
+                                        onChange={() => toggleGroup(group.id)}
+                                    />
+                                    <span>{group.name}</span>
+                                </label>
+                            );
+                        })
+                    )}
+                    <p className={styles.field_hint}>
+                        Visible to users in <em>any</em> selected group (OR-of-membership).
+                    </p>
+                </div>
+
+                <label className={styles.inline_toggle}>
+                    <Switch
+                        size="sm"
+                        on={data.requiresAdmin ?? false}
+                        onChange={(next) => setData({ ...data, requiresAdmin: next })}
+                        disabled={saving}
+                        aria-label="Require admin"
+                    />
+                    <span>Require admin</span>
+                </label>
+            </fieldset>
 
             <label className={styles.inline_toggle}>
                 <Switch

--- a/src/frontend/app/(core)/system/menu/page.tsx
+++ b/src/frontend/app/(core)/system/menu/page.tsx
@@ -894,21 +894,20 @@ function MenuNodeForm({ mode, initial, availableParents, availableGroups, onSubm
             const blankToUndefined = (v: unknown) =>
                 typeof v === 'string' ? (v.trim() || undefined) : v;
 
-            // Identity-state allow-list normalization: empty selection or all
-            // three checked both mean "no gate" — store as undefined so the
-            // database doesn't carry tautological arrays. Backend rejects an
-            // empty array explicitly, so we never send one.
+            // Gating fields are sent through as-is (including `[]` and
+            // `false`) so a PATCH that clears a previously-set gate carries
+            // an explicit clear signal. The backend treats empty arrays and
+            // `requiresAdmin: false` as "remove this gate" and persists them
+            // via `$unset`. Sending `undefined` would drop the key from the
+            // JSON payload, which the partial-update path interprets as
+            // "leave this field unchanged" — preventing operators from ever
+            // clearing a gate from the UI.
             const states = data.allowedIdentityStates ?? [];
+            // All three states checked is semantically identical to no gate;
+            // collapse to an empty array so the persist path unsets the
+            // field rather than storing a tautological full set.
             const normalizedStates =
-                states.length === 0 || states.length === ALL_IDENTITY_STATES.length
-                    ? undefined
-                    : states;
-
-            // Group selection normalization: empty array becomes undefined for
-            // the same "no gate" reason. The backend treats `undefined` and
-            // missing field identically.
-            const groups = data.requiresGroups ?? [];
-            const normalizedGroups = groups.length === 0 ? undefined : groups;
+                states.length === ALL_IDENTITY_STATES.length ? [] : states;
 
             const normalized: Partial<IMenuNode> = {
                 ...data,
@@ -916,8 +915,8 @@ function MenuNodeForm({ mode, initial, availableParents, availableGroups, onSubm
                 url: blankToUndefined(data.url) as string | undefined,
                 icon: blankToUndefined(data.icon) as string | undefined,
                 allowedIdentityStates: normalizedStates,
-                requiresGroups: normalizedGroups,
-                requiresAdmin: data.requiresAdmin || undefined
+                requiresGroups: data.requiresGroups ?? [],
+                requiresAdmin: Boolean(data.requiresAdmin)
             };
             await onSubmit(normalized);
         } finally {

--- a/src/frontend/components/socket/SocketBridge.tsx
+++ b/src/frontend/components/socket/SocketBridge.tsx
@@ -7,7 +7,7 @@ import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { prependMemo } from '../../store/slices/memoSlice';
 import { blockReceived } from '../../features/blockchain/slice';
 import { setUserData, selectUserId } from '../../modules/user';
-import { menuTreeUpdated } from '../../modules/menu/slice';
+import { refetchMenuTree } from '../../modules/menu/slice';
 import {
   connectionDeferred,
   deferredCountdownTick,
@@ -204,7 +204,11 @@ export function SocketBridge() {
     };
 
     const handleMenuUpdate = (payload: MenuUpdatePayload['payload']) => {
-      dispatch(menuTreeUpdated(payload));
+      // Per-user gating means the server can't broadcast a single tree
+      // shape. The signal carries `{ namespace, nodeId, event, timestamp }`;
+      // each client refetches `GET /api/menu` with its own cookie to get
+      // its filtered view.
+      dispatch(refetchMenuTree({ namespace: payload.namespace, timestamp: payload.timestamp }));
     };
 
     const handleVisibility = () => {

--- a/src/frontend/modules/menu/index.ts
+++ b/src/frontend/modules/menu/index.ts
@@ -36,7 +36,7 @@ export { CategoryLandingPage } from './components';
 export { useMenuConfig, useBodyScrollLock } from './hooks';
 
 // Redux slice
-export { default as menuReducer, menuTreeUpdated } from './slice';
+export { default as menuReducer, menuTreeSeeded, refetchMenuTree } from './slice';
 export type { MenuState } from './slice';
 
 // Types

--- a/src/frontend/modules/menu/slice.ts
+++ b/src/frontend/modules/menu/slice.ts
@@ -1,26 +1,25 @@
 /**
  * Menu Redux slice for live WebSocket-driven menu state.
  *
- * Stores menu tree data per namespace, updated in real-time via WebSocket
- * events broadcast by the backend MenuService. Components read from this
- * slice to overlay live state on top of SSR-provided menu items, following
- * the SSR + Live Updates pattern.
+ * Per-user gating means the WebSocket can no longer broadcast a single tree
+ * shape that fits every connected client. The server emits a refetch signal
+ * (`{ namespace, nodeId, event, timestamp }`) and each client requests
+ * `GET /api/menu` with its own credentials to receive the filtered view.
+ *
+ * The slice owns the post-refetch state: it stores tree roots per namespace
+ * so components can overlay live state on top of SSR-provided menu items,
+ * preserving the SSR + Live Updates pattern.
  */
 
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import type { MenuUpdatePayload, MenuNodeSerialized } from '@/shared';
+import { createSlice, createAsyncThunk, type PayloadAction } from '@reduxjs/toolkit';
+import type { MenuNodeSerialized } from '@/shared';
+import { getApiUrl } from '../../lib/config';
 
-/**
- * Per-namespace menu tree state.
- */
 interface MenuNamespaceState {
     roots: MenuNodeSerialized[];
     lastUpdated: string;
 }
 
-/**
- * Root state shape for the menu slice.
- */
 export interface MenuState {
     /** Menu trees keyed by namespace (e.g., 'main', 'system'). */
     namespaces: Record<string, MenuNamespaceState>;
@@ -30,28 +29,56 @@ const initialState: MenuState = {
     namespaces: {}
 };
 
+/**
+ * Re-fetch the user-filtered menu tree for a namespace.
+ *
+ * Triggered when the server emits a `menu:update` refetch signal. Sends
+ * credentials so the cookie-resolved user identity reaches the gating
+ * filter; without it the server would return the anonymous-visitor view
+ * regardless of who is logged in.
+ */
+export const refetchMenuTree = createAsyncThunk<
+    { namespace: string; roots: MenuNodeSerialized[]; timestamp: string },
+    { namespace: string; timestamp: string },
+    { rejectValue: string }
+>('menu/refetchTree', async ({ namespace, timestamp }, { rejectWithValue }) => {
+    try {
+        const url = getApiUrl(`/menu?namespace=${encodeURIComponent(namespace)}`);
+        const response = await fetch(url, { credentials: 'include' });
+        if (!response.ok) {
+            return rejectWithValue(`menu refetch failed: ${response.status}`);
+        }
+        const body = await response.json();
+        const roots = (body?.tree?.roots ?? []) as MenuNodeSerialized[];
+        return { namespace, roots, timestamp };
+    } catch (error) {
+        return rejectWithValue(error instanceof Error ? error.message : 'menu refetch failed');
+    }
+});
+
 const menuSlice = createSlice({
     name: 'menu',
     initialState,
     reducers: {
         /**
-         * Update menu tree for a namespace from a WebSocket menu:update event.
+         * Seed the slice from server-rendered menu data.
          *
-         * Extracts the namespace from the node in the payload and stores
-         * the full tree roots for that namespace, enabling components to
-         * read live menu state.
+         * Lets pages dispatch their SSR-fetched tree into Redux on first
+         * mount so subsequent refetches replace a known baseline rather
+         * than appearing as the first state transition.
          */
-        menuTreeUpdated(state, action: PayloadAction<MenuUpdatePayload['payload']>) {
-            const { node, tree, timestamp } = action.payload;
-            const namespace = node.namespace || 'main';
-
-            state.namespaces[namespace] = {
-                roots: tree.roots,
-                lastUpdated: timestamp
-            };
+        menuTreeSeeded(state, action: PayloadAction<{ namespace: string; roots: MenuNodeSerialized[]; timestamp: string }>) {
+            const { namespace, roots, timestamp } = action.payload;
+            state.namespaces[namespace] = { roots, lastUpdated: timestamp };
         }
+    },
+    extraReducers: (builder) => {
+        builder.addCase(refetchMenuTree.fulfilled, (state, action) => {
+            const { namespace, roots, timestamp } = action.payload;
+            state.namespaces[namespace] = { roots, lastUpdated: timestamp };
+        });
     }
 });
 
-export const { menuTreeUpdated } = menuSlice.actions;
+export const { menuTreeSeeded } = menuSlice.actions;
 export default menuSlice.reducer;

--- a/src/shared/types/socket.ts
+++ b/src/shared/types/socket.ts
@@ -119,7 +119,9 @@ export interface MenuNodeSerialized {
   parent?: string | null;
   enabled: boolean;
   namespace?: string;
-  requiredRole?: string;
+  allowedIdentityStates?: string[];
+  requiresGroups?: string[];
+  requiresAdmin?: boolean;
   children?: MenuNodeSerialized[];
 }
 
@@ -132,12 +134,20 @@ export interface MenuTreeSerialized {
   generatedAt: string;
 }
 
+/**
+ * Refetch signal emitted when a menu node is created, updated, or deleted.
+ *
+ * Per-user gating means there is no single tree shape that fits every
+ * connected client, so the server no longer ships a tree on the wire.
+ * Receivers re-request `GET /api/menu?namespace=...` with their own
+ * credentials and the server returns their filtered view.
+ */
 export interface MenuUpdatePayload {
   event: 'menu:update';
   payload: {
     event: string;
-    node: MenuNodeSerialized;
-    tree: MenuTreeSerialized;
+    namespace: string;
+    nodeId: string;
     timestamp: string;
   };
 }


### PR DESCRIPTION
## Summary

Drops the single `requiredRole` string on menu nodes in favor of three composable gates: `allowedIdentityStates` (anonymous/registered/verified), `requiresGroups` (OR-of-membership against admin-defined groups), and `requiresAdmin` (routed through `IUserGroupService.isAdmin` so future seeded admin tiers automatically qualify). Menu service grows `getTreeForUser` / `getChildrenForUser` that filter by the cookie-resolved user, looking up the user-groups service via late-binding registry lookup.

Because per-user gating means no single tree shape fits every connected client, the WebSocket broadcast collapses to a refetch signal carrying just `{ namespace, nodeId }` — clients re-request `GET /api/menu` with their own cookie and the server returns the filtered view.

Migration 003 backfills existing nodes by clearing `requiredRole`; admin reapplies gating in the new fields. The system menu admin UI is rewritten to edit the three new fields, and module/plugin docs are updated to describe the gating contract and the `IUserGroupService.isAdmin` distinction from the shared-token `requireAdmin` middleware.