### PR TITLE
Add admin UI for editing user group memberships

### DIFF
--- a/packages/types/src/user/IUserGroupService.ts
+++ b/packages/types/src/user/IUserGroupService.ts
@@ -101,6 +101,37 @@ export interface IUserGroupService {
      */
     removeMember(userId: string, groupId: string): Promise<void>;
 
+    /**
+     * Replace the user's complete set of group memberships with `groupIds`.
+     *
+     * Set-semantics. Implementations must validate that every id in
+     * `groupIds` refers to an existing group (throws on the first unknown
+     * id) and that the target user exists (throws otherwise). The new
+     * array is deduplicated and order is not preserved. Returns the
+     * resulting membership array so callers can write a before/after
+     * audit record without re-reading.
+     *
+     * Suitable for admin UIs that present a "tick which groups this user
+     * is in" view. Plugins managing single-group transitions should keep
+     * using `addMember` / `removeMember`.
+     */
+    setUserGroups(userId: string, groupIds: string[]): Promise<string[]>;
+
+    /**
+     * List users currently belonging to the group, paginated.
+     *
+     * Excludes merged tombstones — `mergedInto`-flagged user documents
+     * never appear in the result, so consumers don't need to follow
+     * pointer chains to display canonical identities.
+     *
+     * Throws when the group does not exist so admin UIs can distinguish
+     * "no members" from "you typed the wrong slug".
+     */
+    getMembers(
+        groupId: string,
+        options?: { limit?: number; skip?: number }
+    ): Promise<{ userIds: string[]; total: number }>;
+
     // -------- Special: admin --------
 
     /**

--- a/src/backend/modules/menu/__tests__/menu.service.gating.test.ts
+++ b/src/backend/modules/menu/__tests__/menu.service.gating.test.ts
@@ -114,6 +114,8 @@ function createGroupsService(adminUserIds: Set<string>): IUserGroupService {
         isMember: async (userId: string, groupId: string) => false,
         addMember: async () => undefined,
         removeMember: async () => undefined,
+        setUserGroups: async () => [],
+        getMembers: async () => ({ userIds: [], total: 0 }),
         isAdmin: async (userId: string) => adminUserIds.has(userId)
     } as IUserGroupService;
 }

--- a/src/backend/modules/user/README.md
+++ b/src/backend/modules/user/README.md
@@ -143,9 +143,11 @@ if (groups && req.userId && await groups.isAdmin(req.userId)) {
 | `isMember(userId, groupId)` | Test membership. Never throws on missing user or group — returns `false`. |
 | `addMember(userId, groupId)` | Idempotent. Throws when the group does not exist (treat as deployment mistake). |
 | `removeMember(userId, groupId)` | Idempotent. Removing a non-member is a no-op. |
+| `setUserGroups(userId, groupIds)` | Replace the user's complete membership atomically. Throws on unknown groups or missing user. Used by the admin editor; plugins should prefer `addMember` / `removeMember` for single-group transitions. |
+| `getMembers(groupId, options?)` | Paginated user-id list for a group. Excludes merged tombstones. |
 | `isAdmin(userId)` | True when the user belongs to any system-flagged group whose id matches the reserved-admin pattern. Use this — never compare group ids directly. |
 
-Definition CRUD (`listGroups`, `getGroup`, `createGroup`, `updateGroup`, `deleteGroup`) is operator-facing and exposed via `/api/admin/users/groups`. Membership is read by plugins and mutated programmatically — there is no public HTTP endpoint for `addMember` or `removeMember`. Plugins that need to grant or revoke groups call the service directly from request handlers.
+Definition CRUD (`listGroups`, `getGroup`, `createGroup`, `updateGroup`, `deleteGroup`) and group-member listing (`GET /api/admin/users/groups/:id/members`) live under `/api/admin/users/groups`. The admin set-membership endpoint (`PUT /api/admin/users/:id/groups`) is the operator path for promoting users into any group, including the reserved `admin` group. Both routes are `requireAdmin`-gated; the set-membership write audit-logs the before/after id arrays plus the requester IP, since the shared-token model has no per-human attribution. Plugins still mutate membership by calling the service directly from request handlers.
 
 **Two distinct admin checks coexist — do not conflate them.** `IUserGroupService.isAdmin(userId)` is a per-user predicate keyed off the visitor's UUID. Use it from plugin code that runs in a request context (cookie identity is present) when the question is "should this person see admin UI?" The `requireAdmin` middleware in `src/backend/api/middleware/admin-auth.ts` (and the `requiresAdmin: true` flag on `IApiRouteConfig`) is a shared-token gate — the caller must present `x-admin-token` matching `ADMIN_API_TOKEN`. It is for operators, scripts, and CI tooling; there is no user identity involved. A typical admin SPA page combines both: the route handler is protected by `requireAdmin` (token), and the page component uses `groups.isAdmin(req.userId)` to decide which controls to render to a cookie-identified human. Plugins that want per-user admin gating must use `IUserGroupService.isAdmin` — rolling a parallel scheme is the path the JSDoc on the interface explicitly warns against.
 
@@ -765,6 +767,29 @@ GET /api/admin/users/:id
 Response: IUser (or 404 if not found)
 ```
 
+**Replace User Group Membership:**
+```
+PUT /api/admin/users/:id/groups
+Content-Type: application/json
+
+{
+    "groups": ["admin", "vip-traders"]
+}
+
+Response: { "groups": ["admin", "vip-traders"] }
+```
+
+Set semantics — the body's `groups` array becomes the user's complete membership. Unknown group ids return 400 (mapped from `UserGroupNotFoundError`); unknown users return 404. Audit-logged at info level with target user, requester IP, and before/after arrays.
+
+**List Group Members:**
+```
+GET /api/admin/users/groups/:id/members?limit=100&skip=0
+
+Response: { "userIds": ["uuid1", "uuid2", ...], "total": number }
+```
+
+Paginated user-id list. `limit` defaults to 100, ceiling 500. Excludes merged tombstones.
+
 ## Admin UI
 
 The admin dashboard at `/system/users` provides:
@@ -772,7 +797,9 @@ The admin dashboard at `/system/users` provides:
 - **Statistics overview** - Total users, active today, active this week, users with wallets, total wallet links, average wallets per user
 - **User list** - Paginated view with expandable details
 - **Search** - Find users by UUID or wallet address
-- **User details** - View linked wallets (with primary indicator), preferences, and activity history
+- **User details** - View linked wallets (with primary indicator), preferences, activity history, and current group memberships
+- **Group membership editor** - "Manage Groups" action on the expanded user row opens a checkbox list of all defined groups; ticking and saving calls `PUT /api/admin/users/:id/groups`. This is the operator path for promoting a user into the reserved `admin` group
+- **Group members audit view** - The Groups tab exposes a per-row "Members" action that lists every user currently in a group, backed by `GET /api/admin/users/groups/:id/members`. Available for system groups too (the `admin` row is the canonical use case)
 
 ## Usage Examples
 

--- a/src/backend/modules/user/README.md
+++ b/src/backend/modules/user/README.md
@@ -779,7 +779,7 @@ Content-Type: application/json
 Response: { "groups": ["admin", "vip-traders"] }
 ```
 
-Set semantics — the body's `groups` array becomes the user's complete membership. Unknown group ids return 400 (mapped from `UserGroupNotFoundError`); unknown users return 404. Audit-logged at info level with target user, requester IP, and before/after arrays.
+Set semantics — the body's `groups` array becomes the user's complete membership. Unknown group ids and unknown users both return 404 (mapped from `UserGroupNotFoundError`); a malformed payload returns 400. Audit-logged at info level with target user, requester IP, and before/after arrays.
 
 **List Group Members:**
 ```

--- a/src/backend/modules/user/UserModule.ts
+++ b/src/backend/modules/user/UserModule.ts
@@ -356,7 +356,7 @@ export class UserModule implements IModule<IUserModuleDependencies> {
      * @internal
      */
     private createAdminRouter(): Router {
-        return createAdminUserRouter(this.controller);
+        return createAdminUserRouter(this.controller, this.groupController);
     }
 
     /**

--- a/src/backend/modules/user/__tests__/user-group.service.test.ts
+++ b/src/backend/modules/user/__tests__/user-group.service.test.ts
@@ -283,6 +283,86 @@ describe('UserGroupService', () => {
         });
     });
 
+    // -------- setUserGroups --------
+
+    describe('setUserGroups', () => {
+        const userId = 'user-1';
+
+        beforeEach(() => {
+            seedUser(mockDatabase, userId, ['vip']);
+            seedGroup(mockDatabase, { id: 'vip', name: 'VIP' });
+            seedGroup(mockDatabase, { id: 'whales', name: 'Whales' });
+        });
+
+        it('throws when groupIds is not an array', async () => {
+            await expect(
+                service.setUserGroups(userId, 'admin' as unknown as string[])
+            ).rejects.toThrow(/must be an array/i);
+        });
+
+        it('throws on unknown group id (validates before write)', async () => {
+            await expect(
+                service.setUserGroups(userId, ['vip', 'ghost-group'])
+            ).rejects.toThrow(/does not exist/i);
+        });
+
+        it('throws on unknown user', async () => {
+            await expect(
+                service.setUserGroups('ghost-user', ['vip'])
+            ).rejects.toThrow(/does not exist/i);
+        });
+
+        it('replaces user.groups atomically with dedup and lowercase', async () => {
+            const result = await service.setUserGroups(userId, ['VIP', 'whales', 'vip']);
+            expect(result).toEqual(['vip', 'whales']);
+            // Confirm the persisted document reflects the new array, not the
+            // originally-seeded ['vip']. The mock supports $set on top-level
+            // fields, which is what the service uses for the atomic replace.
+            const doc = mockDatabase.getCollectionData('users').find(u => u.id === userId);
+            expect(doc?.groups).toEqual(['vip', 'whales']);
+        });
+
+        it('accepts an empty array to clear all memberships', async () => {
+            const result = await service.setUserGroups(userId, []);
+            expect(result).toEqual([]);
+            const doc = mockDatabase.getCollectionData('users').find(u => u.id === userId);
+            expect(doc?.groups).toEqual([]);
+        });
+
+        it('invalidates the user cache after a successful write', async () => {
+            await service.setUserGroups(userId, ['whales']);
+            expect(mockCache.invalidate).toHaveBeenCalledWith(`user:${userId}`);
+        });
+    });
+
+    // -------- getMembers --------
+
+    describe('getMembers', () => {
+        beforeEach(() => {
+            seedGroup(mockDatabase, { id: 'vip', name: 'VIP' });
+            seedUser(mockDatabase, 'alice', ['vip']);
+            seedUser(mockDatabase, 'bob', ['vip']);
+            seedUser(mockDatabase, 'carol', []);
+        });
+
+        it('throws on unknown group so admin UIs can distinguish "no members" from "wrong slug"', async () => {
+            await expect(service.getMembers('not-real')).rejects.toThrow(/does not exist/i);
+        });
+
+        it('returns the user ids that belong to the group with total count', async () => {
+            const result = await service.getMembers('vip');
+            expect(new Set(result.userIds)).toEqual(new Set(['alice', 'bob']));
+            expect(result.total).toBe(2);
+        });
+
+        it('returns empty list with zero total when the group has no members', async () => {
+            seedGroup(mockDatabase, { id: 'empty-group', name: 'Empty' });
+            const result = await service.getMembers('empty-group');
+            expect(result.userIds).toEqual([]);
+            expect(result.total).toBe(0);
+        });
+    });
+
     // -------- isAdmin --------
 
     describe('isAdmin', () => {

--- a/src/backend/modules/user/api/user-group.controller.ts
+++ b/src/backend/modules/user/api/user-group.controller.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from 'express';
 import type { ISystemLogService } from '@/types';
 import type { UserGroupService } from '../services/user-group.service.js';
+import { getClientIP } from '../services/geo.service.js';
 import {
     UserGroupValidationError,
     UserGroupNotFoundError,
@@ -8,6 +9,29 @@ import {
     UserGroupSystemProtectedError,
     UserGroupMemberNotFoundError
 } from '../services/user-group.errors.js';
+
+/**
+ * Parse a positive integer query param with a default and ceiling. Returns
+ * the default for missing or unparseable values; otherwise clamps to
+ * `[1, max]`. Used by the members listing endpoint to bound page size.
+ */
+function parsePositiveInt(raw: unknown, defaultVal: number, max: number): number {
+    if (typeof raw !== 'string') return defaultVal;
+    const n = Number.parseInt(raw, 10);
+    if (Number.isNaN(n)) return defaultVal;
+    return Math.min(Math.max(1, n), max);
+}
+
+/**
+ * Parse a non-negative integer query param. Used for pagination offsets
+ * where 0 is valid but negatives must be clamped.
+ */
+function parseNonNegativeInt(raw: unknown, defaultVal: number): number {
+    if (typeof raw !== 'string') return defaultVal;
+    const n = Number.parseInt(raw, 10);
+    if (Number.isNaN(n)) return defaultVal;
+    return Math.max(0, n);
+}
 
 /**
  * Controller for admin user-group endpoints.
@@ -80,6 +104,65 @@ export class UserGroupController {
             res.status(204).end();
         } catch (error) {
             this.respondWithError(res, error, { id: req.params.id }, 'Failed to delete group');
+        }
+    }
+
+    /**
+     * GET /api/admin/users/groups/:id/members
+     *
+     * Paginated user-id list for a single group. Supports `limit` (default
+     * 100, max 500) and `skip` query params. Returns `{ userIds: string[],
+     * total: number }`. Excludes merged tombstones at the service layer.
+     */
+    async listGroupMembers(req: Request, res: Response): Promise<void> {
+        try {
+            const limit = parsePositiveInt(req.query.limit, 100, 500);
+            const skip = parseNonNegativeInt(req.query.skip, 0);
+            const result = await this.groupService.getMembers(req.params.id, { limit, skip });
+            res.json(result);
+        } catch (error) {
+            this.respondWithError(res, error, { id: req.params.id }, 'Failed to list group members');
+        }
+    }
+
+    /**
+     * PUT /api/admin/users/:id/groups
+     *
+     * Replace the user's complete group membership. Audit-logs a single
+     * info entry with target user id, requester IP, and before/after
+     * arrays — the shared-token admin model has no per-human attribution,
+     * so this is the only forensic record if the token leaks. Service
+     * layer is the source of truth: validation (unknown groups, missing
+     * user) and cache invalidation happen there.
+     */
+    async setUserGroups(req: Request, res: Response): Promise<void> {
+        const userId = req.params.id;
+        try {
+            const body = req.body ?? {};
+            if (!Array.isArray(body.groups)) {
+                res.status(400).json({
+                    error: 'BadRequest',
+                    message: 'Body must include "groups" as an array of group ids'
+                });
+                return;
+            }
+
+            const before = await this.groupService.getUserGroups(userId);
+            const after = await this.groupService.setUserGroups(userId, body.groups);
+
+            this.logger.info(
+                {
+                    ip: getClientIP(req),
+                    userId,
+                    before,
+                    after
+                },
+                'Admin replaced user group membership'
+            );
+
+            res.json({ groups: after });
+        } catch (error) {
+            this.respondWithError(res, error, { userId }, 'Failed to update user group membership');
         }
     }
 

--- a/src/backend/modules/user/api/user-group.routes.ts
+++ b/src/backend/modules/user/api/user-group.routes.ts
@@ -16,6 +16,10 @@ export function createAdminUserGroupRouter(controller: UserGroupController): Rou
     router.get('/:id', controller.getGroup.bind(controller));
     router.patch('/:id', controller.updateGroup.bind(controller));
     router.delete('/:id', controller.deleteGroup.bind(controller));
+    // Read-only paginated member list. Mounted last (after ":id" CRUD) so
+    // the more specific path matches before any future "/:id/anything"
+    // additions.
+    router.get('/:id/members', controller.listGroupMembers.bind(controller));
 
     return router;
 }

