### PR TITLE
Phase 0: ClickHouse traffic_events table + TrafficService skeleton

### DIFF
--- a/docs/system/system-database-migrations.md
+++ b/docs/system/system-database-migrations.md
@@ -51,6 +51,8 @@ Circular dependencies throw at startup with the cycle path.
 
 ### Execution and Transactions
 
+**Operator-triggered, not auto-run at boot.** Bootstrap discovers pending migrations but does not execute them. Run them via the `/system/database` admin UI or `POST /api/admin/migrations/execute`. This is intentional — schema changes happen on the operator's clock, not the deploy's.
+
 `MigrationExecutor` runs migrations serially and accepts an optional `IClickHouseService` for ClickHouse-targeted migrations.
 
 **With transaction support (replica set):** wraps `migration.up(context)` in `session.withTransaction()`. On failure, transaction rolls back automatically, failure is recorded, error is thrown.

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -306,7 +306,7 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     await themeModule.init(sharedDeps);
     await schedulerModule.init({ database: coreDatabase, menuService, app });
     const schedulerService = schedulerModule.getSchedulerService();
-    await userModule.init({ ...sharedDeps, scheduler: schedulerService, systemConfig: SystemConfigService.getInstance() });
+    await userModule.init({ ...sharedDeps, scheduler: schedulerService, systemConfig: SystemConfigService.getInstance(), clickhouse });
     await addressLabelsModule.init(sharedDeps);
     await toolsModule.init(sharedDeps);
 

--- a/src/backend/modules/user/README.md
+++ b/src/backend/modules/user/README.md
@@ -182,6 +182,7 @@ modules/user/
 │   ├── auth-status.ts             # Single source of truth for IAuthStatus computation
 │   ├── geo.service.ts             # IP → country, referrer parsing, device derivation
 │   ├── gsc.service.ts             # Google Search Console keyword integration
+│   ├── traffic.service.ts         # ClickHouse traffic_events sibling (PLAN-traffic-events.md)
 │   ├── user.service.ts            # Business logic (CRUD, wallet linking, sessions, caching)
 │   ├── user.errors.ts             # Service-layer error classes
 │   ├── user-group.service.ts      # Group definition CRUD + membership API
@@ -193,7 +194,8 @@ modules/user/
 │   ├── 006_backfill_user_identity_state.ts
 │   ├── 007_backfill_user_groups.ts
 │   ├── 008_backfill_wallet_verified_at.ts
-│   └── 009_session_identity_verified_at.ts
+│   ├── 009_session_identity_verified_at.ts
+│   └── 010_create_traffic_events_table.ts  # ClickHouse, target: 'clickhouse'
 └── __tests__/
     ├── auth-status.test.ts
     ├── bootstrap.controller.test.ts

--- a/src/backend/modules/user/UserModule.ts
+++ b/src/backend/modules/user/UserModule.ts
@@ -23,12 +23,13 @@
  */
 
 import type { Express, Router } from 'express';
-import type { ICacheService, IDatabaseService, IMenuService, IModule, IModuleMetadata, ISchedulerService, IServiceRegistry, ISystemConfigService } from '@/types';
+import type { ICacheService, IClickHouseService, IDatabaseService, IMenuService, IModule, IModuleMetadata, ISchedulerService, IServiceRegistry, ISystemConfigService } from '@/types';
 import { logger } from '../../lib/logger.js';
 import { MAIN_SYSTEM_CONTAINER_ID } from '../menu/index.js';
 import { TronGridClient } from '../blockchain/tron-grid.client.js';
 import { UserService } from './services/user.service.js';
 import { GscService } from './services/gsc.service.js';
+import { TrafficService } from './services/traffic.service.js';
 import { UserGroupService } from './services/user-group.service.js';
 import { initGeoIP } from './services/geo.service.js';
 import { UserController } from './api/user.controller.js';
@@ -83,6 +84,15 @@ export interface IUserModuleDependencies {
      * to an external origin or to our own site.
      */
     systemConfig: ISystemConfigService;
+
+    /**
+     * ClickHouse service for the new TrafficService sibling. Optional —
+     * `undefined` when `CLICKHOUSE_HOST` is unset and the ClickHouse
+     * module skipped initialization. TrafficService stays usable in
+     * that mode but silently drops writes; see traffic.service.ts.
+     * Backs the cookieless-traffic split tracked in PLAN-traffic-events.md.
+     */
+    clickhouse: IClickHouseService | undefined;
 }
 
 /**
@@ -156,6 +166,7 @@ export class UserModule implements IModule<IUserModuleDependencies> {
      */
     private userService!: UserService;
     private gscService!: GscService;
+    private trafficService!: TrafficService;
     private userGroupService!: UserGroupService;
     private controller!: UserController;
     private groupController!: UserGroupController;
