### PR TITLE
Treat completed migrations as satisfying dep declarations

### DIFF
--- a/docs/system/system-database-migrations.md
+++ b/docs/system/system-database-migrations.md
@@ -135,7 +135,7 @@ Accessible at `/system/database` (requires admin token). Displays pending/comple
 
 **Circular dependency:** Error message shows cycle path. Remove one dependency to break the cycle.
 
-**Missing dependency:** Check for typos, ensure dependency file exists with valid filename, use qualified IDs for module/plugin dependencies.
+**Missing dependency:** Check for typos, ensure dependency file exists with valid filename, use qualified IDs for module/plugin dependencies. A dep need not be on disk if its qualified ID is recorded as `completed` in the `migrations` collection — the scanner treats history-completed deps as satisfied so retiring an old migration source is safe in environments that have already run it. A `failed` record does not satisfy the dep; restore the source or rewrite the dependent migration.
 
 **Crash without transactions:** Application exits with `process.exit(1)` when migration fails on standalone MongoDB. Data may be partially modified. Verify database state manually, make migration idempotent, or use replica set for transaction support.
 

--- a/src/backend/modules/database/migration/MigrationScanner.ts
+++ b/src/backend/modules/database/migration/MigrationScanner.ts
@@ -289,7 +289,14 @@ export class MigrationScanner {
      * - Circular dependencies cause scan to fail with cycle path
      * - File read errors are logged as errors and skipped
      *
+     * **Phantom dependencies.** Pass `completedQualifiedIds` to satisfy
+     * declared dependencies whose source has been retired but whose execution
+     * is still recorded in the `migrations` collection. The graph then
+     * accepts them as already-completed leaves and the scan no longer fails
+     * just because an old migration file was deleted — see `topologicalSort`.
+     *
      * @param sortStrategy - How to order migrations before dependency resolution (default: 'id')
+     * @param completedQualifiedIds - Qualified IDs of migrations recorded as completed in history. Empty by default; pass from {@link MigrationTracker.getCompletedMigrationIds} for production use.
      * @returns Promise resolving to array of validated migration metadata in execution order
      * @throws Error if circular dependencies detected or required dependencies missing
      *
@@ -298,14 +305,18 @@ export class MigrationScanner {
      * const scanner = new MigrationScanner();
      *
      * try {
-     *     const migrations = await scanner.scan();
+     *     const completed = new Set(await tracker.getCompletedMigrationIds());
+     *     const migrations = await scanner.scan('id', completed);
      *     console.log(`Ready to execute ${migrations.length} migrations`);
      * } catch (error) {
      *     console.error('Migration scan failed:', error.message);
      * }
      * ```
      */
-    public async scan(sortStrategy: MigrationSortStrategy = 'id'): Promise<IMigrationMetadata[]> {
+    public async scan(
+        sortStrategy: MigrationSortStrategy = 'id',
+        completedQualifiedIds: Set<string> = new Set()
+    ): Promise<IMigrationMetadata[]> {
         logger.info('Scanning for database migrations...');
 
         const migrations: IMigrationMetadata[] = [];
@@ -332,7 +343,7 @@ export class MigrationScanner {
         this.sortMigrations(migrations, sortStrategy);
 
         // Validate dependencies and build execution order
-        const sorted = this.topologicalSort(migrations);
+        const sorted = this.topologicalSort(migrations, completedQualifiedIds);
 
         logger.info({
             total: sorted.length,
@@ -654,18 +665,34 @@ export class MigrationScanner {
      * 4. Detect cycles if we encounter a gray node during traversal
      * 5. Add migrations to result in post-order (dependencies first)
      *
+     * **Phantom dependencies.** A dep listed in `completedQualifiedIds`
+     * but absent from the discovered set is treated as an already-executed
+     * leaf: the validation accepts it, and the DFS does not recurse into
+     * it (it has no further deps to traverse and cannot participate in a
+     * cycle of currently-discoverable migrations). This lets operators
+     * delete migration source files once every environment has run them
+     * without breaking downstream migrations that still declare the
+     * retired ID as a dependency.
+     *
      * @param migrations - Array of migrations to sort
+     * @param completedQualifiedIds - Qualified IDs of migrations recorded as completed in history. Empty by default — every dep must then be on disk.
      * @returns Array of migrations in topological order (dependencies before dependents)
-     * @throws Error if circular dependencies detected or dependency not found
+     * @throws Error if circular dependencies detected or dependency not found on disk and not completed historically
      */
-    private topologicalSort(migrations: IMigrationMetadata[]): IMigrationMetadata[] {
+    private topologicalSort(
+        migrations: IMigrationMetadata[],
+        completedQualifiedIds: Set<string> = new Set()
+    ): IMigrationMetadata[] {
         // Build map for fast lookup using qualified IDs
         const migrationMap = new Map<string, IMigrationMetadata>();
         for (const migration of migrations) {
             migrationMap.set(migration.qualifiedId, migration);
         }
 
-        // Validate all dependencies exist
+        // Validate every dep either exists on disk or is recorded as
+        // completed historically. The completed branch is what makes
+        // retiring an old migration file safe in environments that have
+        // already executed it.
         for (const migration of migrations) {
             for (const depId of migration.dependencies || []) {
                 // Support both plain IDs (resolve to system) and qualified IDs
@@ -673,11 +700,11 @@ export class MigrationScanner {
                 // Qualified dependency ID like 'module:menu:001_add_namespace' is explicit
                 const lookupId = depId.includes(':') ? depId : depId; // Plain ID assumes system
 
-                if (!migrationMap.has(lookupId)) {
+                if (!migrationMap.has(lookupId) && !completedQualifiedIds.has(lookupId)) {
                     throw new Error(
-                        `Migration '${migration.qualifiedId}' depends on '${depId}', but that migration was not found. ` +
+                        `Migration '${migration.qualifiedId}' depends on '${depId}', but that migration was not found on disk and has no completed record in the migrations collection. ` +
                         `Available migrations: ${Array.from(migrationMap.keys()).join(', ')}. ` +
-                        `Ensure the dependency exists or remove it from the dependencies array.`
+                        `Ensure the dependency exists, has been completed historically, or remove it from the dependencies array.`
                     );
                 }
             }
@@ -709,8 +736,13 @@ export class MigrationScanner {
             for (const depId of migration.dependencies || []) {
                 // Support both plain and qualified dependency IDs
                 const lookupId = depId.includes(':') ? depId : depId;
-                const dep = migrationMap.get(lookupId)!;
-                visit(dep, [...path]);
+                const dep = migrationMap.get(lookupId);
+                // Phantom deps (recorded as completed but absent from disk)
+                // are leaves: already executed, no further deps to traverse,
+                // can't participate in a cycle of discoverable migrations.
+                if (dep) {
+                    visit(dep, [...path]);
+                }
             }
 
             visiting.delete(migration.qualifiedId);

--- a/src/backend/modules/database/migration/__tests__/MigrationScanner.test.ts
+++ b/src/backend/modules/database/migration/__tests__/MigrationScanner.test.ts
@@ -207,6 +207,73 @@ describe('MigrationScanner', () => {
         });
     });
 
+    describe('Phantom Dependency Resolution', () => {
+        /**
+         * Test: A dep absent from disk but listed in completed history is
+         * accepted as already-executed. Lets operators retire old
+         * migration source files once every environment has run them.
+         */
+        it('should accept dep recorded as completed even when not on disk', async () => {
+            const migrations = [
+                createMigrationFixture('002_dependent', { dependencies: ['001_retired'] })
+            ];
+            const completed = new Set(['001_retired']);
+
+            const sorted = await (scanner as any).topologicalSort(migrations, completed);
+            expect(sorted).toHaveLength(1);
+            expect(sorted[0].id).toBe('002_dependent');
+        });
+
+        /**
+         * Test: A dep that is neither on disk nor in completed history
+         * still throws — fresh environments without history see the same
+         * fail-fast behavior as before.
+         */
+        it('should throw when dep is absent from both disk and history', async () => {
+            const migrations = [
+                createMigrationFixture('002_dependent', { dependencies: ['999_phantom'] })
+            ];
+            const completed = new Set<string>();
+
+            await expect(async () => {
+                await (scanner as any).topologicalSort(migrations, completed);
+            }).rejects.toThrow(/depends on '999_phantom'/);
+        });
+
+        /**
+         * Test: Phantom deps act as leaves — DFS does not recurse into
+         * them. Regression check: the previous code did
+         * `migrationMap.get(lookupId)!` and would have crashed.
+         */
+        it('should treat phantom deps as DFS leaves without crashing', async () => {
+            const migrations = [
+                createMigrationFixture('A', { dependencies: ['phantom'] }),
+                createMigrationFixture('B', { dependencies: ['A'] })
+            ];
+            const completed = new Set(['phantom']);
+
+            const sorted = await (scanner as any).topologicalSort(migrations, completed);
+            expect(sorted).toHaveLength(2);
+            expect(sorted.findIndex((m: any) => m.id === 'A'))
+                .toBeLessThan(sorted.findIndex((m: any) => m.id === 'B'));
+        });
+
+        /**
+         * Test: Backward compatibility — calling topologicalSort without
+         * the completed-IDs argument behaves exactly as the legacy code
+         * did. Every dep must be on disk.
+         */
+        it('should require deps on disk when no completed set is passed', async () => {
+            const migrations = [
+                createMigrationFixture('002_dependent', { dependencies: ['001_missing'] })
+            ];
+
+            await expect(async () => {
+                await (scanner as any).topologicalSort(migrations);
+            }).rejects.toThrow(/depends on '001_missing'/);
+        });
+    });
+
     describe('Circular Dependency Detection', () => {
         /**
          * Test: Scanner should detect direct circular dependencies.

--- a/src/backend/modules/database/services/database.service.ts
+++ b/src/backend/modules/database/services/database.service.ts
@@ -498,8 +498,20 @@ export class DatabaseService implements IDatabaseService {
             // Ensure migration tracker indexes exist
             await this.migrationTracker.ensureIndexes();
 
+            // Load qualified IDs of migrations recorded as completed. The
+            // scanner uses this set to satisfy dependency declarations
+            // whose source has been retired but whose execution is
+            // preserved in history — without this, deleting an old
+            // migration file breaks the dep graph for every downstream
+            // migration that still references it. Failed records are
+            // intentionally excluded so a deleted-and-failed migration
+            // continues to surface as "missing dependency."
+            const completedQualifiedIds = new Set(
+                await this.migrationTracker.getCompletedMigrationIds()
+            );
+
             // Scan filesystem for migrations
-            this.discoveredMigrations = await this.migrationScanner.scan();
+            this.discoveredMigrations = await this.migrationScanner.scan('id', completedQualifiedIds);
 
             // Remove orphaned pending migrations (code deleted but record exists)
             await this.migrationTracker.removeOrphanedPending(this.discoveredMigrations);


### PR DESCRIPTION
## Summary

The migration scanner used to throw at bootstrap whenever any discovered migration declared a dependency that was not also present on disk. That meant retiring an old migration source — even one every environment had already executed — broke the dependency graph for every downstream migration that still referenced its qualified ID. PR #228 hit exactly this trap when `modules/files/migrations/001_files_settings.ts` was deleted while `module:pages:005_strip_file_fields_from_page_settings` still listed it as a dep; only the prior in-prod state of the `migrations` collection prevented an outage.

`MigrationScanner.topologicalSort` now accepts an optional `completedQualifiedIds: Set<string>` and treats any dep present in that set as an already-executed leaf — the validation accepts it, and the DFS does not recurse into it. Phantom deps cannot participate in a cycle of currently-discoverable migrations and have no further deps to traverse, so leafing them is correct. Failed records do not count, so a deleted-and-failed migration still surfaces as a missing dependency. New environments with empty history fall through to the prior fail-fast behavior unchanged.

`DatabaseService.initializeMigrations()` loads the completed-ID set via the tracker's existing `getCompletedMigrationIds()` before calling `scan()`, so the new behavior is wired into the production bootstrap path. The doc snippet in `system-database-migrations.md` ("Missing dependency") was updated to describe the history-aware semantics.

## Tests

Added a `Phantom Dependency Resolution` describe block covering: dep accepted when in completed set, dep rejected when in neither disk nor history, phantom-as-leaf DFS regression check, and backward compatibility when no set is passed. All 31 scanner tests + the surrounding tracker / executor / database-service / DatabaseModule suites pass (72 / 1 skipped). Backend `tsc --noEmit` clean.