### PR TITLE
Suppress success toast when wallet verification is cancelled

### DIFF
--- a/src/frontend/modules/user/components/WalletButton/WalletButton.tsx
+++ b/src/frontend/modules/user/components/WalletButton/WalletButton.tsx
@@ -116,10 +116,10 @@ export function WalletButton() {
                     description: 'Your wallet has been verified successfully.'
                 });
             }
-            // Failure path: verify() dispatches setConnectionError, which the
-            // connectionError useEffect surfaces as a warning toast.
-        } catch (error) {
-            console.error('Verify failed:', error);
+            // Most verify() failures dispatch setConnectionError, which the
+            // connectionError useEffect surfaces as a warning toast. A few
+            // early-return paths (e.g. missing userId/connectedAddress) exit
+            // silently without setting connectionError.
         } finally {
             setIsVerifying(false);
         }

--- a/src/frontend/modules/user/components/WalletButton/WalletButton.tsx
+++ b/src/frontend/modules/user/components/WalletButton/WalletButton.tsx
@@ -108,19 +108,18 @@ export function WalletButton() {
         setIsVerifying(true);
         try {
             await connect();
-            await verify();
-            push({
-                tone: 'success',
-                title: 'Wallet Verified',
-                description: 'Your wallet has been verified successfully.'
-            });
+            const verified = await verify();
+            if (verified) {
+                push({
+                    tone: 'success',
+                    title: 'Wallet Verified',
+                    description: 'Your wallet has been verified successfully.'
+                });
+            }
+            // Failure path: verify() dispatches setConnectionError, which the
+            // connectionError useEffect surfaces as a warning toast.
         } catch (error) {
             console.error('Verify failed:', error);
-            push({
-                tone: 'warning',
-                title: 'Verification Failed',
-                description: 'Unable to verify wallet. Please try again.'
-            });
         } finally {
             setIsVerifying(false);
         }


### PR DESCRIPTION
## Summary

`verify()` returns `false` and dispatches `setConnectionError` when the user rejects the TronLink signature prompt — it does not throw. Previously `WalletButton.handleVerify` always pushed a success toast in the try block and a redundant warning toast in the catch block, so cancelling the signature prompt produced a "Wallet Verified" toast even though no verification occurred.

This change gates the success toast on the boolean return value and removes the dead-code catch-branch toast. Connection-error feedback continues to flow through the existing `connectionError` effect, which surfaces a warning toast.