### PR TITLE
Pass full IUserData payload through SSR user hydration

### DIFF
--- a/src/backend/modules/user/migrations/006_backfill_user_identity_state.ts
+++ b/src/backend/modules/user/migrations/006_backfill_user_identity_state.ts
@@ -1,5 +1,13 @@
-import { UserIdentityState } from '@/types';
 import type { IMigration, IMigrationContext } from '@/types';
+
+// Inline string literals matching `UserIdentityState`. Migration files are
+// compiled with `bundle: false`, which does not resolve the `@/types` path
+// alias, so a runtime import of the enum breaks the scanner's dynamic
+// import in production. Keep these in sync with
+// packages/types/src/user/IUserIdentityState.ts.
+const IDENTITY_ANONYMOUS = 'anonymous';
+const IDENTITY_REGISTERED = 'registered';
+const IDENTITY_VERIFIED = 'verified';
 
 /**
  * Backfill `identityState` on every existing user document.
@@ -62,13 +70,13 @@ export const migration: IMigration = {
                     { wallets: { $size: 0 } }
                 ]
             },
-            { $set: { identityState: UserIdentityState.Anonymous } }
+            { $set: { identityState: IDENTITY_ANONYMOUS } }
         );
 
         // Any wallet with verified=true → user is verified.
         const verifiedResult = await usersCollection.updateMany(
             { wallets: { $elemMatch: { verified: true } } },
-            { $set: { identityState: UserIdentityState.Verified } }
+            { $set: { identityState: IDENTITY_VERIFIED } }
         );
 
         // Has wallets but none verified → registered. We compute the
@@ -79,7 +87,7 @@ export const migration: IMigration = {
                 'wallets.0': { $exists: true },
                 wallets: { $not: { $elemMatch: { verified: true } } }
             },
-            { $set: { identityState: UserIdentityState.Registered } }
+            { $set: { identityState: IDENTITY_REGISTERED } }
         );
 
         console.log(

--- a/src/frontend/app/layout.tsx
+++ b/src/frontend/app/layout.tsx
@@ -195,12 +195,15 @@ async function fetchInitialBlock(): Promise<BlockSummary | null> {
 }
 
 /**
- * Fetch user data during SSR to prevent wallet button flash.
+ * Fetch user data during SSR to prevent wallet button flash and to
+ * seed the auth gate with server-computed truth on first paint.
  *
- * If user has identity cookie, fetches their data including linked wallets.
- * This allows the wallet button to render correctly on first paint.
- *
- * @returns SSR user data or null if no identity
+ * Returns the full `IUserData` payload — including `identityState`,
+ * `groups`, and `authStatus` — so the Redux preload matches what
+ * the backend would have shipped on a client-side bootstrap call.
+ * Returning `null` (no cookie, fetch failure, or backend miss) lets
+ * `UserIdentityProvider` fall through to its mount-time bootstrap,
+ * which is the only safe way to populate `authStatus` client-side.
  */
 async function fetchSSRUserData(): Promise<SSRUserData | null> {
   try {
@@ -209,16 +212,7 @@ async function fetchSSRUserData(): Promise<SSRUserData | null> {
       return null;
     }
 
-    const userData = await getServerUser(userId);
-    if (!userData) {
-      return { userId, wallets: [], isLoggedIn: false };
-    }
-
-    return {
-      userId,
-      wallets: userData.wallets || [],
-      isLoggedIn: userData.isLoggedIn ?? false
-    };
+    return await getServerUser(userId);
   } catch {
     return null;
   }

--- a/src/frontend/modules/user/lib/ssr-state.ts
+++ b/src/frontend/modules/user/lib/ssr-state.ts
@@ -1,77 +1,51 @@
 /**
  * SSR state building utilities for user module.
  *
- * Provides functions to construct Redux initial state from server-fetched
- * user data, enabling hydration without UI flash.
+ * Constructs the Redux user slice from the full backend `IUserData`
+ * payload fetched during SSR. The payload travels intact from
+ * `getServerUser` through the layout into `buildSSRUserState`, so the
+ * client hydrates with the same `identityState`, `groups`, and
+ * `authStatus` the backend computed — no parallel client-side
+ * derivation that could drift from the freshness-aware backend rule
+ * and no `authStatus`-shaped hole that would force `SystemAuthGate`
+ * into its safe-default "not admin" branch on first paint.
  */
 
-import { UserIdentityState } from '@/types';
 import type { UserState } from '../slice';
-import type { IWalletLink } from '../types';
-
-/**
- * Derive `UserIdentityState` from the wallets array. Mirrors the
- * backend's canonical rule (see user module README): no wallets →
- * Anonymous, at least one verified → Verified, otherwise Registered.
- */
-function deriveIdentityState(wallets: IWalletLink[]): UserIdentityState {
-    if (wallets.length === 0) return UserIdentityState.Anonymous;
-    if (wallets.some(w => w.verified)) return UserIdentityState.Verified;
-    return UserIdentityState.Registered;
-}
+import type { IUserData } from '../types';
 
 /**
  * SSR user data passed from server layout to client providers.
+ *
+ * This is the full `IUserData` payload returned by the backend
+ * (decorated with `authStatus` via `withAuthStatus`), not a
+ * trimmed-down shape. Keeping it whole means every Redux selector
+ * — `selectIsVerified`, `selectIdentityState`, the `SystemAuthGate`
+ * read of `authStatus.isVerified` — sees the same server-computed
+ * truth from the first render.
  */
-export interface SSRUserData {
-    userId: string;
-    wallets: IWalletLink[];
-    isLoggedIn: boolean;
-}
+export type SSRUserData = IUserData;
 
 /**
  * Build Redux UserState from SSR-fetched data.
  *
- * Used during SSR hydration to preload user state, preventing
- * wallet button flash on page load. If user has linked wallets,
- * shows their primary wallet as connected with its actual verification status.
- *
- * The isPrimary field is auto-maintained by the backend based on:
- * 1. Most recent `lastUsed` among verified wallets.
- * 2. Fallback: Most recent `lastUsed` among registered (unsigned) wallets,
- *    used only when the user has no verified wallets.
- *
- * @param ssrData - User data fetched during SSR
- * @returns Complete UserState for Redux preloading
+ * Uses server-computed `identityState`, `groups`, and `authStatus`
+ * directly. The primary wallet (auto-maintained by the backend)
+ * seeds the connection slice so the wallet button paints with its
+ * actual verification status on first frame.
  */
 export function buildSSRUserState(ssrData: SSRUserData): UserState {
-    // isPrimary is auto-maintained by backend - just find it
     const primaryWallet = ssrData.wallets.find(w => w.isPrimary);
 
     return {
-        userId: ssrData.userId,
-        userData: {
-            id: ssrData.userId,
-            isLoggedIn: ssrData.isLoggedIn,
-            identityState: deriveIdentityState(ssrData.wallets),
-            wallets: ssrData.wallets,
-            preferences: {},
-            activity: {
-                firstSeen: new Date().toISOString(),
-                lastSeen: new Date().toISOString(),
-                pageViews: 0
-            },
-            groups: [],
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString()
-        },
+        userId: ssrData.id,
+        userData: ssrData,
         status: 'succeeded',
         error: null,
         initialized: true,
-        // Show primary wallet with its actual verification status
         connectedAddress: primaryWallet?.address ?? null,
         connectionStatus: primaryWallet ? 'connected' : 'idle',
-        providerDetected: false, // Will be updated client-side
+        providerDetected: false,
         connectionError: null,
         walletVerified: primaryWallet?.verified ?? false,
         walletLoginRequired: false,


### PR DESCRIPTION
## Summary

Replaces the trimmed `SSRUserData` shape with the complete backend `IUserData` so server-computed `identityState`, `groups`, and `authStatus` hydrate the Redux user slice directly. Removes a parallel client-side identity-state derivation that could drift from the freshness-aware backend rule, and closes the `authStatus`-shaped hole that forced `SystemAuthGate` into its safe-default "not admin" branch on first paint.

Also inlines `UserIdentityState` string literals in migration 006 — migration files compile with `bundle:false` and don't resolve the `@/types` path alias at runtime, so a value import of the enum broke the production migration scanner.