### PR TITLE
Fix identity-cookie reader bugs and tighten WS to signed-only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
 
             # API Keys
             - ADMIN_API_TOKEN=${ADMIN_API_TOKEN}
+            - SESSION_SECRET=${SESSION_SECRET}
             - TRONGRID_API_KEY=${TRONGRID_API_KEY}
             - TRONGRID_API_KEY_2=${TRONGRID_API_KEY_2}
             - TRONGRID_API_KEY_3=${TRONGRID_API_KEY_3}

--- a/src/backend/api/middleware/admin-auth.ts
+++ b/src/backend/api/middleware/admin-auth.ts
@@ -3,7 +3,7 @@ import { UserIdentityState, hasFreshVerification } from '@/types';
 import { env } from '../../config/env.js';
 import { UserService } from '../../modules/user/services/user.service.js';
 import { UserGroupService } from '../../modules/user/services/user-group.service.js';
-import { USER_ID_COOKIE_NAME } from '../../modules/user/api/identity-cookie.js';
+import { USER_ID_COOKIE_NAME, UUID_V4_REGEX } from '../../modules/user/api/identity-cookie.js';
 
 /**
  * Internal failure reasons returned from `tryUserAdminAuth`. Surfaced in
@@ -47,8 +47,6 @@ declare module 'express-serve-static-core' {
         userId?: string;
     }
 }
-
-const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /**
  * Pull the admin token candidate off a request without enforcing.

--- a/src/backend/api/middleware/user-context.ts
+++ b/src/backend/api/middleware/user-context.ts
@@ -12,48 +12,9 @@ import type { Request, Response, NextFunction, RequestHandler } from 'express';
 import { UserService } from '../../modules/user/services/user.service.js';
 import { logger } from '../../lib/logger.js';
 import {
-    USER_ID_COOKIE_NAME,
-    setIdentityCookie
+    setIdentityCookie,
+    resolveIdentityFromCookies
 } from '../../modules/user/api/identity-cookie.js';
-
-/**
- * UUID v4 format regex for validation.
- * Validates format before trusting client-provided cookie values.
- */
-const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-/**
- * Resolve the visitor's identity UUID from request cookies.
- *
- * Returns `{ userId, signed }` where `signed=true` means the value came from
- * `req.signedCookies` (HMAC-verified by cookie-parser). The legacy
- * `signed=false` path accepts an unsigned UUID v4 from `req.cookies` to
- * preserve continuity for visitors whose cookies were issued before HMAC
- * signing was introduced. Callers can use the flag to decide whether to
- * re-issue the cookie as signed on the response.
- *
- * Returns `null` when no cookie is present or the candidate fails UUID v4
- * format validation. `req.signedCookies[name] === false` (cookie-parser's
- * "tampered" sentinel) is treated as no-cookie — we never honor a forged
- * signed cookie, even on the legacy fallback.
- */
-function resolveIdentityFromCookies(req: Request): { userId: string; signed: boolean } | null {
-    const signedValue = (req as any).signedCookies?.[USER_ID_COOKIE_NAME];
-    if (typeof signedValue === 'string' && UUID_V4_REGEX.test(signedValue)) {
-        return { userId: signedValue, signed: true };
-    }
-    // signedCookies returns `false` on tampered values — never accept those
-    // even via the legacy unsigned path; that would defeat HMAC verification.
-    if (signedValue === false) {
-        return null;
-    }
-
-    const unsignedValue = (req as any).cookies?.[USER_ID_COOKIE_NAME];
-    if (typeof unsignedValue === 'string' && UUID_V4_REGEX.test(unsignedValue)) {
-        return { userId: unsignedValue, signed: false };
-    }
-    return null;
-}
 
 /**
  * Middleware that resolves user context from cookies.
@@ -116,9 +77,21 @@ export const userContextMiddleware: RequestHandler = async (
         // signed so subsequent requests land on the signed path. The flag
         // stays out of admin auth — `requireAdmin` reads only signedCookies
         // — so this fallback never grants admin access on a forged value.
+        // The info log gives operators visibility into legacy-cookie decay
+        // and anomaly detection; see `validateCookie` for the rationale.
         if (!signed) {
             try {
                 setIdentityCookie(res, userId);
+                logger.info(
+                    {
+                        event: 'legacy_cookie_upgraded',
+                        site: 'userContextMiddleware',
+                        userId,
+                        path: req.path,
+                        ip: req.ip
+                    },
+                    'Legacy unsigned identity cookie accepted; re-anchored as signed'
+                );
             } catch (error) {
                 logger.debug({ error, userId }, 'Failed to re-issue identity cookie as signed');
             }

--- a/src/backend/modules/user/README.md
+++ b/src/backend/modules/user/README.md
@@ -239,7 +239,7 @@ The user identity cookie has these characteristics:
 
 **Why signing matters.** HttpOnly only blocks JavaScript reads in browsers — non-browser clients (curl, custom tools) can set arbitrary `Cookie` headers. Without a signature, an attacker who learns a UUID could forge `Cookie: tronrelic_uid=<uuid>` and pass identity checks. Signing requires possession of `SESSION_SECRET` to mint a valid value, so the cookie behaves as a server-bound bearer token, not a guess-the-UUID lottery.
 
-**Reader policy.** `requireAdmin` reads identity **only** from `req.signedCookies` — a forged or unsigned admin cookie is never honored. `userContextMiddleware` and the bootstrap controller prefer `req.signedCookies` and fall back to `req.cookies` for unsigned legacy values; on a fallback the server immediately re-issues the cookie as signed via `setIdentityCookie`, so visitors holding unsigned cookies upgrade transparently without losing their UUID. The websocket handshake parser verifies the HMAC directly via `cookie-signature.unsign` (Socket.IO doesn't run cookie-parser) and applies the same signed-first / legacy-fallback policy for identity-room subscriptions.
+**Reader policy.** `requireAdmin` reads identity **only** from `req.signedCookies` — a forged or unsigned admin cookie is never honored. Every other HTTP entry point (the bootstrap controller, `validateCookie`, `userContextMiddleware`) shares a single resolver, `resolveIdentityFromCookies` in `identity-cookie.ts`, which prefers `req.signedCookies` and falls back to `req.cookies` for unsigned legacy values; on a fallback each of those readers immediately re-issues the cookie as signed via `setIdentityCookie` and emits an info-level `event: 'legacy_cookie_upgraded'` log so operators can track grace-window decay and flag anomalous patterns. Visitors holding unsigned cookies upgrade transparently on the very next request without losing their UUID. The websocket handshake parser verifies the HMAC directly via `cookie-signature.unsign` (Socket.IO doesn't run cookie-parser) and is **signed-only — no legacy fallback.** The handshake has no Set-Cookie channel, so it cannot facilitate the upgrade; accepting unsigned identity would only let a forged-UUID Cookie header subscribe to identity rooms without possessing `SESSION_SECRET`. Browser visitors always reach the handshake with a signed cookie because `SocketBridge` defers the WS connection past hydration, by which point `UserIdentityProvider` has re-anchored the cookie via `/api/user/bootstrap` — so the signed-only policy never breaks legitimate visitors. Non-browser clients must hit any HTTP entry point first to receive the signed cookie, then connect.
 
 **SESSION_SECRET.** Required in production: env validation throws on startup if unset. Development and test fall through to a fixed placeholder with a console.warn — never deploy with the placeholder.
 
@@ -319,21 +319,25 @@ UserController exposes REST API endpoints with cookie validation middleware for 
 
 **Cookie validation middleware:**
 
-The `validateCookie` middleware ensures the `tronrelic_uid` cookie matches the `:id` parameter in the URL. This prevents UUID enumeration attacks and ensures users can only access their own data.
+The `validateCookie` middleware ensures the `tronrelic_uid` cookie matches the `:id` parameter in the URL. This prevents UUID enumeration attacks and ensures users can only access their own data. Identity resolution flows through the shared `resolveIdentityFromCookies` helper in `identity-cookie.ts` — the single source of truth for the signed-first / unsigned-fallback policy used by every HTTP entry point. Legacy unsigned holders are upgraded on the response so the fallback is genuinely temporary, not a permanent shadow path for clients that bypass `/api/user/bootstrap`.
 
 ```typescript
 validateCookie(req: Request, res: Response, next: NextFunction): void {
-    const cookieId = req.cookies?.['tronrelic_uid'];
-    const paramId = req.params.id;
+    const resolved = resolveIdentityFromCookies(req);
 
-    if (!cookieId) {
+    if (!resolved) {
         res.status(401).json({ error: 'Unauthorized', message: 'Missing identity cookie' });
         return;
     }
 
-    if (cookieId !== paramId) {
+    if (resolved.userId !== req.params.id) {
         res.status(403).json({ error: 'Forbidden', message: 'Cookie does not match requested user ID' });
         return;
+    }
+
+    // Upgrade legacy unsigned cookies on the response. Signed path is a no-op.
+    if (!resolved.signed) {
+        setIdentityCookie(res, resolved.userId);
     }
 
     next();

--- a/src/backend/modules/user/__tests__/bootstrap.controller.test.ts
+++ b/src/backend/modules/user/__tests__/bootstrap.controller.test.ts
@@ -130,7 +130,8 @@ describe('UserController.bootstrap', () => {
 
         const req: any = {
             cookies: { [USER_ID_COOKIE_NAME]: VALID_UUID_A },
-            signedCookies: {}
+            signedCookies: {},
+            headers: {}
         };
         const res = makeRes();
 
@@ -180,5 +181,146 @@ describe('UserController.bootstrap', () => {
         // not the tombstone the request arrived with.
         expect(res.jsonBody.id).toBe(VALID_UUID_A);
         expect(res.cookies[0].value).toBe(VALID_UUID_A);
+    });
+});
+
+describe('UserController.validateCookie', () => {
+    let controller: UserController;
+    let mockDb: ReturnType<typeof createMockDatabaseService>;
+    let mockCache: MockCache;
+
+    beforeEach(() => {
+        mockDb = createMockDatabaseService();
+        mockCache = new MockCache();
+        UserService.resetInstance();
+        UserService.setDependencies(
+            mockDb,
+            mockCache,
+            new NullLogger(),
+            { getSiteUrl: async () => 'http://localhost:3000', getConfig: async () => ({ siteUrl: 'http://localhost:3000' }), updateConfig: async (u: any) => u, clearCache: () => {} } as any,
+            {} as any
+        );
+        controller = new UserController(UserService.getInstance(), {} as any, new NullLogger());
+    });
+
+    it('accepts the signed cookie and does NOT re-issue (avoids per-request Set-Cookie spam)', () => {
+        // After PR #197 cookie-parser exposes verified UUIDs on
+        // `signedCookies` and removes them from `cookies`. validateCookie
+        // must read signedCookies first, otherwise every signed visitor
+        // 401s on `/api/user/:id/...` calls (the original logout bug).
+        // The re-issue path is unsigned-only — the signed visitor is
+        // already in the target state, so emitting another Set-Cookie
+        // header here would be pure noise on every authenticated call.
+        const req: any = {
+            params: { id: VALID_UUID_A },
+            cookies: {},
+            signedCookies: { [USER_ID_COOKIE_NAME]: VALID_UUID_A }
+        };
+        const res = makeRes();
+        const next = vi.fn();
+
+        controller.validateCookie(req, res as any, next);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(res.statusCode).toBe(200);
+        expect(res.jsonBody).toBeNull();
+        expect(res.cookies).toHaveLength(0);
+    });
+
+    it('falls back to the unsigned cookie and re-anchors it as signed on the response', () => {
+        // Visitors whose cookie was minted before HMAC signing arrive
+        // with a bare UUID on `req.cookies`. We accept it so they don't
+        // lose access mid-rollout — and re-issue as signed on the same
+        // response so the upgrade is universal across HTTP entry points,
+        // not just bootstrap/userContextMiddleware. Without this a
+        // non-browser caller hitting only /api/user/:id/... would never
+        // visit a path that re-anchors.
+        const req: any = {
+            params: { id: VALID_UUID_A },
+            cookies: { [USER_ID_COOKIE_NAME]: VALID_UUID_A },
+            signedCookies: {},
+            headers: {},
+            path: '/api/user/' + VALID_UUID_A + '/logout'
+        };
+        const res = makeRes();
+        const next = vi.fn();
+
+        controller.validateCookie(req, res as any, next);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(res.statusCode).toBe(200);
+        expect(res.cookies).toHaveLength(1);
+        expect(res.cookies[0].name).toBe(USER_ID_COOKIE_NAME);
+        expect(res.cookies[0].value).toBe(VALID_UUID_A);
+        expect(res.cookies[0].options.signed).toBe(true);
+        expect(res.cookies[0].options.httpOnly).toBe(true);
+    });
+
+    it('returns 401 when neither cookie source carries an identity', () => {
+        const req: any = {
+            params: { id: VALID_UUID_A },
+            cookies: {},
+            signedCookies: {}
+        };
+        const res = makeRes();
+        const next = vi.fn();
+
+        controller.validateCookie(req, res as any, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(401);
+        expect(res.jsonBody).toMatchObject({ error: 'Unauthorized' });
+    });
+
+    it('rejects a tampered signed cookie (signedCookies value is `false`)', () => {
+        // cookie-parser surfaces forged signed cookies as the literal `false`.
+        // The signed branch's `typeof === "string"` guard must reject it,
+        // and the unsigned branch is empty, so the request 401s.
+        const req: any = {
+            params: { id: VALID_UUID_A },
+            cookies: {},
+            signedCookies: { [USER_ID_COOKIE_NAME]: false }
+        };
+        const res = makeRes();
+        const next = vi.fn();
+
+        controller.validateCookie(req, res as any, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(401);
+    });
+
+    it('returns 403 when the cookie identity does not match :id', () => {
+        const req: any = {
+            params: { id: VALID_UUID_A },
+            cookies: {},
+            signedCookies: { [USER_ID_COOKIE_NAME]: VALID_UUID_B }
+        };
+        const res = makeRes();
+        const next = vi.fn();
+
+        controller.validateCookie(req, res as any, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(403);
+        expect(res.jsonBody).toMatchObject({ error: 'Forbidden' });
+    });
+
+    it('prefers the signed cookie over a stale unsigned cookie when both are present', () => {
+        // Defensive: if both arrive (e.g. during the brief window after
+        // the backend re-issued as signed but before the legacy cookie
+        // has been overwritten), the signed value wins.
+        const req: any = {
+            params: { id: VALID_UUID_A },
+            cookies: { [USER_ID_COOKIE_NAME]: VALID_UUID_B },
+            signedCookies: { [USER_ID_COOKIE_NAME]: VALID_UUID_A }
+        };
+        const res = makeRes();
+        const next = vi.fn();
+
+        controller.validateCookie(req, res as any, next);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(res.statusCode).toBe(200);
     });
 });

--- a/src/backend/modules/user/api/identity-cookie.ts
+++ b/src/backend/modules/user/api/identity-cookie.ts
@@ -12,13 +12,75 @@
  * link-wallet handler, and tests asserting cookie shape.
  */
 
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
 
 /** Cookie name for user identity. */
 export const USER_ID_COOKIE_NAME = 'tronrelic_uid';
 
 /** Max age in seconds (1 year). */
 export const USER_ID_COOKIE_MAX_AGE_SECONDS = 31536000;
