### PR TITLE
Drop abandoned transaction clustering fields and indexes

### DIFF
--- a/packages/types/src/transaction/ITransactionPersistencePayload.ts
+++ b/packages/types/src/transaction/ITransactionPersistencePayload.ts
@@ -66,13 +66,11 @@ export interface ITransactionPersistencePayload {
     /** Advanced pattern analysis and risk scoring */
     analysis?: {
         relatedAddresses?: string[];
-        relatedTransactions?: string[];
         pattern?: 'accumulation' | 'distribution' | 'arbitrage' | 'exchange_reshuffle' |
                   'exchange_outflow' | 'exchange_inflow' | 'self_shuffle' |
                   'cluster_distribution' | 'mega_whale' | 'delegation' | 'stake' |
                   'token_creation' | 'unknown';
         riskScore?: number;
-        clusterId?: string;
         confidence?: number;
     };
 }

--- a/src/backend/database/models/transaction-model.ts
+++ b/src/backend/database/models/transaction-model.ts
@@ -55,18 +55,14 @@ const TransactionSchema = new Schema<TransactionDoc>({
   notifications: [String],
   analysis: {
     relatedAddresses: [String],
-    relatedTransactions: [String],
     pattern: String,
     riskScore: Number,
-    clusterId: String,
     confidence: Number
   }
 }, { timestamps: true, versionKey: false });
 
 TransactionSchema.index({ timestamp: -1 });
 TransactionSchema.index({ 'analysis.pattern': 1 });
-TransactionSchema.index({ 'analysis.clusterId': 1, timestamp: -1 });
-TransactionSchema.index({ 'analysis.relatedTransactions': 1 });
 TransactionSchema.index({ memo: 1, timestamp: -1 });
 TransactionSchema.index({ 'internalTransactions.hash': 1 });
 TransactionSchema.index({ type: 1, timestamp: -1 });

