### PR TITLE
Classify traffic_events.bot_class via isbot + explicit rule set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "http-status-codes": "^2.3.0",
         "ioredis": "^5.4.1",
         "ipaddr.js": "^2.2.0",
+        "isbot": "^5.1.39",
         "js-sha3": "^0.8.0",
         "js-yaml": "^4.1.1",
         "lucide": "^0.555.0",
@@ -6661,6 +6662,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/isbot": {
+      "version": "5.1.39",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.39.tgz",
+      "integrity": "sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "dev": true,
@@ -12735,7 +12745,7 @@
     },
     "src/plugins/trp-forum/packages/types": {
       "name": "@delphian/trp-forum-types",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "http-status-codes": "^2.3.0",
     "ioredis": "^5.4.1",
     "ipaddr.js": "^2.2.0",
+    "isbot": "^5.1.39",
     "js-sha3": "^0.8.0",
     "js-yaml": "^4.1.1",
     "lucide": "^0.555.0",

--- a/src/backend/modules/user/README.md
+++ b/src/backend/modules/user/README.md
@@ -183,6 +183,7 @@ modules/user/
 │   ├── geo.service.ts             # IP → country, referrer parsing, device derivation
 │   ├── gsc.service.ts             # Google Search Console keyword integration
 │   ├── traffic.service.ts         # ClickHouse traffic_events sibling (PLAN-traffic-events.md)
+│   ├── bot-classifier.ts          # User-Agent → BotClass enum (powers traffic_events.bot_class)
 │   ├── user.service.ts            # Business logic (CRUD, wallet linking, sessions, caching)
 │   ├── user.errors.ts             # Service-layer error classes
 │   ├── user-group.service.ts      # Group definition CRUD + membership API

--- a/src/backend/modules/user/__tests__/bot-classifier.test.ts
+++ b/src/backend/modules/user/__tests__/bot-classifier.test.ts
@@ -1,0 +1,138 @@
+/// <reference types="vitest" />
+
+/**
+ * Tests for the User-Agent classifier that populates
+ * `traffic_events.bot_class`.
+ *
+ * Each `BotClass` value gets coverage from at least two real-world UA
+ * strings so a regression in any single fragment shows up. Edge cases
+ * (missing UA, length-clamp, casing, isbot fallback) live in their
+ * own describe block so adding new categories doesn't push them down
+ * the file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { classifyUserAgent } from '../services/bot-classifier.js';
+
+describe('classifyUserAgent', () => {
+    describe('search_engine', () => {
+        it.each([
+            ['Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'],
+            ['Mozilla/5.0 (compatible; Googlebot-Image/1.0)'],
+            ['Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'],
+            ['DuckDuckBot/1.1; (+http://duckduckgo.com/duckduckbot.html)'],
+            ['Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)'],
+            ['Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)'],
+            ['Sogou web spider/4.0(+http://www.sogou.com/docs/help/webmasters.htm#07)'],
+            ['Mozilla/5.0 (compatible; Applebot/0.1; +http://www.apple.com/go/applebot)']
+        ])('classifies %p as search_engine', (ua) => {
+            expect(classifyUserAgent(ua)).toBe('search_engine');
+        });
+    });
+
+    describe('ai_crawler', () => {
+        it.each([
+            ['Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.2; +https://openai.com/gptbot'],
+            ['Mozilla/5.0 (compatible; ChatGPT-User/1.0; +https://openai.com/bot)'],
+            ['Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)'],
+            ['Mozilla/5.0 (compatible; PerplexityBot/1.0; +https://docs.perplexity.ai/docs/perplexity-bot)'],
+            ['CCBot/2.0 (https://commoncrawl.org/faq/)'],
+            ['Mozilla/5.0 (compatible; Bytespider; spider-feedback@bytedance.com)'],
+            ['anthropic-ai']
+        ])('classifies %p as ai_crawler', (ua) => {
+            expect(classifyUserAgent(ua)).toBe('ai_crawler');
+        });
+
+        it('classifies Google-Extended as ai_crawler even when UA also contains Googlebot', () => {
+            // Google publishes Google-Extended as a separate opt-out token
+            // for Gemini training. Some crawl variants advertise both
+            // tokens in the same UA; the operator-meaningful classification
+            // is "AI training crawl", not "search ranking crawl".
+            const ua = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html) Google-Extended';
+            expect(classifyUserAgent(ua)).toBe('ai_crawler');
+        });
+    });
+
+    describe('social_unfurler', () => {
+        it.each([
+            ['Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)'],
+            ['Twitterbot/1.0'],
+            ['facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'],
+            ['LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)'],
+            ['Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)'],
+            ['TelegramBot (like TwitterBot)'],
+            ['WhatsApp/2.23.20.0 A']
+        ])('classifies %p as social_unfurler', (ua) => {
+            expect(classifyUserAgent(ua)).toBe('social_unfurler');
+        });
+    });
+
+    describe('uptime_probe', () => {
+        it.each([
+            ['Mozilla/5.0 (compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)'],
+            ['Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)'],
+            ['Mozilla/5.0 (compatible; StatusCake)'],
+            ['Better Uptime Bot Manifold/1.0 (https://betteruptime.com)'],
+            ['Datadog Agent/7.0']
+        ])('classifies %p as uptime_probe', (ua) => {
+            expect(classifyUserAgent(ua)).toBe('uptime_probe');
+        });
+    });
+
+    describe('human', () => {
+        it.each([
+            ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'],
+            ['Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15'],
+            ['Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1'],
+            ['Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0']
+        ])('classifies %p as human', (ua) => {
+            expect(classifyUserAgent(ua)).toBe('human');
+        });
+    });
+
+    describe('bot_other (isbot fallback and missing UA)', () => {
+        it('classifies a generic crawler UA as bot_other', () => {
+            // Some random crawler `isbot` knows about but we don't track
+            // explicitly. Picking one with no overlap with the explicit
+            // categories so the test stays stable as new fragments land.
+            expect(classifyUserAgent('AhrefsBot/7.0 (+http://ahrefs.com/robot/)')).toBe('bot_other');
+        });
+
+        it('classifies python-requests as bot_other', () => {
+            expect(classifyUserAgent('python-requests/2.31.0')).toBe('bot_other');
+        });
+
+        it('returns bot_other for null UA', () => {
+            expect(classifyUserAgent(null)).toBe('bot_other');
+        });
+
+        it('returns bot_other for undefined UA', () => {
+            expect(classifyUserAgent(undefined)).toBe('bot_other');
+        });
+
+        it('returns bot_other for empty string UA', () => {
+            expect(classifyUserAgent('')).toBe('bot_other');
+        });
+    });
+
+    describe('robustness', () => {
+        it('matches case-insensitively', () => {
+            expect(classifyUserAgent('GOOGLEBOT/2.1')).toBe('search_engine');
+            expect(classifyUserAgent('GptBot/1.0')).toBe('ai_crawler');
+        });
+
+        it('handles UA strings longer than the 500-char cap without throwing', () => {
+            // Pad past the cap with garbage that doesn't match any rule;
+            // the prefix carries the matching fragment.
+            const ua = 'Twitterbot/1.0' + ' '.repeat(600) + 'Googlebot';
+            expect(classifyUserAgent(ua)).toBe('social_unfurler');
+        });
+
+        it('returns the first explicit-rule match when a UA contains multiple fragments', () => {
+            // ai_crawler runs before search_engine in the rule order,
+            // so a UA containing both `googlebot` and `gptbot` resolves
+            // to ai_crawler. This documents the ordering choice.
+            expect(classifyUserAgent('GPTBot/1.0 Googlebot/2.1')).toBe('ai_crawler');
+        });
+    });
+});

--- a/src/backend/modules/user/services/bot-classifier.ts
+++ b/src/backend/modules/user/services/bot-classifier.ts
@@ -1,0 +1,202 @@
+/**
+ * Bot classifier for ClickHouse `traffic_events.bot_class`.
+ *
+ * Hybrid approach: `isbot` provides the boolean spine (handles the long
+ * tail of generic crawlers and stays current as new bots emerge), and
+ * a small explicit rule set on top maps the few User-Agent families we
+ * actually want to chart in the Phase 5 admin UI to a stable enum.
+ *
+ * ## Why a hybrid
+ *
+ * Pure `isbot` would tell us "47% of traffic is bots" — useless for an
+ * analytics dashboard. Pure regex would rot, since maintaining a
+ * comprehensive UA database is a full-time job and we'd still miss the
+ * long tail. The hybrid keeps the maintained library for breadth and
+ * adds explicit rules only for the categories whose rate of change
+ * matters to a TRON analytics product (search reach, AI training, link
+ * unfurls, monitoring).
+ *
+ * ## Categories
+ *
+ * - `human` — `isbot` returns false (the default for real visitors).
+ * - `search_engine` — Googlebot, Bingbot, DuckDuckBot, Yandex, Baidu,
+ *   Sogou, Naver, Applebot. Drives organic SEO surface area.
+ * - `ai_crawler` — GPTBot, ClaudeBot, PerplexityBot, Google-Extended,
+ *   CCBot, anthropic-ai. The fastest-growing class in 2026 and the one
+ *   most analytically interesting (training-set ingestion).
+ * - `social_unfurler` — Slackbot, Twitterbot, facebookexternalhit,
+ *   LinkedInBot, Discordbot, TelegramBot, WhatsApp. First-touch link
+ *   previews; correlates with social distribution velocity.
+ * - `uptime_probe` — UptimeRobot, Pingdom, StatusCake, BetterUptime,
+ *   New Relic synthetics. Synthetic monitoring; high cardinality with
+ *   low analytic value, broken out so dashboards can subtract it.
+ * - `bot_other` — `isbot` returned true but no explicit rule matched.
+ *   Captures the long tail without forcing it into a misleading family.
+ *
+ * Keep the enum small. Industry consensus across analytics platforms
+ * (Plausible, Fathom, Cloudflare Web Analytics) lands in this 5-6
+ * category range — beyond that dashboards become illegible and the
+ * classifier drifts toward fingerprinting.
+ *
+ * ## Design constraints
+ *
+ * - **Server-side, write-time.** Classification runs once per row inside
+ *   `buildTrafficEvent`. Never compute on read; ClickHouse can't run
+ *   `isbot` and we don't want a UDF.
+ * - **Family-level, not version-level.** Store `search_engine`, not
+ *   `googlebot-mobile-image`. Drilldowns happen via the raw
+ *   `user_agent` column, kept on every row for exactly this reason.
+ * - **Order matters.** The explicit rules run before the `isbot`
+ *   fallback so a UA that matches both an explicit family and the
+ *   library's bot list gets the more specific label.
+ * - **AI-crawler rules run before search-engine rules.** Google-Extended
+ *   includes the substring `googlebot` in some UA strings; it must be
+ *   tagged `ai_crawler` first, since the operator-distinguishing
+ *   intent (training-data ingest vs search ranking) is what the
+ *   dashboard cares about.
+ * - **No ReDoS surface.** All matching uses `String.prototype.includes`
+ *   on a lowercased, length-clamped UA. No user-controlled regex.
+ */
+
+import { isbot } from 'isbot';
+
+/**
+ * Closed enum written to `traffic_events.bot_class`.
+ *
+ * Stored as `LowCardinality(Nullable(String))`. `null` means "not yet
+ * classified" — pre-classifier rows from Phases 0-4 keep that value
+ * forever (forward-only by project convention; no backfill planned).
+ */
+export type BotClass =
+    | 'human'
+    | 'search_engine'
+    | 'ai_crawler'
+    | 'social_unfurler'
+    | 'uptime_probe'
+    | 'bot_other';
+
+/**
+ * UA fragments per explicit category, lowercased. Match is `includes`,
+ * so partial matches are intentional (e.g. `'googlebot'` covers
+ * `Googlebot`, `Googlebot-Image`, `Googlebot-Mobile`).
+ *
+ * Rule list iterates in declaration order. `ai_crawler` precedes
+ * `search_engine` because Google-Extended advertises itself with a
+ * UA that contains both `Googlebot` and `Google-Extended`; tagging
+ * it as `ai_crawler` matches operator intent (Gemini training crawl
+ * vs search-ranking crawl) and is what the Phase 5 dashboard will
+ * surface as a distinct category.
+ */
+const RULES: ReadonlyArray<{ class: BotClass; fragments: readonly string[] }> = [
+    {
+        class: 'ai_crawler',
+        fragments: [
+            'gptbot',
+            'chatgpt-user',
+            'oai-searchbot',
+            'claudebot',
+            'claude-web',
+            'anthropic-ai',
+            'perplexitybot',
+            'google-extended',
+            'ccbot',
+            'bytespider',
+            'cohere-ai',
+            'meta-externalagent'
+        ]
+    },
+    {
+        class: 'search_engine',
+        fragments: [
+            'googlebot',
+            'bingbot',
+            'duckduckbot',
+            'yandexbot',
+            'yandex.com/bots',
+            'baiduspider',
+            'sogou web spider',
+            'naverbot',
+            'yeti',
+            'applebot',
+            'petalbot',
+            'seznambot',
+            'mojeekbot'
+        ]
+    },
+    {
+        class: 'social_unfurler',
+        fragments: [
+            'slackbot',
+            'slack-imgproxy',
+            'twitterbot',
+            'facebookexternalhit',
+            'facebookcatalog',
+            'linkedinbot',
+            'discordbot',
+            'telegrambot',
+            'whatsapp',
+            'pinterestbot',
+            'redditbot',
+            'embedly',
+            'skypeuripreview'
+        ]
+    },
+    {
+        class: 'uptime_probe',
+        fragments: [
+            'uptimerobot',
+            'pingdom',
+            'statuscake',
+            'betteruptime',
+            'better-uptime',
+            'newrelicpinger',
+            'datadog',
+            'site24x7',
+            'hetrixtools',
+            'updown.io'
+        ]
+    }
+];
+
+/**
+ * Cap UA length before lowercasing/matching. Real browsers stay under
+ * ~250 chars; anything longer is either misconfigured or hostile, and
+ * we don't want pathological inputs driving CPU on the request path.
+ * Matches `getDeviceCategory`'s 500-char cap pattern.
+ */
+const MAX_UA_LENGTH = 500;
+
+/**
+ * Classify a User-Agent header value into one of the six `BotClass`
+ * buckets.
+ *
+ * `null` / `undefined` / empty string is treated as `bot_other` rather
+ * than `human` — a request without a UA in 2026 is overwhelmingly
+ * non-browser traffic (curl scripts, hand-rolled HTTP clients, broken
+ * proxies). Calling it `human` would inflate human metrics with the
+ * exact noise this column exists to filter out.
+ *
+ * @param userAgent - Raw `User-Agent` header value, or null/undefined.
+ * @returns One of the six `BotClass` enum values. Never null.
+ */
+export function classifyUserAgent(userAgent: string | null | undefined): BotClass {
+    if (!userAgent) {
+        return 'bot_other';
+    }
+
+    const ua = userAgent.slice(0, MAX_UA_LENGTH).toLowerCase();
+
+    for (const rule of RULES) {
+        for (const fragment of rule.fragments) {
+            if (ua.includes(fragment)) {
+                return rule.class;
+            }
+        }
+    }
+
+    if (isbot(userAgent)) {
+        return 'bot_other';
+    }
+
+    return 'human';
+}

--- a/src/backend/modules/user/services/bot-classifier.ts
+++ b/src/backend/modules/user/services/bot-classifier.ts
@@ -194,7 +194,7 @@ export function classifyUserAgent(userAgent: string | null | undefined): BotClas
         }
     }
 
