### PR TITLE
Add nested submenu flyout to MenuNav category dropdown

### DIFF
--- a/src/frontend/app/primitives.scss
+++ b/src/frontend/app/primitives.scss
@@ -93,6 +93,7 @@
     --shadow-sm: 0 8px 18px rgba(7, 15, 30, 0.35);
     --shadow-md: 0 18px 36px rgba(10, 20, 45, 0.42);
     --shadow-lg: 0 28px 48px rgba(5, 12, 28, 0.55);
+    --shadow-xl: 0 40px 64px rgba(3, 8, 22, 0.65);   /* Floating overlays (menus, dropdowns) */
 
     /* Border Radius Tokens */
     --radius-xs: 4px;       /* Minimal rounding for small elements */

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -398,6 +398,20 @@
     --input-group-gap: var(--spacing-5);        /* 0.75rem */
 
     /* ========================================================================
+     * NAVIGATION COMPONENT TOKENS
+     * ======================================================================== */
+
+    /* Navigation - Tab Active State
+     *
+     * The selected/active tab in the main nav bar uses a pair of subtle
+     * white-alpha overlays — fill at 0.10 over the dark surface, border at
+     * 0.20 — that don't have a generic surface/border equivalent. They
+     * exist as use-case semantics so the active treatment can be themed
+     * (e.g. brand-tinted) without touching every nav component. */
+    --color-nav-tab-active-background: rgba(255, 255, 255, 0.1);
+    --color-nav-tab-active-border: rgba(255, 255, 255, 0.2);
+
+    /* ========================================================================
      * TABLE COMPONENT TOKENS
      * ======================================================================== */
 

--- a/src/frontend/components/layout/MenuNav/MenuNav.module.scss
+++ b/src/frontend/components/layout/MenuNav/MenuNav.module.scss
@@ -202,7 +202,6 @@
         border-radius: var(--radius-xl) var(--radius-xl) 0 0;
         border-bottom: none;
         padding: var(--padding-md);
-        padding-top: var(--padding-md);
         animation: categoryDropdown_slideUp 0.25s ease-out;
     }
 
@@ -316,7 +315,7 @@
     border: var(--modal-dialog-border);
     border-radius: var(--radius-md);
     padding: var(--padding-xs);
-    box-shadow: var(--shadow-lg);
+    box-shadow: var(--shadow-xl);
     backdrop-filter: blur(18px);
     animation: categoryDropdown_fadeIn var(--transition-base) ease-out;
     z-index: 1;

--- a/src/frontend/components/layout/MenuNav/MenuNav.module.scss
+++ b/src/frontend/components/layout/MenuNav/MenuNav.module.scss
@@ -14,7 +14,7 @@
 
 .nav {
     display: flex;
-    gap: var(--spacing-4);
+    gap: var(--gap-sm);
     flex: 1;
     min-width: 0;
     overflow-x: clip;
@@ -46,7 +46,7 @@
 }
 
 .tab {
-    padding: var(--spacing-4) var(--spacing-7);
+    padding: var(--padding-sm) var(--padding-md);
     background: transparent;
     border: var(--border-width-thin) solid transparent;
     border-radius: var(--radius-sm);
@@ -55,18 +55,18 @@
     color: inherit;
     transition: all var(--transition-base);
     cursor: pointer;
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-body-sm);
     line-height: var(--line-height-normal);
 }
 
 .tab:hover {
     background: var(--color-surface-elevated);
-    border-color: rgba(255, 255, 255, 0.1);
+    border-color: var(--color-nav-tab-active-background);
 }
 
 .tab.active {
-    background: rgba(255, 255, 255, 0.1);
-    border-color: rgba(255, 255, 255, 0.2);
+    background: var(--color-nav-tab-active-background);
+    border-color: var(--color-nav-tab-active-border);
     font-weight: var(--font-weight-medium);
 }
 
@@ -86,8 +86,8 @@
 .categoryButton {
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-2);
-    padding: var(--spacing-4) var(--spacing-7);
+    gap: var(--gap-xs);
+    padding: var(--padding-sm) var(--padding-md);
     background: transparent;
     border: var(--border-width-thin) solid transparent;
     border-radius: var(--radius-sm);
@@ -95,7 +95,7 @@
     color: inherit;
     transition: all var(--transition-base);
     cursor: pointer;
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-body-sm);
     line-height: var(--line-height-normal);
     font-family: inherit;
     white-space: nowrap;