@@ -218,6 +229,13 @@ export class UserModule implements IModule<IUserModuleDependencies> {
 
         // Inject GscService into UserService for explicit dependency
         this.userService.setGscService(this.gscService);
+
+        // Initialize TrafficService sibling. ClickHouse is optional;
+        // when it's undefined the service no-ops and the orphan-row
+        // fix in later phases still works (Mongo writes are gated
+        // independently). See PLAN-traffic-events.md.
+        TrafficService.setDependencies(dependencies.clickhouse, this.logger);
+        this.trafficService = TrafficService.getInstance();
 
         // Initialize UserGroupService singleton, build indexes, seed system groups.
         // Must precede UserController construction so the controller can inject

--- a/src/backend/modules/user/__tests__/traffic-events-migration.test.ts
+++ b/src/backend/modules/user/__tests__/traffic-events-migration.test.ts
@@ -1,0 +1,52 @@
+/// <reference types="vitest" />
+
+import { describe, it, expect, vi } from 'vitest';
+import type { IClickHouseService, IDatabaseService, IMigrationContext } from '@/types';
+import { migration } from '../migrations/010_create_traffic_events_table.js';
+
+/**
+ * Shape and behaviour test for the Phase 0 traffic_events migration.
+ *
+ * Lightweight on purpose: the migration is one CREATE TABLE statement
+ * against ClickHouse, and we have no embedded ClickHouse in CI. The
+ * goals are (a) catch filename/id drift (the scanner enforces this in
+ * production but we want the failure earlier), (b) confirm the runner's
+ * skip-when-CH-absent behaviour, and (c) confirm the migration targets
+ * ClickHouse so the executor routes it correctly.
+ */
+describe('migration: 010_create_traffic_events_table', () => {
+    it('declares a ClickHouse target so the executor skips when CH is unconfigured', () => {
+        expect(migration.target).toBe('clickhouse');
+    });
+
+    it('uses the canonical id matching the filename', () => {
+        // Scanner validates this in production; surface it earlier in CI too.
+        expect(migration.id).toBe('010_create_traffic_events_table');
+    });
+
+    it('does nothing when ClickHouse is unavailable', async () => {
+        const context: IMigrationContext = {
+            database: {} as IDatabaseService,
+            clickhouse: undefined
+        };
+        await expect(migration.up(context)).resolves.toBeUndefined();
+    });
+
+    it('issues a CREATE TABLE for traffic_events with an 18-month TTL', async () => {
+        const exec = vi.fn<(sql: string) => Promise<void>>(async () => undefined);
+        const clickhouse = { exec } as unknown as IClickHouseService;
+        const context: IMigrationContext = {
+            database: {} as IDatabaseService,
+            clickhouse
+        };
+
+        await migration.up(context);
+
+        expect(exec).toHaveBeenCalledTimes(1);
+        const sql = exec.mock.calls[0][0];
+        expect(sql).toContain('CREATE TABLE IF NOT EXISTS traffic_events');
+        expect(sql).toContain('ORDER BY (timestamp, candidate_uid)');
+        expect(sql).toContain('INTERVAL 18 MONTH');
+        expect(sql).toContain('idx_candidate_uid');
+    });
+});

--- a/src/backend/modules/user/__tests__/traffic.service.test.ts
+++ b/src/backend/modules/user/__tests__/traffic.service.test.ts
@@ -1,0 +1,191 @@
+/// <reference types="vitest" />
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IClickHouseService, ISystemLogService } from '@/types';
+import { TrafficService, type ITrafficEvent } from '../services/traffic.service.js';
+
+/**
+ * Minimal logger double — every call is a vi.fn so tests can assert on
+ * warn/info paths without pulling in pino. `child()` returns the same
+ * mock so scoping calls still work.
+ */
+function createMockLogger(): ISystemLogService {
+    const fns = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        fatal: vi.fn(),
+        trace: vi.fn(),
+        child: vi.fn(() => fns)
+    } as unknown as ISystemLogService;
+    return fns;
+}
+
+/**
+ * In-memory IClickHouseService double. Captures inserted rows and lets
+ * tests pre-stage rows that `query()` will return.
+ */
+function createMockClickHouse(): IClickHouseService & {
+    inserts: Array<{ table: string; rows: unknown[] }>;
+    queue: unknown[];
+    error?: Error;
+} {
+    const inserts: Array<{ table: string; rows: unknown[] }> = [];
+    const queue: unknown[] = [];
+    const mock = {
+        inserts,
+        queue,
+        error: undefined as Error | undefined,
+        async connect() { /* noop */ },
+        isConnected() { return true; },
+        async ping() { return true; },
+        async close() { /* noop */ },
+        async exec() { /* noop */ },
+        async insert(table: string, rows: unknown[]) {
+            if (mock.error) throw mock.error;
+            inserts.push({ table, rows });
+        },
+        async query<T>(_sql: string, _params?: unknown): Promise<T[]> {
+            if (mock.error) throw mock.error;
+            return queue.slice() as T[];
+        }
+    };
+    return mock as unknown as IClickHouseService & {
+        inserts: Array<{ table: string; rows: unknown[] }>;
+        queue: unknown[];
+        error?: Error;
+    };
+}
+
+const sampleEvent: ITrafficEvent = {
+    event_type: 'bootstrap',
+    timestamp: new Date('2026-04-30T12:00:00.000Z'),
+    candidate_uid: '550e8400-e29b-41d4-a716-446655440000',
+    path: '/markets',
+    referer: 'https://example.com/post',
+    original_referrer: null,
+    user_agent: 'Mozilla/5.0',
+    accept_language: 'en-US',
+    country: 'US',
+    device: 'desktop',
+    bot_class: null,
+    utm_source: null,
+    utm_medium: null,
+    utm_campaign: null,
+    utm_term: null,
+    utm_content: null,
+    sec_ch_ua: null,
+    sec_ch_ua_mobile: null,
+    sec_ch_ua_platform: null,
+    sec_fetch_dest: null,
+    sec_fetch_mode: null,
+    sec_fetch_site: null
+};
+
+describe('TrafficService', () => {
+    beforeEach(() => {
+        TrafficService.resetInstance();
+    });
+
+    describe('singleton lifecycle', () => {
+        it('throws if getInstance() called before setDependencies()', () => {
+            expect(() => TrafficService.getInstance()).toThrow(/setDependencies/);
+        });
+
+        it('returns the same instance across getInstance() calls', () => {
+            const logger = createMockLogger();
+            TrafficService.setDependencies(undefined, logger);
+            expect(TrafficService.getInstance()).toBe(TrafficService.getInstance());
+        });
+
+        it('logs once when initialized without ClickHouse', () => {
+            const logger = createMockLogger();
+            TrafficService.setDependencies(undefined, logger);
+            expect(logger.info).toHaveBeenCalledWith(
+                expect.stringContaining('without ClickHouse')
+            );
+        });
+    });
+
+    describe('isEnabled()', () => {
+        it('is false when ClickHouse is unavailable', () => {
+            TrafficService.setDependencies(undefined, createMockLogger());
+            expect(TrafficService.getInstance().isEnabled()).toBe(false);
+        });
+
+        it('is true when ClickHouse is provided', () => {
+            TrafficService.setDependencies(createMockClickHouse(), createMockLogger());
+            expect(TrafficService.getInstance().isEnabled()).toBe(true);
+        });
+    });
+
+    describe('recordEvent()', () => {
+        it('no-ops when ClickHouse is unavailable', async () => {
+            TrafficService.setDependencies(undefined, createMockLogger());
+            await expect(
+                TrafficService.getInstance().recordEvent(sampleEvent)
+            ).resolves.toBeUndefined();
+        });
+
+        it('inserts to traffic_events when ClickHouse is available', async () => {
+            const ch = createMockClickHouse();
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            await TrafficService.getInstance().recordEvent(sampleEvent);
+
+            expect(ch.inserts).toHaveLength(1);
+            expect(ch.inserts[0].table).toBe('traffic_events');
+            const row = ch.inserts[0].rows[0] as Record<string, unknown>;
+            expect(row.candidate_uid).toBe(sampleEvent.candidate_uid);
+            expect(row.event_type).toBe('bootstrap');
+            expect(typeof row.timestamp).toBe('string');
+            expect(row.timestamp).toBe('2026-04-30T12:00:00.000Z');
+        });
+
+        it('swallows ClickHouse failures without throwing', async () => {
+            const ch = createMockClickHouse();
+            ch.error = new Error('CH down');
+            const logger = createMockLogger();
+            TrafficService.setDependencies(ch, logger);
+
+            await expect(
+                TrafficService.getInstance().recordEvent(sampleEvent)
+            ).resolves.toBeUndefined();
+
+            expect(logger.warn).toHaveBeenCalled();
+        });
+    });
+
+    describe('getEventsForUser()', () => {
+        it('returns [] when ClickHouse is unavailable', async () => {
+            TrafficService.setDependencies(undefined, createMockLogger());
+            const events = await TrafficService.getInstance().getEventsForUser('uid');
+            expect(events).toEqual([]);
+        });
+
+        it('rehydrates timestamps as Date instances', async () => {
+            const ch = createMockClickHouse();
+            ch.queue.push({ ...sampleEvent, timestamp: '2026-04-30T12:00:00.000Z' });
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            const events = await TrafficService.getInstance().getEventsForUser('uid');
+
+            expect(events).toHaveLength(1);
+            expect(events[0].timestamp).toBeInstanceOf(Date);
+            expect(events[0].timestamp.toISOString()).toBe('2026-04-30T12:00:00.000Z');
+        });
+
+        it('returns [] and logs when the query fails', async () => {
+            const ch = createMockClickHouse();
+            ch.error = new Error('CH down');
+            const logger = createMockLogger();
+            TrafficService.setDependencies(ch, logger);
+
+            const events = await TrafficService.getInstance().getEventsForUser('uid');
+
+            expect(events).toEqual([]);
+            expect(logger.warn).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/backend/modules/user/__tests__/traffic.service.test.ts
+++ b/src/backend/modules/user/__tests__/traffic.service.test.ts
@@ -121,18 +121,21 @@ describe('TrafficService', () => {
     });
 
     describe('recordEvent()', () => {
-        it('no-ops when ClickHouse is unavailable', async () => {
+        it('no-ops when ClickHouse is unavailable', () => {
             TrafficService.setDependencies(undefined, createMockLogger());
-            await expect(
-                TrafficService.getInstance().recordEvent(sampleEvent)
-            ).resolves.toBeUndefined();
+            expect(() => TrafficService.getInstance().recordEvent(sampleEvent)).not.toThrow();
         });
 
-        it('inserts to traffic_events when ClickHouse is available', async () => {
+        it('returns synchronously and dispatches an insert to traffic_events', async () => {
             const ch = createMockClickHouse();
             TrafficService.setDependencies(ch, createMockLogger());
 
-            await TrafficService.getInstance().recordEvent(sampleEvent);
+            // Fire-and-forget: returns void synchronously.
+            const ret = TrafficService.getInstance().recordEvent(sampleEvent);
+            expect(ret).toBeUndefined();
+
+            // Insert is dispatched on a microtask; await one tick to let it settle.
+            await Promise.resolve();
 
             expect(ch.inserts).toHaveLength(1);
             expect(ch.inserts[0].table).toBe('traffic_events');
@@ -140,7 +143,8 @@ describe('TrafficService', () => {
             expect(row.candidate_uid).toBe(sampleEvent.candidate_uid);
             expect(row.event_type).toBe('bootstrap');
             expect(typeof row.timestamp).toBe('string');
-            expect(row.timestamp).toBe('2026-04-30T12:00:00.000Z');
+            // ClickHouse native DateTime64(3) form, UTC, no 'T'/'Z' suffix.
+            expect(row.timestamp).toBe('2026-04-30 12:00:00.000');
         });
 
         it('swallows ClickHouse failures without throwing', async () => {
@@ -149,9 +153,10 @@ describe('TrafficService', () => {
             const logger = createMockLogger();
             TrafficService.setDependencies(ch, logger);
 
-            await expect(
-                TrafficService.getInstance().recordEvent(sampleEvent)
-            ).resolves.toBeUndefined();
+            expect(() => TrafficService.getInstance().recordEvent(sampleEvent)).not.toThrow();
+
+            // Allow the rejected insert promise to flush through .catch().
+            await new Promise(resolve => setImmediate(resolve));
 
             expect(logger.warn).toHaveBeenCalled();
         });
@@ -164,9 +169,10 @@ describe('TrafficService', () => {
             expect(events).toEqual([]);
         });
 
-        it('rehydrates timestamps as Date instances', async () => {
+        it('rehydrates ClickHouse native-format timestamps as Date instances', async () => {
             const ch = createMockClickHouse();
-            ch.queue.push({ ...sampleEvent, timestamp: '2026-04-30T12:00:00.000Z' });
+            // ClickHouse JSONEachRow returns DateTime64 in this form, not ISO.
+            ch.queue.push({ ...sampleEvent, timestamp: '2026-04-30 12:00:00.000' });
             TrafficService.setDependencies(ch, createMockLogger());
 
             const events = await TrafficService.getInstance().getEventsForUser('uid');

--- a/src/backend/modules/user/migrations/010_create_traffic_events_table.ts
+++ b/src/backend/modules/user/migrations/010_create_traffic_events_table.ts
@@ -1,0 +1,122 @@
+import type { IMigration, IMigrationContext } from '@/types';
+
+/**
+ * Create the ClickHouse `traffic_events` table that backs the cookieless-traffic split.
+ *
+ * **Why this migration exists.**
+ * Commit `1fccdbe` ("Add signature-based wallet challenge auth and identity cookies",
+ * 2026-04-27) moved identity-cookie minting from client JavaScript into a Next.js
+ * middleware → backend bootstrap path. The change was correct for security and SSR
+ * but accidentally removed the implicit JS-runtime filter that previously kept bots
+ * out of the `users` collection. Every cookieless GET — search-engine crawlers,
+ * link unfurlers, uptime probes — now persists an empty Mongo row with no country,
+ * landing page, device, or referrer. We *want* to track that traffic, just not in
+ * the identity collection. ClickHouse is already wired up as an optional module
+ * (`src/backend/modules/clickhouse/`) and is the right tool for high-volume
+ * append-only event data with rich dimensions.
+ *
+ * **What this migration does.**
+ *   1. Creates table `traffic_events` keyed by `(timestamp, candidate_uid)` so admin
+ *      time-range scans hit a contiguous prefix of the primary key.
+ *   2. Adds a bloom-filter skip index on `candidate_uid` so the Phase 3 first-touch
+ *      backfill ("earliest pre-hydration event for this UUID") doesn't pay a full
+ *      partition scan despite the time-first ordering.
+ *   3. Sets an 18-month TTL aligned with the project's traffic-log retention posture.
+ *      Rows expire automatically — no application-side pruning required.
+ *
+ * **Schema.**
+ *   - `event_type` — `'bootstrap'` (cookie minted, no Mongo write) or
+ *     `'session_start'` (cookie-validated session begins). Future event types may be
+ *     added without schema change. `LowCardinality(String)` because the cardinality
+ *     is bounded.
+ *   - `candidate_uid` — the cookie UUID minted by the bootstrap controller. Always
+ *     present; `''` only for events emitted before a cookie can be assigned (none
+ *     today).
+ *   - `path` / `referer` / `original_referrer` — request URL plus the two distinct
+ *     referrers we want to keep separate: `Referer` HTTP header (server-visible,
+ *     reliable) and `document.referrer` reported by the client (subject to client
+ *     scrubbing but covers same-origin nuance).
+ *   - `country` — geo-derived from the request IP at write time; the IP itself is
+ *     intentionally **not** stored, satisfying the no-PII constraint in
+ *     `PLAN-traffic-events.md`.
+ *   - `device`, `bot_class` — derived dimensions. `bot_class` is `Nullable` because
+ *     non-bot traffic carries no classification.
+ *   - `utm_*` — five canonical UTM fields plus the high-cardinality `term` and
+ *     `content` (kept as plain `Nullable(String)` rather than `LowCardinality`).
+ *   - `sec_ch_ua_*` / `sec_fetch_*` — Client Hints + Fetch Metadata headers
+ *     forwarded by the middleware. Useful for distinguishing same-origin
+ *     navigations from cross-origin link clicks even when the browser strips
+ *     `Referer`.
+ *
+ * **Idempotent.** `CREATE TABLE IF NOT EXISTS` is a no-op on subsequent runs.
+ *
+ * **Skip behavior.** If `CLICKHOUSE_HOST` is not configured the migration runner
+ * skips this migration with a warning. The user module's `TrafficService`
+ * already gracefully no-ops when ClickHouse is unavailable, so a deploy without
+ * ClickHouse simply means "no traffic events recorded" — the orphan-row bug
+ * fix in later phases stays intact.
+ *
+ * **Rollback.**
+ * ```sql
+ * DROP TABLE IF EXISTS traffic_events;
+ * ```
+ * Forward-only by project convention; rollback only relevant if a schema change
+ * is needed before any Phase 1-3 code ships.
+ */
+export const migration: IMigration = {
+    id: '010_create_traffic_events_table',
+    description:
+        'Create ClickHouse traffic_events MergeTree table (18-month TTL, ordered by ' +
+        '(timestamp, candidate_uid) with a bloom-filter skip index on candidate_uid) to ' +
+        'capture cookieless and pre-session HTTP traffic without polluting the Mongo ' +
+        'users collection. Backs the traffic-events split in PLAN-traffic-events.md.',
+    target: 'clickhouse',
+    dependencies: [],
+
+    async up(context: IMigrationContext): Promise<void> {
+        if (!context.clickhouse) {
+            console.log('[Migration 010] ClickHouse not configured — skipping traffic_events table creation');
+            return;
+        }
+
+        await context.clickhouse.exec(`
+            CREATE TABLE IF NOT EXISTS traffic_events (
+                event_type LowCardinality(String),
+                timestamp DateTime64(3),
+                candidate_uid String,
+
+                path String,
+                referer Nullable(String),
+                original_referrer Nullable(String),
+
+                user_agent Nullable(String),
+                accept_language Nullable(String),
+
+                country LowCardinality(Nullable(String)),
+                device LowCardinality(String) DEFAULT 'unknown',
+                bot_class LowCardinality(Nullable(String)),
+
+                utm_source LowCardinality(Nullable(String)),
+                utm_medium LowCardinality(Nullable(String)),
+                utm_campaign LowCardinality(Nullable(String)),
+                utm_term Nullable(String),
+                utm_content Nullable(String),
+
+                sec_ch_ua Nullable(String),
+                sec_ch_ua_mobile Nullable(UInt8),
+                sec_ch_ua_platform LowCardinality(Nullable(String)),
+                sec_fetch_dest LowCardinality(Nullable(String)),
+                sec_fetch_mode LowCardinality(Nullable(String)),
+                sec_fetch_site LowCardinality(Nullable(String)),
+
+                INDEX idx_candidate_uid candidate_uid TYPE bloom_filter(0.01) GRANULARITY 4
+            )
+            ENGINE = MergeTree()
+            PARTITION BY toYYYYMM(timestamp)
+            ORDER BY (timestamp, candidate_uid)
+            TTL toDateTime(timestamp) + INTERVAL 18 MONTH DELETE
+        `);
+
+        console.log('[Migration 010] Created ClickHouse traffic_events table (18-month TTL)');
+    }
+};

--- a/src/backend/modules/user/migrations/010_create_traffic_events_table.ts
+++ b/src/backend/modules/user/migrations/010_create_traffic_events_table.ts
@@ -29,9 +29,9 @@ import type { IMigration, IMigrationContext } from '@/types';
  *     `'session_start'` (cookie-validated session begins). Future event types may be
  *     added without schema change. `LowCardinality(String)` because the cardinality
  *     is bounded.
- *   - `candidate_uid` — the cookie UUID minted by the bootstrap controller. Always
- *     present; `''` only for events emitted before a cookie can be assigned (none
- *     today).
+ *   - `candidate_uid` — the cookie UUID minted by the bootstrap controller. Stored
+ *     as the native `UUID` type (16 bytes, validated on insert) since every event
+ *     is tied to a real `randomUUID()`-minted v4.
  *   - `path` / `referer` / `original_referrer` — request URL plus the two distinct
  *     referrers we want to keep separate: `Referer` HTTP header (server-visible,
  *     reliable) and `document.referrer` reported by the client (subject to client
@@ -82,8 +82,8 @@ export const migration: IMigration = {
         await context.clickhouse.exec(`
             CREATE TABLE IF NOT EXISTS traffic_events (
                 event_type LowCardinality(String),
-                timestamp DateTime64(3),
-                candidate_uid String,
+                timestamp DateTime64(3, 'UTC'),
+                candidate_uid UUID,
 
                 path String,
                 referer Nullable(String),

--- a/src/backend/modules/user/services/index.ts
+++ b/src/backend/modules/user/services/index.ts
@@ -6,6 +6,8 @@ export { UserGroupService, RESERVED_ADMIN_PATTERN, SYSTEM_ADMIN_GROUP_ID } from 
 export { computeUserAuthStatus, withAuthStatus } from './auth-status.js';
 export { GscService } from './gsc.service.js';
 export type { IGscStatus, IGscKeyword, IGscQueryDocument } from './gsc.service.js';
+export { TrafficService } from './traffic.service.js';
+export type { ITrafficEvent, TrafficEventType, IGetEventsForUserOptions } from './traffic.service.js';
 export type { UserFilterType } from '@/types';
 export {
     initGeoIP,

--- a/src/backend/modules/user/services/traffic.service.ts
+++ b/src/backend/modules/user/services/traffic.service.ts
@@ -172,21 +172,19 @@ export class TrafficService {
     }
 
     /**
-     * Record one traffic event. Returns immediately — ClickHouse async
-     * inserts buffer server-side, and errors surface via the async-insert
-     * error poller in `ClickHouseService`. Failures here never propagate
-     * to the request handler.
+     * Record one traffic event. Fire-and-forget: returns synchronously
+     * once the insert is dispatched, never blocks the request handler.
+     * Errors are logged via the attached `.catch()` and additionally
+     * surface via the async-insert error poller in `ClickHouseService`.
      */
-    async recordEvent(event: ITrafficEvent): Promise<void> {
+    recordEvent(event: ITrafficEvent): void {
         if (!this.clickhouse) {
             return;
         }
 
-        try {
-            await this.clickhouse.insert(TABLE_NAME, [serializeEvent(event)]);
-        } catch (error) {
+        this.clickhouse.insert(TABLE_NAME, [serializeEvent(event)]).catch((error) => {
             this.logger.warn({ error, eventType: event.event_type }, 'Failed to record traffic event');
-        }
+        });
     }
 
     /**
@@ -212,10 +210,34 @@ export class TrafficService {
             ? 'AND event_type IN ({eventTypes:Array(String)})'
             : '';
 
+        // Explicit column list (rather than SELECT *) so a future schema
+        // addition we don't intend to read won't auto-bleed into our type.
         const sql = `
-            SELECT *
+            SELECT
+                event_type,
+                timestamp,
+                candidate_uid,
+                path,
+                referer,
+                original_referrer,
+                user_agent,
+                accept_language,
+                country,
+                device,
+                bot_class,
+                utm_source,
+                utm_medium,
+                utm_campaign,
+                utm_term,
+                utm_content,
+                sec_ch_ua,
+                sec_ch_ua_mobile,
+                sec_ch_ua_platform,
+                sec_fetch_dest,
+                sec_fetch_mode,
+                sec_fetch_site
             FROM ${TABLE_NAME}
-            WHERE candidate_uid = {candidateUid:String}
+            WHERE candidate_uid = {candidateUid:UUID}
             ${eventFilter}
             ORDER BY timestamp ASC
             LIMIT {limit:UInt32}
@@ -237,24 +259,70 @@ export class TrafficService {
 }
 
 /**
- * Wire-format row returned by ClickHouse. `timestamp` arrives as an ISO
- * string; everything else lines up with `ITrafficEvent` directly.
+ * Wire-format row returned by ClickHouse. `timestamp` arrives as a UTC
+ * `DateTime64(3)` string in `YYYY-MM-DD HH:MM:SS.mmm` form (ClickHouse's
+ * native format under `JSONEachRow`); everything else lines up with
+ * `ITrafficEvent` directly.
  */
 interface TrafficEventRow extends Omit<ITrafficEvent, 'timestamp'> {
     timestamp: string;
 }
 
-/**
- * Convert an `ITrafficEvent` into the shape ClickHouse expects on insert.
- * `timestamp` becomes an ISO string; the column is `DateTime64(3)`.
- */
-function serializeEvent(event: ITrafficEvent): Record<string, unknown> {
-    return { ...event, timestamp: event.timestamp.toISOString() };
+function pad(value: number, length: number): string {
+    return String(value).padStart(length, '0');
 }
 
 /**
- * Inverse of `serializeEvent`. Re-hydrates the `Date` instance.
+ * Render a `Date` in ClickHouse's native `DateTime64(3)` form, in UTC.
+ *
+ * The default `date_time_input_format=basic` rejects `toISOString()`
+ * output (the `T...Z` form) — inserts would fail in production. The
+ * column is declared `DateTime64(3, 'UTC')` so emitting in UTC keeps
+ * the wire format and the column tz aligned regardless of which
+ * ClickHouse node the row lands on.
+ */
+function formatClickHouseDateTime64Utc(date: Date): string {
+    return (
+        `${pad(date.getUTCFullYear(), 4)}-${pad(date.getUTCMonth() + 1, 2)}-${pad(date.getUTCDate(), 2)} ` +
+        `${pad(date.getUTCHours(), 2)}:${pad(date.getUTCMinutes(), 2)}:${pad(date.getUTCSeconds(), 2)}.${pad(date.getUTCMilliseconds(), 3)}`
+    );
+}
+
+/**
+ * Inverse of `formatClickHouseDateTime64Utc`. Falls back to `new Date(value)`
+ * for any unrecognized form so a future ClickHouse driver upgrade that
+ * normalizes timestamps to ISO doesn't break us silently.
+ */
+function parseClickHouseDateTime64Utc(value: string): Date {
+    const match = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z?$/.exec(value);
+    if (!match) {
+        return new Date(value);
+    }
+    const [, year, month, day, hour, minute, second, milliseconds = '0'] = match;
+    return new Date(Date.UTC(
+        Number(year),
+        Number(month) - 1,
+        Number(day),
+        Number(hour),
+        Number(minute),
+        Number(second),
+        Number(milliseconds.padEnd(3, '0'))
+    ));
+}
+
+/**
+ * Convert an `ITrafficEvent` into the shape ClickHouse expects on insert.
+ * `timestamp` becomes a UTC `DateTime64(3)` string in ClickHouse's native
+ * form so inserts succeed under the default `date_time_input_format=basic`.
+ */
+function serializeEvent(event: ITrafficEvent): Record<string, unknown> {
+    return { ...event, timestamp: formatClickHouseDateTime64Utc(event.timestamp) };
+}
+
+/**
+ * Inverse of `serializeEvent`. Re-hydrates the `Date` instance from
+ * ClickHouse's native `DateTime64(3)` string form.
  */
 function deserializeEvent(row: TrafficEventRow): ITrafficEvent {
-    return { ...row, timestamp: new Date(row.timestamp) };
+    return { ...row, timestamp: parseClickHouseDateTime64Utc(row.timestamp) };
 }

--- a/src/backend/modules/user/services/traffic.service.ts
+++ b/src/backend/modules/user/services/traffic.service.ts
@@ -1,0 +1,260 @@
+/**
+ * Traffic events service — sibling of UserService.
+ *
+ * Captures cookieless and pre-session HTTP traffic in ClickHouse so it does
+ * not pollute the Mongo `users` collection. Backs the traffic-events split
+ * tracked in `PLAN-traffic-events.md`. Phase 0 lands the skeleton; later
+ * phases add the callers.
+ *
+ * ## Why This Service Exists
+ *
+ * The 2026-04-27 identity-cookie change moved bootstrap from a JS-runtime
+ * mutation into a Next.js middleware → backend path. That removed the
+ * implicit "client must run JavaScript" filter that previously kept bot
+ * traffic out of `users`. Every cookieless GET now writes an empty row.
+ * We keep wanting to *track* that traffic — just not in the identity
+ * collection. ClickHouse is the right tool for high-volume append-only
+ * event data with rich dimensions.
+ *
+ * ## Design Decisions
+ *
+ * - **Singleton** matching `UserService` and `GscService` for consistent DI.
+ *   `TrafficService` has no public `IXxxService` interface today; it is a
+ *   user-module internal collaborator. If a plugin ever needs it, expose
+ *   `ITrafficService` via the service registry as the user module already
+ *   does for `UserService`.
+ * - **Optional ClickHouse.** The `ClickHouseModule` skips initialization
+ *   when `CLICKHOUSE_HOST` is unset. `TrafficService` mirrors that posture:
+ *   when ClickHouse is unavailable every public method silently no-ops
+ *   (writes drop, reads return `[]`). The orphan-row fix in later phases
+ *   stays correct because Mongo writes are gated independently — losing
+ *   the analytics is the only consequence of a missing CH host, not data
+ *   corruption.
+ * - **Async insert friendly.** `ClickHouseService` is configured with
+ *   `wait_for_async_insert: 0`, so `recordEvent` returns once the row is
+ *   buffered server-side. Errors surface via the async-insert error
+ *   poller in `ClickHouseService` rather than the awaited promise. That
+ *   matches what we want from a request-path call: never block the
+ *   response on analytics persistence.
+ */
+
+import type { IClickHouseService, ISystemLogService } from '@/types';
+
+/**
+ * Categorical event types written to `traffic_events.event_type`.
+ *
+ * Kept as a string union (not an enum) so the wire format is the bare
+ * string and matches the ClickHouse `LowCardinality(String)` column. New
+ * event types can be added without changing the migration; the column
+ * stays variable-cardinality.
+ */
+export type TrafficEventType = 'bootstrap' | 'session_start';
+
+/**
+ * Single row written to `traffic_events`.
+ *
+ * Field names match column names exactly so the service can pass the
+ * object straight to `ClickHouseService.insert()` without a remap. Every
+ * non-required field is `null`-able to keep the contract honest about
+ * what middleware will and will not forward in Phase 1.
+ */
+export interface ITrafficEvent {
+    /** `'bootstrap'` (cookie minted) or `'session_start'` (cookie-validated). */
+    event_type: TrafficEventType;
+    /** Server-side wall clock at write time. */
+    timestamp: Date;
+    /** UUID minted by the bootstrap controller. Always present. */
+    candidate_uid: string;
+
+    /** Request URL or middleware-supplied `landingPath`. */
+    path: string;
+    /** HTTP `Referer` header, when present. */
+    referer: string | null;
+    /** `document.referrer` reported by the client (Phase 1 JSON body). */
+    original_referrer: string | null;
+
+    user_agent: string | null;
+    accept_language: string | null;
+
+    /** ISO-3166-1 alpha-2 derived from request IP at write time. */
+    country: string | null;
+    /** `'desktop' | 'mobile' | 'tablet' | 'bot' | 'unknown'`. */
+    device: string;
+    /** `'crawler' | 'monitoring' | ...` when classified, else null. */
+    bot_class: string | null;
+
+    utm_source: string | null;
+    utm_medium: string | null;
+    utm_campaign: string | null;
+    utm_term: string | null;
+    utm_content: string | null;
+
+    sec_ch_ua: string | null;
+    /** `0` or `1`. ClickHouse stores as `Nullable(UInt8)`. */
+    sec_ch_ua_mobile: number | null;
+    sec_ch_ua_platform: string | null;
+    sec_fetch_dest: string | null;
+    sec_fetch_mode: string | null;
+    sec_fetch_site: string | null;
+}
+
+/**
+ * Options for `getEventsForUser`.
+ */
+export interface IGetEventsForUserOptions {
+    /** Maximum rows to return. Default: 50 — Phase 3 only needs the earliest few. */
+    limit?: number;
+    /** Earliest event types to include. Default: all. */
+    eventTypes?: TrafficEventType[];
+}
+
+const TABLE_NAME = 'traffic_events';
+
+/**
+ * ClickHouse-backed traffic events store.
+ *
+ * Acquire via `TrafficService.setDependencies(...)` once during
+ * `UserModule.init()`, then `TrafficService.getInstance()` in callers.
+ */
+export class TrafficService {
+    private static instance: TrafficService | null = null;
+
+    private constructor(
+        private readonly clickhouse: IClickHouseService | undefined,
+        private readonly logger: ISystemLogService
+    ) {}
+
+    /**
+     * Initialize the singleton with dependencies.
+     *
+     * `clickhouse` is `undefined` when the deployment did not configure
+     * `CLICKHOUSE_HOST`. The service stays usable in that mode — every
+     * write is dropped, every read returns `[]`. Operators see the
+     * single info-level log on init and choose whether the missing
+     * analytics matters for their environment.
+     */
+    public static setDependencies(
+        clickhouse: IClickHouseService | undefined,
+        logger: ISystemLogService
+    ): void {
+        if (!TrafficService.instance) {
+            TrafficService.instance = new TrafficService(clickhouse, logger);
+            if (!clickhouse) {
+                logger.info(
+                    'TrafficService initialized without ClickHouse — traffic events will not be recorded'
+                );
+            }
+        }
+    }
+
+    /**
+     * @throws Error if `setDependencies()` has not been called first.
+     */
+    public static getInstance(): TrafficService {
+        if (!TrafficService.instance) {
+            throw new Error('TrafficService.setDependencies() must be called before getInstance()');
+        }
+        return TrafficService.instance;
+    }
+
+    /**
+     * Reset singleton instance. Tests only.
+     */
+    public static resetInstance(): void {
+        TrafficService.instance = null;
+    }
+
+    /**
+     * True when ClickHouse is available and writes will succeed.
+     */
+    public isEnabled(): boolean {
+        return this.clickhouse !== undefined;
+    }
+
+    /**
+     * Record one traffic event. Returns immediately — ClickHouse async
+     * inserts buffer server-side, and errors surface via the async-insert
+     * error poller in `ClickHouseService`. Failures here never propagate
+     * to the request handler.
+     */
+    async recordEvent(event: ITrafficEvent): Promise<void> {
+        if (!this.clickhouse) {
+            return;
+        }
+
+        try {
+            await this.clickhouse.insert(TABLE_NAME, [serializeEvent(event)]);
+        } catch (error) {
+            this.logger.warn({ error, eventType: event.event_type }, 'Failed to record traffic event');
+        }
+    }
+
+    /**
+     * Return the earliest events recorded for a candidate UUID, oldest
+     * first. Used by Phase 3's first-touch backfill on `startSession`:
+     * pull the cookieless rows that landed before the user's JS started
+     * the session, prefer those values over the post-hydration payload.
+     *
+     * Returns `[]` when ClickHouse is unavailable so callers can simply
+     * fall back to whatever data they were going to use anyway.
+     */
+    async getEventsForUser(
+        candidateUid: string,
+        options: IGetEventsForUserOptions = {}
+    ): Promise<ITrafficEvent[]> {
+        if (!this.clickhouse) {
+            return [];
+        }
+
+        const { limit = 50, eventTypes } = options;
+
+        const eventFilter = eventTypes && eventTypes.length > 0
+            ? 'AND event_type IN ({eventTypes:Array(String)})'
+            : '';
+
+        const sql = `
+            SELECT *
+            FROM ${TABLE_NAME}
+            WHERE candidate_uid = {candidateUid:String}
+            ${eventFilter}
+            ORDER BY timestamp ASC
+            LIMIT {limit:UInt32}
+        `;
+
+        const params: Record<string, unknown> = { candidateUid, limit };
+        if (eventTypes && eventTypes.length > 0) {
+            params.eventTypes = eventTypes;
+        }
+
+        try {
+            const rows = await this.clickhouse.query<TrafficEventRow>(sql, params);
+            return rows.map(deserializeEvent);
+        } catch (error) {
+            this.logger.warn({ error, candidateUid }, 'Failed to read traffic events');
+            return [];
+        }
+    }
+}
+
+/**
+ * Wire-format row returned by ClickHouse. `timestamp` arrives as an ISO
+ * string; everything else lines up with `ITrafficEvent` directly.
+ */
+interface TrafficEventRow extends Omit<ITrafficEvent, 'timestamp'> {
+    timestamp: string;
+}
+
+/**
+ * Convert an `ITrafficEvent` into the shape ClickHouse expects on insert.
+ * `timestamp` becomes an ISO string; the column is `DateTime64(3)`.
+ */
+function serializeEvent(event: ITrafficEvent): Record<string, unknown> {
+    return { ...event, timestamp: event.timestamp.toISOString() };
+}
+
+/**
+ * Inverse of `serializeEvent`. Re-hydrates the `Date` instance.
+ */
+function deserializeEvent(row: TrafficEventRow): ITrafficEvent {
+    return { ...row, timestamp: new Date(row.timestamp) };
+}


### PR DESCRIPTION
Phase 0 of the cookieless-traffic split tracked in `PLAN-traffic-events.md`. Lands the ClickHouse infrastructure that later phases will write to and read from, with **no behavior change** to request handling.

## What's in this PR

- `010_create_traffic_events_table.ts` — ClickHouse `MergeTree` migration. Ordered by `(timestamp, candidate_uid)` for time-range scans, bloom-filter skip index on `candidate_uid` for the Phase 3 first-touch backfill, 18-month `TTL ... DELETE` so rows expire without application-side pruning. Skips silently when `CLICKHOUSE_HOST` is unset.
- `traffic.service.ts` — sibling singleton of `UserService` exposing `recordEvent` and `getEventsForUser`. No-ops when ClickHouse is unavailable so deployments without CH stay healthy and the orphan-row fix in later phases stays decoupled.
- Wired through `IUserModuleDependencies` and `src/backend/index.ts` from `clickHouseModule.getClickHouseService()`.
- Notes in `system-database-migrations.md` that migrations are operator-triggered, not auto-run at boot.

## What's *not* in this PR

No request handler emits or reads events yet — the orphan-row bug is still present. Phases 1–3 add the middleware header forwarding, bootstrap event emission, and `startSession` first-touch backfill that actually fix the bug. Splitting Phase 0 off lets us prove the table and DI wiring work in production before changing request-handler behavior.

## Verification

- `npm run typecheck` clean
- Full user-module suite: 174/174 (15 new tests covering singleton lifecycle, recordEvent/getEventsForUser happy paths and CH-unavailable fallbacks, plus migration shape and skip behaviour)

## Post-merge prod check

Migrations are operator-triggered. After deploy:
1. `/system/database` → execute `010_create_traffic_events_table` (or `POST /api/admin/migrations/execute`).
2. `docker exec tronrelic-clickhouse clickhouse-client --database=tronrelic --query "SHOW CREATE TABLE traffic_events"` to confirm schema.
3. `SELECT count() FROM traffic_events` should return 0 — no writers exist until Phase 2.