### PR TITLE
Fail-fast on migration init; fix pages 004 dependency id

### DIFF
--- a/src/backend/modules/database/DatabaseModule.ts
+++ b/src/backend/modules/database/DatabaseModule.ts
@@ -157,22 +157,11 @@ export class DatabaseModule implements IModule<IDatabaseModuleDependencies> {
         this.databaseService = new DatabaseService(this.logger, mongooseConnection);
         this.logger.info('Core DatabaseService instance created');
 
-        // Initialize migration system by scanning filesystem
+        // Fail-fast: a swallowed scan error leaves migrationsInitialized=false,
+        // which makes every /api/admin/migrations/* call 500 with no signal.
         this.logger.info('Initializing database migration system...');
-        try {
-            await this.databaseService.initializeMigrations();
-            this.logger.info('Database migration system initialized');
-        } catch (migrationError) {
-            this.logger.error(
-                {
-                    error: migrationError,
-                    stack: migrationError instanceof Error ? migrationError.stack : undefined
-                },
-                'Migration system initialization failed'
-            );
-            // Continue startup - migration system failure should not prevent app from running
-            // Admin can still access migration UI to diagnose issues
-        }
+        await this.databaseService.initializeMigrations();
+        this.logger.info('Database migration system initialized');
 
         // Create migrations service and controller
         this.migrationsService = new MigrationsService(this.databaseService, this.logger);

--- a/src/backend/modules/database/__tests__/DatabaseModule.test.ts
+++ b/src/backend/modules/database/__tests__/DatabaseModule.test.ts
@@ -167,14 +167,15 @@ describe('DatabaseModule', () => {
         });
 
         /**
-         * Test: init should continue if migration initialization fails.
+         * Test: init should fail-fast when migration initialization fails.
          *
-         * Verifies that migration system failures don't prevent application startup.
-         * Note: This test is skipped because vi.mock hoisting makes it difficult to
-         * conditionally override the DatabaseService mock. The error handling is
-         * verified by integration tests.
+         * Verifies that scan errors (missing dep, circular dep, malformed file)
+         * propagate out of init() so a bad migration crashes smoke-boot rather
+         * than silently breaking /api/admin/migrations/* at runtime. Skipped
+         * because vi.mock hoisting makes it difficult to conditionally override
+         * the DatabaseService mock; covered by integration tests.
          */
-        it.skip('should continue if migration initialization fails', async () => {
+        it.skip('should fail-fast if migration initialization fails', async () => {
             // This test would require dynamically overriding the mocked DatabaseService
             // which conflicts with vi.mock hoisting. Tested in integration instead.
         });

--- a/src/backend/modules/pages/migrations/004_files_inventory.ts
+++ b/src/backend/modules/pages/migrations/004_files_inventory.ts
@@ -44,7 +44,7 @@ export const migration: IMigration = {
     id: '004_files_inventory',
     description:
         'Migrate page_files to module_pages_files with UUID ids, source namespacing, and extended indexes; drop legacy page_files.',
-    dependencies: ['003_add_old_slugs_to_pages'],
+    dependencies: ['module:pages:003_add_old_slugs_to_pages'],
 
     async up(context: IMigrationContext): Promise<void> {
         const legacy = context.database.getCollection('page_files');


### PR DESCRIPTION
## Summary

`DatabaseModule.init()` wrapped `initializeMigrations()` in a try/catch that swallowed every error and continued startup. The flag `migrationsInitialized` stayed `false`, so every `/api/admin/migrations/*` call returned 500 with no signal that the scan had failed. Drop the try/catch so a bad migration crashes the smoke-boot stage of `prod-publish.yml` instead of silently breaking the admin surface at runtime.

The actual failure the swallowed error was hiding: pages migration `004_files_inventory` declared its predecessor as the bare id `003_add_old_slugs_to_pages`, but the discovery system namespaces module migrations as `module:pages:<id>`. The unresolved dependency now resolves correctly.

Test description updated to match the new fail-fast contract; the spec stays `it.skip` because `vi.mock` hoisting prevents per-case override of the `DatabaseService` mock — integration coverage exercises the path.