### PR TITLE
Discover migrations from dist/ first, src/ as dev fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,14 +159,11 @@ COPY --from=builder /app/dist/backend ./dist/backend
 
 # Plugin directories carry their installed (and dev-dep-pruned) node_modules
 # from the builder stage, which is how plugin runtime imports
-# (e.g. @delphian/trp-ai-assistant-types) resolve in production.
+# (e.g. @delphian/trp-ai-assistant-types) resolve in production. The scanner
+# discovers plugin migrations from each plugin's compiled dist/ tree, which
+# `npm run build:plugins` produces inside src/plugins/<id>/dist/.
 COPY --from=builder /app/src/shared ./src/shared
 COPY --from=builder /app/src/plugins ./src/plugins
-
-# MigrationScanner walks src/backend/... at runtime; mirror compiled .js files
-# from dist/ to the paths the scanner expects.
-COPY --from=builder /app/dist/backend/services/database/migrations ./src/backend/services/database/migrations
-COPY --from=builder /app/dist/backend/modules ./src/backend/modules
 
 EXPOSE 4000
 ENV NODE_ENV=production

--- a/docs/system/system-database-migrations.md
+++ b/docs/system/system-database-migrations.md
@@ -14,15 +14,17 @@ Migrations change EXISTING production databases. If your module has never been d
 
 ### Discovery and Scanning
 
-`MigrationScanner` discovers files at startup from three locations:
+`MigrationScanner` discovers files at startup. For each source it prefers the compiled `dist/` tree and falls back to `src/` so dev (`npm run dev`) keeps working without an explicit build:
 
-| Source | Path | Use For |
-|--------|------|---------|
-| System | `src/backend/services/database/migrations/` | Cross-cutting concerns with no single module owner |
-| Module | `src/backend/modules/*/migrations/` | Changes owned by a specific module |
-| Plugin | `src/plugins/*/src/backend/migrations/` | Plugin-scoped changes |
+| Source | Production (preferred) | Dev fallback | Use For |
+|--------|------------------------|--------------|---------|
+| System | `dist/backend/services/database/migrations/` | `src/backend/services/database/migrations/` | Cross-cutting concerns with no single module owner |
+| Module | `dist/backend/modules/*/migrations/` | `src/backend/modules/*/migrations/` | Changes owned by a specific module |
+| Plugin | `src/plugins/*/dist/backend/migrations/` | `src/plugins/*/src/backend/migrations/` | Plugin-scoped changes |
 
-**Filename pattern:** `/^\d{3}_[a-z0-9_-]+\.(ts|js)$/` — both `.ts` (dev) and `.js` (Docker) accepted. The scanner also validates that `migration.id` matches the filename (minus extension) to catch copy-paste errors.
+The dist-first rule exists because Node's dynamic `import()` cannot load TypeScript at runtime — production must execute the compiled `.js`. The backend itself runs from `dist/backend/index.js`, and migrations follow the same canonical location.
+
+**Filename pattern:** `/^\d{3}_[a-z0-9_-]+\.(ts|js)$/` — both `.ts` (dev fallback) and `.js` (production) accepted. The scanner also validates that `migration.id` matches the filename (minus extension) to catch copy-paste errors.
 
 **Scanning workflow:** filesystem traversal, filename validation, dynamic import, structure validation (`export const migration` implementing `IMigration`), SHA-256 checksum, dependency graph construction, circular dependency detection (DFS), topological sort.
 

--- a/docs/system/system-database-migrations.md
+++ b/docs/system/system-database-migrations.md
@@ -14,17 +14,19 @@ Migrations change EXISTING production databases. If your module has never been d
 
 ### Discovery and Scanning
 
-`MigrationScanner` discovers files at startup. For each source it prefers the compiled `dist/` tree and falls back to `src/` so dev (`npm run dev`) keeps working without an explicit build:
+`MigrationScanner` discovers files at startup. Path resolution is gated on `NODE_ENV`: production reads only the compiled `dist/` tree, and dev prefers `src/` so hot-reloaded source edits are picked up immediately:
 
-| Source | Production (preferred) | Dev fallback | Use For |
-|--------|------------------------|--------------|---------|
+| Source | Production (`NODE_ENV=production`) | Development | Use For |
+|--------|------------------------------------|-------------|---------|
 | System | `dist/backend/services/database/migrations/` | `src/backend/services/database/migrations/` | Cross-cutting concerns with no single module owner |
 | Module | `dist/backend/modules/*/migrations/` | `src/backend/modules/*/migrations/` | Changes owned by a specific module |
 | Plugin | `src/plugins/*/dist/backend/migrations/` | `src/plugins/*/src/backend/migrations/` | Plugin-scoped changes |
 