@@ -103,7 +103,7 @@
 
 .categoryButton:hover {
     background: var(--color-surface-elevated);
-    border-color: rgba(255, 255, 255, 0.1);
+    border-color: var(--color-nav-tab-active-background);
 }
 
 .categoryButton:focus-visible {
@@ -112,8 +112,8 @@
 }
 
 .categoryButton.active {
-    background: rgba(255, 255, 255, 0.1);
-    border-color: rgba(255, 255, 255, 0.2);
+    background: var(--color-nav-tab-active-background);
+    border-color: var(--color-nav-tab-active-border);
     font-weight: var(--font-weight-medium);
 }
 
@@ -125,7 +125,7 @@
     display: block;
     width: 100%;
     text-align: left;
-    margin-bottom: var(--spacing-1);
+    margin-bottom: var(--gap-2xs);
 }
 
 .nested:last-child {
@@ -155,7 +155,7 @@
     background: var(--modal-dialog-background);
     border: var(--modal-dialog-border);
     border-radius: var(--radius-md);
-    padding: var(--spacing-2);
+    padding: var(--padding-xs);
     box-shadow: var(--shadow-xl);
     backdrop-filter: blur(18px);
     z-index: calc(var(--z-index-modal) + 11);
@@ -201,8 +201,8 @@
         overscroll-behavior: contain;
         border-radius: var(--radius-xl) var(--radius-xl) 0 0;
         border-bottom: none;
-        padding: var(--spacing-6);
-        padding-top: var(--spacing-8);
+        padding: var(--padding-md);
+        padding-top: var(--padding-md);
         animation: categoryDropdown_slideUp 0.25s ease-out;
     }
 
@@ -216,19 +216,24 @@
             transform: translateY(0);
         }
     }
+
 }
 
 .categoryDropdownItem {
     display: block;
+    // Anchor for an absolutely-positioned `.subcategoryPanel` so a nested
+    // submenu flies out to the right of *its parent row*, not the dropdown.
+    // Inert when no sub-panel is rendered.
+    position: relative;
 }
 
 .categoryDropdownItem > a {
     display: block;
     width: 100%;
-    padding: var(--spacing-3) var(--spacing-4);
+    padding: var(--padding-xs) var(--padding-sm);
     border-radius: var(--radius-sm);
     color: var(--color-text-muted);
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-body-sm);
     text-decoration: none;
     transition: color var(--transition-base), background-color var(--transition-base);
 }
@@ -241,4 +246,105 @@
 .categoryDropdownItem > a:focus-visible {
     outline: var(--focus-outline-width) solid var(--focus-outline-color);
     outline-offset: var(--focus-outline-offset);
+}
+
+/**
+ * Second-level (subcategory) toggle inside a category dropdown.
+ *
+ * Visually matches a dropdown link row so leaf and toggle rows align.
+ * The button is full-width with the label on the left and a chevron on
+ * the right; clicking it opens the corresponding `.subcategoryPanel`.
+ */
+.subcategoryButton {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: var(--padding-xs) var(--padding-sm);
+    background: transparent;
+    border: var(--border-width-thin) solid transparent;
+    border-radius: var(--radius-sm);
+    color: var(--color-text-muted);
+    font-size: var(--font-size-body-sm);
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: color var(--transition-base), background-color var(--transition-base);
+}
+
+.subcategoryButton:hover {
+    color: var(--color-text);
+    background: var(--color-surface-muted);
+}
+
+.subcategoryButton:focus-visible {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: var(--focus-outline-offset);
+}
+
+.subcategoryButton.active {
+    color: var(--color-text);
+    background: var(--color-surface-muted);
+    font-weight: var(--font-weight-medium);
+}
+
+.subcategoryChevron {
+    opacity: 0.6;
+    flex-shrink: 0;
+    margin-left: var(--gap-sm);
+}
+
+/**
+ * Side-flyout panel rendered when a subcategory is expanded. Default
+ * styles target desktop (≥ mobile breakpoint): an absolutely-positioned
+ * panel anchored to the right edge of its parent row, with the same
+ * surface chrome as the parent dropdown so the two visually pair as one
+ * cascading menu.
+ *
+ * The mobile override further down in this file flattens the panel into
+ * an inline accordion that grows within the bottom-sheet, which has no
+ * horizontal room for a flyout. Switching modes is pure CSS; the React
+ * tree is identical at every viewport.
+ */
+.subcategoryPanel {
+    position: absolute;
+    top: 0;
+    left: 100%;
+    margin-left: var(--gap-2xs);
+    min-width: 200px;
+    background: var(--modal-dialog-background);
+    border: var(--modal-dialog-border);
+    border-radius: var(--radius-md);
+    padding: var(--padding-xs);
+    box-shadow: var(--shadow-lg);
+    backdrop-filter: blur(18px);
+    animation: categoryDropdown_fadeIn var(--transition-base) ease-out;
+    z-index: 1;
+}
+
+/**
+ * Inline-accordion variant of `.subcategoryPanel` for the mobile
+ * bottom-sheet, where there is no horizontal room for a side flyout.
+ * The panel returns to the normal flow, drops its surface chrome
+ * (which would compete with the bottom-sheet's own surface), and
+ * indents to communicate hierarchy. The bottom-sheet's `overflow-y:
+ * auto` handles the vertical growth.
+ *
+ * This block lives after the desktop default so equal-specificity
+ * rules cascade correctly inside the matching viewport.
+ */
+@media (max-width: $breakpoint-mobile) {
+    .subcategoryPanel {
+        position: static;
+        left: auto;
+        margin-left: 0;
+        margin-top: var(--gap-2xs);
+        min-width: 0;
+        padding: 0 0 0 var(--padding-sm);
+        background: transparent;
+        border: none;
+        box-shadow: none;
+        backdrop-filter: none;
+        animation: none;
+    }
 }

