### PR TITLE
Drop removed module:files:001 dep from pages migration 005

### DIFF
--- a/src/backend/modules/pages/migrations/005_strip_file_fields_from_page_settings.ts
+++ b/src/backend/modules/pages/migrations/005_strip_file_fields_from_page_settings.ts
@@ -13,16 +13,11 @@ import type { IMigration, IMigrationContext } from '@/types';
  * not the other would silently disagree about policy at the next upload.
  * This migration removes the duplication so `page_settings` only carries
  * page-only concerns (`blacklistedRoutes`).
- *
- * **Ordering**
- *
- * Depends on `module:files:001_files_settings` so the new collection is
- * always populated before the old fields are dropped.
  */
 export const migration: IMigration = {
     id: '005_strip_file_fields_from_page_settings',
     description: 'Remove file-upload policy fields from page_settings (now owned by module_files_settings)',
-    dependencies: ['module:files:001_files_settings'],
+    dependencies: [],
 
     async up(context: IMigrationContext): Promise<void> {
         const pageSettings = context.database.getCollection('page_settings');


### PR DESCRIPTION
## Summary

Migration `module:pages:005_strip_file_fields_from_page_settings` declares a dependency on `module:files:001_files_settings`, which was removed in #228. Production migrates fine because #229 lets the scanner treat completed-history records as satisfying deps — but a fresh database (smoke-boot, dev bring-up, new deploy) has no historical record, so the topological sort throws during `DatabaseModule.init` and the backend exits before serving `/api/health`. This was caught today by the prod-publish smoke gate.

The fix removes the dependency. The migration's `up()` is idempotent — `$unset` on absent fields is a no-op — so it is safe to run with no deps in any environment, including ones that never had the file-policy fields.