+
+/**
+ * UUID v4 regex used by every identity reader. Centralized here so the
+ * auth/authz code paths (`requireAdmin`, `userContextMiddleware`, the
+ * bootstrap and `validateCookie` controllers, the websocket handshake
+ * parser, and the frontend bootstrap response check) share a single
+ * source of truth and cannot drift.
+ */
+export const UUID_V4_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Result of resolving the visitor's UUID from cookie-parser output.
+ *
+ * `signed: true` means the value came from `req.signedCookies` after
+ * HMAC verification. `signed: false` means it came from `req.cookies`
+ * as a legacy unsigned UUID — callers that re-issue cookies (bootstrap,
+ * validateCookie, userContextMiddleware) use this flag to upgrade
+ * legacy holders by calling `setIdentityCookie`. The strict admin
+ * gate deliberately does *not* use this helper — it must reject
+ * unsigned values outright, not upgrade them.
+ */
+export interface IResolvedIdentity {
+    userId: string;
+    signed: boolean;
+}
+
+/**
+ * Resolve the visitor's UUID from cookie-parser-populated request fields,
+ * applying the canonical signed-first / unsigned-fallback policy.
+ *
+ * Returns null when:
+ *   - No identity cookie is present.
+ *   - The signed envelope's HMAC failed verification (cookie-parser
+ *     surfaces this as `req.signedCookies[name] === false`). We never
+ *     fall back to the unsigned bag in this case — accepting a forged
+ *     value via the legacy path would defeat the point of signing.
+ *   - Both cookie sources carry malformed (non-UUID-v4) values.
+ *
+ * The signed-first preference avoids ambiguity during the brief window
+ * after the backend re-issued a cookie as signed but the legacy
+ * unsigned cookie hasn't been overwritten yet.
+ *
+ * @param req - Express request populated by cookie-parser
+ * @returns Resolved UUID + signedness, or null
+ */
+export function resolveIdentityFromCookies(req: Request): IResolvedIdentity | null {
+    const signedValue = (req as any).signedCookies?.[USER_ID_COOKIE_NAME];
+    if (typeof signedValue === 'string' && UUID_V4_REGEX.test(signedValue)) {
+        return { userId: signedValue, signed: true };
+    }
+    // Forged signed cookies surface as `false`. Refuse the legacy
+    // unsigned fallback in this case — that would defeat HMAC.
+    if (signedValue === false) {
+        return null;
+    }
+    const unsignedValue = (req as any).cookies?.[USER_ID_COOKIE_NAME];
+    if (typeof unsignedValue === 'string' && UUID_V4_REGEX.test(unsignedValue)) {
+        return { userId: unsignedValue, signed: false };
+    }
+    return null;
+}
 
 /**
  * Express cookie options for the identity cookie.

--- a/src/backend/modules/user/api/user.controller.ts
+++ b/src/backend/modules/user/api/user.controller.ts
@@ -7,15 +7,10 @@ import type { GscService } from '../services/index.js';
 import type { IUser, IUserPreferences } from '../database/index.js';
 import { getClientIP } from '../services/index.js';
 import { AnalyticsRangeValidationError } from '../services/user.errors.js';
-import { USER_ID_COOKIE_NAME, setIdentityCookie } from './identity-cookie.js';
-
-/**
- * Cookie name for user identity.
- */
-const COOKIE_NAME = USER_ID_COOKIE_NAME;
-
-/** UUID v4 format check, matches `UserService.isValidUUID`. */
-const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+import {
+    setIdentityCookie,
+    resolveIdentityFromCookies
+} from './identity-cookie.js';
 
 /** Maximum length for stored path values. */
 const MAX_PATH_LENGTH = 500;
