### PR TITLE
Add $breakpoint-desktop-lg (1440px) and widen site content cap

### DIFF
--- a/docs/frontend/ui/ui-design-token-layers.md
+++ b/docs/frontend/ui/ui-design-token-layers.md
@@ -87,6 +87,7 @@ Breakpoints are **SCSS variables** in `_breakpoints.scss`, not CSS custom proper
 | `$breakpoint-mobile-lg` | 768px | Large phones, landscape |
 | `$breakpoint-tablet` | 1024px | Tablets, small laptops |
 | `$breakpoint-desktop` | 1200px | Desktop displays |
+| `$breakpoint-desktop-lg` | 1440px | Wide desktop / 1440p monitors; site-wide content cap |
 | `$breakpoint-desktop-xl` | 1920px | Full HD |
 | `$breakpoint-mobile` *(alias)* | = `$breakpoint-mobile-lg` (768px) | Convenience for the common mobile cutoff |
 

--- a/docs/frontend/ui/ui-responsive-design.md
+++ b/docs/frontend/ui/ui-responsive-design.md
@@ -89,6 +89,7 @@ TronRelic uses an Asia-optimized breakpoint system. Breakpoints are SCSS variabl
 | `$breakpoint-mobile-lg` | 768px | Large phones, landscape |
 | `$breakpoint-tablet` | 1024px | Tablets, small laptops |
 | `$breakpoint-desktop` | 1200px | Desktop displays |
+| `$breakpoint-desktop-lg` | 1440px | Wide desktop / 1440p monitors; site-wide content cap |
 | `$breakpoint-desktop-xl` | 1920px | Full HD |
 | `$breakpoint-mobile` *(alias)* | = `$breakpoint-mobile-lg` (768px) | Convenience for the common mobile cutoff |
 

--- a/docs/frontend/ui/ui.md
+++ b/docs/frontend/ui/ui.md
@@ -44,7 +44,7 @@ Component code (`.module.scss`) reaches for use-case-named semantics first (`--c
 | Shadows | `--shadow-sm/md/lg` |
 | Avatars | `--avatar-size-sm/md/lg` |
 | Max Widths | `--max-width-prose` (64ch), `--max-width-xs/sm/md/lg/xl` (320–1080px) |
-| Breakpoints | `$breakpoint-mobile-sm` (360px), `$breakpoint-mobile-md` (480px), `$breakpoint-mobile-lg` (768px), `$breakpoint-tablet` (1024px), `$breakpoint-desktop` (1200px), `$breakpoint-desktop-lg` (1440px) |
+| Breakpoints | `$breakpoint-mobile-sm` (360px), `$breakpoint-mobile-md` (480px), `$breakpoint-mobile-lg` (768px), `$breakpoint-tablet` (1024px), `$breakpoint-desktop` (1200px), `$breakpoint-desktop-lg` (1440px), `$breakpoint-desktop-xl` (1920px); alias `$breakpoint-mobile` = `$breakpoint-mobile-lg` (768px) |
 
 ### SCSS Module Naming
 

--- a/docs/frontend/ui/ui.md
+++ b/docs/frontend/ui/ui.md
@@ -44,7 +44,7 @@ Component code (`.module.scss`) reaches for use-case-named semantics first (`--c
 | Shadows | `--shadow-sm/md/lg` |
 | Avatars | `--avatar-size-sm/md/lg` |
 | Max Widths | `--max-width-prose` (64ch), `--max-width-xs/sm/md/lg/xl` (320–1080px) |
-| Breakpoints | `$breakpoint-mobile-sm` (360px), `$breakpoint-mobile-md` (480px), `$breakpoint-mobile-lg` (768px), `$breakpoint-tablet` (1024px), `$breakpoint-desktop` (1200px) |
+| Breakpoints | `$breakpoint-mobile-sm` (360px), `$breakpoint-mobile-md` (480px), `$breakpoint-mobile-lg` (768px), `$breakpoint-tablet` (1024px), `$breakpoint-desktop` (1200px), `$breakpoint-desktop-lg` (1440px) |
 
 ### SCSS Module Naming
 

--- a/src/frontend/app/_breakpoints.scss
+++ b/src/frontend/app/_breakpoints.scss
@@ -15,6 +15,7 @@ $breakpoint-mobile-md: 480px;   // Primary mobile target
 $breakpoint-mobile-lg: 768px;   // Large phones, landscape
 $breakpoint-tablet: 1024px;     // Tablets
 $breakpoint-desktop: 1200px;    // Desktop and larger
+$breakpoint-desktop-lg: 1440px; // Wide desktop / 1440p monitors; also the site-wide content cap
 $breakpoint-desktop-xl: 1920px; // Full HD displays
 
 // Convenience alias for common mobile breakpoint

--- a/src/frontend/app/globals.scss
+++ b/src/frontend/app/globals.scss
@@ -74,7 +74,7 @@ main {
   min-height: 0;
   display: flex;
   flex-direction: column;
-  width: min($breakpoint-desktop, 100%);
+  width: min($breakpoint-desktop-lg, 100%);
   margin: 0 auto;
   padding: var(--main-padding-lg);
 }

--- a/src/frontend/app/globals.scss
+++ b/src/frontend/app/globals.scss
@@ -74,7 +74,8 @@ main {
   min-height: 0;
   display: flex;
   flex-direction: column;
-  width: min($breakpoint-desktop-lg, 100%);
+  max-width: $breakpoint-desktop-lg;
+  width: 100%;
   margin: 0 auto;
   padding: var(--main-padding-lg);
 }


### PR DESCRIPTION
## Summary

- New `$breakpoint-desktop-lg: 1440px` in `_breakpoints.scss`, sitting between `$breakpoint-desktop` (1200px) and `$breakpoint-desktop-xl` (1920px).
- `main` in `globals.scss` now caps at `min($breakpoint-desktop-lg, 100%)` instead of 1200px, so 1440p+ monitors get 240px more content width.
- Decoupling the cap from `$breakpoint-desktop` keeps every existing `@media`/`@container` rule on the 1200px tier unchanged — only the site-wide content width moves.
- The breakpoint reference tables in `ui.md`, `ui-responsive-design.md`, and `ui-design-token-layers.md` gain a row for the new tier.