--- a/src/backend/modules/user/api/user.routes.ts
+++ b/src/backend/modules/user/api/user.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import type { UserController } from './user.controller.js';
+import type { UserGroupController } from './user-group.controller.js';
 import { createRateLimiter } from '../../../api/middleware/rate-limit.js';
 
 /**
@@ -194,12 +195,19 @@ export function createProfileRouter(controller: UserController): Router {
  * Create Express router for admin user endpoints.
  *
  * All routes require admin authentication (handled by parent router middleware).
- * Routes are mounted at /api/admin/users.
+ * Routes are mounted at /api/admin/users. The user-group controller is
+ * injected so the per-user membership editor (`PUT /:id/groups`) can live
+ * inside the user admin tree without coupling UserController to group
+ * concerns.
  *
  * @param controller - User controller instance
+ * @param groupController - User-group controller for membership mutation
  * @returns Express router with admin endpoints
  */
-export function createAdminUserRouter(controller: UserController): Router {
+export function createAdminUserRouter(
+    controller: UserController,
+    groupController: UserGroupController
+): Router {
     const router = Router();
 
     /**
@@ -330,6 +338,13 @@ export function createAdminUserRouter(controller: UserController): Router {
      * Get any user by UUID (admin bypass)
      */
     router.get('/:id', controller.getAnyUser.bind(controller));
+
+    /**
+     * PUT /api/admin/users/:id/groups
+     * Replace the user's complete group membership. Body: { groups: string[] }.
+     * Audit-logged at info level by the controller.
+     */
+    router.put('/:id/groups', groupController.setUserGroups.bind(groupController));
 
     return router;
 }

--- a/src/backend/modules/user/services/user-group.service.ts
+++ b/src/backend/modules/user/services/user-group.service.ts
@@ -313,6 +313,99 @@ export class UserGroupService implements IUserGroupService {
         await this.invalidateUserCache(canonicalId);
     }
 
+    /**
+     * Replace the user's full membership array. See contract JSDoc in
+     * `IUserGroupService` for semantics.
+     *
+     * The intentional difference from looping `addMember`/`removeMember`:
+     * one atomic `$set` of the deduplicated target array. This collapses
+     * N existence-checks and N updateOne calls into a single round trip,
+     * and matches the admin UX — operator sees a snapshot, ticks boxes,
+     * saves their explicit intent. Concurrent plugin writes between the
+     * admin's read and save are deliberately overwritten because that is
+     * what "set the membership to exactly this" means.
+     */
+    async setUserGroups(userId: string, groupIds: string[]): Promise<string[]> {
+        if (!Array.isArray(groupIds)) {
+            throw new UserGroupValidationError('groups must be an array of group ids');
+        }
+
+        // Coerce, trim, lowercase, dedupe. Drops empty strings introduced
+        // by clients that pass blank inputs.
+        const desired = Array.from(new Set(
+            groupIds
+                .filter((id): id is string => typeof id === 'string')
+                .map(id => id.trim().toLowerCase())
+                .filter(id => id.length > 0)
+        ));
+
+        // Validate every id resolves to a real group definition. A single
+        // $in query is cheaper than N findOnes and surfaces all unknown
+        // ids in the same trip if needed (we throw on the first one).
+        if (desired.length > 0) {
+            const existing = await this.groupsCollection
+                .find({ id: { $in: desired } }, { projection: { id: 1 } })
+                .toArray();
+            const existingIds = new Set(existing.map(g => g.id));
+            const unknown = desired.find(id => !existingIds.has(id));
+            if (unknown) {
+                throw new UserGroupNotFoundError(unknown);
+            }
+        }
+
+        const canonicalId = await this.resolveCanonicalUserId(userId);
+        const result = await this.usersCollection.updateOne(
+            { id: canonicalId },
+            { $set: { groups: desired, updatedAt: new Date() } }
+        );
+        if (result.matchedCount === 0) {
+            throw new UserGroupMemberNotFoundError(userId);
+        }
+        await this.invalidateUserCache(canonicalId);
+        this.logger.info(
+            { userId: canonicalId, groupCount: desired.length },
+            'User group membership replaced'
+        );
+        return desired;
+    }
+
+    /**
+     * Paginated member list for a single group. See contract JSDoc in
+     * `IUserGroupService` for semantics.
+     *
+     * Filters out `mergedInto`-flagged tombstones so the admin UI never
+     * shows duplicate identities for a single human after a wallet-driven
+     * identity merge.
+     */
+    async getMembers(
+        groupId: string,
+        options: { limit?: number; skip?: number } = {}
+    ): Promise<{ userIds: string[]; total: number }> {
+        const group = await this.groupsCollection.findOne({ id: groupId });
+        if (!group) {
+            throw new UserGroupNotFoundError(groupId);
+        }
+
+        const limit = Math.min(Math.max(1, options.limit ?? 100), 500);
+        const skip = Math.max(0, options.skip ?? 0);
+
+        const filter = { groups: groupId, mergedInto: { $exists: false } };
+        const [docs, total] = await Promise.all([
+            this.usersCollection
+                .find(filter, { projection: { id: 1 } })
+                .sort({ id: 1 })
+                .skip(skip)
+                .limit(limit)
+                .toArray(),
+            this.usersCollection.countDocuments(filter)
+        ]);
+
+        return {
+            userIds: docs.map(d => d.id),
+            total
+        };
+    }
+
     // ==================== Special: admin ====================
 
     async isAdmin(userId: string): Promise<boolean> {

--- a/src/backend/modules/user/services/user.service.ts
+++ b/src/backend/modules/user/services/user.service.ts
@@ -1666,9 +1666,19 @@ export class UserService {
             : {};
 
         // Combine filter and search with AND logic
-        const combinedQuery = Object.keys(filterQuery).length > 0 && Object.keys(searchQuery).length > 0
+        const userQuery = Object.keys(filterQuery).length > 0 && Object.keys(searchQuery).length > 0
             ? { $and: [filterQuery, searchQuery] }
             : { ...filterQuery, ...searchQuery };
+
+        // Exclude merge tombstones. They retain a stale groups[] snapshot
+        // from merge time and are never updated again, so surfacing them
+        // in admin tables lets operators write groups based on data that
+        // does not represent any live identity. Convention matches
+        // UserGroupService.getMembers.
+        const tombstoneFilter = { mergedInto: { $exists: false } };
+        const combinedQuery = Object.keys(userQuery).length > 0
+            ? { $and: [userQuery, tombstoneFilter] }
+            : tombstoneFilter;
 
         const [docs, filteredTotal] = await Promise.all([
             this.collection

--- a/src/frontend/modules/user/components/admin/GroupsManager/GroupMembersList.module.scss
+++ b/src/frontend/modules/user/components/admin/GroupsManager/GroupMembersList.module.scss
@@ -1,0 +1,69 @@
+/**
+ * Group members modal — read-only audit view of who currently belongs to
+ * a specific group. Sized to fit the small modal width with an internal
+ * scroll for groups exceeding ~10 visible rows.
+ */
+
+.container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+}
+
+.summary {
+    margin: 0;
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+}
+
+.error {
+    margin: 0;
+    color: var(--color-danger);
+    font-size: var(--font-size-body-sm);
+}
+
+.empty {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-style: italic;
+}
+
+.list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+    max-height: 18rem;
+    overflow-y: auto;
+}
+
+.item {
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--padding-xs) var(--padding-sm);
+}
+
+.user_id {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-body-sm);
+}
+
+.pagination {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--gap-sm);
+}
+
+.page_info {
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+}
+
+.actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--gap-sm);
+}

