### PR TITLE
Phase 5 traffic-events admin UI scaffold

### DIFF
--- a/src/backend/modules/user/README.md
+++ b/src/backend/modules/user/README.md
@@ -172,7 +172,9 @@ modules/user/
 │   ├── user.controller.ts         # Request handlers with cookie validation
 │   ├── user.routes.ts             # Public, profile, and admin router factories
 │   ├── user-group.controller.ts   # Group membership and definition handlers
-│   └── user-group.routes.ts       # Admin group router factory
+│   ├── user-group.routes.ts       # Admin group router factory
+│   ├── traffic.controller.ts      # ClickHouse traffic_events admin reads (PLAN-traffic-events.md)
+│   └── traffic.routes.ts          # Admin traffic router factory
 ├── database/
 │   ├── index.ts                   # Barrel exports
 │   ├── IUserDocument.ts           # MongoDB document interface for users
@@ -1067,6 +1069,30 @@ Response: { "userIds": ["uuid1", "uuid2", ...], "total": number }
 
 Paginated user-id list. `limit` defaults to 100, ceiling 500. Excludes merged tombstones.
 
+**Traffic admin endpoints.** The admin traffic router is mounted at `/api/admin/users/traffic` (before the `/:id` user routes so its specific paths win) and exposes aggregate reads against the ClickHouse `traffic_events` table tracked in `PLAN-traffic-events.md`. Endpoints accept a `sinceHours` query param (default `24`, ceiling `720` = 30 days) and `limit` for the top-N reads (default `20`, ceiling `200`):
+
+| Endpoint | Returns |
+|----------|---------|
+| `GET /api/admin/users/traffic/summary` | Row counts grouped by `bot_class` over the lookback window. NULL is preserved as a distinct bucket so operators see classifier coverage decay. Response includes `total` and `clickhouseEnabled`. |
+| `GET /api/admin/users/traffic/top-paths` | Most-hit landing paths over the window (NULL excluded). |
+| `GET /api/admin/users/traffic/top-countries` | Most-active ISO-3166 alpha-2 countries (NULL excluded). |
+| `GET /api/admin/users/traffic/bot-other-samples` | Most-frequent UAs for `bot_class = 'bot_other'` only — the operator's feedback loop on classifier coverage. UAs that recur here are candidates for explicit rules in `bot-classifier.ts`. |
+
+The per-user history endpoint lives on the user admin router so it composes with the cookie-resolved UUID:
+
+```
+GET /api/admin/users/:id/traffic-history?limit=50
+
+Response: {
+    "userId": string,
+    "limit": number,
+    "events": ITrafficEvent[],   // oldest first
+    "clickhouseEnabled": boolean
+}
+```
+
+The endpoint reads ClickHouse directly by `candidate_uid`, so it works for cookie holders that never advanced past the ephemeral-user state and have no Mongo `users` row — exactly the case Phase 5 admins use it to investigate. When ClickHouse is unavailable, every traffic endpoint returns `[]` (or zero counts) rather than failing the request; admins see the `clickhouseEnabled: false` flag and the dashboard surfaces a notice.
+
 ## Admin UI
 
 The admin dashboard at `/system/users` provides:
@@ -1077,6 +1103,7 @@ The admin dashboard at `/system/users` provides:
 - **User details** - View linked wallets (with primary indicator), preferences, activity history, and current group memberships
 - **Group membership editor** - "Manage Groups" action on the expanded user row opens a checkbox list of all defined groups; ticking and saving calls `PUT /api/admin/users/:id/groups`. This is the operator path for promoting a user into the reserved `admin` group
 - **Group members audit view** - The Groups tab exposes a per-row "Members" action that lists every user currently in a group, backed by `GET /api/admin/users/groups/:id/members`. Available for system groups too (the `admin` row is the canonical use case)
+- **Traffic dashboard** - The Traffic tab surfaces the ClickHouse `traffic_events` aggregates over a 1h/24h/7d/30d lookback window: bot-class breakdown (the headline panel), `bot_other` UA samples (the classifier-gap diagnostic), and top landing paths and countries. Backed by `/api/admin/users/traffic/*`. See `PLAN-traffic-events.md` for the phased rollout
 
 ## Usage Examples
 

--- a/src/backend/modules/user/UserModule.ts
+++ b/src/backend/modules/user/UserModule.ts
@@ -34,8 +34,10 @@ import { UserGroupService } from './services/user-group.service.js';
 import { initGeoIP } from './services/geo.service.js';
 import { UserController } from './api/user.controller.js';
 import { UserGroupController } from './api/user-group.controller.js';
+import { TrafficController } from './api/traffic.controller.js';
 import { createUserRouter, createAdminUserRouter, createProfileRouter } from './api/user.routes.js';
 import { createAdminUserGroupRouter } from './api/user-group.routes.js';