@@ -84,15 +79,24 @@ export class UserController {
      * Ensures the request cookie matches the :id parameter. This prevents
      * UUID enumeration and ensures users can only access their own data.
      *
+     * Identity resolution flows through the shared
+     * `resolveIdentityFromCookies` helper, which applies the canonical
+     * signed-first / unsigned-fallback policy documented in the User
+     * Module README. Legacy unsigned holders are upgraded on the
+     * response — mirroring `userContextMiddleware` — so that any HTTP
+     * entry point a non-browser caller might use re-anchors the cookie
+     * as signed on the first authenticated call. Without that the
+     * unsigned fallback would be a permanent shadow path for clients
+     * that bypass `/api/user/bootstrap`.
+     *
      * @param req - Express request
      * @param res - Express response
      * @param next - Express next function
      */
     validateCookie(req: Request, res: Response, next: NextFunction): void {
-        const cookieId = req.cookies?.[COOKIE_NAME];
-        const paramId = req.params.id;
+        const resolved = resolveIdentityFromCookies(req);
 
-        if (!cookieId) {
+        if (!resolved) {
             res.status(401).json({
                 error: 'Unauthorized',
                 message: 'Missing identity cookie'
@@ -100,12 +104,34 @@ export class UserController {
             return;
         }
 
-        if (cookieId !== paramId) {
+        if (resolved.userId !== req.params.id) {
             res.status(403).json({
                 error: 'Forbidden',
                 message: 'Cookie does not match requested user ID'
             });
             return;
+        }
+
+        // Upgrade legacy unsigned cookies on every authenticated call so
+        // the grace-window fallback is genuinely temporary. The signed
+        // path is a no-op here. The info log gives operators a signal
+        // they can use to (a) decide when the grace window has decayed
+        // far enough to remove the fallback, and (b) flag anomalous
+        // patterns — every legacy-fallback hit is also the shape of a
+        // forged-UUID attempt, so volume spikes or repeated UUIDs from
+        // one IP deserve attention.
+        if (!resolved.signed) {
+            setIdentityCookie(res, resolved.userId);
+            this.logger.info(
+                {
+                    event: 'legacy_cookie_upgraded',
+                    site: 'validateCookie',
+                    userId: resolved.userId,
+                    path: req.path,
+                    ip: getClientIP(req)
+                },
+                'Legacy unsigned identity cookie accepted; re-anchored as signed'
+            );
         }
 
         next();
@@ -162,22 +188,15 @@ export class UserController {
      */
     async bootstrap(req: Request, res: Response): Promise<void> {
         try {
-            // Prefer the HMAC-verified signed cookie. Legacy unsigned cookies
-            // (issued before signing was introduced) live on `req.cookies` and
-            // are accepted as a fallback so visitors don't lose their UUID
-            // during the rollout — `setIdentityCookie` below re-anchors them
-            // as signed on the response. Forged signed cookies surface as
-            // `false` in signedCookies and are ignored here.
-            const signedId = (req as any).signedCookies?.[COOKIE_NAME];
-            const unsignedId = req.cookies?.[COOKIE_NAME];
-            const cookieId =
-                typeof signedId === 'string' ? signedId
-                : typeof unsignedId === 'string' ? unsignedId
-                : undefined;
-            const isValidExisting = typeof cookieId === 'string' && UUID_V4_REGEX.test(cookieId);
-
-            // Mint a fresh UUID when the cookie is missing or malformed.
-            const candidateId = isValidExisting ? cookieId : randomUUID();
+            // The shared resolver applies the signed-first / unsigned-
+            // fallback policy and validates UUID v4 format in one step.
+            // Forged signed cookies and malformed values both collapse to
+            // null here, which we treat as "no existing identity" and
+            // mint fresh. setIdentityCookie below re-anchors any unsigned
+            // fallback as signed on the response.
+            const resolved = resolveIdentityFromCookies(req);
+            const isValidExisting = resolved !== null;
+            const candidateId = resolved?.userId ?? randomUUID();
 
             // getOrCreate resolves merge pointers, so a stale cookie that
             // points at a tombstone returns the canonical user. The returned
@@ -189,6 +208,21 @@ export class UserController {
             // to HttpOnly. For a new visitor it's the initial mint. For a
             // merged identity it points the cookie at the canonical user.
             setIdentityCookie(res, user.id);
+
+            // Surface unsigned-cookie upgrades as info-level so operators
+            // can track legacy-cookie decay and flag anomalous patterns.
+            // See validateCookie's matching log for the security rationale.
+            if (resolved && !resolved.signed) {
+                this.logger.info(
+                    {
+                        event: 'legacy_cookie_upgraded',
+                        site: 'bootstrap',
+                        userId: user.id,
+                        ip: getClientIP(req)
+                    },
+                    'Legacy unsigned identity cookie accepted; re-anchored as signed'
+                );
+            }
 
             this.logger.debug(
                 { userId: user.id, minted: !isValidExisting, merged: user.id !== candidateId },

--- a/src/backend/services/__tests__/websocket-cookie-parser.test.ts
+++ b/src/backend/services/__tests__/websocket-cookie-parser.test.ts
@@ -39,17 +39,22 @@ describe('parseUserIdFromCookieHeader', () => {
         expect(parseUserIdFromCookieHeader(`tronrelic_uid=${value}`)).toBeNull();
     });
 
-    it('accepts an unsigned legacy cookie for backwards compatibility', () => {
-        // Cookies issued before HMAC signing was introduced still carry
-        // raw UUID values. Identity-room subscriptions accept these so
-        // visitors don't lose continuity during the rollout window. Admin
-        // auth runs off `req.signedCookies` and never sees this path.
-        expect(parseUserIdFromCookieHeader(`tronrelic_uid=${VALID}`)).toBe(VALID);
+    it('rejects an unsigned cookie even when the value is a valid UUID', () => {
+        // The websocket handshake has no Set-Cookie channel, so it cannot
+        // re-anchor a legacy cookie the way HTTP entry points do. Accepting
+        // unsigned identity here would let any client that learned a
+        // victim's UUID forge a Cookie header and subscribe to that user's
+        // identity room without possessing SESSION_SECRET — the exact
+        // attack signing was meant to close. Browser visitors always reach
+        // the WS handshake with a signed cookie because SocketBridge
+        // defers the connection past hydration, by which point bootstrap
+        // has re-anchored.
+        expect(parseUserIdFromCookieHeader(`tronrelic_uid=${VALID}`)).toBeNull();
     });
 
-    it('decodes URL-encoded unsigned cookie values', () => {
+    it('rejects a URL-encoded unsigned cookie value', () => {
         const encoded = encodeURIComponent(VALID);
-        expect(parseUserIdFromCookieHeader(`tronrelic_uid=${encoded}`)).toBe(VALID);
+        expect(parseUserIdFromCookieHeader(`tronrelic_uid=${encoded}`)).toBeNull();
     });
 
     it('returns null when the cookie header is missing', () => {

--- a/src/backend/services/websocket.service.ts
+++ b/src/backend/services/websocket.service.ts
@@ -7,10 +7,7 @@ import { logger } from '../lib/logger.js';
 import { PluginWebSocketRegistry } from './plugin-websocket-registry.js';
 import { corsOriginCallback } from '../config/cors.js';
 import { env } from '../config/env.js';
-import { USER_ID_COOKIE_NAME } from '../modules/user/api/identity-cookie.js';
-
-/** UUID v4 format check; mirrors UserService.isValidUUID. */
-const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+import { USER_ID_COOKIE_NAME, UUID_V4_REGEX } from '../modules/user/api/identity-cookie.js';
 
 /**
  * Pull the identity UUID out of a handshake Cookie header string.
@@ -23,11 +20,30 @@ const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[
  * adds the `s%3A` prefix that `decodeURIComponent` strips back to `s:`.
  *
  * Returns null on missing, malformed, forged-signature, decode-error, or
- * non-UUID cookie values so the caller can short-circuit cleanly. Legacy
- * unsigned cookies issued before HMAC signing are also accepted — admin
- * auth runs on `req.signedCookies` and never sees identity rooms anyway,
- * so accepting unsigned values here only affects user-room subscriptions
- * and matches the grace-window behavior in `userContextMiddleware`.
+ * non-UUID cookie values so the caller can short-circuit cleanly.
+ *
+ * **No legacy unsigned fallback.** Unlike the HTTP entry points
+ * (`bootstrap`, `validateCookie`, `userContextMiddleware`), which accept
+ * unsigned cookies *and re-anchor them as signed via `setIdentityCookie`*,
+ * the websocket handshake has no Set-Cookie response channel — it cannot
+ * facilitate the upgrade. The only thing accepting unsigned cookies here
+ * would do is let any client that learned a victim's UUID forge a Cookie
+ * header and subscribe to that user's `user:<uuid>` room without
+ * possessing `SESSION_SECRET`. That is exactly the attack signing was
+ * meant to close.
+ *
+ * Browser visitors are unaffected: `SocketBridge` defers the WS
+ * connection 5s past hydration (or until first interaction), and
+ * `UserIdentityProvider` runs `/api/user/bootstrap` on mount — completing
+ * in well under that window. By the time the handshake fires, the cookie
+ * is signed. A legacy-cookie holder visiting the site for the first time
+ * post-deploy gets the upgrade on the page request before the WS even
+ * tries to connect.
+ *
+ * Non-browser clients that bypass the HTTP API entirely will fail
+ * identity-room subscriptions — by design. Subscribing requires a server-
+ * issued signed cookie, which means going through the bootstrap endpoint
+ * at least once.
  */
 export function parseUserIdFromCookieHeader(cookieHeader: string | undefined | null): string | null {
     if (typeof cookieHeader !== 'string' || cookieHeader.length === 0) {
@@ -42,17 +58,14 @@ export function parseUserIdFromCookieHeader(cookieHeader: string | undefined | n
         return null;
     }
 
-    // Signed cookies are `s:<uuid>.<HMAC>`. Verify with the same secret
+    // Only signed envelopes are honored. Verify with the same secret
     // cookie-parser uses for Express requests; reject on tamper.
-    if (raw.startsWith('s:')) {
-        const unsigned = unsign(raw.slice(2), env.SESSION_SECRET ?? '');
-        if (unsigned === false) return null;
-        return UUID_V4_REGEX.test(unsigned) ? unsigned : null;
+    if (!raw.startsWith('s:')) {
+        return null;
     }
-
-    // Legacy unsigned cookies: accept if UUID v4. Admin auth doesn't read
-    // this path; only identity-room subscriptions use it.
-    return UUID_V4_REGEX.test(raw) ? raw : null;
+    const unsigned = unsign(raw.slice(2), env.SESSION_SECRET ?? '');
+    if (unsigned === false) return null;
+    return UUID_V4_REGEX.test(unsigned) ? unsigned : null;
 }
 
 /**

--- a/src/frontend/middleware.ts
+++ b/src/frontend/middleware.ts
@@ -168,8 +168,28 @@ export async function middleware(request: NextRequest) {
     // (app/layout.tsx → getServerUser) finds a cookie and can prefetch the
     // user record. Without this, brand-new visitors would see a flash on
     // first load while the client-side bootstrap completes after hydration.
+    //
+    // Skip bootstrap whenever the browser sends *any* non-empty identity
+    // cookie:
+    //   - Bare UUID (`<uuid>`): legacy unsigned cookie minted before PR
+    //     #197 or by this middleware on a prior cookieless visit. The
+    //     backend bootstrap accepts it on the next `/api/user/bootstrap`
+    //     call and re-anchors as signed.
+    //   - Signed envelope (`s:<uuid>.<sig>`): the current server-set
+    //     value. The wire format is opaque here — only the backend
+    //     holds `SESSION_SECRET` — but its presence proves the visitor
+    //     already has a canonical identity. Re-bootstrapping would mint
+    //     a fresh UUID and overwrite the signed cookie with an unsigned
+    //     one, orphaning the existing user record on every navigation.
+    //   - Garbage value: ignored on the middleware side; backend
+    //     bootstrap will mint a fresh UUID on the next client-side
+    //     bootstrap call when it can't recover a UUID from the cookie.
+    //
+    // Only mint here when the cookie is genuinely absent or empty. The
+    // raw UUID-regex check that used to gate this call rejected the
+    // signed envelope and orphaned every returning user post-PR-197.
     const existingId = request.cookies.get(USER_ID_COOKIE_NAME)?.value;
-    const needsBootstrap = !existingId || !UUID_V4_REGEX.test(existingId);
+    const needsBootstrap = typeof existingId !== 'string' || existingId.length === 0;
 
     let injectedUserId: string | null = null;
     if (needsBootstrap) {

--- a/src/frontend/modules/user/lib/server.ts
+++ b/src/frontend/modules/user/lib/server.ts
@@ -37,16 +37,25 @@ import type { IUserData } from '../types';
 /**
  * Get user ID from cookies during SSR.
  *
- * Uses Next.js `cookies()` function to read the identity cookie
- * from the request. Returns null if cookie is missing or invalid.
+ * Handles both shapes the cookie can take on the wire:
+ *   - Bare UUID (`<uuid>`): legacy unsigned cookie or freshly-minted
+ *     middleware bootstrap cookie. Validated as UUID v4.
+ *   - Signed envelope (`s:<uuid>.<HMAC>`): the standard server-set
+ *     value after PR #197. The HMAC cannot be verified on the
+ *     frontend (the secret lives only on the backend, by design),
+ *     so we extract the inner UUID best-effort and trust the backend
+ *     to verify when `getServerUser` forwards the raw cookie. This
+ *     is safe because every privileged path funnels through the
+ *     backend, which rejects forged envelopes via cookie-parser
+ *     (`signedCookies[name] === false`) — SSR with a forged UUID
+ *     gets a 401 from `getServerUser` and renders the unauthenticated
+ *     shell, no data leak.
+ *
+ * Without this signed-envelope parsing, every signed visitor would
+ * fall through to client-side bootstrap and see a wallet-button flash
+ * on first paint of every navigation.
  *
  * @returns User UUID or null if not found/invalid
- *
- * @example
- * ```typescript
- * // In a server component
- * const userId = await getServerUserId();
- * ```
  */
 export async function getServerUserId(): Promise<string | null> {
     const cookieStore = await cookies();
@@ -56,7 +65,22 @@ export async function getServerUserId(): Promise<string | null> {
         return null;
     }
 
-    const value = cookie.value;
+    let value = cookie.value;
+
+    // Signed envelope: `s:<uuid>.<HMAC>`. Strip the prefix and trailing
+    // signature to recover the inner UUID. Authoritative verification
+    // happens on the backend via cookie-parser; here we just need a
+    // UUID candidate to pass into the backend SSR fetch.
+    if (value.startsWith('s:')) {
+        const dotIdx = value.lastIndexOf('.');
+        // Require both a non-empty inner value and a non-empty signature.
+        if (dotIdx > 2) {
+            value = value.slice(2, dotIdx);
+        } else {
+            return null;
+        }
+    }
+
     if (!isValidUUID(value)) {
         return null;
     }


### PR DESCRIPTION
## Summary

After PR #197 cookie-parser puts HMAC-verified UUIDs on `req.signedCookies` and strips them from `req.cookies`, but `validateCookie` still read only `req.cookies` — so every signed visitor 401'd on `/api/user/:id/...` calls (broken logout) and the Next.js edge middleware treated the `s:<uuid>.<HMAC>` envelope as malformed and bootstrapped a fresh UUID on every navigation, orphaning existing users (the "not in admin group" symptom).

## Changes

**Bug fixes**
- `validateCookie` reads `req.signedCookies` first, falls back to `req.cookies`. Logout and every other `/api/user/:id/...` endpoint accept the signed cookie again.
- Next.js middleware preserves any non-empty identity cookie (signed envelope or legacy bare UUID) instead of treating non-UUID-shaped values as missing and orphaning the user record on every navigation.

**Universal upgrade path**
- `validateCookie` re-anchors legacy unsigned cookies as signed on the response, mirroring `userContextMiddleware`. Closes the theoretical hole where a non-browser caller hitting only `/api/user/:id/...` could hold an unsigned cookie indefinitely.

**DRY pass across auth/authz paths**
- `UUID_V4_REGEX` and `resolveIdentityFromCookies` now live in `identity-cookie.ts` as the single source of truth. Five duplicate regex declarations and one duplicated 17-line resolver across `user-context`, `admin-auth`, `websocket.service`, `user.controller`, and `bootstrap` collapse to imports.
- `requireAdmin` deliberately keeps its direct `req.signedCookies`-only read. The strict admin gate must reject unsigned values, not upgrade them — a different security contract from the HTTP entry points.

**WebSocket signed-only**
- The handshake parser drops the legacy unsigned fallback. The WS path has no Set-Cookie channel, so accepting unsigned identity did no upgrade work and only let a forged-UUID Cookie header subscribe to a victim's identity room without holding `SESSION_SECRET`.
- `SocketBridge` defers the connection 5s past hydration (or until first interaction), and `UserIdentityProvider` runs `/api/user/bootstrap` on mount in well under that window. Legitimate browser visitors always reach the handshake with a signed cookie via the HTTP-side upgrade. Non-browser clients must hit any HTTP entry point first to receive the signed cookie, then connect.

**Observability**
- Info-level `event: 'legacy_cookie_upgraded'` log on each HTTP re-anchor (bootstrap, validateCookie, userContextMiddleware) with `userId`, `site`, `path`, and `ip`. Operators get a curve to time the eventual fallback removal, and the same log doubles as a security signal — every legacy-fallback hit is also the shape of a forged-UUID attempt, so volume spikes or repeated UUIDs from one IP become visible.

**Infra**
- Wire `SESSION_SECRET` from `.env` into the backend container in `docker-compose.yml`. Without it the backend falls back to the placeholder and signing silently no-ops.

**Docs + tests**
- User Module README's "Reader policy" paragraph and `validateCookie` example reflect the post-refactor shape, including the WS signed-only policy.
- Six new `validateCookie` test cases (signed-match no-reissue, unsigned-fallback re-issue, missing 401, tampered 401, mismatch 403, signed-wins-over-stale-unsigned). WS legacy-acceptance test flipped to legacy-rejection.