--- a/src/frontend/modules/user/components/admin/GroupsManager/GroupMembersList.tsx
+++ b/src/frontend/modules/user/components/admin/GroupsManager/GroupMembersList.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { config as runtimeConfig } from '../../../../../lib/config';
+import { getRuntimeConfig } from '../../../../../lib/runtimeConfig';
 import { Button } from '../../../../../components/ui/Button';
 import styles from './GroupMembersList.module.scss';
 
@@ -39,7 +39,7 @@ export function GroupMembersList({ token, groupId, groupName, onClose }: Props) 
 
     const baseUrl = useMemo(
         () =>
-            `${runtimeConfig.apiBaseUrl}/admin/users/groups/${encodeURIComponent(groupId)}/members`,
+            `${getRuntimeConfig().apiUrl}/admin/users/groups/${encodeURIComponent(groupId)}/members`,
         [groupId]
     );
 

--- a/src/frontend/modules/user/components/admin/GroupsManager/GroupMembersList.tsx
+++ b/src/frontend/modules/user/components/admin/GroupsManager/GroupMembersList.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+/**
+ * Modal body listing the current members of a single group.
+ *
+ * Read-only audit view — for "promote this user", admins use the editor
+ * in `UsersMonitor`. This view exists because finding everyone currently
+ * in a particular group (especially `admin`) is the rare-but-important
+ * operator question that the per-user editor can't answer cheaply.
+ *
+ * Pattern: client-only admin tool, mirrors GroupsManager / UserGroupsForm.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { config as runtimeConfig } from '../../../../../lib/config';
+import { Button } from '../../../../../components/ui/Button';
+import styles from './GroupMembersList.module.scss';
+
+interface MembersResponse {
+    userIds: string[];
+    total: number;
+}
+
+interface Props {
+    token: string;
+    groupId: string;
+    groupName: string;
+    onClose: () => void;
+}
+
+const PAGE_SIZE = 100;
+
+export function GroupMembersList({ token, groupId, groupName, onClose }: Props) {
+    const [members, setMembers] = useState<string[]>([]);
+    const [total, setTotal] = useState(0);
+    const [skip, setSkip] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const baseUrl = useMemo(
+        () =>
+            `${runtimeConfig.apiBaseUrl}/admin/users/groups/${encodeURIComponent(groupId)}/members`,
+        [groupId]
+    );
+
+    useEffect(() => {
+        let cancelled = false;
+        async function load() {
+            setLoading(true);
+            setError(null);
+            try {
+                const response = await fetch(
+                    `${baseUrl}?limit=${PAGE_SIZE}&skip=${skip}`,
+                    { headers: { 'X-Admin-Token': token } }
+                );
+                if (!response.ok) {
+                    throw new Error(`Failed to load members (${response.status})`);
+                }
+                const data: MembersResponse = await response.json();
+                if (!cancelled) {
+                    setMembers(data.userIds);
+                    setTotal(data.total);
+                }
+            } catch (err) {
+                if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load members');
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        }
+        void load();
+        return () => { cancelled = true; };
+    }, [baseUrl, token, skip]);
+
+    const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+    const currentPage = Math.floor(skip / PAGE_SIZE) + 1;
+
+    return (
+        <div className={styles.container}>
+            <p className={styles.summary}>
+                <strong>{groupName}</strong> — {total.toLocaleString()} member{total === 1 ? '' : 's'}
+            </p>
+
+            {error && <p className={styles.error}>{error}</p>}
+
+            {loading && <p>Loading members…</p>}
+
+            {!loading && !error && members.length === 0 && (
+                <p className={styles.empty}>
+                    No users belong to this group yet. Assign membership from the Users
+                    tab.
+                </p>
+            )}
+
+            {!loading && !error && members.length > 0 && (
+                <ul className={styles.list}>
+                    {members.map(id => (
+                        <li key={id} className={styles.item}>
+                            <code className={styles.user_id}>{id}</code>
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {total > PAGE_SIZE && (
+                <div className={styles.pagination}>
+                    <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setSkip(Math.max(0, skip - PAGE_SIZE))}
+                        disabled={skip === 0 || loading}
+                    >
+                        Previous
+                    </Button>
+                    <span className={styles.page_info}>
+                        Page {currentPage} of {totalPages}
+                    </span>
+                    <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setSkip(skip + PAGE_SIZE)}
+                        disabled={skip + PAGE_SIZE >= total || loading}
+                    >
+                        Next
+                    </Button>
+                </div>
+            )}
+
+            <div className={styles.actions}>
+                <Button type="button" variant="ghost" onClick={onClose}>
+                    Close
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/frontend/modules/user/components/admin/GroupsManager/GroupsManager.tsx
+++ b/src/frontend/modules/user/components/admin/GroupsManager/GroupsManager.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Plus, Pencil, Trash2, Lock } from 'lucide-react';
+import { Plus, Pencil, Trash2, Lock, Users as UsersIcon } from 'lucide-react';
 import { config as runtimeConfig } from '../../../../../lib/config';
 import { Button } from '../../../../../components/ui/Button';
 import { Card } from '../../../../../components/ui/Card';
@@ -24,6 +24,7 @@ import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { useModal } from '../../../../../components/ui/ModalProvider';
 import { useToast } from '../../../../../components/ui/ToastProvider';
 import { GroupForm, type GroupFormValues } from './GroupForm';
+import { GroupMembersList } from './GroupMembersList';
 import styles from './GroupsManager.module.scss';
 
 interface UserGroup {
@@ -134,6 +135,21 @@ export function GroupsManager({ token }: Props) {
             )
         });
     }, [openModal, closeModal, submitCreate, fetchGroups, pushToast]);
+
+    const openMembersModal = useCallback((group: UserGroup) => {
+        const id = openModal({
+            title: `Members of "${group.id}"`,
+            size: 'sm',
+            content: (
+                <GroupMembersList
+                    token={token}
+                    groupId={group.id}
+                    groupName={group.name}
+                    onClose={() => closeModal(id)}
+                />
+            )
+        });
+    }, [openModal, closeModal, token]);
 
     const openEditModal = useCallback((group: UserGroup) => {
         const id = openModal({
@@ -261,6 +277,15 @@ export function GroupsManager({ token }: Props) {
                                         <ClientTime date={group.updatedAt} format="date" />
                                     </td>
                                     <td className={styles.actions}>
+                                        <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() => openMembersModal(group)}
+                                            aria-label={`View members of ${group.name}`}
+                                            title="View members"
+                                        >
+                                            <UsersIcon size={14} aria-hidden="true" />
+                                        </Button>
                                         {group.system ? (
                                             <span className="text-muted">Read-only</span>
                                         ) : (

--- a/src/frontend/modules/user/components/admin/UsersMonitor/UserGroupsForm.module.scss
+++ b/src/frontend/modules/user/components/admin/UsersMonitor/UserGroupsForm.module.scss
@@ -1,0 +1,94 @@
+/**
+ * Group-membership editor modal styles.
+ *
+ * Compact checkbox list for the admin "tick which groups this user is in"
+ * UX. Sized to fit the small modal width without forcing scrolls until
+ * the catalog grows past ~10 groups.
+ */
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+}
+
+.user_id {
+    margin: 0;
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+
+    code {
+        font-family: var(--font-mono);
+        background: var(--color-surface-muted);
+        padding: var(--padding-2xs) var(--padding-xs);
+        border-radius: var(--radius-sm);
+    }
+}
+
+.error {
+    margin: 0;
+    color: var(--color-danger);
+    font-size: var(--font-size-body-sm);
+}
+
+.empty {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-style: italic;
+}
+
+.group_list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+    max-height: 18rem;
+    overflow-y: auto;
+}
+
+.group_item {
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--padding-xs) var(--padding-sm);
+
+    &:hover {
+        background: var(--color-surface-muted);
+    }
+}
+
+.group_label {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--gap-sm);
+    cursor: pointer;
+}
+
+.group_text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+}
+
+.group_name {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+}
+
+.group_slug {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-body-sm);
+}
+
+.group_description {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+}
+
+.actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--gap-sm);
+}