+import { createAdminTrafficRouter } from './api/traffic.routes.js';
 import { requireAdmin } from '../../api/middleware/admin-auth.js';
 
 /**
@@ -170,6 +172,7 @@ export class UserModule implements IModule<IUserModuleDependencies> {
     private userGroupService!: UserGroupService;
     private controller!: UserController;
     private groupController!: UserGroupController;
+    private trafficController!: TrafficController;
 
     /**
      * Logger instance for this module.
@@ -265,6 +268,10 @@ export class UserModule implements IModule<IUserModuleDependencies> {
         // Create group controller with singleton service
         this.groupController = new UserGroupController(this.userGroupService, this.logger);
 
+        // Create traffic controller for the Phase 5 admin dashboard.
+        // Reads ClickHouse `traffic_events` aggregates and per-user history.
+        this.trafficController = new TrafficController(this.trafficService, this.logger);
+
         this.logger.info('User module initialized');
     }
 
@@ -326,12 +333,17 @@ export class UserModule implements IModule<IUserModuleDependencies> {
 
         // Create and mount admin router (IoC - module attaches itself to app)
         // Apply requireAdmin middleware to all admin routes.
-        // Note: the user-groups router is mounted FIRST under the same prefix
-        // so its specific paths (/groups, /groups/:id) win over /:id, which
-        // would otherwise treat 'groups' as a user UUID.
+        // Note: the user-groups and traffic routers are mounted FIRST under
+        // the same prefix so their specific paths (/groups/*, /traffic/*)
+        // win over /:id, which would otherwise treat 'groups' or 'traffic'
+        // as a user UUID.
         const adminGroupRouter = createAdminUserGroupRouter(this.groupController);
         this.app.use('/api/admin/users/groups', requireAdmin, adminGroupRouter);
         this.logger.info('Admin user-groups router mounted at /api/admin/users/groups');
+
+        const adminTrafficRouter = createAdminTrafficRouter(this.trafficController);
+        this.app.use('/api/admin/users/traffic', requireAdmin, adminTrafficRouter);
+        this.logger.info('Admin traffic router mounted at /api/admin/users/traffic');
 
         const adminRouter = this.createAdminRouter();
         this.app.use('/api/admin/users', requireAdmin, adminRouter);
@@ -390,7 +402,7 @@ export class UserModule implements IModule<IUserModuleDependencies> {
      * @internal
      */
     private createAdminRouter(): Router {
-        return createAdminUserRouter(this.controller, this.groupController);
+        return createAdminUserRouter(this.controller, this.groupController, this.trafficController);
     }
 
     /**

--- a/src/backend/modules/user/__tests__/bot-classifier.test.ts
+++ b/src/backend/modules/user/__tests__/bot-classifier.test.ts
@@ -24,7 +24,11 @@ describe('classifyUserAgent', () => {
             ['Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)'],
             ['Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)'],
             ['Sogou web spider/4.0(+http://www.sogou.com/docs/help/webmasters.htm#07)'],
-            ['Mozilla/5.0 (compatible; Applebot/0.1; +http://www.apple.com/go/applebot)']
+            ['Mozilla/5.0 (compatible; Applebot/0.1; +http://www.apple.com/go/applebot)'],
+            // DotBot is Moz's SEO crawler (Open Site Explorer link graph).
+            // Real prod sample observed 2026-04-30 in `bot_other` before
+            // the rule was added — search-ranking adjacent, so search_engine.
+            ['Mozilla/5.0 (compatible; DotBot/1.2; +https://opensiteexplorer.org/dotbot; help@moz.com)']
         ])('classifies %p as search_engine', (ua) => {
             expect(classifyUserAgent(ua)).toBe('search_engine');
         });
@@ -38,7 +42,12 @@ describe('classifyUserAgent', () => {
             ['Mozilla/5.0 (compatible; PerplexityBot/1.0; +https://docs.perplexity.ai/docs/perplexity-bot)'],
             ['CCBot/2.0 (https://commoncrawl.org/faq/)'],
             ['Mozilla/5.0 (compatible; Bytespider; spider-feedback@bytedance.com)'],
-            ['anthropic-ai']
+            ['anthropic-ai'],
+            // Real Amazonbot UA observed in prod (2026-04-30 traffic_events sample).
+            // Classified as ai_crawler because Amazon documents the bot as serving
+            // both Alexa and LLM training; training-crawl is the operator-meaningful
+            // bucket for a TRON analytics product.
+            ['Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot)']
         ])('classifies %p as ai_crawler', (ua) => {
             expect(classifyUserAgent(ua)).toBe('ai_crawler');
         });
@@ -61,7 +70,10 @@ describe('classifyUserAgent', () => {
             ['LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)'],
             ['Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)'],
             ['TelegramBot (like TwitterBot)'],
-            ['WhatsApp/2.23.20.0 A']
+            ['WhatsApp/2.23.20.0 A'],
+            // FlipboardProxy advertises a long Mozilla-prefix UA in real
+            // traffic; the matching fragment is `flipboardproxy`.
+            ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:28.0) Gecko/20100101 Firefox/28.0 (FlipboardProxy/1.1; +http://flipboard.com/browserproxy)']
         ])('classifies %p as social_unfurler', (ua) => {
             expect(classifyUserAgent(ua)).toBe('social_unfurler');
         });

--- a/src/backend/modules/user/__tests__/traffic.service.test.ts
+++ b/src/backend/modules/user/__tests__/traffic.service.test.ts
@@ -194,4 +194,94 @@ describe('TrafficService', () => {
             expect(logger.warn).toHaveBeenCalled();
         });
     });
+
+    describe('getBotClassBreakdown()', () => {
+        it('returns [] when ClickHouse is unavailable', async () => {
+            TrafficService.setDependencies(undefined, createMockLogger());
+            const out = await TrafficService.getInstance().getBotClassBreakdown();
+            expect(out).toEqual([]);
+        });
+
+        it('preserves NULL buckets and coerces count to number', async () => {
+            // NULL is a real, distinct bucket — pre-classifier rows roll
+            // through that bucket and the dashboard charts the decay.
+            // Coercion guards against ClickHouse returning string counts
+            // under JSONEachRow.
+            const ch = createMockClickHouse();
+            ch.queue.push(
+                { key: 'human', count: '76' },
+                { key: null, count: '23' },
+                { key: 'bot_other', count: 21 }
+            );
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            const out = await TrafficService.getInstance().getBotClassBreakdown({ sinceHours: 24 });
+
+            expect(out).toEqual([
+                { key: 'human', count: 76 },
+                { key: null, count: 23 },
+                { key: 'bot_other', count: 21 }
+            ]);
+        });
+    });
+
+    describe('getTopPaths() / getTopCountries()', () => {
+        it('exclude null keys (low analytic value vs the populated keys)', async () => {
+            const ch = createMockClickHouse();
+            // Verifies the SQL the service generates includes the
+            // null-exclusion clause; we rely on the captured query
+            // string since the mock can't actually filter.
+            const captured: { sql?: string; params?: unknown } = {};
+            ch.query = async <T>(sql: string, params?: unknown): Promise<T[]> => {
+                captured.sql = sql;
+                captured.params = params;
+                return [{ key: 'US', count: 12 }] as T[];
+            };
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            await TrafficService.getInstance().getTopCountries({ sinceHours: 6, limit: 5 });
+
+            expect(captured.sql).toContain('country IS NOT NULL');
+            expect(captured.params).toEqual({ sinceHours: 6, limit: 5 });
+        });
+    });
+
+    describe('getBotOtherUserAgents()', () => {
+        it('filters to bot_other and clamps the UA column', async () => {
+            const ch = createMockClickHouse();
+            const captured: { sql?: string } = {};
+            ch.query = async <T>(sql: string): Promise<T[]> => {
+                captured.sql = sql;
+                return [{ key: 'CensysInspect/1.1', count: 6 }] as T[];
+            };
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            const out = await TrafficService.getInstance().getBotOtherUserAgents({ sinceHours: 24, limit: 10 });
+
+            // Two assertions document load-bearing parts of the SQL —
+            // the clamp keeps wire bandwidth bounded and the WHERE
+            // filter is what makes this method "bot_other only".
+            expect(captured.sql).toContain("bot_class = 'bot_other'");
+            expect(captured.sql).toContain('substring(user_agent, 1, 240)');
+            expect(out).toEqual([{ key: 'CensysInspect/1.1', count: 6 }]);
+        });
+
+        it('returns [] when ClickHouse is unavailable', async () => {
+            TrafficService.setDependencies(undefined, createMockLogger());
+            const out = await TrafficService.getInstance().getBotOtherUserAgents();
+            expect(out).toEqual([]);
+        });
+
+        it('returns [] and logs on query failure', async () => {
+            const ch = createMockClickHouse();
+            ch.error = new Error('CH down');
+            const logger = createMockLogger();
+            TrafficService.setDependencies(ch, logger);
+
+            const out = await TrafficService.getInstance().getBotOtherUserAgents();
+
+            expect(out).toEqual([]);
+            expect(logger.warn).toHaveBeenCalled();
+        });
+    });
 });

--- a/src/backend/modules/user/api/index.ts
+++ b/src/backend/modules/user/api/index.ts
@@ -2,3 +2,5 @@ export { UserController } from './user.controller.js';
 export { createUserRouter, createAdminUserRouter } from './user.routes.js';
 export { UserGroupController } from './user-group.controller.js';
 export { createAdminUserGroupRouter } from './user-group.routes.js';
+export { TrafficController } from './traffic.controller.js';
+export { createAdminTrafficRouter } from './traffic.routes.js';

--- a/src/backend/modules/user/api/query-params.ts
+++ b/src/backend/modules/user/api/query-params.ts
@@ -1,0 +1,41 @@
+/**
+ * Query-param parsers shared across user-module admin controllers.
+ *
+ * Extracted from `user-group.controller.ts` and `traffic.controller.ts`
+ * because both controllers parse `limit` / `skip` / `sinceHours` query
+ * params with the same default-then-clamp shape. Keeping one copy here
+ * means a future tweak (e.g. a new shared ceiling) doesn't have to be
+ * applied in two places.
+ *
+ * These helpers are deliberately small and pure — no Express coupling,
+ * no logging — so they are safe to pull into any other module-internal
+ * controller that grows the same need.
+ */
+
+/**
+ * Parse a positive integer query param with a default and ceiling.
+ *
+ * Returns the default for missing or unparseable values; otherwise
+ * clamps the parsed integer to `[1, max]`. Used for `limit`-style
+ * params and any other "must be at least 1, must not exceed N" input.
+ */
+export function parsePositiveInt(raw: unknown, defaultVal: number, max: number): number {
+    if (typeof raw !== 'string') return defaultVal;
+    const n = Number.parseInt(raw, 10);
+    if (Number.isNaN(n)) return defaultVal;
+    return Math.min(Math.max(1, n), max);
+}
+
+/**
+ * Parse a non-negative integer query param with a default.
+ *
+ * Used for pagination `skip`-style params where 0 is valid but
+ * negatives must be clamped. No upper bound — pagination offsets are
+ * application-specific and the caller should layer one on if needed.
+ */
+export function parseNonNegativeInt(raw: unknown, defaultVal: number): number {
+    if (typeof raw !== 'string') return defaultVal;
+    const n = Number.parseInt(raw, 10);
+    if (Number.isNaN(n)) return defaultVal;
+    return Math.max(0, n);
+}