--- a/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
@@ -408,8 +408,9 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
                         e.stopPropagation();
                         toggleSubcategory(child._id);
                     }}
+                    role="menuitem"
                     aria-expanded={isSubExpanded}
-                    aria-haspopup="true"
+                    aria-haspopup="menu"
                     aria-label={`${isSubExpanded ? 'Collapse' : 'Expand'} ${child.label} submenu`}
                 >
                     <span>{child.label}</span>

--- a/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
@@ -100,6 +100,11 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
     const dispatch = useAppDispatch();
     const menuConfig = useMenuConfig(namespace);
     const [expandedCategoryId, setExpandedCategoryId] = useState<string | null>(null);
+    // Tracks an open second-level submenu inside the currently expanded category
+    // dropdown. Single-open invariant matches top-level categories. Initial null
+    // is shared by server and first client render so this state never causes a
+    // hydration mismatch — both render the dropdown closed.
+    const [expandedSubcategoryId, setExpandedSubcategoryId] = useState<string | null>(null);
     const [isMounted, setIsMounted] = useState(false);
     const [hasInitialized, setHasInitialized] = useState(false);
     const hasInitializedRef = useRef(false);
@@ -169,6 +174,9 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
         if (expandedCategoryId) {
             const button = categoryButtonRefs.current.get(expandedCategoryId);
             setExpandedCategoryId(null);
+            // Reset nested submenu so reopening the parent never restores
+            // a stale second-level expansion.
+            setExpandedSubcategoryId(null);
             button?.focus();
         }
     }, [expandedCategoryId]);
