### PR TITLE
Drop redundant token guards from /system/pages and /system/users

### DIFF
--- a/src/frontend/app/(core)/system/pages/page.tsx
+++ b/src/frontend/app/(core)/system/pages/page.tsx
@@ -2,8 +2,6 @@
 
 import { useState } from 'react';
 import { useSystemAuth } from '../../../../features/system';
-import { Page } from '../../../../components/layout';
-import { Card } from '../../../../components/ui/Card';
 import styles from './page.module.css';
 import { PagesTab } from './tabs/PagesTab';
 import { FilesTab } from './tabs/FilesTab';
@@ -21,16 +19,6 @@ import { SettingsTab } from './tabs/SettingsTab';
 export default function PagesAdminPage() {
     const { token } = useSystemAuth();
     const [activeTab, setActiveTab] = useState<'pages' | 'files' | 'settings'>('pages');
-
-    if (!token) {
-        return (
-            <Page>
-                <Card padding="lg">
-                    <p>Authentication required</p>
-                </Card>
-            </Page>
-        );
-    }
 
     return (
         <div className={styles.container}>

--- a/src/frontend/app/(core)/system/users/page.tsx
+++ b/src/frontend/app/(core)/system/users/page.tsx
@@ -2,8 +2,6 @@
 
 import { useState } from 'react';
 import { useSystemAuth } from '../../../../features/system';
-import { Page } from '../../../../components/layout';
-import { Card } from '../../../../components/ui/Card';
 import { UsersMonitor, AnalyticsDashboard, ReferralOverview, GscSettings, GroupsManager } from '../../../../modules/user';
 import styles from './page.module.scss';
 
@@ -26,16 +24,6 @@ type UsersTab = 'users' | 'analytics' | 'referrals' | 'groups' | 'settings';
 export default function SystemUsersPage() {
     const { token } = useSystemAuth();
     const [activeTab, setActiveTab] = useState<UsersTab>('users');
-
-    if (!token) {
-        return (
-            <Page>
-                <Card padding="lg">
-                    <p>Authentication required</p>
-                </Card>
-            </Page>
-        );
-    }
 
     return (
         <div className={styles.container}>


### PR DESCRIPTION
## Summary

The `/system` route is wrapped by `SystemAuthGate` in `src/frontend/app/(core)/system/layout.tsx`, which renders the token-entry screen for unauthenticated visitors. The local "Authentication required" fallbacks inside `pages/page.tsx` and `users/page.tsx` were unreachable — visitors without a token never reach those components.

Removes the dead branches and the now-unused `Page` and `Card` imports.