--- a/src/backend/modules/blockchain/blockchain.service.ts
+++ b/src/backend/modules/blockchain/blockchain.service.ts
@@ -52,11 +52,10 @@ interface ContractActivityAccumulator {
 
 /**
  * Shared context passed through transaction enrichment pipeline.
- * Provides block-level data needed to enrich individual transactions with USD prices and relationship graphs.
+ * Provides block-level data needed to enrich individual transactions with USD prices.
  */
 interface TransactionBuildContext {
     priceUSD: number | null;
-    addressGraph: Map<string, Set<string>>;
     blockTime: Date;
 }
 
@@ -989,11 +988,8 @@ export class BlockchainService implements IBlockchainService {
             const priceUSD = await this.priceService.getTrxPriceUsd();
             timings.getTrxPrice = Date.now() - stageStart;
 
-            const addressGraph = new Map<string, Set<string>>();
-
             const buildContext: TransactionBuildContext = {
                 priceUSD,
-                addressGraph,
                 blockTime
             };
 
@@ -1245,10 +1241,9 @@ export class BlockchainService implements IBlockchainService {
      * Transform a raw TronGrid transaction into an enriched ProcessedTransaction model.
      *
      * This method converts hex addresses to Base58, resolves transaction amounts in both sun and TRX, applies USD pricing from the
-     * block context, enriches sender and receiver addresses with exchange/wallet labels, extracts memos and contract details, builds
-     * resource consumption metrics, and constructs a relationship graph connecting addresses within the block. The resulting ProcessedTransaction
-     * provides a complete, framework-independent view of the transaction that observers and the database layer can consume without touching
-     * raw TronGrid responses, making future blockchain provider swaps easier.
+     * block context, enriches sender and receiver addresses with exchange/wallet labels, extracts memos and contract details, and builds
+     * resource consumption metrics. The resulting ProcessedTransaction provides a complete, framework-independent view of the transaction
+     * that observers and the database layer can consume without touching raw TronGrid responses, making future blockchain provider swaps easier.
      */
     private buildTransactionRecord(
         block: TronGridBlock,
@@ -1316,20 +1311,14 @@ export class BlockchainService implements IBlockchainService {
             }
         };
 
-        const relatedTransactions = this.resolveRelatedTransactions(context.addressGraph, payload.txId, [ownerAddress, recipientAddress]);
-
-        // Build analysis with related addresses and transactions
         const relatedAddresses = new Set<string>(
             [ownerAddress, recipientAddress].filter(address => address && address !== 'unknown')
         );
 
         payload.analysis = {
             ...(payload.analysis ?? {}),
-            relatedTransactions,
             relatedAddresses: Array.from(relatedAddresses).slice(0, 50)
         };
-
-        payload.analysis.clusterId = this.deriveClusterId(payload, relatedTransactions, context.blockTime);
 
         const snapshot = this.toSnapshot(payload);
 
@@ -1350,54 +1339,6 @@ export class BlockchainService implements IBlockchainService {
         const rawTransaction: ITransaction = { payload, snapshot, categories: emptyCategories, rawValue, info };
 
         return new ProcessedTransaction(rawTransaction);
-    }
-
-    /**
-     * Build a list of related transactions by tracking address reuse within the block.
-     *
-     * Maintains an in-memory graph of addresses to transaction IDs, allowing detection of chained activity like exchange shuffles or
-     * arbitrage sequences. When the same address appears in multiple transactions within a block, those transactions are linked together
-     * for pattern analysis, capped at 25 relationships per transaction to prevent unbounded growth on high-volume addresses.
-     */
-    private resolveRelatedTransactions(
-        addressGraph: Map<string, Set<string>>,
-        txId: string,
-        participants: string[]
-    ): string[] {
-        const related = new Set<string>();
-
-        for (const participant of participants) {
-            if (!participant || participant === 'unknown') {
-                continue;
-            }
-
-            const existing = addressGraph.get(participant);
-
-            if (existing) {
-                existing.forEach(id => {
-                    if (id !== txId) {
-                        related.add(id);
-                    }
-                });
-                existing.add(txId);
-            } else {
-                addressGraph.set(participant, new Set([txId]));
-            }
-        }
-
-        return Array.from(related).slice(0, 25);
-    }
-
-    /**
-     * Derive a cluster ID for grouping related transactions across multiple blocks.
-     * Currently a placeholder that returns existing cluster IDs. Future implementation could use graph algorithms to identify whale activity clusters or exchange flow patterns.
-     */
-    private deriveClusterId(
-        payload: TransactionPersistencePayload,
-        relatedTransactions: string[],
-        blockTime: Date
-    ): string | undefined {
-        return payload.analysis?.clusterId;
     }
 
     /**

--- a/src/backend/services/database/migrations/002_drop_transaction_clustering_indexes.ts
+++ b/src/backend/services/database/migrations/002_drop_transaction_clustering_indexes.ts
@@ -1,0 +1,91 @@
+import type { IMigration, IMigrationContext } from '@/types';
+
+/**
+ * Drop the two indexes that backed the abandoned in-block transaction
+ * clustering feature.
+ *
+ * **Why this migration exists:**
+ * The `analysis.relatedTransactions` field and the `analysis.clusterId`
+ * field have been removed from the transaction schema. They were populated
+ * by an in-block address-graph scan and a `deriveClusterId` stub that
+ * never produced a non-undefined value, and no consumer (frontend, plugin,
+ * analytics, observer) ever read either field. The schema, type
+ * definitions, calculation code, and the lone whale-alerts plugin
+ * reference have all been removed in the same change.
+ *
+ * Mongoose's `autoIndex` only creates indexes that exist in the schema —
+ * it does not drop indexes that disappear from it. Without an explicit
+ * drop the two indexes linger in MongoDB indefinitely:
+ *   - `analysis.relatedTransactions_1` — multikey index on the array
+ *     field. New writes no longer populate it, but the index definition
+ *     remains and continues to consume cache space.
+ *   - `analysis.clusterId_1_timestamp_-1` — compound index. Even though
+ *     `clusterId` is no longer written, the compound key still fires on
+ *     every transaction insert because `timestamp` is part of it,
+ *     wasting CPU on no-value index updates.
+ *
+ * **Field data is not unset:**
+ * The hourly `blockchain:prune` job in `BlockchainService.pruneOldTransactions`
+ * `deleteMany`s transactions older than 7 days in 2-hour batches. Every
+ * existing document that still carries `analysis.relatedTransactions` or
+ * `analysis.clusterId` will be deleted within at most 7 days through
+ * normal rotation, so a wholesale `$unset` over the entire collection
+ * would just duplicate I/O the prune already does.
+ *
+ * **Idempotency:**
+ * Each `dropIndex` call is wrapped in a try/catch that swallows
+ * MongoDB's `IndexNotFound` error (code 27, message contains "not
+ * found"). Re-runs after a successful pass are no-ops, and fresh
+ * environments that never created the indexes (new dev DBs, CI) skip
+ * cleanly. Other errors propagate so the executor can record the
+ * failure.
+ *
+ * **Transaction semantics:**
+ * The migration executor wraps `up()` in `session.withTransaction()`
+ * when running against a replica set, but `context.database.getCollection()`
+ * returns a raw MongoDB collection that does not carry the session, so
+ * `dropIndex` runs as a normal DDL operation outside the transaction —
+ * the same pattern used by `001_drop_legacy_market_collections.ts` for
+ * `collection.drop()`. DDL inside a multi-document transaction is not
+ * supported by MongoDB anyway.
+ *
+ * **Rollback:**
+ * Not provided. Recreating the indexes would only be useful to undo a
+ * mistaken application of this migration; the application code has
+ * already removed every consumer of the underlying fields, so empty
+ * indexes would carry no signal.
+ */
+export const migration: IMigration = {
+    id: '002_drop_transaction_clustering_indexes',
+    description: 'Drop unused analysis.relatedTransactions_1 and analysis.clusterId_1_timestamp_-1 indexes from the transactions collection. Field data ages out via the existing blockchain:prune job within 7 days.',
+    dependencies: [],
+
+    async up(context: IMigrationContext): Promise<void> {
+        const transactions = context.database.getCollection('transactions');
+
+        const indexesToDrop = [
+            'analysis.relatedTransactions_1',
+            'analysis.clusterId_1_timestamp_-1'
+        ];
+
+        for (const indexName of indexesToDrop) {
+            try {
+                await transactions.dropIndex(indexName);
+                console.log(`[Migration] Dropped index: ${indexName}`);
+            } catch (error) {
+                // MongoDB throws IndexNotFound (code 27) with a "not found"
+                // message when the index is already absent — expected on
+                // re-runs and on fresh environments that never had it.
+                if (error instanceof Error && error.message.includes('not found')) {
+                    console.log(`[Migration] Skipped (not found): ${indexName}`);
+                } else {
+                    throw new Error(
+                        `Failed to drop index ${indexName} on transactions: ${error instanceof Error ? error.message : String(error)}`
+                    );
+                }
+            }
+        }
+
+        console.log('[Migration] Successfully dropped abandoned transaction clustering indexes');
+    }
+};

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -232,7 +232,6 @@ export interface WhaleHighlightRecord {
   toAddress: string;
   memo?: string;
   pattern?: string;
-  clusterId?: string;
   confidence?: number;
 }
 

--- a/src/shared/types/transaction.d.ts
+++ b/src/shared/types/transaction.d.ts
@@ -12,10 +12,8 @@ export interface ContractDetails {
 }
 export interface TransactionAnalysis {
     relatedAddresses?: string[];
-    relatedTransactions?: string[];
     pattern?: 'accumulation' | 'distribution' | 'arbitrage' | 'exchange_reshuffle' | 'exchange_outflow' | 'exchange_inflow' | 'self_shuffle' | 'cluster_distribution' | 'mega_whale' | 'delegation' | 'stake' | 'token_creation' | 'unknown';
     riskScore?: number;
-    clusterId?: string;
     confidence?: number;
 }
 export interface TronTransactionDocument {

--- a/src/shared/types/transaction.ts
+++ b/src/shared/types/transaction.ts
@@ -29,7 +29,6 @@ export interface ContractDetails {
 
 export interface TransactionAnalysis {
   relatedAddresses?: string[];
-  relatedTransactions?: string[];
   pattern?:
     | 'accumulation'
     | 'distribution'
@@ -45,7 +44,6 @@ export interface TransactionAnalysis {
     | 'token_creation'
     | 'unknown';
   riskScore?: number;
-  clusterId?: string;
   confidence?: number;
 }
 


### PR DESCRIPTION
## Summary

Removes the unused `analysis.relatedTransactions` and `analysis.clusterId` fields from the transaction schema, shared types, and persistence payload. These were populated by an in-block address-graph scan and a `deriveClusterId` stub that never produced a non-undefined value, and no consumer (frontend, plugin, observer, analytics) ever read either field.

Adds migration `002_drop_transaction_clustering_indexes` to drop the lingering `analysis.relatedTransactions_1` and `analysis.clusterId_1_timestamp_-1` MongoDB indexes — Mongoose `autoIndex` does not remove indexes when fields disappear from the schema, so without this they would continue consuming cache and firing on every insert. Field data is left to age out within 7 days via the existing `blockchain:prune` job rather than a wholesale `$unset`.