### PR TITLE
Fix SEO section centering and add README agent-reference guidance

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -38,6 +38,8 @@ If a topic requires more than 300 lines, split it into multiple focused document
 
 **Exception: Module and plugin README.md files.** A `README.md` colocated in a module directory (`src/backend/modules/*/README.md`) or plugin directory (`src/plugins/*/README.md`) serves as the *complete* documentation for that feature — architecture, API reference, database schema, usage examples, and troubleshooting in a single file. These files are intentionally exempt from the 300-line limit because they are the canonical source of truth for their feature and splitting them would scatter context that developers need in one place.
 
+**Plugin and module READMEs are AI-agent reference, not narrative.** Their primary consumer is an AI coding agent that needs to interface with or modify the feature. Lead with the surfaces an agent must locate fast — plugin id, service registry name, admin URL, types package, manifest path, and a source map — then publish the contract (service signatures, REST endpoints, WebSocket events, storage schema, scheduler jobs, lifecycle obligations) as scannable tables. Keep prose only where the contract alone cannot carry the "why" (e.g., why a tool description dominates selection accuracy, why `services.watch()` beats `services.get()`). Drop narrative onboarding, marketing prose, implementation trivia ("markdown rendered via remark processSync"), and rationale repetition — agents read source for behavior. The line-limit waiver is not a license for verbosity; brevity still applies. See `src/plugins/trp-ai-assistant/README.md` for the reference implementation.
+
 ## Structure Template
 
 Every document should follow the "why → how → example" rhythm. Adapt headings as needed, but maintain this flow:

--- a/src/frontend/components/PluginPageWithZones.module.css
+++ b/src/frontend/components/PluginPageWithZones.module.css
@@ -5,9 +5,22 @@
  * Max-width constrained for readability, centered within the page layout.
  */
 
+/*
+ * `<main>` and `.core-layout` are nested flex columns. `align-self: center`
+ * opts the section out of `align-items: stretch` so width can be capped by
+ * `max-width: 80ch`. Horizontal margins must NOT be `auto` — auto cross-axis
+ * margins on a flex item override `align-self` and combine with this element's
+ * own `container-type: inline-size` (which forces inline size to be computed
+ * without descendant contribution) to collapse the box to min-content. Use
+ * explicit horizontal margins (0) and rely on `align-self: center` for
+ * centering.
+ */
 .seo_section {
+    align-self: center;
+    width: 100%;
     max-width: 80ch;
-    margin: var(--spacing-14) auto var(--spacing-10);
+    box-sizing: border-box;
+    margin: var(--spacing-14) 0 var(--spacing-10);
     padding: 0 var(--spacing-8);
     color: var(--color-text-muted);
     container-type: inline-size;


### PR DESCRIPTION
## Summary

- **PluginPageWithZones SEO section centering**: the `.seo_section` flex item was collapsing to min-content. Auto cross-axis margins on a flex item override `align-self`, and `container-type: inline-size` forces inline size to be computed without descendant contribution. Replaced `margin: ... auto ...` with `align-self: center`, `width: 100%`, and explicit horizontal margins of 0.
- **Documentation guideline**: plugin and module README.md files are AI-agent reference (contract-first tables, scannable surfaces), not narrative onboarding. The README size waiver is not a license for verbosity.