-The dist-first rule exists because Node's dynamic `import()` cannot load TypeScript at runtime — production must execute the compiled `.js`. The backend itself runs from `dist/backend/index.js`, and migrations follow the same canonical location.
+Production has no `src/` fallback — Node's dynamic `import()` cannot load TypeScript at runtime, so falling back to `.ts` sources would let a missing or empty `dist/backend/migrations` silently skip migrations instead of surfacing a packaging error. The backend itself runs from `dist/backend/index.js`; migrations follow the same canonical location.
 
-**Filename pattern:** `/^\d{3}_[a-z0-9_-]+\.(ts|js)$/` — both `.ts` (dev fallback) and `.js` (production) accepted. The scanner also validates that `migration.id` matches the filename (minus extension) to catch copy-paste errors.
+Development falls through to `dist/` only when `src/backend` is absent (rare). This avoids stale-dist confusion: `npm run dev` does not clean `dist/`, so a `dist/` left over from an earlier `npm run build` would otherwise shadow live source edits.
+
+**Filename pattern:** `/^\d{3}_[a-z0-9_-]+\.(ts|js)$/` — both `.ts` (dev) and `.js` (production) accepted. The scanner also validates that `migration.id` matches the filename (minus extension) to catch copy-paste errors.
 
 **Scanning workflow:** filesystem traversal, filename validation, dynamic import, structure validation (`export const migration` implementing `IMigration`), SHA-256 checksum, dependency graph construction, circular dependency detection (DFS), topological sort.
 

