### PR TITLE
Fix ESM resolution for FileValidationError re-export

### DIFF
--- a/packages/types/src/pages/index.ts
+++ b/packages/types/src/pages/index.ts
@@ -21,5 +21,5 @@ export type {
     IFileUploadOptions,
     IFileListFilter
 } from './IFileService';
-export { FileValidationError, FileSizeExceededError } from './IFileService';
+export { FileValidationError, FileSizeExceededError } from './IFileService.js';
 export type { IMarkdownService, IFrontmatterData, IParsedMarkdown } from './IMarkdownService';

--- a/packages/types/src/pages/index.ts
+++ b/packages/types/src/pages/index.ts
@@ -9,17 +9,17 @@
  * - Markdown parsing and rendering with caching
  */
 
-export type { IPage } from './IPage';
-export type { IPageFile } from './IPageFile';
-export type { IPageSettings } from './IPageSettings';
-export type { IStorageProvider } from './IStorageProvider';
-export type { IPageService } from './IPageService';
+export type { IPage } from './IPage.js';
+export type { IPageFile } from './IPageFile.js';
+export type { IPageSettings } from './IPageSettings.js';
+export type { IStorageProvider } from './IStorageProvider.js';
+export type { IPageService } from './IPageService.js';
 export type {
     IFileService,
     IFileRecord,
     IFileSource,
     IFileUploadOptions,
     IFileListFilter
-} from './IFileService';
+} from './IFileService.js';
 export { FileValidationError, FileSizeExceededError } from './IFileService.js';
-export type { IMarkdownService, IFrontmatterData, IParsedMarkdown } from './IMarkdownService';
+export type { IMarkdownService, IFrontmatterData, IParsedMarkdown } from './IMarkdownService.js';


### PR DESCRIPTION
## Summary

The value re-export of `FileValidationError` and `FileSizeExceededError` in `packages/types/src/pages/index.ts` was the only line in the package that omitted the `.js` extension on its source specifier. `tsc` with `moduleResolution: "Node"` preserves the literal specifier untouched, but the package is `"type": "module"` and Node's ESM loader requires an explicit extension at runtime. The compiled `dist/pages/index.js` therefore had `from './IFileService'` and Node refused to resolve it, so the production backend crashed on import with `ERR_MODULE_NOT_FOUND` and `tronrelic-ops`'s smoke-boot step failed.

## Why this happened now

Before #217 the `pages/index.ts` barrel was 100% `export type` — TypeScript erases type-only re-exports entirely, so the compiled `.js` had no runtime imports and the missing-extension trap was invisible. Once `IFileService.ts` introduced runtime classes and the barrel started re-exporting them as values, the compiled output gained a real `import` statement that Node ESM had to honor.

## Convention

Every other value re-export in the package already uses the `.js` form: `user/index.ts`, `transaction/index.ts`, `plugin/index.ts`, `system-log/index.ts`, `widget/index.ts`. This change brings the new line into line with the rest.