### PR TITLE
Resolve relative plugin canonical paths against siteUrl

### DIFF
--- a/src/frontend/app/[...slug]/page.tsx
+++ b/src/frontend/app/[...slug]/page.tsx
@@ -5,7 +5,7 @@ import { Page } from '../../components/layout';
 import { PluginPageWithZones } from '../../components/PluginPageWithZones';
 import { CategoryLandingPage } from '../../modules/menu';
 import { getServerSideApiUrlWithPath } from '../../lib/api-url';
-import { buildMetadata, buildArticleStructuredData } from '../../lib/seo';
+import { buildMetadata, buildArticleStructuredData, absoluteUrl } from '../../lib/seo';
 import { getServerConfig } from '../../lib/serverConfig';
 import { getEnabledPluginPageConfig } from '../../lib/serverPluginRegistry';
 import styles from './page.module.css';
@@ -222,8 +222,13 @@ export async function generateMetadata({ params }: { params: Promise<IPageParams
             if (pluginPage.keywords) {
                 metadata.keywords = pluginPage.keywords;
             }
-            if (pluginPage.canonical) {
-                metadata.alternates = { canonical: pluginPage.canonical };
+            // Resolve relative canonical paths against siteUrl so the rendered
+            // <link rel="canonical"> and og:url are always absolute.
+            const canonicalUrl = pluginPage.canonical
+                ? absoluteUrl(siteUrl, pluginPage.canonical)
+                : undefined;
+            if (canonicalUrl) {
+                metadata.alternates = { canonical: canonicalUrl };
             }
             // Build openGraph only when at least one OG-relevant field is
             // present, so we don't synthesize an empty default OG block for
@@ -233,7 +238,7 @@ export async function generateMetadata({ params }: { params: Promise<IPageParams
                     type: pluginPage.ogType ?? 'website',
                     ...(pluginPage.title ? { title: pluginPage.title } : {}),
                     ...(pluginPage.description ? { description: pluginPage.description } : {}),
-                    ...(pluginPage.canonical ? { url: pluginPage.canonical } : {}),
+                    ...(canonicalUrl ? { url: canonicalUrl } : {}),
                     ...(pluginPage.ogImage
                         ? {
                             images: [{

--- a/src/frontend/lib/seo.ts
+++ b/src/frontend/lib/seo.ts
@@ -57,7 +57,10 @@ export function buildMetadata(options: BuildMetadataOptions): Metadata {
     canonical
   } = options;
 
-  const url = canonical ?? absoluteUrl(siteUrl, path);
+  // Resolve relative canonical paths (e.g. '/resource-markets') against
+  // siteUrl so the rendered <link rel="canonical"> is always absolute.
+  // absoluteUrl() passes through values that are already absolute.
+  const url = absoluteUrl(siteUrl, canonical ?? path);
   const ogImage = image ?? `${siteUrl}/images/og-image.jpg`;
 
   return {


### PR DESCRIPTION
## Summary

The `IPageConfig.canonical` field was passed through `buildMetadata` verbatim, so a relative value like `/resource-markets` rendered as a relative `<link rel="canonical">` and `og:url`. Search engines accept relative canonicals but absolute URLs are the documented best practice and what every other code path in `buildMetadata` already produces.

Fix: route the supplied canonical through `absoluteUrl(siteUrl, canonical)` in both code paths — the full `buildMetadata` flow in `lib/seo.ts` and the fields-only fallback in the catch-all route. `absoluteUrl()` passes already-absolute URLs through unchanged, so callers that supply a full URL still work.

No plugin currently sets `canonical`, so this changes no live behavior — it just lets the upcoming `trp-resource-markets` plugin update use the relative path form without losing absolute URL emission.