### PR TITLE
Sync lockfile with trp-resource-markets-types@1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -242,6 +242,10 @@
       "resolved": "src/plugins/trp-memo-tracker/packages/types",
       "link": true
     },
+    "node_modules/@delphian/trp-resource-markets-types": {
+      "resolved": "src/plugins/trp-resource-markets/packages/types",
+      "link": true
+    },
     "node_modules/@delphian/trp-resource-tracker-types": {
       "resolved": "src/plugins/trp-resource-tracker/packages/types",
       "link": true
@@ -12771,6 +12775,14 @@
         "typescript": "^5.3.3"
       }
     },
+    "src/plugins/trp-resource-markets/packages/types": {
+      "name": "@delphian/trp-resource-markets-types",
+      "version": "1.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
     "src/plugins/trp-resource-tracker/packages/types": {
       "name": "@delphian/trp-resource-tracker-types",
       "version": "1.0.0",
@@ -12781,7 +12793,7 @@
     },
     "src/plugins/trp-telegram-bot/packages/types": {
       "name": "@delphian/trp-telegram-bot-types",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.3.3"


### PR DESCRIPTION
## Summary

The `trp-resource-markets` plugin bumped its `packages/types` subpackage to `1.1.0` but the root `package-lock.json` wasn't regenerated. CI `npm ci` aborts with `Missing: @delphian/trp-resource-markets-types@1.1.0 from lock file` (see [run 25611960865](https://github.com/delphian/tronrelic-ops/actions/runs/25611960865)). This commit regenerates the lock against the current workspace state — only entries for that package change.