### PR TITLE
Register trp-image-gen workspace in core lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -234,6 +234,10 @@
       "resolved": "src/plugins/trp-forum/packages/types",
       "link": true
     },
+    "node_modules/@delphian/trp-image-gen-types": {
+      "resolved": "src/plugins/trp-image-gen/packages/types",
+      "link": true
+    },
     "node_modules/@delphian/trp-memo-tracker-types": {
       "resolved": "src/plugins/trp-memo-tracker/packages/types",
       "link": true
@@ -12751,9 +12755,17 @@
         "typescript": "^5.3.3"
       }
     },
+    "src/plugins/trp-image-gen/packages/types": {
+      "name": "@delphian/trp-image-gen-types",
+      "version": "0.1.2",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
     "src/plugins/trp-memo-tracker/packages/types": {
       "name": "@delphian/trp-memo-tracker-types",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.3.3"


### PR DESCRIPTION
## Summary

`trp-image-gen` was added to `plugins.json` (ops repo `9aac174`) without a paired regeneration of the core `package-lock.json`, so the plugin's npm workspaces (`src/plugins/trp-image-gen/packages/*`) were never registered. The first prod-publish CI build to include the plugin failed at the test stage with:

```
npm error Missing: @delphian/trp-image-gen-types@0.1.2 from lock file
```

Past type-version bumps for other plugins didn't break CI because those workspaces were already registered — `npm ci` tolerates `version` drift on a registered workspace, but rejects an unregistered workspace it discovers on disk via the `src/plugins/*/packages/*` glob.

This commit is the regenerated lockfile from running `npm install` at the core root with `trp-image-gen` cloned at origin/main (types `0.1.2`).