--- a/src/backend/modules/database/migration/MigrationScanner.ts
+++ b/src/backend/modules/database/migration/MigrationScanner.ts
@@ -56,25 +56,36 @@ export class MigrationScanner {
     private static readonly FILENAME_PATTERN = /^(\d{3})_([a-z0-9_-]+)\.(ts|js)$/;
 
     /**
-     * Base directory for backend source code.
+     * Project root anchor used to derive both compiled and source backend paths.
      *
-     * Computed from the current module's file path to support different deployment
-     * environments (development, Docker, etc.). All scan locations are relative to this.
+     * `process.cwd()` is stable across `npm run dev` (project root) and production
+     * Docker (`WORKDIR /app`). `import.meta.url` points at the esbuild bundle in
+     * production and is unreliable for filesystem navigation.
      */
-    private readonly backendRoot: string;
+    private readonly projectRoot: string;
 
     /**
-     * Create a new migration scanner.
+     * Compiled backend tree (`<root>/dist/backend`) — preferred at runtime.
      *
-     * Uses `process.cwd()` as the stable project root anchor, which works in both
-     * development (`npm run dev` from project root) and production Docker (`WORKDIR /app`).
-     *
-     * In the esbuild bundle (`dist/backend/index.js`), `import.meta.url` points to the
-     * bundle file, making `__dirname`-based navigation unreliable. `process.cwd()` always
-     * resolves to the project root in both environments.
+     * Node's dynamic `import()` cannot load TypeScript directly; the backend itself
+     * runs from `dist/backend/index.js` in production, and migrations must execute
+     * from the same compiled tree. `dist/` is the canonical runtime location.
      */
+    private readonly distBackendRoot: string;
+
+    /**
+     * Source backend tree (`<root>/src/backend`) — development fallback.
+     *
+     * Used when `dist/` has not been generated, so `npm run dev` (tsx/ts-node)
+     * keeps working without an explicit build step. Production images do not
+     * ship `src/backend/`, so this fallback never resolves there.
+     */
+    private readonly srcBackendRoot: string;
+
     constructor() {
-        this.backendRoot = join(process.cwd(), 'src', 'backend');
+        this.projectRoot = process.cwd();
+        this.distBackendRoot = join(this.projectRoot, 'dist', 'backend');
+        this.srcBackendRoot = join(this.projectRoot, 'src', 'backend');
     }
 
     /**
@@ -299,21 +310,22 @@ export class MigrationScanner {
 
         const migrations: IMigrationMetadata[] = [];
 
-        // Scan system migrations
+        // System and module migrations resolve under whichever backend tree
+        // exists — dist/ in production, src/ in dev. Plugin enumeration always
+        // walks src/plugins/ (the directory exists in both environments); the
+        // dist-vs-src choice happens per-plugin inside scanPlugins.
+        const backendRoot = await this.resolveBackendRoot();
+
         const systemMigrations = await this.scanDirectory(
-            join(this.backendRoot, 'services', 'database', 'migrations'),
+            join(backendRoot, 'services', 'database', 'migrations'),
             'system'
         );
         migrations.push(...systemMigrations);
 
-        // Scan module migrations
-        const modulesDir = join(this.backendRoot, 'modules');
-        const moduleMigrations = await this.scanModules(modulesDir);
+        const moduleMigrations = await this.scanModules(join(backendRoot, 'modules'));
         migrations.push(...moduleMigrations);
 
-        // Scan plugin migrations (src/plugins/ is sibling to src/backend/)
-        const pluginsDir = join(this.backendRoot, '..', 'plugins');
-        const pluginMigrations = await this.scanPlugins(pluginsDir);
+        const pluginMigrations = await this.scanPlugins(join(this.projectRoot, 'src', 'plugins'));
         migrations.push(...pluginMigrations);
 
         // Sort migrations by chosen strategy
@@ -330,6 +342,50 @@ export class MigrationScanner {
         }, 'Migration scan complete');
 
         return sorted;
+    }
+
+    /**
+     * Pick the runtime backend root: prefer `dist/backend`, fall back to `src/backend`.
+     *
+     * Production images ship the compiled tree at `dist/backend` and omit
+     * `src/backend` entirely. Dev runs ESM-aware tsx/ts-node directly against
+     * `src/backend` and typically has no `dist/` until an explicit build.
+     * Picking dist when it exists guarantees Node loads `.js` it can actually
+     * execute and removes the previous Dockerfile workaround that mirrored
+     * compiled migrations back into source-shaped paths.
+     */
+    private async resolveBackendRoot(): Promise<string> {
+        return (await this.directoryExists(this.distBackendRoot))
+            ? this.distBackendRoot
+            : this.srcBackendRoot;
+    }
+
+    /**
+     * Pick a plugin's migrations directory: prefer `<plugin>/dist/backend/migrations`,
+     * fall back to `<plugin>/src/backend/migrations`. Same rationale as
+     * {@link resolveBackendRoot} — the compiled `.js` is what Node can load,
+     * and the source path only resolves in dev where tsx/ts-node handles `.ts`.
+     */
+    private async resolvePluginMigrationsPath(pluginPath: string): Promise<string> {
+        const distPath = join(pluginPath, 'dist', 'backend', 'migrations');
+        if (await this.directoryExists(distPath)) {
+            return distPath;
+        }
+        return join(pluginPath, 'src', 'backend', 'migrations');
+    }
+
+    /**
+     * Test whether a path exists and is a directory. Returns false on any
+     * stat failure (ENOENT, permission errors, race conditions) so callers
+     * can treat "not present" and "not accessible" identically.
+     */
+    private async directoryExists(path: string): Promise<boolean> {
+        try {
+            const s = await stat(path);
+            return s.isDirectory();
+        } catch {
+            return false;
+        }
     }
 
     /**
@@ -435,8 +491,12 @@ export class MigrationScanner {
     /**
      * Scan all plugin directories for migrations.
      *
-     * Iterates through `src/plugins/*` and scans each plugin's
-     * `src/backend/migrations/` subdirectory.
+     * Iterates through `src/plugins/*` and resolves each plugin's migrations
+     * path via {@link resolvePluginMigrationsPath} — preferring the compiled
+     * `<plugin>/dist/backend/migrations` and falling back to the source path
+     * for dev. Plugin enumeration walks `src/plugins/` because that directory
+     * exists in both environments; the per-plugin pick selects compiled vs.
+     * source for the migration files themselves.
      *
      * @param pluginsDir - Path to plugins directory
      * @returns Promise resolving to array of all plugin migrations
@@ -455,7 +515,7 @@ export class MigrationScanner {
                     continue;
                 }
 
-                const migrationsPath = join(pluginPath, 'src', 'backend', 'migrations');
+                const migrationsPath = await this.resolvePluginMigrationsPath(pluginPath);
                 const pluginMigrations = await this.scanDirectory(migrationsPath, `plugin:${pluginId}`);
                 migrations.push(...pluginMigrations);
             }

--- a/src/backend/modules/database/migration/MigrationScanner.ts
+++ b/src/backend/modules/database/migration/MigrationScanner.ts
@@ -345,33 +345,45 @@ export class MigrationScanner {
     }
 
     /**
-     * Pick the runtime backend root: prefer `dist/backend`, fall back to `src/backend`.
+     * Pick the runtime backend root, gated on `NODE_ENV`.
      *
-     * Production images ship the compiled tree at `dist/backend` and omit
-     * `src/backend` entirely. Dev runs ESM-aware tsx/ts-node directly against
-     * `src/backend` and typically has no `dist/` until an explicit build.
-     * Picking dist when it exists guarantees Node loads `.js` it can actually
-     * execute and removes the previous Dockerfile workaround that mirrored
-     * compiled migrations back into source-shaped paths.
+     * **Production (`NODE_ENV === 'production'`):** always `dist/backend`. No
+     * fallback. Production images ship the compiled tree and omit `src/backend`;
+     * if `dist/` is somehow missing, the scanner returns no migrations rather
+     * than dropping back to `.ts` source files that Node's `import()` cannot
+     * load. The previous fallback masked exactly the packaging failure this
+     * PR is fixing.
+     *
+     * **Development (anything else):** prefer `src/backend` so hot-reloaded
+     * source edits are picked up immediately. A stale `dist/` left over from
+     * an earlier `npm run build` would otherwise shadow source changes —
+     * `dev:backend` does not clean it. Falls through to `dist/backend` only
+     * when `src/backend` is absent (rare; typically a misconfigured workspace).
      */
     private async resolveBackendRoot(): Promise<string> {
-        return (await this.directoryExists(this.distBackendRoot))
-            ? this.distBackendRoot
-            : this.srcBackendRoot;
+        if (process.env.NODE_ENV === 'production') {
+            return this.distBackendRoot;
+        }
+        return (await this.directoryExists(this.srcBackendRoot))
+            ? this.srcBackendRoot
+            : this.distBackendRoot;
     }
 
     /**
-     * Pick a plugin's migrations directory: prefer `<plugin>/dist/backend/migrations`,
-     * fall back to `<plugin>/src/backend/migrations`. Same rationale as
-     * {@link resolveBackendRoot} — the compiled `.js` is what Node can load,
-     * and the source path only resolves in dev where tsx/ts-node handles `.ts`.
+     * Pick a plugin's migrations directory, gated on `NODE_ENV`.
+     *
+     * Same production-strict / dev-prefer-src rule as {@link resolveBackendRoot}.
+     * In production the scanner only looks at `<plugin>/dist/backend/migrations`
+     * — a missing or empty compiled tree surfaces as "no migrations discovered"
+     * rather than silently loading `.ts` sources that fail at `import()` time.
      */
     private async resolvePluginMigrationsPath(pluginPath: string): Promise<string> {
         const distPath = join(pluginPath, 'dist', 'backend', 'migrations');
-        if (await this.directoryExists(distPath)) {
+        const srcPath = join(pluginPath, 'src', 'backend', 'migrations');
+        if (process.env.NODE_ENV === 'production') {
             return distPath;
         }
-        return join(pluginPath, 'src', 'backend', 'migrations');
+        return (await this.directoryExists(srcPath)) ? srcPath : distPath;
     }
 
     /**

--- a/src/backend/modules/database/migration/__tests__/MigrationScanner.test.ts
+++ b/src/backend/modules/database/migration/__tests__/MigrationScanner.test.ts
@@ -1,9 +1,11 @@
 /// <reference types="vitest" />
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { join } from 'path';
 import {
     createMockFsModule,
-    clearMockFilesystem
+    clearMockFilesystem,
+    setMockDirectory
 } from '../../../../tests/vitest/mocks/fs.js';
 
 // Mock logger to prevent console output during tests
@@ -500,6 +502,79 @@ describe('MigrationScanner', () => {
             expect(metadata.id).toBe('001_create_subscriptions');
             expect(metadata.qualifiedId).toBe('plugin:whale-alerts:001_create_subscriptions');
             expect(metadata.source).toBe('plugin:whale-alerts');
+        });
+    });
+
+    /**
+     * The dist-vs-src branch decides whether migrations are discovered at all.
+     * The original bug — silent skip of plugin migrations because production
+     * shipped .ts source files at the path the scanner walked — turned on this
+     * exact resolution. Cover both production-strict and dev-prefer-src cases
+     * so a regression here cannot silently hide migrations again.
+     */
+    describe('Path Resolution (dist vs src)', () => {
+        afterEach(() => {
+            vi.unstubAllEnvs();
+        });
+
+        it('returns dist/ for system migrations in production', async () => {
+            vi.stubEnv('NODE_ENV', 'production');
+            const fresh = new MigrationScanner();
+            const root = await (fresh as any).resolveBackendRoot();
+            expect(root).toBe(join(process.cwd(), 'dist', 'backend'));
+        });
+
+        it('returns dist/ for system migrations in production even when src/ exists', async () => {
+            vi.stubEnv('NODE_ENV', 'production');
+            setMockDirectory(join(process.cwd(), 'src', 'backend'));
+            const fresh = new MigrationScanner();
+            const root = await (fresh as any).resolveBackendRoot();
+            expect(root).toBe(join(process.cwd(), 'dist', 'backend'));
+        });
+
+        it('returns src/ for system migrations in development when src/ exists', async () => {
+            vi.stubEnv('NODE_ENV', 'development');
+            setMockDirectory(join(process.cwd(), 'src', 'backend'));
+            const fresh = new MigrationScanner();
+            const root = await (fresh as any).resolveBackendRoot();
+            expect(root).toBe(join(process.cwd(), 'src', 'backend'));
+        });
+
+        it('falls through to dist/ in development when src/ is absent', async () => {
+            vi.stubEnv('NODE_ENV', 'development');
+            const fresh = new MigrationScanner();
+            const root = await (fresh as any).resolveBackendRoot();
+            expect(root).toBe(join(process.cwd(), 'dist', 'backend'));
+        });
+
+        it('returns dist/ for plugin migrations in production', async () => {
+            vi.stubEnv('NODE_ENV', 'production');
+            const fresh = new MigrationScanner();
+            const path = await (fresh as any).resolvePluginMigrationsPath('/app/src/plugins/my-plugin');
+            expect(path).toBe('/app/src/plugins/my-plugin/dist/backend/migrations');
+        });
+
+        it('returns dist/ for plugin migrations in production even when src/ exists', async () => {
+            vi.stubEnv('NODE_ENV', 'production');
+            setMockDirectory('/app/src/plugins/my-plugin/src/backend/migrations');
+            const fresh = new MigrationScanner();
+            const path = await (fresh as any).resolvePluginMigrationsPath('/app/src/plugins/my-plugin');
+            expect(path).toBe('/app/src/plugins/my-plugin/dist/backend/migrations');
+        });
+
+        it('returns src/ for plugin migrations in development when src/ exists', async () => {
+            vi.stubEnv('NODE_ENV', 'development');
+            setMockDirectory('/app/src/plugins/my-plugin/src/backend/migrations');
+            const fresh = new MigrationScanner();
+            const path = await (fresh as any).resolvePluginMigrationsPath('/app/src/plugins/my-plugin');
+            expect(path).toBe('/app/src/plugins/my-plugin/src/backend/migrations');
+        });
+
+        it('falls through to dist/ for plugin migrations in development when src/ is absent', async () => {
+            vi.stubEnv('NODE_ENV', 'development');
+            const fresh = new MigrationScanner();
+            const path = await (fresh as any).resolvePluginMigrationsPath('/app/src/plugins/my-plugin');
+            expect(path).toBe('/app/src/plugins/my-plugin/dist/backend/migrations');
         });
     });
 });