@@ -213,9 +221,24 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
 
     /**
      * Toggles a category's expanded state.
+     *
+     * Reopening or switching the top-level category also collapses any open
+     * second-level submenu so the dropdown never restores stale nested state.
      */
     const toggleCategory = (categoryId: string) => {
         setExpandedCategoryId(prev => prev === categoryId ? null : categoryId);
+        setExpandedSubcategoryId(null);
+    };
+
+    /**
+     * Toggles the expanded state of a nested subcategory inside the open
+     * category dropdown. Mirrors the single-open invariant of toggleCategory:
+     * opening a different subcategory id collapses the previously expanded one.
+     *
+     * @param subcategoryId - Menu node id of the second-level container being toggled
+     */
+    const toggleSubcategory = (subcategoryId: string) => {
+        setExpandedSubcategoryId(prev => prev === subcategoryId ? null : subcategoryId);
     };
 
     /**
@@ -348,6 +371,81 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
     const navAriaLabel = ariaLabel || `${namespace} navigation`;
 
     /**
+     * Renders one row inside an expanded category dropdown.
+     *
+     * Leaf rows render as a navigation link. Rows whose node has its own
+     * children render as a second-level toggle paired with a sub-panel
+     * containing the node's own link (when it has a URL) plus its
+     * grandchildren. The sub-panel positions as a side flyout above the
+     * mobile breakpoint and as an inline accordion below it via CSS in
+     * MenuNav.module.scss — there is no JS branch for viewport.
+     *
+     * @param child - Menu node to render
+     * @returns Dropdown row JSX
+     */
+    const renderDropdownChild = (child: MenuNodeSerialized): JSX.Element => {
+        const hasChildren = !!(child.children && child.children.length > 0);
+
+        if (!hasChildren) {
+            return (
+                <div key={child._id} className={styles.categoryDropdownItem} role="none">
+                    {renderLinkItem(child, true)}
+                </div>
+            );
+        }
+
+        const isSubExpanded = expandedSubcategoryId === child._id;
+        const isActive = child.url
+            ? (pathname === child.url || pathname.startsWith(`${child.url}/`))
+            : false;
+
+        return (
+            <div key={child._id} className={styles.categoryDropdownItem} role="none">
+                <button
+                    type="button"
+                    className={`${styles.subcategoryButton} ${isActive ? styles.active : ''}`}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        toggleSubcategory(child._id);
+                    }}
+                    aria-expanded={isSubExpanded}
+                    aria-haspopup="true"
+                    aria-label={`${isSubExpanded ? 'Collapse' : 'Expand'} ${child.label} submenu`}
+                >
+                    <span>{child.label}</span>
+                    {isSubExpanded ? (
+                        <ChevronDown size={14} className={styles.subcategoryChevron} />
+                    ) : (
+                        <ChevronRight size={14} className={styles.subcategoryChevron} />
+                    )}
+                </button>
+                {isSubExpanded && (
+                    <div
+                        className={styles.subcategoryPanel}
+                        role="menu"
+                        aria-label={`${child.label} submenu`}
+                    >
+                        {child.url && (
+                            <div className={styles.categoryDropdownItem} role="none">
+                                {renderLinkItem(child, true)}
+                            </div>
+                        )}
+                        {child.children!.map(grandchild => (
+                            <div
+                                key={grandchild._id}
+                                className={styles.categoryDropdownItem}
+                                role="none"
+                            >
+                                {renderLinkItem(grandchild, true)}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        );
+    };
+
+    /**
      * Renders the category dropdown portal.
      * Portaled to document.body to escape overflow:hidden constraints.
      */
@@ -386,15 +484,7 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
                             {renderLinkItem(expandedCategory, true)}
                         </div>
                     )}
-                    {expandedCategory.children.map(child => (
-                        <div
-                            key={child._id}
-                            className={styles.categoryDropdownItem}
-                            role="none"
-                        >
-                            {renderLinkItem(child, true)}
-                        </div>
-                    ))}
+                    {expandedCategory.children.map(child => renderDropdownChild(child))}
                 </div>
             </>,
             document.body

--- a/src/frontend/modules/menu/components/CategoryLandingPage/CategoryLandingPage.module.scss
+++ b/src/frontend/modules/menu/components/CategoryLandingPage/CategoryLandingPage.module.scss
@@ -1,7 +1,7 @@
 .card {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-4);
+    gap: var(--gap-sm);
     padding: var(--card-padding-md);
     background: var(--card-background);
     border: var(--card-border);
@@ -21,13 +21,13 @@
     }
 
     &__title {
-        font-size: var(--font-size-lg);
+        font-size: var(--font-size-heading-sm);
         font-weight: var(--font-weight-semibold);
         margin: 0;
     }
 
     &__description {
-        font-size: var(--font-size-sm);
+        font-size: var(--font-size-body-sm);
         color: var(--color-text-muted);
         margin: 0;
         line-height: var(--line-height-relaxed);

--- a/src/frontend/modules/menu/components/PriorityNav/PriorityNav.module.scss
+++ b/src/frontend/modules/menu/components/PriorityNav/PriorityNav.module.scss
@@ -211,7 +211,6 @@
         border-radius: var(--radius-xl) var(--radius-xl) 0 0;
         border-bottom: none;
         padding: var(--padding-md);
-        padding-top: var(--padding-md);
 
         /* Slide up animation */
         animation: slideUp 0.3s ease-out;

--- a/src/frontend/modules/menu/components/PriorityNav/PriorityNav.module.scss
+++ b/src/frontend/modules/menu/components/PriorityNav/PriorityNav.module.scss
@@ -20,7 +20,7 @@
 .container {
     display: flex;
     align-items: center;
-    gap: var(--spacing-2);
+    gap: var(--gap-xs);
     width: 100%;
     min-width: 0;
     overflow-x: clip;
@@ -37,7 +37,7 @@
 .primary {
     display: flex;
     align-items: center;
-    gap: var(--spacing-2);
+    gap: var(--gap-xs);
     flex: 1;
     min-width: 0;
     overflow-x: clip;
@@ -76,15 +76,15 @@
     display: none;
     align-items: center;
     justify-content: center;
-    gap: var(--spacing-1);
+    gap: var(--gap-2xs);
     flex-shrink: 0;
-    padding: var(--spacing-2) var(--spacing-3);
+    padding: var(--padding-xs) var(--padding-xs);
     border: none;
     background: transparent;
     color: var(--color-text-muted);
     cursor: pointer;
     border-radius: var(--radius-sm);
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-body-sm);
     transition: background-color var(--transition-base), color var(--transition-base);
 }
 
@@ -113,11 +113,11 @@
     justify-content: center;
     min-width: 18px;
     height: 18px;
-    padding: 0 var(--spacing-1);
+    padding: 0 var(--padding-2xs);
     background: var(--color-primary);
     color: var(--color-text-on-primary);
     border-radius: var(--radius-full);
-    font-size: var(--font-size-xs);
+    font-size: var(--font-size-caption);
     font-weight: var(--font-weight-medium);
 }
 