--- a/src/frontend/modules/user/components/admin/UsersMonitor/UserGroupsForm.tsx
+++ b/src/frontend/modules/user/components/admin/UsersMonitor/UserGroupsForm.tsx
@@ -16,7 +16,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Lock } from 'lucide-react';
-import { config as runtimeConfig } from '../../../../../lib/config';
+import { getRuntimeConfig } from '../../../../../lib/runtimeConfig';
 import { Button } from '../../../../../components/ui/Button';
 import styles from './UserGroupsForm.module.scss';
 
@@ -47,7 +47,7 @@ export function UserGroupsForm({ token, userId, initialGroups, onCancel, onSubmi
     const [submitting, setSubmitting] = useState(false);
 
     const baseUrl = useMemo(
-        () => `${runtimeConfig.apiBaseUrl}/admin/users/groups`,
+        () => `${getRuntimeConfig().apiUrl}/admin/users/groups`,
         []
     );
 
@@ -64,7 +64,20 @@ export function UserGroupsForm({ token, userId, initialGroups, onCancel, onSubmi
                     throw new Error(`Failed to load groups (${response.status})`);
                 }
                 const data: ListResponse = await response.json();
-                if (!cancelled) setGroups(data.groups);
+                if (!cancelled) {
+                    setGroups(data.groups);
+                    // Drop selected ids that no longer exist in the catalog.
+                    // Without this, a group deleted between the users-table
+                    // fetch and this load stays in `selected` but renders no
+                    // checkbox, so the admin can't untick it and save fails
+                    // with UserGroupNotFoundError.
+                    const known = new Set(data.groups.map(g => g.id));
+                    setSelected(prev => {
+                        const next = new Set<string>();
+                        for (const id of prev) if (known.has(id)) next.add(id);
+                        return next;
+                    });
+                }
             } catch (err) {
                 if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load groups');
             } finally {

--- a/src/frontend/modules/user/components/admin/UsersMonitor/UserGroupsForm.tsx
+++ b/src/frontend/modules/user/components/admin/UsersMonitor/UserGroupsForm.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+/**
+ * Modal body that lets an admin replace a user's complete group membership.
+ *
+ * Loads the catalog of group definitions on mount, pre-checks the user's
+ * current memberships, and on save calls `PUT /api/admin/users/:id/groups`.
+ * The server is authoritative for "set" semantics — the form simply ships
+ * the ticked ids and trusts the response. Error states surface as toasts
+ * via the caller's `onSubmit` handler.
+ *
+ * Pattern: client-only admin tool. SSR + Live Updates does not apply here
+ * because `/system/users` is admin-gated. Mirrors the established approach
+ * in `GroupForm.tsx`.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Lock } from 'lucide-react';
+import { config as runtimeConfig } from '../../../../../lib/config';
+import { Button } from '../../../../../components/ui/Button';
+import styles from './UserGroupsForm.module.scss';
+
+interface UserGroup {
+    id: string;
+    name: string;
+    description: string;
+    system: boolean;
+}
+
+interface ListResponse {
+    groups: UserGroup[];
+}
+
+interface Props {
+    token: string;
+    userId: string;
+    initialGroups: string[];
+    onCancel: () => void;
+    onSubmit: (selectedGroupIds: string[]) => void | Promise<void>;
+}
+
+export function UserGroupsForm({ token, userId, initialGroups, onCancel, onSubmit }: Props) {
+    const [groups, setGroups] = useState<UserGroup[]>([]);
+    const [selected, setSelected] = useState<Set<string>>(() => new Set(initialGroups));
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [submitting, setSubmitting] = useState(false);
+
+    const baseUrl = useMemo(
+        () => `${runtimeConfig.apiBaseUrl}/admin/users/groups`,
+        []
+    );
+
+    useEffect(() => {
+        let cancelled = false;
+        async function load() {
+            setLoading(true);
+            setError(null);
+            try {
+                const response = await fetch(baseUrl, {
+                    headers: { 'X-Admin-Token': token }
+                });
+                if (!response.ok) {
+                    throw new Error(`Failed to load groups (${response.status})`);
+                }
+                const data: ListResponse = await response.json();
+                if (!cancelled) setGroups(data.groups);
+            } catch (err) {
+                if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load groups');
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        }
+        void load();
+        return () => { cancelled = true; };
+    }, [baseUrl, token]);
+
+    const toggle = useCallback((groupId: string) => {
+        setSelected(prev => {
+            const next = new Set(prev);
+            if (next.has(groupId)) {
+                next.delete(groupId);
+            } else {
+                next.add(groupId);
+            }
+            return next;
+        });
+    }, []);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setSubmitting(true);
+        try {
+            await onSubmit(Array.from(selected));
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className={styles.form}>
+            <p className={styles.user_id}>
+                User: <code>{userId}</code>
+            </p>
+
+            {error && <p className={styles.error}>{error}</p>}
+
+            {loading && <p>Loading groups…</p>}
+
+            {!loading && !error && groups.length === 0 && (
+                <p className={styles.empty}>
+                    No groups defined yet. Create one in the Groups tab first.
+                </p>
+            )}
+
+            {!loading && !error && groups.length > 0 && (
+                <ul className={styles.group_list}>
+                    {groups.map(group => {
+                        const checked = selected.has(group.id);
+                        return (
+                            <li key={group.id} className={styles.group_item}>
+                                <label className={styles.group_label}>
+                                    <input
+                                        type="checkbox"
+                                        checked={checked}
+                                        onChange={() => toggle(group.id)}
+                                        disabled={submitting}
+                                    />
+                                    <span className={styles.group_text}>
+                                        <span className={styles.group_name}>
+                                            <code className={styles.group_slug}>{group.id}</code>
+                                            {group.system && (
+                                                <span
+                                                    className="badge badge--info"
+                                                    title="System group"
+                                                >
+                                                    <Lock size={12} aria-hidden="true" /> system
+                                                </span>
+                                            )}
+                                        </span>
+                                        {group.description && (
+                                            <span className={styles.group_description}>
+                                                {group.description}
+                                            </span>
+                                        )}
+                                    </span>
+                                </label>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+
+            <div className={styles.actions}>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={onCancel}
+                    disabled={submitting}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    type="submit"
+                    variant="primary"
+                    disabled={submitting || loading || !!error}
+                >
+                    {submitting ? 'Saving…' : 'Save'}
+                </Button>
+            </div>
+        </form>
+    );
+}

--- a/src/frontend/modules/user/components/admin/UsersMonitor/UsersMonitor.module.scss
+++ b/src/frontend/modules/user/components/admin/UsersMonitor/UsersMonitor.module.scss
@@ -288,6 +288,13 @@
     border-bottom: var(--border-width-thin) solid var(--color-border);
 }
 
+/* Group chip list shown in the Groups detail section */
+.group_chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-xs);
+}
+
 .section_header h4 {
     margin: 0;
     padding: 0;

--- a/src/frontend/modules/user/components/admin/UsersMonitor/UsersMonitor.tsx
+++ b/src/frontend/modules/user/components/admin/UsersMonitor/UsersMonitor.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import type { UserFilterType } from '@/types';
 import { Smartphone, Tablet, Monitor, HelpCircle, Users as UsersIcon } from 'lucide-react';
-import { config as runtimeConfig } from '../../../../../lib/config';
+import { getRuntimeConfig } from '../../../../../lib/runtimeConfig';
 import { Button } from '../../../../../components/ui/Button';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { useModal } from '../../../../../components/ui/ModalProvider';
@@ -272,7 +272,7 @@ export function UsersMonitor({ token }: Props) {
             }
 
             const response = await fetch(
-                `${runtimeConfig.apiBaseUrl}/admin/users?${params.toString()}`,
+                `${getRuntimeConfig().apiUrl}/admin/users?${params.toString()}`,
                 {
                     headers: {
                         'X-Admin-Token': token
@@ -318,7 +318,7 @@ export function UsersMonitor({ token }: Props) {
                     onSubmit={async (selectedIds) => {
                         try {
                             const response = await fetch(
-                                `${runtimeConfig.apiBaseUrl}/admin/users/${encodeURIComponent(user.id)}/groups`,
+                                `${getRuntimeConfig().apiUrl}/admin/users/${encodeURIComponent(user.id)}/groups`,
                                 {
                                     method: 'PUT',
                                     headers: {

--- a/src/frontend/modules/user/components/admin/UsersMonitor/UsersMonitor.tsx
+++ b/src/frontend/modules/user/components/admin/UsersMonitor/UsersMonitor.tsx
@@ -2,11 +2,14 @@
 
 import React, { useEffect, useState, useCallback } from 'react';
 import type { UserFilterType } from '@/types';
-import { Smartphone, Tablet, Monitor, HelpCircle } from 'lucide-react';
+import { Smartphone, Tablet, Monitor, HelpCircle, Users as UsersIcon } from 'lucide-react';
 import { config as runtimeConfig } from '../../../../../lib/config';
 import { Button } from '../../../../../components/ui/Button';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
+import { useModal } from '../../../../../components/ui/ModalProvider';
+import { useToast } from '../../../../../components/ui/ToastProvider';
 import { VisitorAnalytics } from '../VisitorAnalytics';
+import { UserGroupsForm } from './UserGroupsForm';
 import styles from './UsersMonitor.module.scss';
 
 /**
@@ -114,6 +117,7 @@ interface UserRecord {
     wallets: WalletLink[];
     preferences: UserPreferences;
     activity: UserActivity;
+    groups: string[];
     createdAt: string;
     updatedAt: string;
 }
@@ -221,6 +225,9 @@ export function UsersMonitor({ token }: Props) {
     const [expandedUserId, setExpandedUserId] = useState<string | null>(null);
     const [sessionPages, setSessionPages] = useState<Record<string, number>>({});
 
+    const { open: openModal, close: closeModal } = useModal();
+    const { push: pushToast } = useToast();
+
     /** Sessions per page in the Recent Sessions section */
     const SESSIONS_PER_PAGE = 5;
 
@@ -292,6 +299,53 @@ export function UsersMonitor({ token }: Props) {
     useEffect(() => {
         fetchUsers();
     }, [fetchUsers]);
+
+    /**
+     * Open the membership editor modal for a user. The save handler PUTs
+     * the new id list and refreshes the table on success so admins see the
+     * authoritative server state, not just the optimistic value.
+     */
+    const openGroupsModal = useCallback((user: UserRecord) => {
+        const modalId = openModal({
+            title: 'Manage Groups',
+            size: 'sm',
+            content: (
+                <UserGroupsForm
+                    token={token}
+                    userId={user.id}
+                    initialGroups={user.groups ?? []}
+                    onCancel={() => closeModal(modalId)}
+                    onSubmit={async (selectedIds) => {
+                        try {
+                            const response = await fetch(
+                                `${runtimeConfig.apiBaseUrl}/admin/users/${encodeURIComponent(user.id)}/groups`,
+                                {
+                                    method: 'PUT',
+                                    headers: {
+                                        'X-Admin-Token': token,
+                                        'Content-Type': 'application/json'
+                                    },
+                                    body: JSON.stringify({ groups: selectedIds })
+                                }
+                            );
+                            if (!response.ok) {
+                                const payload = await response.json().catch(() => null);
+                                throw new Error(payload?.message ?? `Update failed (${response.status})`);
+                            }
+                            pushToast({ tone: 'success', title: 'Group membership updated' });
+                            closeModal(modalId);
+                            await fetchUsers();
+                        } catch (error) {
+                            pushToast({
+                                tone: 'danger',
+                                title: error instanceof Error ? error.message : 'Update failed'
+                            });
+                        }
+                    }}
+                />
+            )
+        });
+    }, [openModal, closeModal, pushToast, fetchUsers, token]);
 
     const handleSearch = () => {
         setPage(1);
@@ -570,6 +624,37 @@ export function UsersMonitor({ token }: Props) {
                                                 <dt>Total Time</dt>
                                                 <dd>{formatDuration(user.activity.totalDurationSeconds)}</dd>
                                             </dl>
+                                        </div>
+
+                                        <div className={styles.detail_section}>
+                                            <div className={styles.section_header}>
+                                                <h4>Groups</h4>
+                                                <Button
+                                                    size="sm"
+                                                    variant="secondary"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        openGroupsModal(user);
+                                                    }}
+                                                    aria-label={`Manage groups for ${user.id}`}
+                                                >
+                                                    <UsersIcon size={14} aria-hidden="true" /> Manage
+                                                </Button>
+                                            </div>
+                                            {(user.groups ?? []).length === 0 ? (
+                                                <p className={styles.no_data}>No groups assigned</p>
+                                            ) : (
+                                                <div className={styles.group_chips}>
+                                                    {user.groups.map(groupId => (
+                                                        <span
+                                                            key={groupId}
+                                                            className="badge badge--info"
+                                                        >
+                                                            <code>{groupId}</code>
+                                                        </span>
+                                                    ))}
+                                                </div>
+                                            )}
                                         </div>
 
                                         {/* Country Distribution */}


### PR DESCRIPTION
## Summary

- Extends `IUserGroupService` with `setUserGroups` (bulk replace, set-semantics) and `getMembers` (paginated, excludes merged tombstones).
- Wires `PUT /api/admin/users/:id/groups` and `GET /api/admin/users/groups/:id/members` through the existing user-group controller, keeping `UserController` decoupled from group concerns.
- Adds two admin panels: `UserGroupsForm` (edit a user's groups from `UsersMonitor`) and `GroupMembersList` (browse a group's members from `GroupsManager`).