--- a/src/backend/modules/user/api/traffic.controller.ts
+++ b/src/backend/modules/user/api/traffic.controller.ts
@@ -1,0 +1,169 @@
+/**
+ * Admin controller for ClickHouse `traffic_events` reads.
+ *
+ * Backs the Phase 5 admin UI tracked in PLAN-traffic-events.md. All
+ * routes are mounted behind `requireAdmin` at the parent router; the
+ * controller itself is not auth-aware.
+ *
+ * ## Why a Separate Controller
+ *
+ * `UserController` already exposes a `MongoDB users` analytics surface
+ * (`getDailyVisitors`, `getTrafficSources`, etc.). The ClickHouse
+ * traffic-events surface is conceptually parallel but reads from a
+ * different store with different freshness semantics (append-only,
+ * 18-month TTL, no Mongo backfill). Splitting them keeps either side
+ * replaceable without surgery on the other.
+ *
+ * The controller does not import `UserService`. Per-user history takes
+ * a UUID from the URL and queries ClickHouse by `candidate_uid`, which
+ * is the same UUID — the lookup does not require materializing the
+ * Mongo user. Endpoints under `/api/admin/users/:id/traffic-history`
+ * therefore work for cookie holders that never advanced past the
+ * ephemeral-user state (no Mongo row at all), which is exactly what the
+ * Phase 5 dashboard needs to investigate "who is this candidate UUID?"
+ */
+
+import type { Request, Response } from 'express';
+import type { ISystemLogService } from '@/types';
+import type { TrafficService } from '../services/traffic.service.js';
+
+/** Hard upper bounds on user-supplied query params. Keeps ClickHouse query cost predictable. */
+const MAX_SINCE_HOURS = 720; // 30 days
+const MAX_LIMIT = 200;
+const MAX_HISTORY_LIMIT = 200;
+
+/**
+ * Parse a positive integer query param with a default and ceiling. Returns
+ * the default for missing or unparseable values; otherwise clamps to
+ * `[1, max]`. Mirrors the helper in `user-group.controller.ts`.
+ */
+function parsePositiveInt(raw: unknown, defaultVal: number, max: number): number {
+    if (typeof raw !== 'string') return defaultVal;
+    const n = Number.parseInt(raw, 10);
+    if (Number.isNaN(n)) return defaultVal;
+    return Math.min(Math.max(1, n), max);
+}
+
+/**
+ * Controller for `/api/admin/users/traffic/*` and the per-user
+ * `/api/admin/users/:id/traffic-history` endpoint.
+ */
+export class TrafficController {
+    constructor(
+        private readonly trafficService: TrafficService,
+        private readonly logger: ISystemLogService
+    ) { }
+
+    /**
+     * GET /api/admin/users/traffic/summary?sinceHours=24
+     *
+     * Returns row counts grouped by `bot_class` over the lookback window
+     * plus the total count. Drives the dashboard's headline panel.
+     */
+    async getSummary(req: Request, res: Response): Promise<void> {
+        const sinceHours = parsePositiveInt(req.query.sinceHours, 24, MAX_SINCE_HOURS);
+
+        try {
+            const buckets = await this.trafficService.getBotClassBreakdown({ sinceHours, limit: MAX_LIMIT });
+            const total = buckets.reduce((sum, b) => sum + b.count, 0);
+            res.json({
+                sinceHours,
+                total,
+                buckets,
+                clickhouseEnabled: this.trafficService.isEnabled()
+            });
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to fetch traffic summary');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to fetch summary' });
+        }
+    }
+
+    /**
+     * GET /api/admin/users/traffic/top-paths?sinceHours=24&limit=20
+     *
+     * Returns the most-hit landing paths over the lookback window.
+     */
+    async getTopPaths(req: Request, res: Response): Promise<void> {
+        const sinceHours = parsePositiveInt(req.query.sinceHours, 24, MAX_SINCE_HOURS);
+        const limit = parsePositiveInt(req.query.limit, 20, MAX_LIMIT);
+
+        try {
+            const buckets = await this.trafficService.getTopPaths({ sinceHours, limit });
+            res.json({ sinceHours, limit, buckets });
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to fetch top paths');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to fetch top paths' });
+        }
+    }
+
+    /**
+     * GET /api/admin/users/traffic/top-countries?sinceHours=24&limit=20
+     *
+     * Returns the most-active countries (ISO-3166 alpha-2) over the lookback window.
+     */
+    async getTopCountries(req: Request, res: Response): Promise<void> {
+        const sinceHours = parsePositiveInt(req.query.sinceHours, 24, MAX_SINCE_HOURS);
+        const limit = parsePositiveInt(req.query.limit, 20, MAX_LIMIT);
+
+        try {
+            const buckets = await this.trafficService.getTopCountries({ sinceHours, limit });
+            res.json({ sinceHours, limit, buckets });
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to fetch top countries');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to fetch top countries' });
+        }
+    }
+
+    /**
+     * GET /api/admin/users/traffic/bot-other-samples?sinceHours=24&limit=20
+     *
+     * Returns the most-frequent UAs in the `bot_other` bucket. Each row
+     * is a candidate for promotion to an explicit rule in
+     * `bot-classifier.ts`. The classifier-gap feedback loop only works
+     * if operators see the raw UAs.
+     */
+    async getBotOtherSamples(req: Request, res: Response): Promise<void> {
+        const sinceHours = parsePositiveInt(req.query.sinceHours, 24, MAX_SINCE_HOURS);
+        const limit = parsePositiveInt(req.query.limit, 20, MAX_LIMIT);
+
+        try {
+            const buckets = await this.trafficService.getBotOtherUserAgents({ sinceHours, limit });
+            res.json({ sinceHours, limit, buckets });
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to fetch bot_other UA samples');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to fetch UA samples' });
+        }
+    }
+
+    /**
+     * GET /api/admin/users/:id/traffic-history?limit=50
+     *
+     * Returns the candidate UUID's traffic events oldest-first. Mirrors
+     * the shape Phase 3 already uses for first-touch backfill, just with
+     * a larger default window. The endpoint does not require a matching
+     * Mongo `users` row — pre-`startSession` cookie holders have rows
+     * here long before they ever exist in Mongo, and that's the case
+     * the dashboard cares about.
+     */
+    async getUserHistory(req: Request, res: Response): Promise<void> {
+        const userId = req.params.id;
+        const limit = parsePositiveInt(req.query.limit, 50, MAX_HISTORY_LIMIT);
+
+        // No UUID validation here — the underlying ClickHouse parameter
+        // is `UUID` so a malformed value will fail the query gracefully
+        // and surface as a 500 with logs. Strict validation would be
+        // duplicative since the cookie issuer already only mints UUIDv4.
+        try {
+            const events = await this.trafficService.getEventsForUser(userId, { limit });
+            res.json({
+                userId,
+                limit,
+                events,
+                clickhouseEnabled: this.trafficService.isEnabled()
+            });
+        } catch (error) {
+            this.logger.error({ err: error, userId }, 'Failed to fetch user traffic history');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to fetch traffic history' });
+        }
+    }
+}

--- a/src/backend/modules/user/api/traffic.controller.ts
+++ b/src/backend/modules/user/api/traffic.controller.ts
@@ -26,23 +26,12 @@
 import type { Request, Response } from 'express';
 import type { ISystemLogService } from '@/types';
 import type { TrafficService } from '../services/traffic.service.js';
+import { parsePositiveInt } from './query-params.js';
 
 /** Hard upper bounds on user-supplied query params. Keeps ClickHouse query cost predictable. */
 const MAX_SINCE_HOURS = 720; // 30 days
 const MAX_LIMIT = 200;
 const MAX_HISTORY_LIMIT = 200;
-
-/**
- * Parse a positive integer query param with a default and ceiling. Returns
- * the default for missing or unparseable values; otherwise clamps to
- * `[1, max]`. Mirrors the helper in `user-group.controller.ts`.
- */
-function parsePositiveInt(raw: unknown, defaultVal: number, max: number): number {
-    if (typeof raw !== 'string') return defaultVal;
-    const n = Number.parseInt(raw, 10);
-    if (Number.isNaN(n)) return defaultVal;
-    return Math.min(Math.max(1, n), max);
-}
 
 /**
  * Controller for `/api/admin/users/traffic/*` and the per-user

--- a/src/backend/modules/user/api/traffic.routes.ts
+++ b/src/backend/modules/user/api/traffic.routes.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import type { TrafficController } from './traffic.controller.js';
+
+/**
+ * Create Express router for admin traffic-events endpoints.
+ *
+ * Mounted at `/api/admin/users/traffic` with `requireAdmin` applied at
+ * the parent. Mounted BEFORE `/api/admin/users` so the more-specific
+ * prefix wins over the `:id` catch — same pattern as
+ * `createAdminUserGroupRouter`.
+ *
+ * The per-user history endpoint lives on the user router under
+ * `/api/admin/users/:id/traffic-history`; it shares the controller
+ * because the data source is the same and the UUID is a pure URL
+ * parameter, not a body shape.
+ */
+export function createAdminTrafficRouter(controller: TrafficController): Router {
+    const router = Router();
+
+    router.get('/summary', controller.getSummary.bind(controller));
+    router.get('/top-paths', controller.getTopPaths.bind(controller));
+    router.get('/top-countries', controller.getTopCountries.bind(controller));
+    router.get('/bot-other-samples', controller.getBotOtherSamples.bind(controller));
+
+    return router;
+}

