### PR TITLE
Land Phases 1-3 of the traffic-events split: cookieless traffic now lands in ClickHouse, not Mongo users

### DIFF
--- a/src/backend/modules/user/README.md
+++ b/src/backend/modules/user/README.md
@@ -260,6 +260,8 @@ The user identity cookie has these characteristics:
 
 **Server is the only writer.** The server mints the UUID at the bootstrap endpoint, refreshes max-age on each bootstrap, and re-anchors the cookie when identity-swap reconciliation produces a new canonical UUID. The legacy JS UUID generator and localStorage mirror have been removed.
 
+**Bootstrap is Mongo-read-only; first write happens in `startSession`.** Phase 2 of the traffic-events split (see [PLAN-traffic-events.md](../../../../PLAN-traffic-events.md)) made `POST /api/user/bootstrap` mint the cookie and emit one ClickHouse `traffic_event`, but never write to the `users` collection. The first Mongo write is the upsert inside `startSession` (Phase 3) — the first cookie-validated mutation that proves the visitor honors cookies and runs JavaScript. Pre-Phase-2 every cookieless GET (search-engine crawlers, link unfurlers, uptime probes) wrote an empty user row; that traffic is still tracked, but in ClickHouse `traffic_events` rather than the identity collection. `GET /api/user/:id` returns 404 when no row exists for the cookie-resolved UUID; `getServerUser` already maps 404 onto the unauthenticated shell, and `userContextMiddleware` proceeds with `req.user` undefined — both pre-existing graceful-degradation paths the orphan-row fix relies on.
+
 **Why signing matters.** HttpOnly only blocks JavaScript reads in browsers — non-browser clients (curl, custom tools) can set arbitrary `Cookie` headers. Without a signature, an attacker who learns a UUID could forge `Cookie: tronrelic_uid=<uuid>` and pass identity checks. Signing requires possession of `SESSION_SECRET` to mint a valid value, so the cookie behaves as a server-bound bearer token, not a guess-the-UUID lottery.
 
 **Reader policy.** `requireAdmin` reads identity **only** from `req.signedCookies` — a forged or unsigned admin cookie is never honored. Every other HTTP entry point (the bootstrap controller, `validateCookie`, `userContextMiddleware`) shares a single resolver, `resolveIdentityFromCookies` in `identity-cookie.ts`, which prefers `req.signedCookies` and falls back to `req.cookies` for unsigned legacy values; on a fallback each of those readers immediately re-issues the cookie as signed via `setIdentityCookie` and emits an info-level `event: 'legacy_cookie_upgraded'` log so operators can track grace-window decay and flag anomalous patterns. Visitors holding unsigned cookies upgrade transparently on the very next request without losing their UUID. The websocket handshake parser verifies the HMAC directly via `cookie-signature.unsign` (Socket.IO doesn't run cookie-parser) and is **signed-only — no legacy fallback.** The handshake has no Set-Cookie channel, so it cannot facilitate the upgrade; accepting unsigned identity would only let a forged-UUID Cookie header subscribe to identity rooms without possessing `SESSION_SECRET`. Browser visitors always reach the handshake with a signed cookie because `SocketBridge` defers the WS connection past hydration, by which point `UserIdentityProvider` has re-anchored the cookie via `/api/user/bootstrap` — so the signed-only policy never breaks legitimate visitors. Non-browser clients must hit any HTTP entry point first to receive the signed cookie, then connect.
@@ -639,8 +641,10 @@ interface IUserGroupDocument {
 The user module implements the `IModule` interface with two-phase initialization:
 
 **Phase 1: init()** - Prepare module without activation
-- Store injected dependencies (database, cache, menu service, app, scheduler, service registry, system config)
+- Store injected dependencies (database, cache, menu service, app, scheduler, service registry, system config, optional ClickHouse)
 - Initialize UserService singleton with `setDependencies()` and create its indexes
+- Initialize GscService singleton; inject into UserService for keyword enrichment
+- Initialize TrafficService singleton (no-ops when `CLICKHOUSE_HOST` is unset); inject into UserService for first-touch backfill on `startSession`
 - Initialize UserGroupService singleton, create its indexes, and seed system groups (the reserved `admin` row)
 - Create user and user-group controllers with their service references
 
@@ -798,24 +802,28 @@ The `mergedInto` field is an optional string on `IUserDocument`. A sparse index 
 
 Most public endpoints require cookie validation — the `tronrelic_uid` cookie must match the `:id` parameter. The bootstrap endpoint is the exception (it mints the cookie). Rate limits are applied per IP address.
 
-**Bootstrap Identity** *(10 req/min)* — Idempotent. The single entry point for visitors. Mints a UUID and sets the HttpOnly cookie when none is present; refreshes max-age and resolves merge tombstones when one is present.
+**Bootstrap Identity** *(10 req/min)* — Idempotent. The single entry point for visitors. Mints a UUID and sets the HttpOnly cookie when none is present; refreshes max-age and resolves merge tombstones when one is present. **Mongo-read-only** since the traffic-events split — the first write happens in `startSession`. Emits one ClickHouse `traffic_events` row per call.
 ```
 POST /api/user/bootstrap
 Content-Type: application/json
 
-(empty body)
+{
+    "landingPath": "/markets",
+    "utm": { "source": "twitter" },
+    "originalReferrer": "https://example.com/post"
+}
 
 Response: IUser
 Set-Cookie: tronrelic_uid=<uuid>; HttpOnly; SameSite=Lax; Secure; Path=/; Max-Age=31536000
 ```
 
-The frontend calls this once on mount via the `initializeUser` thunk; the Next.js middleware (`src/frontend/middleware.ts`) calls it server-to-server when an inbound page request lacks a cookie, so SSR finds an identity on the very first visit.
+The frontend calls this once on mount via the `initializeUser` thunk; the Next.js middleware (`src/frontend/middleware.ts`) calls it server-to-server when an inbound page request lacks a cookie, so SSR finds an identity on the very first visit. The middleware forwards `User-Agent`, `Referer`, `Accept-Language`, `Sec-CH-UA*`, `Sec-Fetch-*`, and `X-Forwarded-For` plus the JSON body shown above so the backend's `traffic_events` row carries real visitor context (not the Docker bridge IP and Node default UA). The body is capped at 1 KB.
 
-**Get or Create User** *(30 req/min)*:
+**Get User** *(30 req/min)* — Read-only since Phase 2 of the traffic-events split. Returns 404 when no Mongo row exists for the cookie-resolved UUID (ephemeral anonymous; first write happens in `startSession`).
 ```
 GET /api/user/:id
 
-Response: IUser
+Response: IUser, or 404 when ephemeral
 ```
 
 **Connect Wallet** *(10 req/min)* — Stage 1: register the wallet (no signature). Moves the user from *anonymous* to *registered*:
@@ -928,7 +936,7 @@ Response: { "success": true }
 
 Legacy single-bump tracker. Prefer the session endpoints below for any new instrumentation.
 
-**Start Session** *(60 req/min)* — Idempotent within the 30-minute inactivity window. Returns the active session if one is alive, otherwise opens a new one. Captures device, country (from IP), screen size, referrer, UTM, and landing page on first session; the user-level `activity.origin` is set once and never overwritten:
+**Start Session** *(60 req/min)* — Idempotent within the 30-minute inactivity window. Returns the active session if one is alive, otherwise opens a new one. **Upserts the Mongo row** when bootstrap left no record (Phase 3 of the traffic-events split); also queries ClickHouse for the visitor's earliest pre-hydration `bootstrap` event by candidate UUID and prefers those values (device, country, referrer domain, landing page, UTM) over the post-hydration session payload, so a crawler-then-browser sequence attributes to the cookieless first impression. Captures device, country (from IP), screen size, referrer, UTM, and landing page on first session; the user-level `activity.origin` is set once and never overwritten. Emits one ClickHouse `session_start` event:
 ```
 POST /api/user/:id/session/start
 Content-Type: application/json

--- a/src/backend/modules/user/UserModule.ts
+++ b/src/backend/modules/user/UserModule.ts
@@ -237,6 +237,13 @@ export class UserModule implements IModule<IUserModuleDependencies> {
         TrafficService.setDependencies(dependencies.clickhouse, this.logger);
         this.trafficService = TrafficService.getInstance();
 
+        // Inject TrafficService into UserService so `startSession` can
+        // backfill from ClickHouse first-touch events (Phase 3). Explicit
+        // dependency rather than a hidden singleton lookup so tests can
+        // boot the user module without ClickHouse and assert on the
+        // post-hydration fallback path.
+        this.userService.setTrafficService(this.trafficService);
+
         // Initialize UserGroupService singleton, build indexes, seed system groups.
         // Must precede UserController construction so the controller can inject
         // it for `withAuthStatus` response shaping — keeps the cross-tier
@@ -247,7 +254,13 @@ export class UserModule implements IModule<IUserModuleDependencies> {
         await this.userGroupService.seedSystemGroups();
 
         // Create controller with singleton services
-        this.controller = new UserController(this.userService, this.gscService, this.userGroupService, this.logger);
+        this.controller = new UserController(
+            this.userService,
+            this.gscService,
+            this.userGroupService,
+            this.trafficService,
+            this.logger
+        );
 
         // Create group controller with singleton service
         this.groupController = new UserGroupController(this.userGroupService, this.logger);

--- a/src/backend/modules/user/__tests__/bootstrap.controller.test.ts
+++ b/src/backend/modules/user/__tests__/bootstrap.controller.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { ICacheService, ISystemLogService } from '@/types';
 import { UserService } from '../services/user.service.js';
+import { TrafficService } from '../services/traffic.service.js';
 import { UserController } from '../api/user.controller.js';
 import { USER_ID_COOKIE_NAME } from '../api/identity-cookie.js';
 import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
@@ -86,6 +87,8 @@ describe('UserController.bootstrap', () => {
         mockDb = createMockDatabaseService();
         mockCache = new MockCache();
         UserService.resetInstance();
+        TrafficService.resetInstance();
+        TrafficService.setDependencies(undefined, new NullLogger());
         UserService.setDependencies(
             mockDb,
             mockCache,
@@ -94,7 +97,7 @@ describe('UserController.bootstrap', () => {
             {} as any
         );
         userService = UserService.getInstance();
-        controller = new UserController(userService, {} as any, mockGroupService(), new NullLogger());
+        controller = new UserController(userService, {} as any, mockGroupService(), TrafficService.getInstance(), new NullLogger());
     });
 
     it('mints a fresh UUID and sets the HttpOnly cookie when no cookie is present', async () => {
@@ -174,6 +177,56 @@ describe('UserController.bootstrap', () => {
         expect(res.cookies[0].value).toBe(res.jsonBody.id);
     });
 
+    it('does NOT persist a Mongo row on cookieless first contact (Phase 2 traffic-events split)', async () => {
+        // Pre-Phase-2, every cookieless GET wrote an empty `users` row
+        // because the bootstrap controller called `getOrCreate`. Phase 2
+        // makes bootstrap read-only with respect to MongoDB — bots and
+        // uptime probes minted a UUID and got the cookie, but never
+        // polluted the identity collection. The first Mongo write now
+        // happens in `startSession`.
+        const req: any = { cookies: {}, signedCookies: {}, headers: {}, body: {} };
+        const res = makeRes();
+
+        await controller.bootstrap(req, res as any);
+
+        const collection = mockDb.getCollection('users');
+        const persisted = await collection.findOne({ id: res.jsonBody.id });
+        expect(persisted).toBeNull();
+
+        // The response still contains a fully-shaped IUser so the
+        // frontend Redux preload doesn't need an ephemeral-anonymous
+        // branch — the synthetic payload mirrors what `getOrCreate`
+        // would have written.
+        expect(res.jsonBody.identityState).toBe('anonymous');
+        expect(res.jsonBody.wallets).toEqual([]);
+        expect(res.jsonBody.activity).toMatchObject({ pageViews: 0, sessionsCount: 0 });
+    });
+
+    it('reads an existing user without writing when the cookie resolves to a persisted row', async () => {
+        // A returning visitor arrives with a valid cookie; the row was
+        // created on a prior `startSession`. Bootstrap must read it back
+        // (so Redux gets the correct wallets/identityState on first paint)
+        // without bumping `updatedAt` — bootstrap is read-only.
+        await userService.getOrCreate(VALID_UUID_A);
+        const collection = mockDb.getCollection('users');
+        const before = await collection.findOne({ id: VALID_UUID_A });
+
+        const req: any = {
+            cookies: {},
+            signedCookies: { [USER_ID_COOKIE_NAME]: VALID_UUID_A },
+            headers: {},
+            body: {}
+        };
+        const res = makeRes();
+
+        await controller.bootstrap(req, res as any);
+
+        const after = await collection.findOne({ id: VALID_UUID_A });
+        expect(res.jsonBody.id).toBe(VALID_UUID_A);
+        // No write — `updatedAt` matches the seeded value.
+        expect(after?.updatedAt).toEqual(before?.updatedAt);
+    });
+
     it('resolves a merged tombstone and re-anchors the cookie to the canonical user', async () => {
         // Create canonical user A, then create B as a tombstone pointing to A.
         await userService.getOrCreate(VALID_UUID_A);
@@ -211,6 +264,8 @@ describe('UserController.validateCookie', () => {
         mockDb = createMockDatabaseService();
         mockCache = new MockCache();
         UserService.resetInstance();
+        TrafficService.resetInstance();
+        TrafficService.setDependencies(undefined, new NullLogger());
         UserService.setDependencies(
             mockDb,
             mockCache,
@@ -218,7 +273,7 @@ describe('UserController.validateCookie', () => {
             { getSiteUrl: async () => 'http://localhost:3000', getConfig: async () => ({ siteUrl: 'http://localhost:3000' }), updateConfig: async (u: any) => u, clearCache: () => {} } as any,
             {} as any
         );
-        controller = new UserController(UserService.getInstance(), {} as any, mockGroupService(), new NullLogger());
+        controller = new UserController(UserService.getInstance(), {} as any, mockGroupService(), TrafficService.getInstance(), new NullLogger());
     });
 
     it('accepts the signed cookie and does NOT re-issue (avoids per-request Set-Cookie spam)', () => {

--- a/src/backend/modules/user/__tests__/start-session.test.ts
+++ b/src/backend/modules/user/__tests__/start-session.test.ts
@@ -1,0 +1,251 @@
+/// <reference types="vitest" />
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IClickHouseService, ISystemLogService } from '@/types';
+import { UserService } from '../services/user.service.js';
+import { TrafficService, type ITrafficEvent } from '../services/traffic.service.js';
+import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+
+vi.mock('../../auth/signature.service.js', () => ({
+    SignatureService: class {
+        normalizeAddress(a: string) { return a; }
+        async verifyMessage(a: string) { return a; }
+    }
+}));
+
+/**
+ * Tests for Phase 3 of the traffic-events split: `startSession` is the
+ * first Mongo write in the visitor lifecycle, and it pulls first-touch
+ * attribution from ClickHouse when a pre-hydration `bootstrap` event
+ * exists for the same UUID.
+ *
+ * These tests assert two behaviours together because they're load-
+ * bearing in the same code path:
+ *   1. Upsert — `startSession` creates the row when bootstrap didn't.
+ *   2. First-touch backfill — when CH has a `bootstrap` event for the
+ *      visitor, prefer its attribution dimensions over the post-hydration
+ *      session payload.
+ */
+
+class MockCache {
+    private store = new Map<string, any>();
+    async get<T>(k: string) { return (this.store.get(k) ?? null) as T | null; }
+    async set<T>(k: string, v: T) { this.store.set(k, v); }
+    async del(k: string) { return this.store.delete(k) ? 1 : 0; }
+    async invalidate() { /* unused */ }
+    async keys() { return []; }
+}
+
+class NullLogger implements ISystemLogService {
+    info() {} warn() {} error() {} debug() {} trace() {} fatal() {}
+    child(): ISystemLogService { return this; }
+    async initialize() {} async saveLog() {}
+    async getLogs() { return { logs: [], total: 0, page: 1, limit: 50, totalPages: 0, hasNextPage: false, hasPrevPage: false }; }
+    async markAsResolved() {} async markAsUnresolved() { return null; }
+    async cleanup() { return 0; }
+    async getStatistics(): Promise<any> { return { total: 0, byLevel: {}, byService: {}, unresolved: 0 }; }
+    async getLogById() { return null; }
+    async deleteAllLogs() { return 0; }
+    async getStats(): Promise<any> { return { total: 0, byLevel: {}, resolved: 0, unresolved: 0 }; }
+    level = 'info';
+}
+
+/**
+ * In-memory ClickHouse double. The traffic-service test in this folder
+ * already exercises low-level shape concerns; here we only need a
+ * `query()` that returns a pre-staged row so `startSession` can read it
+ * back through `TrafficService.getEventsForUser`.
+ */
+function createMockClickHouse(rows: unknown[] = []): IClickHouseService {
+    return {
+        async connect() { /* noop */ },
+        isConnected() { return true; },
+        async ping() { return true; },
+        async close() { /* noop */ },
+        async exec() { /* noop */ },
+        async insert() { /* noop */ },
+        async query<T>() { return rows.slice() as T[]; }
+    } as unknown as IClickHouseService;
+}
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('UserService.startSession (Phase 3)', () => {
+    let mockDb: ReturnType<typeof createMockDatabaseService>;
+    let mockCache: MockCache;
+
+    beforeEach(() => {
+        mockDb = createMockDatabaseService();
+        mockCache = new MockCache();
+        UserService.resetInstance();
+        TrafficService.resetInstance();
+    });
+
+    function bootService(clickhouse?: IClickHouseService) {
+        TrafficService.setDependencies(clickhouse, new NullLogger());
+        UserService.setDependencies(
+            mockDb,
+            mockCache,
+            new NullLogger(),
+            {
+                getSiteUrl: async () => 'http://localhost:3000',
+                getConfig: async () => ({ siteUrl: 'http://localhost:3000' }),
+                updateConfig: async (u: any) => u,
+                clearCache: () => {}
+            } as any,
+            {} as any
+        );
+        const userService = UserService.getInstance();
+        userService.setTrafficService(TrafficService.getInstance());
+        return userService;
+    }
+
+    it('upserts a new user row when bootstrap left no record', async () => {
+        // Pre-Phase-3 this would have thrown "User not found" because
+        // bootstrap was the only writer. Phase 2 dropped the bootstrap
+        // write, so `startSession` must create the row itself for
+        // first-time visitors (humans who actually run JS — bots never
+        // reach this endpoint).
+        const userService = bootService();
+        const collection = mockDb.getCollection('users');
+
+        const before = await collection.findOne({ id: VALID_UUID });
+        expect(before).toBeNull();
+
+        const session = await userService.startSession({
+            userId: VALID_UUID,
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+            landingPage: '/markets',
+            screenWidth: 1920
+        });
+
+        expect(session.landingPage).toBe('/markets');
+        expect(session.device).toBe('desktop');
+
+        const persisted = await collection.findOne({ id: VALID_UUID });
+        expect(persisted).not.toBeNull();
+        expect(persisted?.identityState).toBe('anonymous');
+        expect(persisted?.activity?.sessionsCount).toBe(1);
+    });
+
+    it('prefers ClickHouse first-touch attribution over post-hydration session payload', async () => {
+        // The visitor's first impression was a cookieless crawler GET
+        // for `/articles/tron-energy` from a duckduckgo referrer; the
+        // middleware bootstrapped them and wrote a CH row. Some time
+        // later they hit `/markets` from the homepage with JS enabled,
+        // and the frontend fires session/start. Phase 3 says: attribute
+        // to the duckduckgo first-touch, not the homepage navigation.
+        const firstTouch = {
+            event_type: 'bootstrap',
+            timestamp: '2026-04-30 10:00:00.000',
+            candidate_uid: VALID_UUID,
+            path: '/articles/tron-energy',
+            referer: 'https://duckduckgo.com/?q=tron+energy',
+            original_referrer: null,
+            user_agent: 'Mozilla/5.0 (compatible; Googlebot/2.1)',
+            accept_language: 'en-US',
+            country: 'DE',
+            device: 'desktop',
+            bot_class: null,
+            utm_source: 'duckduckgo',
+            utm_medium: 'organic',
+            utm_campaign: null,
+            utm_term: null,
+            utm_content: null,
+            sec_ch_ua: null,
+            sec_ch_ua_mobile: null,
+            sec_ch_ua_platform: null,
+            sec_fetch_dest: null,
+            sec_fetch_mode: null,
+            sec_fetch_site: null
+        };
+        const userService = bootService(createMockClickHouse([firstTouch]));
+
+        const session = await userService.startSession({
+            userId: VALID_UUID,
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+            clientIP: '127.0.0.1',
+            landingPage: '/markets',
+            bodyReferrer: 'https://tronrelic.com/',
+            rawUtm: { source: 'internal', medium: 'nav' }
+        });
+
+        // First-touch wins on every dimension it carries.
+        expect(session.landingPage).toBe('/articles/tron-energy');
+        expect(session.country).toBe('DE');
+        expect(session.referrerDomain).toBe('duckduckgo.com');
+        expect(session.searchKeyword).toBe('tron energy');
+        expect(session.utm).toEqual({
+            source: 'duckduckgo',
+            medium: 'organic',
+            campaign: undefined,
+            term: undefined,
+            content: undefined
+        });
+
+        // The persisted `activity.origin` mirrors the first-touch row.
+        const persisted = await mockDb.getCollection('users').findOne({ id: VALID_UUID });
+        expect(persisted?.activity?.origin?.landingPage).toBe('/articles/tron-energy');
+        expect(persisted?.activity?.origin?.country).toBe('DE');
+        expect(persisted?.activity?.origin?.referrerDomain).toBe('duckduckgo.com');
+    });
+
+    it('falls back to post-hydration values when ClickHouse has no first-touch row', async () => {
+        // No CH first-touch event for this UUID — `startSession` proceeds
+        // with the post-hydration payload exactly as it did pre-Phase-3.
+        const userService = bootService(createMockClickHouse([]));
+
+        const session = await userService.startSession({
+            userId: VALID_UUID,
+            userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)',
+            landingPage: '/markets',
+            bodyReferrer: 'https://twitter.com/some/post',
+            rawUtm: { source: 'twitter', medium: 'social' }
+        });
+
+        expect(session.landingPage).toBe('/markets');
+        expect(session.referrerDomain).toBe('twitter.com');
+        expect(session.utm).toEqual({
+            source: 'twitter',
+            medium: 'social',
+            campaign: undefined,
+            term: undefined,
+            content: undefined
+        });
+        expect(session.device).toBe('mobile');
+    });
+
+    it('falls back to post-hydration values when no TrafficService is injected (no-CH deployment)', async () => {
+        // Mirrors a deployment that boots without `CLICKHOUSE_HOST` set:
+        // the user module never calls `setTrafficService`, so the service
+        // cannot read first-touch events. Behaviour collapses to the
+        // pre-Phase-3 path — the orphan-row fix still works because the
+        // upsert is independent of the CH read.
+        TrafficService.setDependencies(undefined, new NullLogger());
+        UserService.setDependencies(
+            mockDb,
+            mockCache,
+            new NullLogger(),
+            {
+                getSiteUrl: async () => 'http://localhost:3000',
+                getConfig: async () => ({ siteUrl: 'http://localhost:3000' }),
+                updateConfig: async (u: any) => u,
+                clearCache: () => {}
+            } as any,
+            {} as any
+        );
+        const userService = UserService.getInstance();
+        // Intentionally do NOT call setTrafficService.
+
+        const session = await userService.startSession({
+            userId: VALID_UUID,
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+            landingPage: '/markets'
+        });
+
+        expect(session.landingPage).toBe('/markets');
+        expect(session.device).toBe('desktop');
+        const persisted = await mockDb.getCollection('users').findOne({ id: VALID_UUID });
+        expect(persisted).not.toBeNull();
+    });
+});

--- a/src/backend/modules/user/__tests__/start-session.test.ts
+++ b/src/backend/modules/user/__tests__/start-session.test.ts
@@ -112,7 +112,7 @@ describe('UserService.startSession (Phase 3)', () => {
         const before = await collection.findOne({ id: VALID_UUID });
         expect(before).toBeNull();
 
-        const session = await userService.startSession({
+        const { session, userId } = await userService.startSession({
             userId: VALID_UUID,
             userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
             landingPage: '/markets',
@@ -121,6 +121,10 @@ describe('UserService.startSession (Phase 3)', () => {
 
         expect(session.landingPage).toBe('/markets');
         expect(session.device).toBe('desktop');
+        // Canonical id matches input.userId on the upsert path (no merge
+        // pointer involved); same equality is asserted in the merge-
+        // resolution test in user.service.test.ts.
+        expect(userId).toBe(VALID_UUID);
 
         const persisted = await collection.findOne({ id: VALID_UUID });
         expect(persisted).not.toBeNull();
@@ -161,7 +165,7 @@ describe('UserService.startSession (Phase 3)', () => {
         };
         const userService = bootService(createMockClickHouse([firstTouch]));
 
-        const session = await userService.startSession({
+        const { session } = await userService.startSession({
             userId: VALID_UUID,
             userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
             clientIP: '127.0.0.1',
@@ -195,7 +199,7 @@ describe('UserService.startSession (Phase 3)', () => {
         // with the post-hydration payload exactly as it did pre-Phase-3.
         const userService = bootService(createMockClickHouse([]));
 
-        const session = await userService.startSession({
+        const { session } = await userService.startSession({
             userId: VALID_UUID,
             userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)',
             landingPage: '/markets',
@@ -237,7 +241,7 @@ describe('UserService.startSession (Phase 3)', () => {
         const userService = UserService.getInstance();
         // Intentionally do NOT call setTrafficService.
 
-        const session = await userService.startSession({
+        const { session } = await userService.startSession({
             userId: VALID_UUID,
             userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
             landingPage: '/markets'

--- a/src/backend/modules/user/api/user.controller.ts
+++ b/src/backend/modules/user/api/user.controller.ts
@@ -16,6 +16,70 @@ import {
 const MAX_PATH_LENGTH = 500;
 
 /**
+ * Per-field length caps for UTM dimensions written to `traffic_events`.
+ *
+ * Mirrors the truncation rules `UserService.extractUtmParams` applies to
+ * the post-hydration session payload. Centralizing the limits here (and
+ * in the service) avoids divergence between the CH row and the Mongo
+ * `activity.sessions[].utm` shape that downstream analytics joins.
+ */
+const UTM_FIELD_LIMITS: Record<'source' | 'medium' | 'campaign' | 'term' | 'content', number> = {
+    source: 200,
+    medium: 200,
+    campaign: 500,
+    term: 200,
+    content: 200
+};
+
+/**
+ * Maximum stored length for an originalReferrer URL or `bodyReferrer`.
+ *
+ * Bootstrap and session-start are publicly callable, so even with the
+ * 1 KB middleware body cap a single field could still consume the whole
+ * budget. 500 chars matches the path cap and accommodates URLs with
+ * long query strings without inviting unbounded ingestion.
+ */
+const MAX_REFERRER_LENGTH = 500;
+
+/**
+ * Truncate a request-supplied string to `max` chars, returning `null` when
+ * the input is not a string. Used to apply the same caps `UserService`
+ * applies to its post-hydration payload to fields that bypass the service
+ * (the CH `traffic_events` row written by the controller).
+ */
+function clampString(raw: unknown, max: number): string | null {
+    if (typeof raw !== 'string') {
+        return null;
+    }
+    return raw.slice(0, max);
+}
+
+/**
+ * Apply per-field UTM truncation. Returns `null` when the input isn't an
+ * object so callers can preserve the "no UTM" semantics that
+ * `buildTrafficEvent` collapses into all-null columns.
+ */
+function clampUtm(raw: unknown): {
+    source: string | null;
+    medium: string | null;
+    campaign: string | null;
+    term: string | null;
+    content: string | null;
+} | null {
+    if (!raw || typeof raw !== 'object') {
+        return null;
+    }
+    const r = raw as Record<string, unknown>;
+    return {
+        source:   clampString(r.source,   UTM_FIELD_LIMITS.source),
+        medium:   clampString(r.medium,   UTM_FIELD_LIMITS.medium),
+        campaign: clampString(r.campaign, UTM_FIELD_LIMITS.campaign),
+        term:     clampString(r.term,     UTM_FIELD_LIMITS.term),
+        content:  clampString(r.content,  UTM_FIELD_LIMITS.content)
+    };
+}
+
+/**
  * Sanitize a URL path for storage.
  *
  * Ensures the value starts with '/', strips query strings and hash
@@ -184,10 +248,17 @@ export class UserController {
     /**
      * GET /api/user/:id
      *
-     * Get user by UUID. Creates user if not exists.
+     * Get user by UUID. Read-only since Phase 2 of the traffic-events
+     * split: returns 404 when no Mongo row exists for the cookie-resolved
+     * UUID. The first persistence happens in `startSession`, so a fresh
+     * visitor's bootstrap leaves them as ephemeral anonymous on the
+     * server. Frontend `getServerUser` already maps 404 onto the
+     * unauthenticated SSR shell, and `userContextMiddleware` proceeds
+     * with `req.user` undefined — both pre-existing graceful-degradation
+     * paths the orphan-row fix relies on.
      *
      * Requires: Cookie must match :id
-     * Response: IUser
+     * Response: IUser, or 404 when ephemeral
      */
     async getUser(req: Request, res: Response): Promise<void> {
         try {
@@ -329,39 +400,43 @@ export class UserController {
     }
 
     /**
-     * Pull `landingPath`, `utm`, and `originalReferrer` from the
-     * middleware-supplied bootstrap body. The middleware caps the body at
-     * 1 KB, so anything we read here is already bounded; we still
-     * defensively type-check before forwarding to the traffic-event
-     * builder.
+     * Pull `landingPath`, `utm`, and `originalReferrer` from the bootstrap
+     * body and apply the same caps the service-layer mutation handlers
+     * already enforce on the post-hydration session payload.
+     *
+     * The bootstrap endpoint is publicly callable — middleware is the
+     * intended caller, but a hand-rolled client can hit it directly and
+     * the 1 KB middleware body cap doesn't apply. Uncapped strings would
+     * otherwise be persisted to ClickHouse, inflating row size and
+     * polluting analytics dashboards. We apply `sanitizePath` to
+     * `landingPath`, length-cap each UTM field via `clampUtm`, and clamp
+     * `originalReferrer` at `MAX_REFERRER_LENGTH` so the CH row matches
+     * the Mongo `activity.sessions[].utm` shape downstream consumers
+     * expect.
      */
     private extractBootstrapBody(req: Request): {
         landingPath?: string;
-        utm?: Record<string, string | null>;
+        utm?: NonNullable<ReturnType<typeof clampUtm>>;
         originalReferrer?: string | null;
     } {
         const body = (req.body ?? {}) as Record<string, unknown>;
         const result: {
             landingPath?: string;
-            utm?: Record<string, string | null>;
+            utm?: NonNullable<ReturnType<typeof clampUtm>>;
             originalReferrer?: string | null;
         } = {};
 
-        if (typeof body.landingPath === 'string') {
-            result.landingPath = body.landingPath;
+        const landingPath = sanitizePath(body.landingPath);
+        if (landingPath) {
+            result.landingPath = landingPath;
         }
-        if (typeof body.originalReferrer === 'string') {
-            result.originalReferrer = body.originalReferrer;
+        const originalReferrer = clampString(body.originalReferrer, MAX_REFERRER_LENGTH);
+        if (originalReferrer !== null) {
+            result.originalReferrer = originalReferrer;
         }
-        if (body.utm && typeof body.utm === 'object') {
-            const rawUtm = body.utm as Record<string, unknown>;
-            result.utm = {
-                source: typeof rawUtm.source === 'string' ? rawUtm.source : null,
-                medium: typeof rawUtm.medium === 'string' ? rawUtm.medium : null,
-                campaign: typeof rawUtm.campaign === 'string' ? rawUtm.campaign : null,
-                term: typeof rawUtm.term === 'string' ? rawUtm.term : null,
-                content: typeof rawUtm.content === 'string' ? rawUtm.content : null
-            };
+        const utm = clampUtm(body.utm);
+        if (utm) {
+            result.utm = utm;
         }
         return result;
     }
@@ -732,7 +807,7 @@ export class UserController {
             // empty-UTM detection, and body-vs-header referrer priority
             // (with internal-domain filtering) all live in `UserService`
             // so any future caller gets identical behaviour.
-            const session = await this.userService.startSession({
+            const { session, userId } = await this.userService.startSession({
                 userId: req.params.id,
                 clientIP: getClientIP(req),
                 userAgent: typeof req.headers['user-agent'] === 'string'
@@ -755,14 +830,23 @@ export class UserController {
             // bootstrap row from earlier in this visitor's lifecycle. Same
             // fire-and-forget posture as bootstrap — we never block the
             // response on analytics persistence, and a missing ClickHouse
-            // host silently no-ops.
+            // host silently no-ops. UTM and referrer fields are capped via
+            // the same `clampUtm` / `MAX_REFERRER_LENGTH` rules the
+            // bootstrap controller applies, so the CH row stays bounded
+            // even though a hand-rolled client could submit oversized
+            // values directly to `/api/user/:id/session/start`.
+            //
+            // Use the canonical `userId` returned by `startSession` (not
+            // `req.params.id`) so a request that arrives carrying a merged
+            // tombstone still records analytics under the canonical UUID.
+            // Without this the next visit's first-touch lookup — which
+            // queries CH by canonical id — would miss this session_start
+            // row and the visitor would lose attribution continuity.
             this.trafficService.recordEvent(
-                buildTrafficEvent('session_start', req.params.id, req, {
+                buildTrafficEvent('session_start', userId, req, {
                     landingPath: sanitizePath(req.body.landingPage),
-                    utm: this.extractSessionUtm(req.body.utm),
-                    originalReferrer: typeof req.body.referrer === 'string'
-                        ? req.body.referrer
-                        : null
+                    utm: clampUtm(req.body.utm) ?? undefined,
+                    originalReferrer: clampString(req.body.referrer, MAX_REFERRER_LENGTH)
                 })
             );
 
@@ -774,33 +858,6 @@ export class UserController {
                 message: error instanceof Error ? error.message : 'Unknown error'
             });
         }
-    }
-
-    /**
-     * Coerce the session-start body's free-form `utm` object into the
-     * shape `buildTrafficEvent` expects. The session-start payload is
-     * already truncated and validated by the service-layer
-     * `extractUtmParams`, but the CH row is a sibling write that runs
-     * before that — so we apply the same defensive type checks here.
-     */
-    private extractSessionUtm(raw: unknown): {
-        source?: string | null;
-        medium?: string | null;
-        campaign?: string | null;
-        term?: string | null;
-        content?: string | null;
-    } | undefined {
-        if (!raw || typeof raw !== 'object') {
-            return undefined;
-        }
-        const r = raw as Record<string, unknown>;
-        return {
-            source: typeof r.source === 'string' ? r.source : null,
-            medium: typeof r.medium === 'string' ? r.medium : null,
-            campaign: typeof r.campaign === 'string' ? r.campaign : null,
-            term: typeof r.term === 'string' ? r.term : null,
-            content: typeof r.content === 'string' ? r.content : null
-        };
     }
 
     /**

--- a/src/backend/modules/user/api/user.controller.ts
+++ b/src/backend/modules/user/api/user.controller.ts
@@ -2,10 +2,10 @@ import type { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'node:crypto';
 import { USER_FILTERS } from '@/types';
 import type { ISystemLogService, UserFilterType, IUserGroupService } from '@/types';
-import type { UserService, IUserStats, IDateRange } from '../services/index.js';
+import type { UserService, IUserStats, IDateRange, TrafficService } from '../services/index.js';
 import type { GscService } from '../services/index.js';
 import type { IUser, IUserPreferences } from '../database/index.js';
-import { getClientIP, withAuthStatus } from '../services/index.js';
+import { buildTrafficEvent, getClientIP, withAuthStatus } from '../services/index.js';
 import { AnalyticsRangeValidationError } from '../services/user.errors.js';
 import {
     setIdentityCookie,
@@ -67,6 +67,7 @@ export class UserController {
         private readonly userService: UserService,
         private readonly gscService: GscService,
         private readonly userGroupService: IUserGroupService,
+        private readonly trafficService: TrafficService,
         private readonly logger: ISystemLogService
     ) {}
 
@@ -192,7 +193,21 @@ export class UserController {
         try {
             const { id } = req.params;
 
-            const user = await this.userService.getOrCreate(id);
+            // Phase 2 of the traffic-events split (PLAN-traffic-events.md):
+            // bootstrap no longer writes a Mongo row, so the user record may
+            // not yet exist. Treat that as ephemeral anonymous and return 404
+            // — `getServerUser` on the frontend already maps 404 onto the
+            // unauthenticated shell, and `userContextMiddleware` already
+            // gracefully proceeds when `req.user` is absent. The first Mongo
+            // write happens in `startSession`.
+            const user = await this.userService.getById(id);
+            if (!user) {
+                res.status(404).json({
+                    error: 'User not found',
+                    message: 'No persisted record for this identity yet'
+                });
+                return;
+            }
 
             await this.respondWithUser(res, user);
         } catch (error) {
@@ -211,17 +226,35 @@ export class UserController {
      * `tronrelic_uid` cookie. This endpoint is the canonical entry point
      * for first-time visitors and the safe no-op for returning visitors.
      *
+     * Phase 2 of the traffic-events split (PLAN-traffic-events.md) makes
+     * this endpoint **read-only with respect to MongoDB**. Bootstrap
+     * mints/refreshes the cookie and emits one ClickHouse `traffic_event`,
+     * but never persists to the `users` collection. The first Mongo write
+     * happens in `startSession`, which is the first cookie-validated
+     * mutation that proves the visitor honors cookies and runs JavaScript.
+     * Pre-Phase-2 every cookieless GET (crawlers, link unfurlers, uptime
+     * probes) wrote an empty user row; tracking that traffic is still
+     * valuable, but it belongs in ClickHouse, not the identity collection.
+     *
      * Behavior:
-     * - Cookie present and valid → resolve to canonical user (follows merge
-     *   pointers), refresh the cookie's max-age, return the user.
-     * - Cookie absent, malformed, or pointing to a never-created UUID →
-     *   mint a fresh UUID v4, create the user record, set the HttpOnly
-     *   cookie, return the new user.
+     * - Cookie present and resolves to an existing user → return that
+     *   user (follows merge pointers); refresh cookie max-age.
+     * - Cookie present but no Mongo row exists → return an *ephemeral*
+     *   anonymous IUser payload built from the cookie's UUID; cookie
+     *   refreshed; no Mongo write.
+     * - Cookie absent / malformed → mint a fresh UUID v4, return ephemeral
+     *   anonymous payload, set HttpOnly cookie; no Mongo write.
      *
      * No `:id` parameter — the server resolves identity entirely from the
-     * cookie or mints one. Clients that ran in this environment with the
-     * legacy JS-minted cookie continue to work; the response refreshes the
-     * cookie with HttpOnly so the upgrade is transparent on next visit.
+     * cookie or mints one. The response shape stays IUser-compatible so
+     * the frontend Redux preload doesn't need a separate ephemeral path.
+     *
+     * Forwarded request context (User-Agent, Referer, Sec-CH-UA*,
+     * Sec-Fetch-*, X-Forwarded-For) plus the body's `landingPath`, `utm`,
+     * and `originalReferrer` populate the `traffic_events` row. The
+     * Next.js middleware (Phase 1) is the canonical caller for inbound
+     * SSR requests; the frontend `initializeUser` thunk supplies its own
+     * `landingPath` from `window.location` for client-driven bootstraps.
      *
      * Response: IUser
      */
@@ -237,15 +270,19 @@ export class UserController {
             const isValidExisting = resolved !== null;
             const candidateId = resolved?.userId ?? randomUUID();
 
-            // getOrCreate resolves merge pointers, so a stale cookie that
-            // points at a tombstone returns the canonical user. The returned
-            // id is what we re-anchor the cookie to.
-            const user = await this.userService.getOrCreate(candidateId);
+            // Read-only lookup. `getById` follows merge pointers, so a stale
+            // cookie pointing at a tombstone resolves to the canonical user
+            // without a write. When no row exists we synthesize an ephemeral
+            // anonymous IUser; the frontend never sees the difference, but
+            // bots and uptime probes never persist.
+            const existing = await this.userService.getById(candidateId);
+            const user = existing ?? this.userService.buildEphemeralUser(candidateId);
 
             // Always set the cookie on the response. For a returning visitor
             // this refreshes max-age and rewrites the legacy JS-minted cookie
-            // to HttpOnly. For a new visitor it's the initial mint. For a
-            // merged identity it points the cookie at the canonical user.
+            // to HttpOnly. For a new or ephemeral visitor it's the initial
+            // mint. For a merged identity it points the cookie at the
+            // canonical user.
             setIdentityCookie(res, user.id);
 
             // Surface unsigned-cookie upgrades as info-level so operators
@@ -263,8 +300,22 @@ export class UserController {
                 );
             }
 
+            // Record the bootstrap as a ClickHouse traffic event. Fire-and-
+            // forget; never blocks the response, never throws into the
+            // request path. When ClickHouse is unconfigured the service
+            // no-ops silently — the orphan-row fix above stays correct
+            // because Mongo writes are gated independently.
+            this.trafficService.recordEvent(
+                buildTrafficEvent('bootstrap', user.id, req, this.extractBootstrapBody(req))
+            );
+
             this.logger.debug(
-                { userId: user.id, minted: !isValidExisting, merged: user.id !== candidateId },
+                {
+                    userId: user.id,
+                    minted: !isValidExisting,
+                    merged: existing !== null && user.id !== candidateId,
+                    persisted: existing !== null
+                },
                 'User identity bootstrapped'
             );
             await this.respondWithUser(res, user);
@@ -275,6 +326,44 @@ export class UserController {
                 message: error instanceof Error ? error.message : 'Unknown error'
             });
         }
+    }
+
+    /**
+     * Pull `landingPath`, `utm`, and `originalReferrer` from the
+     * middleware-supplied bootstrap body. The middleware caps the body at
+     * 1 KB, so anything we read here is already bounded; we still
+     * defensively type-check before forwarding to the traffic-event
+     * builder.
+     */
+    private extractBootstrapBody(req: Request): {
+        landingPath?: string;
+        utm?: Record<string, string | null>;
+        originalReferrer?: string | null;
+    } {
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const result: {
+            landingPath?: string;
+            utm?: Record<string, string | null>;
+            originalReferrer?: string | null;
+        } = {};
+
+        if (typeof body.landingPath === 'string') {
+            result.landingPath = body.landingPath;
+        }
+        if (typeof body.originalReferrer === 'string') {
+            result.originalReferrer = body.originalReferrer;
+        }
+        if (body.utm && typeof body.utm === 'object') {
+            const rawUtm = body.utm as Record<string, unknown>;
+            result.utm = {
+                source: typeof rawUtm.source === 'string' ? rawUtm.source : null,
+                medium: typeof rawUtm.medium === 'string' ? rawUtm.medium : null,
+                campaign: typeof rawUtm.campaign === 'string' ? rawUtm.campaign : null,
+                term: typeof rawUtm.term === 'string' ? rawUtm.term : null,
+                content: typeof rawUtm.content === 'string' ? rawUtm.content : null
+            };
+        }
+        return result;
     }
 
     /**
@@ -662,6 +751,21 @@ export class UserController {
                     : undefined
             });
 
+            // Phase 3: emit a ClickHouse `session_start` event alongside the
+            // bootstrap row from earlier in this visitor's lifecycle. Same
+            // fire-and-forget posture as bootstrap — we never block the
+            // response on analytics persistence, and a missing ClickHouse
+            // host silently no-ops.
+            this.trafficService.recordEvent(
+                buildTrafficEvent('session_start', req.params.id, req, {
+                    landingPath: sanitizePath(req.body.landingPage),
+                    utm: this.extractSessionUtm(req.body.utm),
+                    originalReferrer: typeof req.body.referrer === 'string'
+                        ? req.body.referrer
+                        : null
+                })
+            );
+
             res.json({ session });
         } catch (error) {
             this.logger.warn({ error, userId: req.params.id }, 'Failed to start session');
@@ -670,6 +774,33 @@ export class UserController {
                 message: error instanceof Error ? error.message : 'Unknown error'
             });
         }
+    }
+
+    /**
+     * Coerce the session-start body's free-form `utm` object into the
+     * shape `buildTrafficEvent` expects. The session-start payload is
+     * already truncated and validated by the service-layer
+     * `extractUtmParams`, but the CH row is a sibling write that runs
+     * before that — so we apply the same defensive type checks here.
+     */
+    private extractSessionUtm(raw: unknown): {
+        source?: string | null;
+        medium?: string | null;
+        campaign?: string | null;
+        term?: string | null;
+        content?: string | null;
+    } | undefined {
+        if (!raw || typeof raw !== 'object') {
+            return undefined;
+        }
+        const r = raw as Record<string, unknown>;
+        return {
+            source: typeof r.source === 'string' ? r.source : null,
+            medium: typeof r.medium === 'string' ? r.medium : null,
+            campaign: typeof r.campaign === 'string' ? r.campaign : null,
+            term: typeof r.term === 'string' ? r.term : null,
+            content: typeof r.content === 'string' ? r.content : null
+        };
     }
 
     /**

--- a/src/backend/modules/user/services/index.ts
+++ b/src/backend/modules/user/services/index.ts
@@ -6,8 +6,13 @@ export { UserGroupService, RESERVED_ADMIN_PATTERN, SYSTEM_ADMIN_GROUP_ID } from 
 export { computeUserAuthStatus, withAuthStatus } from './auth-status.js';
 export { GscService } from './gsc.service.js';
 export type { IGscStatus, IGscKeyword, IGscQueryDocument } from './gsc.service.js';
-export { TrafficService } from './traffic.service.js';
-export type { ITrafficEvent, TrafficEventType, IGetEventsForUserOptions } from './traffic.service.js';
+export { TrafficService, buildTrafficEvent } from './traffic.service.js';
+export type {
+    ITrafficEvent,
+    TrafficEventType,
+    IGetEventsForUserOptions,
+    ITrafficEventBuilderInputs
+} from './traffic.service.js';
 export type { UserFilterType } from '@/types';
 export {
     initGeoIP,

--- a/src/backend/modules/user/services/traffic.service.ts
+++ b/src/backend/modules/user/services/traffic.service.ts
@@ -38,7 +38,9 @@
  *   response on analytics persistence.
  */
 
+import type { Request } from 'express';
 import type { IClickHouseService, ISystemLogService } from '@/types';
+import { getClientIP, getCountryFromIP, getDeviceCategory } from './geo.service.js';
 
 /**
  * Categorical event types written to `traffic_events.event_type`.
@@ -256,6 +258,122 @@ export class TrafficService {
             return [];
         }
     }
+}
+
+/**
+ * Inputs the controller can derive from the request body and cookie state
+ * but the request headers cannot supply on their own.
+ *
+ * Phase 1 forwards a small JSON body alongside the inbound headers so the
+ * backend has real visitor context (landing path, UTM params, original
+ * referrer captured by the legacy-redirect middleware) on the bootstrap
+ * call. The `startSession` payload supplies the same shape from the
+ * frontend session-start fetch.
+ */
+export interface ITrafficEventBuilderInputs {
+    /** Sanitized landing path; falls back to `req.path` when omitted. */
+    landingPath?: string;
+    /** UTM params parsed from the URL or session-start payload. */
+    utm?: {
+        source?: string | null;
+        medium?: string | null;
+        campaign?: string | null;
+        term?: string | null;
+        content?: string | null;
+    };
+    /** `document.referrer` reported by the client at landing. */
+    originalReferrer?: string | null;
+}
+
+/**
+ * Build an `ITrafficEvent` from an Express request and a candidate UUID.
+ *
+ * Centralizes "request → ITrafficEvent" mapping so both the bootstrap
+ * controller (Phase 2) and the session-start controller (Phase 3) emit
+ * rows with the same shape. The geo / device helpers are reused from
+ * `geo.service.ts` so the device-category and country-derivation rules
+ * stay in one place.
+ *
+ * The builder never throws — every dimension is `Nullable` in the
+ * ClickHouse schema, so missing or malformed input collapses to `null`
+ * rather than failing the inbound request.
+ */
+export function buildTrafficEvent(
+    eventType: TrafficEventType,
+    candidateUid: string,
+    req: Request,
+    inputs: ITrafficEventBuilderInputs = {}
+): ITrafficEvent {
+    const headers = req.headers ?? {};
+    const userAgent = readSingleHeader(headers['user-agent']);
+    const referer = readSingleHeader(headers['referer']);
+    const acceptLanguage = readSingleHeader(headers['accept-language']);
+    const secChUa = readSingleHeader(headers['sec-ch-ua']);
+    const secChUaMobile = readSingleHeader(headers['sec-ch-ua-mobile']);
+    const secChUaPlatform = readSingleHeader(headers['sec-ch-ua-platform']);
+    const secFetchDest = readSingleHeader(headers['sec-fetch-dest']);
+    const secFetchMode = readSingleHeader(headers['sec-fetch-mode']);
+    const secFetchSite = readSingleHeader(headers['sec-fetch-site']);
+
+    const utm = inputs.utm ?? {};
+
+    return {
+        event_type: eventType,
+        timestamp: new Date(),
+        candidate_uid: candidateUid,
+
+        path: inputs.landingPath ?? (typeof req.path === 'string' ? req.path : '/'),
+        referer: referer ?? null,
+        original_referrer: inputs.originalReferrer ?? null,
+
+        user_agent: userAgent ?? null,
+        accept_language: acceptLanguage ?? null,
+
+        country: getCountryFromIP(getClientIP({ ip: req.ip, headers })),
+        device: getDeviceCategory(userAgent),
+        // bot_class deferred — see PLAN-traffic-events.md "Open Questions".
+        // Until the library-vs-regex decision lands, every row carries
+        // null. Future Phase 4+ work can backfill via a CH `ALTER TABLE
+        // ... UPDATE` over recent rows once the classifier exists.
+        bot_class: null,
+
+        utm_source: utm.source ?? null,
+        utm_medium: utm.medium ?? null,
+        utm_campaign: utm.campaign ?? null,
+        utm_term: utm.term ?? null,
+        utm_content: utm.content ?? null,
+
+        sec_ch_ua: secChUa ?? null,
+        sec_ch_ua_mobile: parseSecChUaMobile(secChUaMobile),
+        sec_ch_ua_platform: secChUaPlatform ?? null,
+        sec_fetch_dest: secFetchDest ?? null,
+        sec_fetch_mode: secFetchMode ?? null,
+        sec_fetch_site: secFetchSite ?? null
+    };
+}
+
+/**
+ * Express normalizes most headers to a single string but allows arrays
+ * for ones that can repeat (e.g. `Set-Cookie`). For our forwarded set we
+ * only care about the first occurrence; coercing the array form here
+ * keeps the call site free of `Array.isArray` checks.
+ */
+function readSingleHeader(value: string | string[] | undefined): string | undefined {
+    if (Array.isArray(value)) {
+        return value[0];
+    }
+    return value;
+}
+
+/**
+ * Parse the `Sec-CH-UA-Mobile` header (`"?0"` / `"?1"`) into the 0/1 form
+ * the ClickHouse `Nullable(UInt8)` column expects. Anything else maps to
+ * null so a malformed client header doesn't poison the row.
+ */
+function parseSecChUaMobile(value: string | undefined): number | null {
+    if (value === '?1') return 1;
+    if (value === '?0') return 0;
+    return null;
 }
 
 /**

--- a/src/backend/modules/user/services/traffic.service.ts
+++ b/src/backend/modules/user/services/traffic.service.ts
@@ -297,6 +297,25 @@ export interface ITrafficEventBuilderInputs {
  * The builder never throws — every dimension is `Nullable` in the
  * ClickHouse schema, so missing or malformed input collapses to `null`
  * rather than failing the inbound request.
+ *
+ * @param eventType - Categorical kind of event (`'bootstrap'` or
+ *   `'session_start'`). Future event types extend the union without a
+ *   schema change since the column is `LowCardinality(String)`.
+ * @param candidateUid - UUID v4 the cookie is anchored to. The caller is
+ *   responsible for resolving merge tombstones to the canonical id
+ *   before emitting; otherwise analytics split across stale/canonical
+ *   ids and Phase 3's first-touch lookup misses.
+ * @param req - Express request whose headers carry the visitor's
+ *   browser context (UA, Referer, Sec-CH-UA*, Sec-Fetch-*) and whose IP
+ *   resolves the country dimension. Headers default to `{}` when
+ *   absent, keeping the builder safe to call with stub requests in
+ *   tests.
+ * @param inputs - Optional extra context the controller derived from
+ *   the request body or cookie state and that headers cannot supply on
+ *   their own (`landingPath`, `utm`, `originalReferrer`). See
+ *   `ITrafficEventBuilderInputs` for per-field docs. Defaults to `{}`
+ *   so callers that only have request-level context (none of the body
+ *   payload) can call the builder without a sentinel object.
  */
 export function buildTrafficEvent(
     eventType: TrafficEventType,

--- a/src/backend/modules/user/services/user.service.ts
+++ b/src/backend/modules/user/services/user.service.ts
@@ -1239,12 +1239,21 @@ export class UserService {
      * when ClickHouse is unavailable, so deployments without CH simply
      * get the post-hydration values.
      *
+     * Returns both the session and the **canonical user id** so callers
+     * that emit downstream analytics (the controller's `session_start`
+     * ClickHouse event) can attribute under the canonical id even when
+     * `input.userId` arrived as a merge tombstone. Without this, the
+     * controller would record events under the stale id, splitting
+     * analytics across two UUIDs and breaking the next session's
+     * first-touch lookup.
+     *
      * @param input - Raw session input fields (userId, clientIP, userAgent,
      *                screenWidth, landingPage, rawUtm, bodyReferrer,
      *                headerReferrer)
-     * @returns The active session
+     * @returns `{ session, userId }` where `userId` is the canonical UUID
+     *   the session was persisted under (resolves merge pointers)
      */
-    async startSession(input: IStartSessionInput): Promise<IUserSession> {
+    async startSession(input: IStartSessionInput): Promise<{ session: IUserSession; userId: string }> {
         try {
             const { clientIP, userAgent, screenWidth, landingPage } = input;
 
@@ -1282,7 +1291,7 @@ export class UserService {
 
                 if (now.getTime() - lastActivity.getTime() < this.SESSION_TIMEOUT_MS) {
                     // Session still active - return as-is (duration tracked by heartbeat)
-                    return activeSession;
+                    return { session: activeSession, userId };
                 }
 
                 // Session timed out - close it
@@ -1430,7 +1439,7 @@ export class UserService {
                 'Session started'
             );
 
-            return newSession;
+            return { session: newSession, userId };
         } catch (error) {
             // Use input.userId here: the canonical `userId` is bound
             // inside the try (`const userId = doc.id`) so it isn't visible
@@ -4654,6 +4663,14 @@ export class UserService {
      * defaults that `getOrCreate` used to write at bootstrap and insert
      * them. Format validation lives here so an invalid UUID can't slip
      * past resolveDocument's silent null-on-missing path.
+     *
+     * Idempotent under concurrent calls. Two simultaneous `startSession`
+     * requests for the same UUID would both `resolveDocument → null` and
+     * race into this method; the unique index on `users.id` makes the
+     * second insert throw E11000. We catch that and re-resolve the
+     * canonical document, returning it as if we had won the race —
+     * subsequent activity writes in `startSession` then merge into the
+     * winner's row. Any non-duplicate error rethrows untouched.
      */
     private async createUserForSession(userId: string): Promise<IUserDocument> {
         if (!this.isValidUUID(userId)) {
@@ -4682,9 +4699,22 @@ export class UserService {
             createdAt: now,
             updatedAt: now
         };
-        await this.collection.insertOne(fresh as any);
-        this.logger.info({ userId }, 'User created via session start');
-        return fresh as IUserDocument;
+        try {
+            await this.collection.insertOne(fresh as any);
+            this.logger.info({ userId }, 'User created via session start');
+            return fresh as IUserDocument;
+        } catch (error: any) {
+            // MongoServerError code 11000 = duplicate key. A concurrent
+            // startSession won the race; re-fetch the winner's doc.
+            if (error?.code === 11000) {
+                const existing = await this.resolveDocument(userId);
+                if (existing) {
+                    this.logger.debug({ userId }, 'createUserForSession lost a concurrent race; reusing existing row');
+                    return existing;
+                }
+            }
+            throw error;
+        }
     }
 
     /**
@@ -4693,6 +4723,15 @@ export class UserService {
      * `startSession`. Returns `null` when ClickHouse is unavailable, the
      * lookup fails, or no rows match — every caller falls back to the
      * post-hydration session payload in that case.
+     *
+     * Field-level caps are applied here as defense-in-depth on the read
+     * path. The bootstrap controller already clamps `landingPath`, UTM,
+     * and `originalReferrer` before writing to ClickHouse (see
+     * `clampUtm` / `MAX_REFERRER_LENGTH` in user.controller.ts), so in
+     * the steady state CH rows are already bounded. The redundant caps
+     * here protect against rows already in CH from before the write-
+     * boundary fix landed and against any future emit site that adds
+     * a CH event without going through the existing chokepoint.
      */
     private async fetchFirstTouchEvent(userId: string) {
         if (!this.trafficService) {
@@ -4702,7 +4741,55 @@ export class UserService {
             eventTypes: ['bootstrap'],
             limit: 1
         });
-        return events[0] ?? null;
+        const raw = events[0];
+        if (!raw) return null;
+        return this.clampFirstTouchEvent(raw);
+    }
+
+    /**
+     * Apply field-level caps to a CH first-touch row before its values
+     * flow into Mongo writes. Mirrors the limits the controller applies
+     * to the post-hydration session payload (`MAX_PATH_LENGTH = 500`,
+     * UTM truncation matching `extractUtmParams`, country normalized to
+     * a 2-char ISO code).
+     */
+    private clampFirstTouchEvent<T extends {
+        path: string;
+        referer: string | null;
+        country: string | null;
+        utm_source: string | null;
+        utm_medium: string | null;
+        utm_campaign: string | null;
+        utm_term: string | null;
+        utm_content: string | null;
+    }>(event: T): T {
+        const FIRST_TOUCH_PATH_MAX = 500;
+        const FIRST_TOUCH_REFERER_MAX = 500;
+        const COUNTRY_CODE_REGEX = /^[A-Z]{2}$/;
+
+        const clamp = (value: string | null, max: number) =>
+            typeof value === 'string' ? value.slice(0, max) : value;
+
+        return {
+            ...event,
+            path: typeof event.path === 'string' ? event.path.slice(0, FIRST_TOUCH_PATH_MAX) : event.path,
+            // Cap the referrer before it reaches `new URL(...)` /
+            // `extractReferrerDomain` / `extractSearchKeyword`. Those
+            // helpers already truncate their *outputs* but pay the
+            // parse cost on the unbounded input — capping here defends
+            // against a crafted multi-MB referer in a stale CH row.
+            referer: clamp(event.referer, FIRST_TOUCH_REFERER_MAX),
+            // Country must be a 2-char ISO code; anything else collapses
+            // to null so we don't persist garbage into countryCounts.
+            country: typeof event.country === 'string' && COUNTRY_CODE_REGEX.test(event.country)
+                ? event.country
+                : null,
+            utm_source:   clamp(event.utm_source,   200),
+            utm_medium:   clamp(event.utm_medium,   200),
+            utm_campaign: clamp(event.utm_campaign, 500),
+            utm_term:     clamp(event.utm_term,     200),
+            utm_content:  clamp(event.utm_content,  200)
+        };
     }
 
     /**

--- a/src/backend/modules/user/services/user.service.ts
+++ b/src/backend/modules/user/services/user.service.ts
@@ -63,6 +63,7 @@ import type TronWeb from 'tronweb';
 import { SignatureService } from '../../auth/signature.service.js';
 import { WalletChallengeService, type IWalletChallenge, type WalletChallengeAction } from './wallet-challenge.service.js';
 import { GscService } from './gsc.service.js';
+import { TrafficService } from './traffic.service.js';
 import { AnalyticsRangeValidationError } from './user.errors.js';
 
 /**
@@ -215,6 +216,7 @@ export class UserService {
     private readonly signatureService: SignatureService;
     private readonly walletChallengeService: WalletChallengeService;
     private gscService: GscService | null = null;
+    private trafficService: TrafficService | null = null;
     private readonly CACHE_KEY_PREFIX = 'user:';
     private readonly CACHE_KEY_WALLET_PREFIX = 'user:wallet:';
     private readonly CACHE_TTL = 3600; // 1 hour
@@ -309,6 +311,22 @@ export class UserService {
         this.gscService = gscService;
     }
 
+    /**
+     * Inject the TrafficService for first-touch backfill on session start.
+     *
+     * Called from `UserModule.init()` after both singletons are initialized.
+     * The dependency is optional in that `startSession` falls through to its
+     * pre-Phase-3 behaviour (post-hydration values only) when the service
+     * is unavailable — that path matters for tests that boot the user
+     * module without ClickHouse, and for deployments where `CLICKHOUSE_HOST`
+     * is unset.
+     *
+     * @param trafficService - Initialized TrafficService singleton
+     */
+    public setTrafficService(trafficService: TrafficService): void {
+        this.trafficService = trafficService;
+    }
+
     // ==================== Core CRUD Operations ====================
 
     /**
@@ -387,6 +405,51 @@ export class UserService {
         const user = this.toPublicUser(newUser as IUserDocument);
         await this.cacheUser(user);
         return user;
+    }
+
+    /**
+     * Build an ephemeral `IUser` payload for a UUID without writing to MongoDB.
+     *
+     * Phase 2 of the traffic-events split makes `POST /api/user/bootstrap`
+     * read-only — the first Mongo write happens in `startSession`. When a
+     * brand-new visitor (no row yet) hits bootstrap, the response still
+     * needs an `IUser`-shaped payload so the frontend can populate Redux
+     * and render the unauthenticated shell without a flash. This helper
+     * returns that payload with the same anonymous defaults `getOrCreate`
+     * would have written, but never persists.
+     *
+     * The returned object is *not* cached. Subsequent reads (`getById`)
+     * still return null until `startSession` upserts the row, which is
+     * the intended outcome — bots and uptime probes never reach
+     * `startSession`, so they never persist.
+     *
+     * @param id - UUID v4 identifier minted at bootstrap
+     * @returns Anonymous `IUser` payload with `firstSeen = lastSeen = now`
+     */
+    buildEphemeralUser(id: string): IUser {
+        const now = new Date();
+        return {
+            id,
+            identityState: UserIdentityState.Anonymous,
+            identityVerifiedAt: null,
+            wallets: [],
+            preferences: {},
+            activity: {
+                firstSeen: now,
+                lastSeen: now,
+                pageViews: 0,
+                sessionsCount: 0,
+                totalDurationSeconds: 0,
+                sessions: [],
+                pageViewsByPath: {},
+                countryCounts: {},
+                origin: null
+            },
+            groups: [],
+            referral: null,
+            createdAt: now,
+            updatedAt: now
+        };
     }
 
     /**
@@ -1161,6 +1224,21 @@ export class UserService {
      * The controller passes raw request fields via `IStartSessionInput` and
      * does not interpret them.
      *
+     * **Phase 3 of the traffic-events split (PLAN-traffic-events.md).** This
+     * is the **first Mongo write** in the visitor lifecycle. Bootstrap no
+     * longer persists, so the canonical user document may not yet exist
+     * when this runs. We upsert: if no row resolves for `input.userId`, we
+     * create one from anonymous defaults instead of throwing. On the
+     * upsert path we also query ClickHouse for the visitor's earliest
+     * pre-hydration `bootstrap` event and prefer those values over the
+     * post-hydration session payload — bots and uptime probes never get
+     * here, but humans whose first event was a cookieless GET (search
+     * crawlers indexed the same URL, or middleware bootstrap fired before
+     * JS loaded) get attribution from that first touch instead of the
+     * client-supplied fields. The CH read silently falls back to `[]`
+     * when ClickHouse is unavailable, so deployments without CH simply
+     * get the post-hydration values.
+     *
      * @param input - Raw session input fields (userId, clientIP, userAgent,
      *                screenWidth, landingPage, rawUtm, bodyReferrer,
      *                headerReferrer)
@@ -1179,10 +1257,15 @@ export class UserService {
                 input.headerReferrer
             );
 
-            // Resolve to canonical document (single DB hit, follows merge pointer if needed)
-            const doc = await this.resolveDocument(input.userId);
+            // Resolve to canonical document (single DB hit, follows merge pointer if needed).
+            // Phase 3 upsert: a null result is *not* an error — bootstrap no
+            // longer creates the row, so first-time visitors land here without
+            // a Mongo doc yet. We synthesize the defaults and insert. The
+            // canonical id stays equal to input.userId in that case (no merge
+            // pointer to follow).
+            let doc = await this.resolveDocument(input.userId);
             if (!doc) {
-                throw new Error(`User with id "${input.userId}" not found`);
+                doc = await this.createUserForSession(input.userId);
             }
             const userId = doc.id;
 
@@ -1212,19 +1295,44 @@ export class UserService {
                 activity.totalDurationSeconds += activeSession.durationSeconds;
             }
 
-            // Derive context from request (IP/UA never stored)
-            const device = getDeviceCategory(userAgent);
-            const referrerDomain = extractReferrerDomain(referrer);
-            const country = getCountryFromIP(clientIP);
+            // Pull the visitor's earliest pre-hydration bootstrap event from
+            // ClickHouse so a crawler-then-browser sequence attributes to the
+            // crawler's first touch instead of the post-hydration browser
+            // fetch. Returns `[]` when CH is unavailable or no rows match
+            // — both collapse to "use post-hydration values," which is the
+            // pre-Phase-3 behaviour and matches the no-ClickHouse posture in
+            // PLAN-traffic-events.md.
+            const firstTouch = await this.fetchFirstTouchEvent(userId);
+
+            // Derive context from request (IP/UA never stored). The CH first-
+            // touch event takes precedence on every dimension it carries —
+            // these are stored as part of the user's traffic-acquisition
+            // origin, so the cookieless first impression is what we want
+            // recorded, not the post-hydration page-view that happens to
+            // reach `startSession` first.
+            const device = this.coerceDeviceCategory(firstTouch?.device) ?? getDeviceCategory(userAgent);
+            const referrerDomain = firstTouch?.referer
+                ? extractReferrerDomain(firstTouch.referer)
+                : extractReferrerDomain(referrer);
+            const country = firstTouch?.country ?? getCountryFromIP(clientIP);
             const screenSize = getScreenSizeCategory(screenWidth);
-            const searchKeyword = extractSearchKeyword(referrer);
+            const searchKeyword = firstTouch?.referer
+                ? extractSearchKeyword(firstTouch.referer)
+                : extractSearchKeyword(referrer);
 
             // Track country distribution
             if (country) {
                 activity.countryCounts[country] = (activity.countryCounts[country] || 0) + 1;
             }
 
-            // Create new session
+            // Create new session. Landing page and UTM also prefer the CH
+            // first-touch values (same rationale as device/country above —
+            // origin attribution should reflect the first impression, not
+            // the page that happened to fire startSession).
+            const utmFromFirstTouch = this.extractUtmFromTrafficEvent(firstTouch);
+            const sessionUtm = utmFromFirstTouch
+                ?? (utm && Object.values(utm).some(v => v) ? utm : null);
+            const sessionLandingPage = firstTouch?.path ?? landingPage ?? null;
             const newSession: IUserSession = {
                 startedAt: now,
                 endedAt: null,
@@ -1235,8 +1343,8 @@ export class UserService {
                 screenSize,
                 referrerDomain,
                 country,
-                utm: utm && Object.values(utm).some(v => v) ? utm : null,
-                landingPage: landingPage || null,
+                utm: sessionUtm,
+                landingPage: sessionLandingPage,
                 searchKeyword
             };
 
@@ -1260,7 +1368,7 @@ export class UserService {
                 } else {
                     activity.origin = {
                         referrerDomain,
-                        landingPage: landingPage || null,
+                        landingPage: sessionLandingPage,
                         country,
                         device,
                         utm: newSession.utm,
@@ -4536,6 +4644,100 @@ export class UserService {
      * The truncation limits (200 chars for source/medium/term/content,
      * 500 for campaign) protect the database from unbounded growth.
      */
+    /**
+     * Insert a fresh anonymous user for a session start.
+     *
+     * Phase 3 of the traffic-events split makes `startSession` the first
+     * Mongo write in the visitor lifecycle. When the resolved document is
+     * null (bootstrap no longer persists; this is a brand-new visitor or a
+     * cookie holder whose row hasn't been created yet) we synthesize the
+     * defaults that `getOrCreate` used to write at bootstrap and insert
+     * them. Format validation lives here so an invalid UUID can't slip
+     * past resolveDocument's silent null-on-missing path.
+     */
+    private async createUserForSession(userId: string): Promise<IUserDocument> {
+        if (!this.isValidUUID(userId)) {
+            throw new Error('Invalid UUID format. Must be a valid UUID v4.');
+        }
+        const now = new Date();
+        const fresh: Omit<IUserDocument, '_id'> = {
+            id: userId,
+            identityState: UserIdentityState.Anonymous,
+            identityVerifiedAt: null,
+            wallets: [],
+            preferences: {},
+            activity: {
+                firstSeen: now,
+                lastSeen: now,
+                pageViews: 0,
+                sessionsCount: 0,
+                totalDurationSeconds: 0,
+                sessions: [],
+                pageViewsByPath: {},
+                countryCounts: {},
+                origin: null
+            },
+            groups: [],
+            referral: null,
+            createdAt: now,
+            updatedAt: now
+        };
+        await this.collection.insertOne(fresh as any);
+        this.logger.info({ userId }, 'User created via session start');
+        return fresh as IUserDocument;
+    }
+
+    /**
+     * Fetch the visitor's earliest pre-hydration `bootstrap` event from
+     * ClickHouse, if any. Drives Phase 3's first-touch backfill on
+     * `startSession`. Returns `null` when ClickHouse is unavailable, the
+     * lookup fails, or no rows match — every caller falls back to the
+     * post-hydration session payload in that case.
+     */
+    private async fetchFirstTouchEvent(userId: string) {
+        if (!this.trafficService) {
+            return null;
+        }
+        const events = await this.trafficService.getEventsForUser(userId, {
+            eventTypes: ['bootstrap'],
+            limit: 1
+        });
+        return events[0] ?? null;
+    }
+
+    /**
+     * Narrow the loosely-typed `device` string from a ClickHouse traffic
+     * event row back to the `DeviceCategory` union the user document
+     * expects. Returns `undefined` when the value isn't one of the known
+     * categories so callers fall through to the post-hydration derivation.
+     */
+    private coerceDeviceCategory(value: string | undefined | null): DeviceCategory | undefined {
+        if (value === 'mobile' || value === 'tablet' || value === 'desktop' || value === 'unknown') {
+            return value;
+        }
+        return undefined;
+    }
+
+    /**
+     * Build an `IUtmParams` from a traffic event row, returning `null` when
+     * every UTM field is null. Mirrors the empty-utm collapse rule the
+     * service applies to post-hydration UTMs so a CH row with all-null
+     * UTMs doesn't displace a populated post-hydration set.
+     */
+    private extractUtmFromTrafficEvent(event: { utm_source: string | null; utm_medium: string | null; utm_campaign: string | null; utm_term: string | null; utm_content: string | null } | null | undefined): IUtmParams | null {
+        if (!event) {
+            return null;
+        }
+        const utm: IUtmParams = {
+            source: event.utm_source ?? undefined,
+            medium: event.utm_medium ?? undefined,
+            campaign: event.utm_campaign ?? undefined,
+            term: event.utm_term ?? undefined,
+            content: event.utm_content ?? undefined
+        };
+        return Object.values(utm).some(v => v !== undefined) ? utm : null;
+    }
+
     private extractUtmParams(raw: unknown): IUtmParams | undefined {
         if (!raw || typeof raw !== 'object') {
             return undefined;

--- a/src/frontend/middleware.ts
+++ b/src/frontend/middleware.ts
@@ -30,24 +30,143 @@ const USER_ID_COOKIE_MAX_AGE_SECONDS = 31536000;
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /**
+ * Cap on the JSON body forwarded to the backend bootstrap endpoint. The
+ * payload only carries small derived signals (landing path, UTM params,
+ * `document.referrer`) so 1 KB is generous; the cap exists to defend
+ * against a malicious or pathological URL that could otherwise inflate
+ * the request indefinitely.
+ */
+const BOOTSTRAP_BODY_BYTE_CAP = 1024;
+
+/**
+ * Headers we want the backend to see on `POST /api/user/bootstrap` so the
+ * Phase 1 traffic-event row carries real visitor context instead of the
+ * Docker bridge IP and Node default User-Agent. Order matches the columns
+ * in the `traffic_events` ClickHouse table.
+ */
+const FORWARDED_HEADERS = [
+    'user-agent',
+    'referer',
+    'accept-language',
+    'sec-ch-ua',
+    'sec-ch-ua-mobile',
+    'sec-ch-ua-platform',
+    'sec-fetch-dest',
+    'sec-fetch-mode',
+    'sec-fetch-site'
+] as const;
+
+/** UTM keys we accept from the URL. Anything else is dropped. */
+const UTM_KEYS = ['source', 'medium', 'campaign', 'term', 'content'] as const;
+
+/**
+ * Build the JSON body for the backend bootstrap call.
+ *
+ * Carries the derived per-request context that the backend cannot see by
+ * inspecting the inbound request alone:
+ *   - `landingPath`  the path the visitor actually requested (the bootstrap
+ *     fetch itself targets `/api/user/bootstrap`, which would otherwise be
+ *     the only path the backend sees);
+ *   - `utm` UTM params parsed from the request URL's query string;
+ *   - `originalReferrer` value preserved by the legacy-redirect path in
+ *     `_original_ref` cookie when the visitor arrived via an external link.
+ *
+ * The body is capped at `BOOTSTRAP_BODY_BYTE_CAP` bytes. Oversized payloads
+ * fall back to an empty object so the backend bootstrap still succeeds.
+ */
+function buildBootstrapBody(request: NextRequest): string {
+    const utm: Record<string, string> = {};
+    for (const key of UTM_KEYS) {
+        const value = request.nextUrl.searchParams.get(`utm_${key}`);
+        if (value) {
+            utm[key] = value;
+        }
+    }
+
+    const originalReferrer = request.cookies.get(ORIGINAL_REFERRER_COOKIE)?.value;
+
+    const payload: Record<string, unknown> = {
+        landingPath: request.nextUrl.pathname
+    };
+    if (Object.keys(utm).length > 0) {
+        payload.utm = utm;
+    }
+    if (originalReferrer) {
+        payload.originalReferrer = originalReferrer;
+    }
+
+    const serialized = JSON.stringify(payload);
+    // The middleware runs on Next.js's Edge runtime where `Buffer` is not
+    // guaranteed; `TextEncoder` is a Web-standard API and gives us the
+    // UTF-8 byte length directly without a Node-only dependency.
+    if (new TextEncoder().encode(serialized).byteLength > BOOTSTRAP_BODY_BYTE_CAP) {
+        return '{}';
+    }
+    return serialized;
+}
+
+/**
+ * Forward selected request headers to the backend bootstrap call.
+ *
+ * The middleware runs behind the public ingress, so by the time a request
+ * reaches us the original client IP and user-agent are visible only on
+ * inbound headers — not on the server-to-server fetch we're about to make.
+ * Without this forwarding the backend would see the Docker bridge IP and
+ * `node-fetch`'s default UA on every event.
+ *
+ * `X-Forwarded-For` is appended to (or seeded from) the inbound chain so
+ * the backend's `getClientIP` helper still reads the original client at
+ * the head of the list.
+ */
+function buildForwardedHeaders(request: NextRequest): Record<string, string> {
+    const headers: Record<string, string> = {
+        'Content-Type': 'application/json'
+    };
+
+    for (const name of FORWARDED_HEADERS) {
+        const value = request.headers.get(name);
+        if (value) {
+            headers[name] = value;
+        }
+    }
+
+    // Preserve the original client IP at the head of X-Forwarded-For so
+    // the backend's getClientIP reads through to the real visitor instead
+    // of the Docker bridge.
+    const inboundForwardedFor = request.headers.get('x-forwarded-for');
+    const directIp = request.headers.get('x-real-ip');
+    if (inboundForwardedFor) {
+        headers['x-forwarded-for'] = inboundForwardedFor;
+    } else if (directIp) {
+        headers['x-forwarded-for'] = directIp;
+    }
+
+    return headers;
+}
+
+/**
  * Mint the identity cookie via the backend's bootstrap endpoint.
  *
  * Resolves to a valid UUID string when the bootstrap call succeeds. Returns
  * null on any failure — middleware must never block page loads on a backend
  * outage; the client-side `UserIdentityProvider` retries on mount.
  *
- * The fetch is server-to-server (within the same Docker network), so the
- * empty cookie jar is expected and the backend mints a fresh UUID. We
+ * The fetch is server-to-server (within the same Docker network). We
  * intentionally don't forward the inbound request's cookies — there's
- * nothing useful in them when this code path runs.
+ * nothing useful in them when this code path runs (the bootstrap fires
+ * only when the identity cookie is absent). We *do* forward the visitor
+ * context the backend needs to record a useful `traffic_events` row:
+ * client headers (UA, Referer, Sec-CH-UA*, Sec-Fetch-*), the original
+ * client IP via `X-Forwarded-For`, and a small JSON body with the
+ * landing path, UTM params, and `_original_ref` cookie.
  */
-async function bootstrapIdentity(): Promise<string | null> {
+async function bootstrapIdentity(request: NextRequest): Promise<string | null> {
     const backendUrl = process.env.SITE_BACKEND || 'http://localhost:4000';
     try {
         const response = await fetch(`${backendUrl}/api/user/bootstrap`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: '{}',
+            headers: buildForwardedHeaders(request),
+            body: buildBootstrapBody(request),
             // Prevent edge runtime from caching identity bootstrap.
             cache: 'no-store',
             signal: AbortSignal.timeout(3000)
@@ -193,7 +312,7 @@ export async function middleware(request: NextRequest) {
 
     let injectedUserId: string | null = null;
     if (needsBootstrap) {
-        injectedUserId = await bootstrapIdentity();
+        injectedUserId = await bootstrapIdentity(request);
         if (injectedUserId) {
             // Mutate the request's cookie jar so server components running
             // in the same render tree see the cookie via `next/headers`.

--- a/src/frontend/middleware.ts
+++ b/src/frontend/middleware.ts
@@ -114,9 +114,13 @@ function buildBootstrapBody(request: NextRequest): string {
  * Without this forwarding the backend would see the Docker bridge IP and
  * `node-fetch`'s default UA on every event.
  *
- * `X-Forwarded-For` is appended to (or seeded from) the inbound chain so
- * the backend's `getClientIP` helper still reads the original client at
- * the head of the list.
+ * `X-Forwarded-For` is preserved verbatim from the inbound chain (or
+ * seeded from `X-Real-IP` when no chain exists) so the backend's
+ * `getClientIP` helper still reads the original client at the head of
+ * the list. We deliberately do NOT append our own hop: the next hop is
+ * an in-cluster server-to-server fetch and adding the Docker bridge IP
+ * would shift the original client out of the head position, defeating
+ * the helper.
  */
 function buildForwardedHeaders(request: NextRequest): Record<string, string> {
     const headers: Record<string, string> = {


### PR DESCRIPTION
## Summary

Bootstrap is now Mongo-read-only; the first identity write happens in `startSession`. Cookieless traffic — search-engine crawlers, link unfurlers, uptime probes — gets a cookie and a ClickHouse `traffic_events` row, but no longer pollutes the `users` collection. Tracks Phases 1, 2, and 3 of [PLAN-traffic-events.md](https://github.com/delphian/tronrelic-ops/blob/main/PLAN-traffic-events.md).

## Why this is one PR

The three phases are load-bearing and interdependent. Phase 1 supplies the headers, Phase 2 stops the Mongo write at bootstrap, Phase 3 makes `startSession` the new persistence point. Shipping any subset alone either loses visitor context for the CH row or leaves the orphan-row bug unfixed. Phase 0 (PR #208) was split off so the ClickHouse infra could be production-tested before this fix.

## Phase 1 — middleware header forwarding

`bootstrapIdentity()` in `src/frontend/middleware.ts` now forwards the inbound visitor's `User-Agent`, `Referer`, `Accept-Language`, `Sec-CH-UA*`, `Sec-Fetch-*` headers and seeds `X-Forwarded-For`, plus a JSON body (`landingPath`, `utm`, `originalReferrer` from the legacy-redirect cookie) capped at 1 KB. Uses `TextEncoder` for byte-length so the middleware stays Edge-runtime safe — no `Buffer` dependency. Without this the backend sees the Docker bridge IP and node-fetch's default UA on every event.

## Phase 2 — decouple bootstrap from Mongo persistence

`UserController.bootstrap` now reads via `getById` (no creation), synthesizes an ephemeral anonymous `IUser` via the new `UserService.buildEphemeralUser` when no row exists, refreshes the HttpOnly cookie, and emits one ClickHouse `bootstrap` event. A new `buildTrafficEvent` helper in `traffic.service.ts` centralizes Express-request-to-ITrafficEvent mapping so bootstrap and session-start emit identical shapes. `GET /api/user/:id` returns 404 when no row exists for the cookie-resolved UUID — `getServerUser` already maps 404 onto the unauthenticated SSR shell, and `userContextMiddleware` already proceeds gracefully with `req.user` undefined.

## Phase 3 — startSession upsert + ClickHouse first-touch backfill

`UserService.startSession` is now the first Mongo write in the visitor lifecycle. When `resolveDocument` returns null, `createUserForSession` inserts the anonymous defaults. The new `setTrafficService` injection lets `startSession` query ClickHouse for the visitor's earliest pre-hydration `bootstrap` event by candidate UUID and prefer its `device`, `country`, referrer-derived `referrerDomain` and `searchKeyword`, landing `path`, and `utm_*` over the post-hydration session payload — so a crawler-then-browser sequence attributes to the cookieless first impression instead of the post-hydration page-view. Controller emits a `session_start` CH event alongside the upsert. Falls back gracefully when ClickHouse is unavailable or no first-touch row exists.

## Verification

- `tsc --noEmit` clean.
- 863 tests pass (up from 857).
- New coverage: orphan-row fix and read-without-write in `bootstrap.controller.test.ts`; upsert + first-touch backfill + two fallback branches in new `start-session.test.ts`.
- User module README and `PLAN-traffic-events.md` updated to reflect the new bootstrap=read-only / startSession=first-write contract.

## Out of scope (deferred to later phases)

- Phase 4 sweep of the other write endpoints (`connectWallet`, `linkWallet`, etc.) — they all currently call `resolveDocument` which throws on null; they need a centralized `userService.ensureExists(id)` and a security review since "this endpoint requires a validated cookie before any write" is the contract.
- Phase 5 admin UI split (Users vs Traffic).
- Phase 6 prune of empty Mongo rows already produced by the bug.
- `bot_class` derivation: column stays `Nullable` and always-null for now; the open question (regex vs library) is deferred but rows are forward-compatible — a future classifier can backfill via `ALTER TABLE ... UPDATE`.