-    if (isbot(userAgent)) {
+    if (isbot(ua)) {
         return 'bot_other';
     }
 

--- a/src/backend/modules/user/services/index.ts
+++ b/src/backend/modules/user/services/index.ts
@@ -13,6 +13,8 @@ export type {
     IGetEventsForUserOptions,
     ITrafficEventBuilderInputs
 } from './traffic.service.js';
+export { classifyUserAgent } from './bot-classifier.js';
+export type { BotClass } from './bot-classifier.js';
 export type { UserFilterType } from '@/types';
 export {
     initGeoIP,

--- a/src/backend/modules/user/services/traffic.service.ts
+++ b/src/backend/modules/user/services/traffic.service.ts
@@ -41,7 +41,7 @@
 import type { Request } from 'express';
 import type { IClickHouseService, ISystemLogService } from '@/types';
 import { getClientIP, getCountryFromIP, getDeviceCategory } from './geo.service.js';
-import { classifyUserAgent } from './bot-classifier.js';
+import { classifyUserAgent, type BotClass } from './bot-classifier.js';
 
 /**
  * Categorical event types written to `traffic_events.event_type`.
@@ -83,8 +83,13 @@ export interface ITrafficEvent {
     country: string | null;
     /** `'desktop' | 'mobile' | 'tablet' | 'bot' | 'unknown'`. */
     device: string;
-    /** `'crawler' | 'monitoring' | ...` when classified, else null. */
-    bot_class: string | null;
+    /**
+     * Closed enum produced by `classifyUserAgent` at write time. `null`
+     * is reserved for legacy rows written before the classifier landed
+     * (Phases 0-4 of the traffic-events split) and for ClickHouse reads
+     * that materialize those rows back through `getEventsForUser`.
+     */
+    bot_class: BotClass | null;
 
     utm_source: string | null;
     utm_medium: string | null;

--- a/src/backend/modules/user/services/traffic.service.ts
+++ b/src/backend/modules/user/services/traffic.service.ts
@@ -41,6 +41,7 @@
 import type { Request } from 'express';
 import type { IClickHouseService, ISystemLogService } from '@/types';
 import { getClientIP, getCountryFromIP, getDeviceCategory } from './geo.service.js';
+import { classifyUserAgent } from './bot-classifier.js';
 
 /**
  * Categorical event types written to `traffic_events.event_type`.
@@ -350,11 +351,7 @@ export function buildTrafficEvent(
 
         country: getCountryFromIP(getClientIP({ ip: req.ip, headers })),
         device: getDeviceCategory(userAgent),
-        // bot_class deferred — see PLAN-traffic-events.md "Open Questions".
-        // Until the library-vs-regex decision lands, every row carries
-        // null. Future Phase 4+ work can backfill via a CH `ALTER TABLE
-        // ... UPDATE` over recent rows once the classifier exists.
-        bot_class: null,
+        bot_class: classifyUserAgent(userAgent),
 
         utm_source: utm.source ?? null,
         utm_medium: utm.medium ?? null,


### PR DESCRIPTION
## Summary

Hybrid User-Agent classifier (`src/backend/modules/user/services/bot-classifier.ts`) populates the previously-null `traffic_events.bot_class` column so the Phase 5 admin UI can chart real categories instead of a boolean. `isbot` (npm) provides the boolean spine; an explicit fragment-matching rule set on top maps to a closed enum: `human | search_engine | ai_crawler | social_unfurler | uptime_probe | bot_other`.

## Why hybrid

Pure `isbot` would tell us "47% of traffic is bots" — useless for an analytics dashboard. Pure regex would rot, since maintaining a comprehensive UA database is a full-time job and we'd still miss the long tail. The hybrid keeps the maintained library for breadth and adds explicit rules only for the categories whose rate of change matters to a TRON analytics product (search reach, AI training, link unfurls, monitoring).

## Notes

- `ai_crawler` runs before `search_engine` in the rule order so Google-Extended (Gemini training) tags as `ai_crawler` even when its UA also contains the `Googlebot` fragment — operator intent is "training-data ingest", not "search ranking".
- Wired into `buildTrafficEvent` so both `bootstrap` and `session_start` events get classified at write time. Server-side, write-time only — never compute on read.
- Forward-only: pre-classifier rows from Phases 0-4 keep `bot_class: null`. The column is `Nullable(String)` already so no schema change.
- Closes the `bot_class` open question in `PLAN-traffic-events.md` (the last unresolved Phase 5 prerequisite).
- 40 new unit tests; 232/232 user-module tests pass; `tsc --noEmit` clean.