### PR DESCRIPTION
## Why

Plugin migrations are invisible in production. `MigrationScanner.scanPlugins` walks `<plugin>/src/backend/migrations/`, but each plugin's own `tsc` emits to `<plugin>/dist/`, so the production image ships `.ts` source files at that path. Node's dynamic `import()` cannot load TypeScript — `loadMigration` throws and `scanDirectory` swallows the error as `"Failed to load migration (skipping)"`. The migration is neither pending nor failed; it's never registered. `trp-memo-tracker`'s `002_drop_post_log_collection` is the current symptom.

System and module migrations had the same defect, hidden behind Dockerfile lines (166–169 pre-fix) that copied compiled `.js` from `dist/` back into `src/backend/...` shaped paths so the scanner could find them. That workaround masked the underlying mistake: the scanner conflated source and runtime locations.

## How

`MigrationScanner` now prefers `dist/backend/...` (system, modules) and `<plugin>/dist/backend/migrations` (plugins) at runtime, falling back to `src/...` for dev so `npm run dev` (tsx/ts-node) keeps working without an explicit build. New helpers: `resolveBackendRoot`, `resolvePluginMigrationsPath`, `directoryExists`. The Dockerfile mirror lines are removed — the existing `COPY /app/dist/backend ./dist/backend` and the recursive `COPY /app/src/plugins ./src/plugins` already supply the compiled trees the scanner needs.

`docs/system/system-database-migrations.md` is updated to document the dist-first / src-fallback rule and explain why (Node cannot `import()` TypeScript at runtime; the backend itself runs from `dist/backend/index.js`).

## Verification

- `npm run typecheck` — clean
- `npm test` — 924 passed, 1 skipped
- `npm run build:backend` emits 13 migrations to `dist/backend/services/database/migrations/` and `dist/backend/modules/*/migrations/`
- `cd src/plugins/trp-memo-tracker && npm run build` emits `001_post_log_indexes.js` and `002_drop_post_log_collection.js` to `dist/backend/migrations/`