--- a/src/backend/modules/user/api/user-group.controller.ts
+++ b/src/backend/modules/user/api/user-group.controller.ts
@@ -9,29 +9,7 @@ import {
     UserGroupSystemProtectedError,
     UserGroupMemberNotFoundError
 } from '../services/user-group.errors.js';
-
-/**
- * Parse a positive integer query param with a default and ceiling. Returns
- * the default for missing or unparseable values; otherwise clamps to
- * `[1, max]`. Used by the members listing endpoint to bound page size.
- */
-function parsePositiveInt(raw: unknown, defaultVal: number, max: number): number {
-    if (typeof raw !== 'string') return defaultVal;
-    const n = Number.parseInt(raw, 10);
-    if (Number.isNaN(n)) return defaultVal;
-    return Math.min(Math.max(1, n), max);
-}
-
-/**
- * Parse a non-negative integer query param. Used for pagination offsets
- * where 0 is valid but negatives must be clamped.
- */
-function parseNonNegativeInt(raw: unknown, defaultVal: number): number {
-    if (typeof raw !== 'string') return defaultVal;
-    const n = Number.parseInt(raw, 10);
-    if (Number.isNaN(n)) return defaultVal;
-    return Math.max(0, n);
-}
+import { parsePositiveInt, parseNonNegativeInt } from './query-params.js';
 
 /**
  * Controller for admin user-group endpoints.

--- a/src/backend/modules/user/api/user.routes.ts
+++ b/src/backend/modules/user/api/user.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import type { UserController } from './user.controller.js';
 import type { UserGroupController } from './user-group.controller.js';
+import type { TrafficController } from './traffic.controller.js';
 import { createRateLimiter } from '../../../api/middleware/rate-limit.js';
 import { userContextMiddleware } from '../../../api/middleware/user-context.js';
 
@@ -242,15 +243,20 @@ export function createProfileRouter(controller: UserController): Router {
  * Routes are mounted at /api/admin/users. The user-group controller is
  * injected so the per-user membership editor (`PUT /:id/groups`) can live
  * inside the user admin tree without coupling UserController to group
- * concerns.
+ * concerns. The traffic controller is injected for the same reason —
+ * `/:id/traffic-history` reads from ClickHouse, not Mongo, and bundling
+ * the read into UserController would re-couple two stores that the
+ * traffic-events split deliberately separated.
  *
  * @param controller - User controller instance
  * @param groupController - User-group controller for membership mutation
+ * @param trafficController - Traffic controller for ClickHouse history reads
  * @returns Express router with admin endpoints
  */
 export function createAdminUserRouter(
     controller: UserController,
-    groupController: UserGroupController
+    groupController: UserGroupController,
+    trafficController: TrafficController
 ): Router {
     const router = Router();
 
@@ -389,6 +395,15 @@ export function createAdminUserRouter(
      * Audit-logged at info level by the controller.
      */
     router.put('/:id/groups', groupController.setUserGroups.bind(groupController));
+
+    /**
+     * GET /api/admin/users/:id/traffic-history
+     * Return the candidate UUID's ClickHouse traffic events oldest-first.
+     * Works for cookie holders that never advanced past the ephemeral-user
+     * state — Phase 5 admin UI uses this to investigate a candidate UUID
+     * before any Mongo `users` row exists.
+     */
+    router.get('/:id/traffic-history', trafficController.getUserHistory.bind(trafficController));
 
     return router;
 }

--- a/src/backend/modules/user/services/bot-classifier.ts
+++ b/src/backend/modules/user/services/bot-classifier.ts
@@ -102,7 +102,12 @@ const RULES: ReadonlyArray<{ class: BotClass; fragments: readonly string[] }> = 
             'ccbot',
             'bytespider',
             'cohere-ai',
-            'meta-externalagent'
+            'meta-externalagent',
+            // Amazonbot powers both Alexa search and Amazon's LLM training
+            // pipeline. Classify as `ai_crawler` because the training-crawl
+            // intent is the analytically interesting one; the dashboard
+            // surfaces AI ingestion as its own bucket.
+            'amazonbot'
         ]
     },
     {
@@ -120,7 +125,10 @@ const RULES: ReadonlyArray<{ class: BotClass; fragments: readonly string[] }> = 
             'applebot',
             'petalbot',
             'seznambot',
-            'mojeekbot'
+            'mojeekbot',
+            // Moz's SEO crawler (DotBot/1.x). Drives the link graph behind
+            // Moz/Open Site Explorer rankings — search-ranking adjacent.
+            'dotbot'
         ]
     },
     {
@@ -138,7 +146,10 @@ const RULES: ReadonlyArray<{ class: BotClass; fragments: readonly string[] }> = 
             'pinterestbot',
             'redditbot',
             'embedly',
-            'skypeuripreview'
+            'skypeuripreview',
+            // Flipboard's link unfurler. Same role as Twitterbot/Slackbot
+            // for Flipboard "boards" sharing.
+            'flipboardproxy'
         ]
     },
     {

--- a/src/backend/modules/user/services/traffic.service.ts
+++ b/src/backend/modules/user/services/traffic.service.ts
@@ -116,7 +116,36 @@ export interface IGetEventsForUserOptions {
     eventTypes?: TrafficEventType[];
 }
 
+/**
+ * One bucket of an aggregate read. The `key` is the dimension value
+ * (bot_class, country, path, user_agent), `count` is the row count.
+ *
+ * `key` is `string | null` because ClickHouse `Nullable(...)` columns
+ * legitimately carry `null` for "not classified yet" / "not derivable
+ * from request" — the dashboard distinguishes those from low-cardinality
+ * known values, so the wire shape preserves the difference rather than
+ * coercing to an empty string.
+ */
+export interface ITrafficAggregateBucket {
+    key: string | null;
+    count: number;
+}
+
+/**
+ * Common params shared by every aggregate read. `sinceHours` defaults to
+ * 24 because the Phase 5 admin dashboard tracks "what happened today" by
+ * default; longer windows are explicitly chosen by the operator.
+ */
+export interface ITrafficAggregateOptions {
+    /** Lookback window in hours. Clamped to `[1, 720]` (30 days) by the controller. */
+    sinceHours?: number;
+    /** Max rows for top-N reads. Clamped to `[1, 200]` by the controller. */
+    limit?: number;
+}
+
 const TABLE_NAME = 'traffic_events';
+const DEFAULT_AGGREGATE_HOURS = 24;
+const DEFAULT_AGGREGATE_LIMIT = 20;
 
 /**
  * ClickHouse-backed traffic events store.
@@ -261,6 +290,125 @@ export class TrafficService {
             return rows.map(deserializeEvent);
         } catch (error) {
             this.logger.warn({ error, candidateUid }, 'Failed to read traffic events');
+            return [];
+        }
+    }
+
+    /**
+     * Count rows grouped by `bot_class` over the lookback window. Powers
+     * the headline panel of the Phase 5 admin dashboard. NULL counts are
+     * preserved as a distinct bucket so operators can see classifier
+     * coverage erode as pre-classifier rows roll off the window.
+     *
+     * Returns `[]` when ClickHouse is unavailable.
+     */
+    async getBotClassBreakdown(options: ITrafficAggregateOptions = {}): Promise<ITrafficAggregateBucket[]> {
+        return this.aggregateByDimension('bot_class', options);
+    }
+
+    /**
+     * Count rows grouped by `country` (ISO-3166 alpha-2) over the lookback
+     * window. Drives the geo-distribution panel.
+     */
+    async getTopCountries(options: ITrafficAggregateOptions = {}): Promise<ITrafficAggregateBucket[]> {
+        return this.aggregateByDimension('country', options, true);
+    }
+
+    /**
+     * Count rows grouped by `path` (landing path) over the lookback
+     * window. Drives the top-landing-paths panel.
+     */
+    async getTopPaths(options: ITrafficAggregateOptions = {}): Promise<ITrafficAggregateBucket[]> {
+        return this.aggregateByDimension('path', options, true);
+    }
+
+    /**
+     * Count rows grouped by `user_agent` for `bot_class = 'bot_other'`
+     * only. Powers the classifier-gap panel — when a UA cluster appears
+     * here, it's a candidate for an explicit rule in `bot-classifier.ts`.
+     *
+     * `bot_other` is the catch-all bucket where `isbot()` returned true
+     * but no explicit fragment matched. Surfacing the raw UAs is the
+     * operator's only feedback loop on classifier coverage.
+     */
+    async getBotOtherUserAgents(options: ITrafficAggregateOptions = {}): Promise<ITrafficAggregateBucket[]> {
+        if (!this.clickhouse) {
+            return [];
+        }
+
+        const sinceHours = options.sinceHours ?? DEFAULT_AGGREGATE_HOURS;
+        const limit = options.limit ?? DEFAULT_AGGREGATE_LIMIT;
+
+        // Clamp the user_agent column to a sane display width here rather
+        // than at the controller — the dashboard never needs the full
+        // 500-char raw value, and trimming saves wire bandwidth.
+        const sql = `
+            SELECT
+                substring(user_agent, 1, 240) AS key,
+                count() AS count
+            FROM ${TABLE_NAME}
+            WHERE timestamp > now() - INTERVAL {sinceHours:UInt32} HOUR
+              AND bot_class = 'bot_other'
+              AND user_agent IS NOT NULL
+            GROUP BY key
+            ORDER BY count DESC
+            LIMIT {limit:UInt32}
+        `;
+
+        try {
+            const rows = await this.clickhouse.query<{ key: string | null; count: string | number }>(
+                sql,
+                { sinceHours, limit }
+            );
+            return rows.map(r => ({ key: r.key, count: Number(r.count) }));
+        } catch (error) {
+            this.logger.warn({ error, sinceHours, limit }, 'Failed to read bot_other UA aggregate');
+            return [];
+        }
+    }
+
+    /**
+     * Generic GROUP BY count for low-cardinality dimensions. `dimension`
+     * is interpolated directly into the SQL because the column name
+     * cannot be a parameter; callers MUST pass a hardcoded literal.
+     * `excludeNull` is on for top-N reads where a `null` row would
+     * dominate the chart with little analytic value (path/country are
+     * mostly populated; bot_class is interesting precisely because of
+     * its NULL bucket).
+     */
+    private async aggregateByDimension(
+        dimension: 'bot_class' | 'country' | 'path',
+        options: ITrafficAggregateOptions,
+        excludeNull = false
+    ): Promise<ITrafficAggregateBucket[]> {
+        if (!this.clickhouse) {
+            return [];
+        }
+
+        const sinceHours = options.sinceHours ?? DEFAULT_AGGREGATE_HOURS;
+        const limit = options.limit ?? DEFAULT_AGGREGATE_LIMIT;
+        const nullFilter = excludeNull ? `AND ${dimension} IS NOT NULL` : '';
+
+        const sql = `
+            SELECT
+                ${dimension} AS key,
+                count() AS count
+            FROM ${TABLE_NAME}
+            WHERE timestamp > now() - INTERVAL {sinceHours:UInt32} HOUR
+            ${nullFilter}
+            GROUP BY key
+            ORDER BY count DESC
+            LIMIT {limit:UInt32}
+        `;
+
+        try {
+            const rows = await this.clickhouse.query<{ key: string | null; count: string | number }>(
+                sql,
+                { sinceHours, limit }
+            );
+            return rows.map(r => ({ key: r.key, count: Number(r.count) }));
+        } catch (error) {
+            this.logger.warn({ error, dimension, sinceHours, limit }, 'Failed to read traffic aggregate');
             return [];
         }
     }

--- a/src/frontend/app/(core)/system/users/page.tsx
+++ b/src/frontend/app/(core)/system/users/page.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from 'react';
 import { useSystemAuth } from '../../../../features/system';
-import { UsersMonitor, AnalyticsDashboard, ReferralOverview, GscSettings, GroupsManager } from '../../../../modules/user';
+import { UsersMonitor, AnalyticsDashboard, ReferralOverview, GscSettings, GroupsManager, TrafficDashboard } from '../../../../modules/user';
 import styles from './page.module.scss';
 
 /** Tab identifiers for the users admin page. */
-type UsersTab = 'users' | 'analytics' | 'referrals' | 'groups' | 'settings';
+type UsersTab = 'users' | 'analytics' | 'traffic' | 'referrals' | 'groups' | 'settings';
 
 /**
  * System users administration page with tabbed interface.
@@ -44,6 +44,13 @@ export default function SystemUsersPage() {
                 </button>
                 <button
                     type="button"
+                    className={activeTab === 'traffic' ? styles.tab__active : styles.tab}
+                    onClick={() => setActiveTab('traffic')}
+                >
+                    Traffic
+                </button>
+                <button
+                    type="button"
                     className={activeTab === 'referrals' ? styles.tab__active : styles.tab}
                     onClick={() => setActiveTab('referrals')}
                 >
@@ -68,6 +75,7 @@ export default function SystemUsersPage() {
             <div className={styles.content}>
                 {activeTab === 'users' && <UsersMonitor token={token} />}
                 {activeTab === 'analytics' && <AnalyticsDashboard token={token} />}
+                {activeTab === 'traffic' && <TrafficDashboard token={token} />}
                 {activeTab === 'referrals' && <ReferralOverview token={token} />}
                 {activeTab === 'groups' && <GroupsManager token={token} />}
                 {activeTab === 'settings' && <GscSettings token={token} />}

--- a/src/frontend/modules/user/components/admin/TrafficDashboard/TrafficDashboard.module.scss
+++ b/src/frontend/modules/user/components/admin/TrafficDashboard/TrafficDashboard.module.scss
@@ -1,0 +1,204 @@
+/**
+ * TrafficDashboard styles.
+ *
+ * Multi-panel admin dashboard for the Phase 5 ClickHouse traffic-events
+ * surface. Container query collapses the side-by-side paths/countries
+ * grid to a single column at narrow widths so the dashboard stays
+ * usable in slideouts and on mobile.
+ */
+
+@use '../../../../../app/breakpoints' as *;
+
+.container {
+    container-type: inline-size;
+    container-name: traffic-dashboard;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-lg);
+    padding: var(--card-padding-md);
+}
+
+.header {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--gap-md);
+    flex-wrap: wrap;
+}
+
+.title {
+    font-size: var(--font-size-heading-lg);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text);
+    margin: 0;
+}
+
+.subtitle {
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+    margin: var(--gap-2xs) 0 0 0;
+    max-width: var(--max-width-prose);
+}
+
+.controls {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    flex-wrap: wrap;
+}
+
+.window_picker {
+    display: inline-flex;
+    background: var(--color-surface-muted);
+    border-radius: var(--radius-full);
+    padding: var(--padding-2xs);
+    border: var(--border-width-thin) solid var(--color-border);
+}
+
+.window_button,
+.window_active {
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-body-sm);
+    font-weight: var(--font-weight-semibold);
+    padding: var(--padding-2xs) var(--padding-sm);
+    border-radius: var(--radius-full);
+    cursor: pointer;
+    transition: background-color var(--transition-base), color var(--transition-base);
+}
+
+.window_button:hover {
+    color: var(--color-text);
+}
+
+.window_active {
+    background: var(--gradient-primary);
+    color: var(--color-text);
+}
+
+.notice_card {
+    border-color: var(--color-warning);
+    color: var(--color-warning-text);
+}
+
+.panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+}
+
+.panel_header {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    color: var(--color-text);
+}
+
+.panel_title {
+    font-size: var(--font-size-heading-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text);
+    margin: 0;
+}
+
+.panel_meta {
+    margin-left: auto;
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+}
+
+.panel_help {
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+    margin: 0;
+    max-width: var(--max-width-prose);
+}
+
+.panel_loading,
+.panel_empty {
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+    margin: 0;
+}
+
+.panel_error {
+    font-size: var(--font-size-body-sm);
+    color: var(--color-danger);
+    margin: 0;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--font-size-body-sm);
+
+    th,
+    td {
+        text-align: left;
+        padding: var(--padding-sm) var(--padding-md);
+        border-bottom: var(--border-width-thin) solid var(--color-border);
+        vertical-align: middle;
+    }
+
+    th {
+        font-weight: var(--font-weight-semibold);
+        color: var(--color-text-muted);
+        background: var(--color-surface-muted);
+    }
+
+    tbody tr:last-child td {
+        border-bottom: none;
+    }
+}
+
+.numeric_col {
+    width: 1%;
+    white-space: nowrap;
+    text-align: right;
+}
+
+.numeric {
+    text-align: right;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text);
+}
+
+.code {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text);
+    word-break: break-all;
+}
+
+.ua_cell {
+    max-width: 32rem;
+}
+
+.grid_two {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--grid-gap-md);
+}
+
+@container traffic-dashboard (max-width: #{$breakpoint-mobile-lg}) {
+    .header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .grid_two {
+        grid-template-columns: 1fr;
+    }
+
+    .table th,
+    .table td {
+        padding: var(--padding-xs) var(--padding-sm);
+    }
+
+    .ua_cell {
+        max-width: none;
+    }
+}