@@ -171,7 +171,7 @@
     box-shadow: var(--shadow-xl);
     backdrop-filter: blur(18px);
     z-index: var(--z-index-modal);
-    padding: var(--spacing-4);
+    padding: var(--padding-sm);
     animation: slideDown var(--transition-base) ease-out;
 }
 
@@ -210,8 +210,8 @@
         /* Bottom sheet styling */
         border-radius: var(--radius-xl) var(--radius-xl) 0 0;
         border-bottom: none;
-        padding: var(--spacing-6);
-        padding-top: var(--spacing-8);
+        padding: var(--padding-md);
+        padding-top: var(--padding-md);
 
         /* Slide up animation */
         animation: slideUp 0.3s ease-out;
@@ -243,7 +243,7 @@
     .drag_handle {
         display: block;
         position: absolute;
-        top: var(--spacing-3);
+        top: var(--padding-xs);
         left: 50%;
         transform: translateX(-50%);
         width: 36px;
@@ -258,8 +258,8 @@
  */
 .close_button {
     position: absolute;
-    top: var(--spacing-2);
-    right: var(--spacing-2);
+    top: var(--padding-xs);
+    right: var(--padding-xs);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -290,8 +290,8 @@
 .dropdown_items {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-1);
-    padding-top: var(--spacing-6);
+    gap: var(--gap-2xs);
+    padding-top: var(--padding-md);
 }
 
 /**
@@ -307,10 +307,10 @@
 .dropdown_item > * {
     display: block;
     width: 100%;
-    padding: var(--spacing-3) var(--spacing-4);
+    padding: var(--padding-xs) var(--padding-sm);
     border-radius: var(--radius-sm);
     color: var(--color-text-muted);
-    font-size: var(--font-size-base);
+    font-size: var(--font-size-body);
     text-decoration: none;
     background: transparent;
     border: none;


### PR DESCRIPTION
## Summary

- Second-level menu nodes now render as expandable subcategory toggles inside the category dropdown. Desktop renders a side flyout anchored to the parent row; mobile flattens it to an inline accordion within the bottom-sheet via CSS only — the React tree is identical at every viewport.
- Reopening or switching a top-level category collapses any open subcategory so reopened dropdowns never restore stale nested state.
- Replaces foundation spacing/color primitives in `MenuNav`, `CategoryLandingPage`, and `PriorityNav` with use-case semantic tokens (`--gap-*`, `--padding-*`, `--font-size-body*`, `--color-nav-tab-active-*`).
- Adds `--shadow-xl` and the `--color-nav-tab-active-{background,border}` token pair to the design system so the active-tab treatment is themable without touching every nav component.