### PR TITLE
Toggle Tooltip on tap so touch devices can dismiss it

### DIFF
--- a/src/frontend/components/ui/Tooltip/Tooltip.tsx
+++ b/src/frontend/components/ui/Tooltip/Tooltip.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import { useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type PointerEvent, type ReactNode } from 'react';
 import styles from './Tooltip.module.css';
 
 /**
  * Tooltip props interface defining trigger and content configuration.
  *
- * Controls the explanatory text displayed on hover and the trigger element
- * that activates the tooltip.
+ * Controls the explanatory text displayed on hover/tap and the trigger
+ * element that activates the tooltip.
  */
 interface TooltipProps {
     /** Text content to display in the tooltip overlay */
     content: string;
-    /** Trigger element that activates the tooltip on hover */
+    /** Trigger element that activates the tooltip on hover/tap */
     children: ReactNode;
     /** Placement of the tooltip relative to the trigger (default: 'top') */
     placement?: 'top' | 'bottom';
@@ -21,17 +21,16 @@ interface TooltipProps {
 /**
  * Tooltip Component
  *
- * Displays a contextual tooltip with explanatory text when hovering over the trigger
- * element. The tooltip can appear above or below the trigger with an arrow indicator
- * and fades in smoothly with animation. Positioning is centered relative to the trigger
- * and includes viewport boundary considerations.
+ * Displays a contextual tooltip with explanatory text. On mouse devices the
+ * tooltip appears on hover; on touch devices it toggles on tap and dismisses
+ * on tap-outside, since synthesized hover events do not work reliably across
+ * mobile browsers. Hover and tap behaviors are dispatched separately based
+ * on `PointerEvent.pointerType` so neither input mode interferes with the
+ * other.
  *
- * The tooltip automatically hides when the mouse leaves the trigger area and uses
- * pointer-events: none to prevent interference with mouse interaction. Max width is
- * constrained to maintain readability while supporting multi-line content.
- *
- * Use `placement="bottom"` when the tooltip appears in a container with overflow
- * constraints (like table headers with horizontal scroll) to prevent clipping.
+ * Use `placement="bottom"` when the tooltip appears in a container with
+ * overflow constraints (like table headers with horizontal scroll) to
+ * prevent clipping.
  *
  * @example
  * ```tsx
@@ -39,31 +38,56 @@ interface TooltipProps {
  *   <button>Refresh</button>
  * </Tooltip>
  * ```
- *
- * @example
- * ```tsx
- * <Tooltip content="Energy cost is calculated based on current network rates" placement="bottom">
- *   <Info size={14} />
- * </Tooltip>
- * ```
- *
- * @param props.content - The text to display in the tooltip
- * @param props.children - The trigger element that activates the tooltip on hover
- * @param props.placement - Position of the tooltip relative to the trigger ('top' | 'bottom')
- * @returns A hoverable element with an absolutely positioned tooltip overlay
  */
 export function Tooltip({ content, children, placement = 'top' }: TooltipProps) {
     const [isVisible, setIsVisible] = useState(false);
+    const triggerRef = useRef<HTMLSpanElement | null>(null);
+
+    function handlePointerEnter(event: PointerEvent<HTMLSpanElement>) {
+        if (event.pointerType === 'mouse') {
+            setIsVisible(true);
+        }
+    }
+
+    function handlePointerLeave(event: PointerEvent<HTMLSpanElement>) {
+        if (event.pointerType === 'mouse') {
+            setIsVisible(false);
+        }
+    }
+
+    function handleClick() {
+        setIsVisible(prev => !prev);
+    }
+
+    // Close on outside tap so a touch user can dismiss without finding a
+    // second tap target on the trigger itself. Listener is attached only
+    // while the tooltip is open, so it is a no-op for hover-driven sessions.
+    useEffect(() => {
+        if (!isVisible) return undefined;
+        function handleDocumentPointerDown(event: globalThis.PointerEvent) {
+            const trigger = triggerRef.current;
+            if (trigger && !trigger.contains(event.target as Node)) {
+                setIsVisible(false);
+            }
+        }
+        document.addEventListener('pointerdown', handleDocumentPointerDown);
+        return () => document.removeEventListener('pointerdown', handleDocumentPointerDown);
+    }, [isVisible]);
 
     return (
         <span
+            ref={triggerRef}
             className={styles.trigger}
-            onMouseEnter={() => setIsVisible(true)}
-            onMouseLeave={() => setIsVisible(false)}
+            onPointerEnter={handlePointerEnter}
+            onPointerLeave={handlePointerLeave}
+            onClick={handleClick}
         >
             {children}
             {isVisible && (
-                <span className={`${styles.content} ${placement === 'bottom' ? styles.content_bottom : ''}`}>
+                <span
+                    role="tooltip"
+                    className={`${styles.content} ${placement === 'bottom' ? styles.content_bottom : ''}`}
+                >
                     {content}
                     <span className={`${styles.arrow} ${placement === 'bottom' ? styles.arrow_bottom : ''}`} />
                 </span>


### PR DESCRIPTION
## Summary

- Switch the `Tooltip` component from `onMouseEnter`/`onMouseLeave` to pointer events so it works on mouse, touch, and pen inputs without relying on synthesized hover.
- On touch devices the tooltip toggles on tap of the trigger and dismisses on tap-outside (document-level `pointerdown` listener attached only while visible).
- Adds `role="tooltip"` to the content node for assistive technology.