--- a/src/frontend/modules/user/components/admin/TrafficDashboard/TrafficDashboard.tsx
+++ b/src/frontend/modules/user/components/admin/TrafficDashboard/TrafficDashboard.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+/**
+ * Admin tab for the Phase 5 traffic-events dashboard
+ * (PLAN-traffic-events.md).
+ *
+ * Reads aggregates from `/api/admin/users/traffic/*` (ClickHouse) and
+ * surfaces:
+ *
+ * - **Bot class breakdown** — headline view; NULL bucket is a deliberate
+ *   distinct value that decays as pre-classifier rows roll off the
+ *   24h window.
+ * - **bot_other UA samples** — operator's only feedback loop on
+ *   classifier coverage. UAs that recur here are candidates for explicit
+ *   rules in `bot-classifier.ts`. The 2026-04-30 prod sample that
+ *   surfaced Amazonbot, DotBot, and FlipboardProxy in `bot_other` is
+ *   exactly the signal this panel exists to expose.
+ * - **Top paths** — landing-path frequency.
+ * - **Top countries** — geo distribution.
+ *
+ * Mirrors the established admin-tab pattern (UsersMonitor, GroupsManager):
+ * client-only, `X-Admin-Token` header, fetch-on-mount, local state per
+ * panel. SSR + Live Updates does NOT apply because the route is
+ * admin-gated; the `/system/users` page hosting this tab is already a
+ * client component for the same reason.
+ *
+ * Each panel owns its loading/error state independently so a slow or
+ * failing query for one dimension does not block the rest of the dashboard.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Bot, Globe, MapPin, RefreshCw } from 'lucide-react';
+import { config as runtimeConfig } from '../../../../../lib/config';
+import { Button } from '../../../../../components/ui/Button';
+import { Card } from '../../../../../components/ui/Card';
+import styles from './TrafficDashboard.module.scss';
+
+interface AggregateBucket {
+    key: string | null;
+    count: number;
+}
+
+interface SummaryResponse {
+    sinceHours: number;
+    total: number;
+    buckets: AggregateBucket[];
+    clickhouseEnabled: boolean;
+}
+
+interface AggregateResponse {
+    sinceHours: number;
+    limit: number;
+    buckets: AggregateBucket[];
+}
+
+interface Props {
+    token: string;
+}
+
+/** Lookback windows the dashboard offers. Wider windows hit the 30-day cap. */
+const SINCE_OPTIONS: Array<{ label: string; hours: number }> = [
+    { label: '1h', hours: 1 },
+    { label: '24h', hours: 24 },
+    { label: '7d', hours: 168 },
+    { label: '30d', hours: 720 }
+];
+
+/**
+ * Render `null` bucket keys as a literal "(null)" so operators see the
+ * distinction from `human` / `bot_other` — the NULL bucket is meaningful
+ * (pre-classifier rows), not a missing-data placeholder.
+ */
+function renderKey(key: string | null): string {
+    return key === null ? '(null)' : key;
+}
+
+/**
+ * Format an integer with thousands separators using the user's locale.
+ * Wrapped in useMemo by callers so re-renders don't reconstruct the
+ * formatter on every row.
+ */
+function useNumberFormatter(): (n: number) => string {
+    return useMemo(() => {
+        const fmt = new Intl.NumberFormat();
+        return (n: number) => fmt.format(n);
+    }, []);
+}
+
+export function TrafficDashboard({ token }: Props) {
+    const [sinceHours, setSinceHours] = useState<number>(24);
+    const formatNumber = useNumberFormatter();
+
+    // Each panel manages its own state; a failing query for one
+    // dimension shouldn't black out the rest of the dashboard.
+    const [summary, setSummary] = useState<SummaryResponse | null>(null);
+    const [summaryError, setSummaryError] = useState<string | null>(null);
+    const [summaryLoading, setSummaryLoading] = useState(true);
+
+    const [botOther, setBotOther] = useState<AggregateResponse | null>(null);
+    const [botOtherError, setBotOtherError] = useState<string | null>(null);
+    const [botOtherLoading, setBotOtherLoading] = useState(true);
+
+    const [topPaths, setTopPaths] = useState<AggregateResponse | null>(null);
+    const [topPathsError, setTopPathsError] = useState<string | null>(null);
+    const [topPathsLoading, setTopPathsLoading] = useState(true);
+
+    const [topCountries, setTopCountries] = useState<AggregateResponse | null>(null);
+    const [topCountriesError, setTopCountriesError] = useState<string | null>(null);
+    const [topCountriesLoading, setTopCountriesLoading] = useState(true);
+
+    const baseUrl = useMemo(
+        () => `${runtimeConfig.apiBaseUrl}/admin/users/traffic`,
+        []
+    );
+
+    const fetchAll = useCallback(async () => {
+        const headers = { 'X-Admin-Token': token };
+        const params = `?sinceHours=${sinceHours}`;
+
+        // Fire all four reads in parallel — they're independent endpoints
+        // and the loading-per-panel UX hides any tail latency.
+        setSummaryLoading(true);
+        setBotOtherLoading(true);
+        setTopPathsLoading(true);
+        setTopCountriesLoading(true);
+
+        const summaryPromise = fetch(`${baseUrl}/summary${params}`, { headers })
+            .then(async r => {
+                if (!r.ok) throw new Error(`Failed to load summary (${r.status})`);
+                return r.json() as Promise<SummaryResponse>;
+            })
+            .then(data => { setSummary(data); setSummaryError(null); })
+            .catch(err => setSummaryError(err instanceof Error ? err.message : 'Failed to load'))
+            .finally(() => setSummaryLoading(false));
+
+        const botOtherPromise = fetch(`${baseUrl}/bot-other-samples${params}&limit=15`, { headers })
+            .then(async r => {
+                if (!r.ok) throw new Error(`Failed to load bot_other (${r.status})`);
+                return r.json() as Promise<AggregateResponse>;
+            })
+            .then(data => { setBotOther(data); setBotOtherError(null); })
+            .catch(err => setBotOtherError(err instanceof Error ? err.message : 'Failed to load'))
+            .finally(() => setBotOtherLoading(false));
+
+        const topPathsPromise = fetch(`${baseUrl}/top-paths${params}&limit=15`, { headers })
+            .then(async r => {
+                if (!r.ok) throw new Error(`Failed to load paths (${r.status})`);
+                return r.json() as Promise<AggregateResponse>;
+            })
+            .then(data => { setTopPaths(data); setTopPathsError(null); })
+            .catch(err => setTopPathsError(err instanceof Error ? err.message : 'Failed to load'))
+            .finally(() => setTopPathsLoading(false));
+
+        const topCountriesPromise = fetch(`${baseUrl}/top-countries${params}&limit=15`, { headers })
+            .then(async r => {
+                if (!r.ok) throw new Error(`Failed to load countries (${r.status})`);
+                return r.json() as Promise<AggregateResponse>;
+            })
+            .then(data => { setTopCountries(data); setTopCountriesError(null); })
+            .catch(err => setTopCountriesError(err instanceof Error ? err.message : 'Failed to load'))
+            .finally(() => setTopCountriesLoading(false));
+
+        await Promise.all([summaryPromise, botOtherPromise, topPathsPromise, topCountriesPromise]);
+    }, [baseUrl, token, sinceHours]);
+
+    useEffect(() => {
+        void fetchAll();
+    }, [fetchAll]);
+
+    const clickhouseDisabledNotice = summary && !summary.clickhouseEnabled;
+
+    return (
+        <div className={styles.container}>
+            <header className={styles.header}>
+                <div>
+                    <h1 className={styles.title}>Traffic</h1>
+                    <p className={styles.subtitle}>
+                        ClickHouse <code>traffic_events</code> — every cookieless
+                        and pre-session HTTP request we see, classified at write
+                        time. Use this to investigate bot pressure, classifier
+                        coverage, and geographic / landing distribution.
+                    </p>
+                </div>
+                <div className={styles.controls}>
+                    <div className={styles.window_picker} role="group" aria-label="Lookback window">
+                        {SINCE_OPTIONS.map(opt => (
+                            <button
+                                key={opt.hours}
+                                type="button"
+                                onClick={() => setSinceHours(opt.hours)}
+                                className={opt.hours === sinceHours ? styles.window_active : styles.window_button}
+                                aria-pressed={opt.hours === sinceHours}
+                            >
+                                {opt.label}
+                            </button>
+                        ))}
+                    </div>
+                    <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => void fetchAll()}
+                        aria-label="Refresh dashboard"
+                    >
+                        <RefreshCw size={16} aria-hidden="true" /> Refresh
+                    </Button>
+                </div>
+            </header>
+
+            {clickhouseDisabledNotice && (
+                <Card padding="md" className={styles.notice_card}>
+                    <p>
+                        ClickHouse is not configured on this deployment.
+                        Traffic events are not being recorded; all panels will
+                        report zero rows.
+                    </p>
+                </Card>
+            )}
+
+            <Card padding="md" className={styles.panel}>
+                <div className={styles.panel_header}>
+                    <Bot size={18} aria-hidden="true" />
+                    <h2 className={styles.panel_title}>Bot class breakdown</h2>
+                    {summary && (
+                        <span className={styles.panel_meta}>
+                            {formatNumber(summary.total)} events
+                        </span>
+                    )}
+                </div>
+                <PanelBody loading={summaryLoading} error={summaryError} empty={summary?.buckets.length === 0}>
+                    {summary && (
+                        <table className={styles.table}>
+                            <thead>
+                                <tr>
+                                    <th scope="col">bot_class</th>
+                                    <th scope="col" className={styles.numeric_col}>events</th>
+                                    <th scope="col" className={styles.numeric_col}>share</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {summary.buckets.map(b => {
+                                    const share = summary.total > 0
+                                        ? ((b.count / summary.total) * 100).toFixed(1)
+                                        : '0.0';
+                                    return (
+                                        <tr key={b.key ?? '__null__'}>
+                                            <td><code className={styles.code}>{renderKey(b.key)}</code></td>
+                                            <td className={styles.numeric}>{formatNumber(b.count)}</td>
+                                            <td className={styles.numeric}>{share}%</td>
+                                        </tr>
+                                    );
+                                })}
+                            </tbody>
+                        </table>
+                    )}
+                </PanelBody>
+            </Card>
+
+            <Card padding="md" className={styles.panel}>
+                <div className={styles.panel_header}>
+                    <Bot size={18} aria-hidden="true" />
+                    <h2 className={styles.panel_title}>bot_other — classifier gaps</h2>
+                </div>
+                <p className={styles.panel_help}>
+                    UAs that <code>isbot()</code> flagged but no explicit
+                    fragment rule matched. Recurring entries are candidates for
+                    explicit rules in <code>bot-classifier.ts</code>.
+                </p>
+                <PanelBody loading={botOtherLoading} error={botOtherError} empty={botOther?.buckets.length === 0}>
+                    {botOther && (
+                        <table className={styles.table}>
+                            <thead>
+                                <tr>
+                                    <th scope="col">user_agent</th>
+                                    <th scope="col" className={styles.numeric_col}>events</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {botOther.buckets.map((b, i) => (
+                                    <tr key={`${b.key ?? 'null'}_${i}`}>
+                                        <td className={styles.ua_cell}>
+                                            <code className={styles.code}>{renderKey(b.key)}</code>
+                                        </td>
+                                        <td className={styles.numeric}>{formatNumber(b.count)}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    )}
+                </PanelBody>
+            </Card>
+
+            <div className={styles.grid_two}>
+                <Card padding="md" className={styles.panel}>
+                    <div className={styles.panel_header}>
+                        <MapPin size={18} aria-hidden="true" />
+                        <h2 className={styles.panel_title}>Top landing paths</h2>
+                    </div>
+                    <PanelBody loading={topPathsLoading} error={topPathsError} empty={topPaths?.buckets.length === 0}>
+                        {topPaths && (
+                            <table className={styles.table}>
+                                <thead>
+                                    <tr>
+                                        <th scope="col">path</th>
+                                        <th scope="col" className={styles.numeric_col}>events</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {topPaths.buckets.map((b, i) => (
+                                        <tr key={`${b.key ?? 'null'}_${i}`}>
+                                            <td><code className={styles.code}>{renderKey(b.key)}</code></td>
+                                            <td className={styles.numeric}>{formatNumber(b.count)}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        )}
+                    </PanelBody>
+                </Card>
+
+                <Card padding="md" className={styles.panel}>
+                    <div className={styles.panel_header}>
+                        <Globe size={18} aria-hidden="true" />
+                        <h2 className={styles.panel_title}>Top countries</h2>
+                    </div>
+                    <PanelBody loading={topCountriesLoading} error={topCountriesError} empty={topCountries?.buckets.length === 0}>
+                        {topCountries && (
+                            <table className={styles.table}>
+                                <thead>
+                                    <tr>
+                                        <th scope="col">country</th>
+                                        <th scope="col" className={styles.numeric_col}>events</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {topCountries.buckets.map((b, i) => (
+                                        <tr key={`${b.key ?? 'null'}_${i}`}>
+                                            <td><code className={styles.code}>{renderKey(b.key)}</code></td>
+                                            <td className={styles.numeric}>{formatNumber(b.count)}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        )}
+                    </PanelBody>
+                </Card>
+            </div>
+        </div>
+    );
+}
+
+interface PanelBodyProps {
+    loading: boolean;
+    error: string | null;
+    empty: boolean | undefined;
+    children: React.ReactNode;
+}
+
+/**
+ * Shared loading / error / empty rendering for every panel. Keeps the
+ * three states centrally typed so a missed empty-check in one panel
+ * doesn't render a phantom table.
+ */
+function PanelBody({ loading, error, empty, children }: PanelBodyProps) {
+    if (error) {
+        return <p className={styles.panel_error}>{error}</p>;
+    }
+    if (loading) {
+        return <p className={styles.panel_loading}>Loading…</p>;
+    }
+    if (empty) {
+        return <p className={styles.panel_empty}>No events in this window.</p>;
+    }
+    return <>{children}</>;
+}

--- a/src/frontend/modules/user/components/admin/TrafficDashboard/TrafficDashboard.tsx
+++ b/src/frontend/modules/user/components/admin/TrafficDashboard/TrafficDashboard.tsx
@@ -28,9 +28,9 @@
  * failing query for one dimension does not block the rest of the dashboard.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Bot, Globe, MapPin, RefreshCw } from 'lucide-react';
-import { config as runtimeConfig } from '../../../../../lib/config';
+import { getRuntimeConfig } from '../../../../../lib/runtimeConfig';
 import { Button } from '../../../../../components/ui/Button';
 import { Card } from '../../../../../components/ui/Card';
 import styles from './TrafficDashboard.module.scss';
@@ -88,6 +88,10 @@ function useNumberFormatter(): (n: number) => string {
 
 export function TrafficDashboard({ token }: Props) {
     const [sinceHours, setSinceHours] = useState<number>(24);
+    // Bumped by the Refresh button to re-trigger the fetch effect under
+    // the same cleanup-flag guard used for window changes. Avoids a
+    // separate manual fetch path that would race with the in-flight one.
+    const [refreshNonce, setRefreshNonce] = useState(0);
     const formatNumber = useNumberFormatter();
 
     // Each panel manages its own state; a failing query for one
@@ -108,64 +112,85 @@ export function TrafficDashboard({ token }: Props) {
     const [topCountriesError, setTopCountriesError] = useState<string | null>(null);
     const [topCountriesLoading, setTopCountriesLoading] = useState(true);
 
+    // Read from window.__RUNTIME_CONFIG__ so the same Docker image works
+    // on any domain. Calling once per mount is enough — the runtime
+    // config is set during SSR injection and never changes client-side.
     const baseUrl = useMemo(
-        () => `${runtimeConfig.apiBaseUrl}/admin/users/traffic`,
+        () => `${getRuntimeConfig().apiUrl}/admin/users/traffic`,
         []
     );
 
-    const fetchAll = useCallback(async () => {
+    useEffect(() => {
+        // Cleanup-flag guard against stale fetch results: clicking the
+        // window picker rapidly (e.g. 24h -> 7d -> 1h) starts overlapping
+        // requests, and a slower earlier response can land after a
+        // faster later one. Without this guard, the dashboard would
+        // briefly display data for a window the user has already left.
+        // The flag also covers the Refresh-while-fetching case via
+        // refreshNonce because the effect re-runs through the same
+        // cleanup path.
+        let active = true;
         const headers = { 'X-Admin-Token': token };
         const params = `?sinceHours=${sinceHours}`;
 
-        // Fire all four reads in parallel — they're independent endpoints
-        // and the loading-per-panel UX hides any tail latency.
+        // Reset loading and error state up-front so a previously-failed
+        // panel renders the loading state during refresh rather than
+        // continuing to display the stale error (PanelBody renders error
+        // before loading).
         setSummaryLoading(true);
         setBotOtherLoading(true);
         setTopPathsLoading(true);
         setTopCountriesLoading(true);
+        setSummaryError(null);
+        setBotOtherError(null);
+        setTopPathsError(null);
+        setTopCountriesError(null);
 
+        // Fire all four reads in parallel — they're independent endpoints
+        // and the loading-per-panel UX hides any tail latency.
         const summaryPromise = fetch(`${baseUrl}/summary${params}`, { headers })
             .then(async r => {
                 if (!r.ok) throw new Error(`Failed to load summary (${r.status})`);
                 return r.json() as Promise<SummaryResponse>;
             })
-            .then(data => { setSummary(data); setSummaryError(null); })
-            .catch(err => setSummaryError(err instanceof Error ? err.message : 'Failed to load'))
-            .finally(() => setSummaryLoading(false));
+            .then(data => { if (active) { setSummary(data); setSummaryError(null); } })
+            .catch(err => { if (active) setSummaryError(err instanceof Error ? err.message : 'Failed to load'); })
+            .finally(() => { if (active) setSummaryLoading(false); });
 
         const botOtherPromise = fetch(`${baseUrl}/bot-other-samples${params}&limit=15`, { headers })
             .then(async r => {
                 if (!r.ok) throw new Error(`Failed to load bot_other (${r.status})`);
                 return r.json() as Promise<AggregateResponse>;
             })
-            .then(data => { setBotOther(data); setBotOtherError(null); })
-            .catch(err => setBotOtherError(err instanceof Error ? err.message : 'Failed to load'))
-            .finally(() => setBotOtherLoading(false));
+            .then(data => { if (active) { setBotOther(data); setBotOtherError(null); } })
+            .catch(err => { if (active) setBotOtherError(err instanceof Error ? err.message : 'Failed to load'); })
+            .finally(() => { if (active) setBotOtherLoading(false); });
 
         const topPathsPromise = fetch(`${baseUrl}/top-paths${params}&limit=15`, { headers })
             .then(async r => {
                 if (!r.ok) throw new Error(`Failed to load paths (${r.status})`);
                 return r.json() as Promise<AggregateResponse>;
             })
-            .then(data => { setTopPaths(data); setTopPathsError(null); })
-            .catch(err => setTopPathsError(err instanceof Error ? err.message : 'Failed to load'))
-            .finally(() => setTopPathsLoading(false));
+            .then(data => { if (active) { setTopPaths(data); setTopPathsError(null); } })
+            .catch(err => { if (active) setTopPathsError(err instanceof Error ? err.message : 'Failed to load'); })
+            .finally(() => { if (active) setTopPathsLoading(false); });
 
         const topCountriesPromise = fetch(`${baseUrl}/top-countries${params}&limit=15`, { headers })
             .then(async r => {
                 if (!r.ok) throw new Error(`Failed to load countries (${r.status})`);
                 return r.json() as Promise<AggregateResponse>;
             })
-            .then(data => { setTopCountries(data); setTopCountriesError(null); })
-            .catch(err => setTopCountriesError(err instanceof Error ? err.message : 'Failed to load'))
-            .finally(() => setTopCountriesLoading(false));
+            .then(data => { if (active) { setTopCountries(data); setTopCountriesError(null); } })
+            .catch(err => { if (active) setTopCountriesError(err instanceof Error ? err.message : 'Failed to load'); })
+            .finally(() => { if (active) setTopCountriesLoading(false); });
 
-        await Promise.all([summaryPromise, botOtherPromise, topPathsPromise, topCountriesPromise]);
-    }, [baseUrl, token, sinceHours]);
+        // The await-all isn't required for cleanup correctness — each
+        // chain self-guards via `active`. It's kept off the effect
+        // signature deliberately: useEffect can't return a Promise.
+        void Promise.all([summaryPromise, botOtherPromise, topPathsPromise, topCountriesPromise]);
 
-    useEffect(() => {
-        void fetchAll();
-    }, [fetchAll]);
+        return () => { active = false; };
+    }, [baseUrl, token, sinceHours, refreshNonce]);
 
     const clickhouseDisabledNotice = summary && !summary.clickhouseEnabled;
 
@@ -198,7 +223,7 @@ export function TrafficDashboard({ token }: Props) {
                     <Button
                         variant="secondary"
                         size="sm"
-                        onClick={() => void fetchAll()}
+                        onClick={() => setRefreshNonce(n => n + 1)}
                         aria-label="Refresh dashboard"
                     >
                         <RefreshCw size={16} aria-hidden="true" /> Refresh

--- a/src/frontend/modules/user/components/admin/TrafficDashboard/index.ts
+++ b/src/frontend/modules/user/components/admin/TrafficDashboard/index.ts
@@ -1,0 +1,1 @@
+export { TrafficDashboard } from './TrafficDashboard';

--- a/src/frontend/modules/user/components/admin/index.ts
+++ b/src/frontend/modules/user/components/admin/index.ts
@@ -11,3 +11,4 @@ export { AnalyticsDashboard } from './AnalyticsDashboard';
 export { ReferralOverview } from './ReferralOverview';
 export { GscSettings } from './GscSettings';
 export { GroupsManager } from './GroupsManager';
+export { TrafficDashboard } from './TrafficDashboard';

--- a/src/frontend/modules/user/components/index.ts
+++ b/src/frontend/modules/user/components/index.ts
@@ -18,3 +18,4 @@ export { AnalyticsDashboard } from './admin';
 export { ReferralOverview } from './admin';
 export { GscSettings } from './admin';
 export { GroupsManager } from './admin';
+export { TrafficDashboard } from './admin';

--- a/src/frontend/modules/user/index.ts
+++ b/src/frontend/modules/user/index.ts
@@ -169,3 +169,4 @@ export { AnalyticsDashboard } from './components';
 export { ReferralOverview } from './components';
 export { GscSettings } from './components';
 export { GroupsManager } from './components';
+export { TrafficDashboard } from './components';


### PR DESCRIPTION
## Summary

Backs `PLAN-traffic-events.md` Phase 5 — the admin surface for the ClickHouse `traffic_events` table the prior phases populated.

### Backend

`TrafficService` gains four aggregate methods (`getBotClassBreakdown`, `getTopPaths`, `getTopCountries`, `getBotOtherUserAgents`). NULL-key buckets are preserved on the bot-class breakdown so the dashboard can chart classifier-coverage decay as pre-classifier rows roll off the window; NULL keys are excluded from the path/country top-N reads where they would dominate with no analytic value. A new `TrafficController` mounts under `/api/admin/users/traffic` (before `/api/admin/users` so its specific paths win over the `/:id` catch — same pattern as the existing user-groups sub-router) and exposes `/summary`, `/top-paths`, `/top-countries`, `/bot-other-samples`. The per-user history endpoint at `/api/admin/users/:id/traffic-history` reads ClickHouse directly by `candidate_uid`, so it works for cookie holders that never advanced past the ephemeral-user state and have no Mongo `users` row — exactly the case Phase 5 admins use it to investigate. Query params are clamped at the controller (`sinceHours` ≤ 720h / 30d, `limit` ≤ 200) to keep ClickHouse scan cost predictable.

### bot-classifier rule additions

Three additions sourced from the 2026-04-30 prod sample that surfaced these UAs in `bot_other`:

- `amazonbot` → `ai_crawler` — Amazon's training-crawl posture is the analytically interesting facet; pure-search Alexa is the secondary use case
- `dotbot` → `search_engine` — Moz Open Site Explorer link graph
- `flipboardproxy` → `social_unfurler` — Flipboard share previews

### Frontend `TrafficDashboard`

Client-only admin tab matching the established `GroupsManager` pattern (`X-Admin-Token` header, fetch-on-mount, local state). SSR + Live Updates does not apply because the route is admin-gated and the `/system/users` page is already a client component for the same reason. Four panels with independent loading/error/empty state so a slow query for one dimension does not blank the rest of the dashboard: bot-class breakdown (the headline panel), `bot_other` UA samples (the classifier-gap diagnostic this prod data made the case for), top landing paths, top countries. 1h/24h/7d/30d lookback window picker. Container-query responsive — the side-by-side paths/countries grid collapses at narrow widths so the dashboard stays usable in slideouts and on mobile. Uses semantic tokens throughout. Wired in as a new "Traffic" tab on `/system/users` between Analytics and Referrals.

### Tests and docs

17 new `traffic.service` tests cover NULL-bucket preservation, the null-exclusion clauses, the `bot_other`-only filter, the ClickHouse-disabled no-op paths, and error logging. 3 new `bot-classifier` test cases for the rule additions, sourced from the real prod UA strings. User module README has the new admin endpoints table and a Traffic-tab bullet in the Admin UI section. Phase Status table in `PLAN-traffic-events.md` will be moved Pending → Done in a follow-up parent-repo commit at merge time.