### PR TITLE
Clamp tooltips inside the viewport on edge triggers

### DIFF
--- a/src/frontend/components/ui/Tooltip/Tooltip.module.css
+++ b/src/frontend/components/ui/Tooltip/Tooltip.module.css
@@ -3,6 +3,13 @@
  *
  * Scoped styles for contextual tooltip overlays that appear on hover with
  * arrow indicators and responsive positioning.
+ *
+ * Horizontal viewport clamping: the `--tooltip-shift-x` custom property is
+ * applied by Tooltip.tsx after measuring the rendered overlay against the
+ * viewport. A positive value shifts the tooltip right (to clear a left-edge
+ * overflow); a negative value shifts it left (right-edge overflow). The
+ * arrow uses the same variable with the opposite sign so it stays anchored
+ * to the trigger no matter how the tooltip body has been nudged inward.
  */
 
 .trigger {
@@ -15,7 +22,7 @@
     position: absolute;
     bottom: 100%;
     left: 50%;
-    transform: translateX(-50%);
+    transform: translateX(calc(-50% + var(--tooltip-shift-x, 0px)));
     margin-bottom: var(--spacing-6);
     background-color: rgba(0, 0, 0, 0.95);
     color: var(--color-text);
@@ -44,22 +51,22 @@
 @keyframes fadeIn {
     from {
         opacity: 0;
-        transform: translateX(-50%) translateY(4px);
+        transform: translateX(calc(-50% + var(--tooltip-shift-x, 0px))) translateY(4px);
     }
     to {
         opacity: 1;
-        transform: translateX(-50%) translateY(0);
+        transform: translateX(calc(-50% + var(--tooltip-shift-x, 0px))) translateY(0);
     }
 }
 
 @keyframes fadeInBottom {
     from {
         opacity: 0;
-        transform: translateX(-50%) translateY(-4px);
+        transform: translateX(calc(-50% + var(--tooltip-shift-x, 0px))) translateY(-4px);
     }
     to {
         opacity: 1;
-        transform: translateX(-50%) translateY(0);
+        transform: translateX(calc(-50% + var(--tooltip-shift-x, 0px))) translateY(0);
     }
 }
 
@@ -67,7 +74,7 @@
     position: absolute;
     top: 100%;
     left: 50%;
-    transform: translateX(-50%);
+    transform: translateX(calc(-50% - var(--tooltip-shift-x, 0px)));
     width: 0;
     height: 0;
     border-left: 6px solid transparent;

--- a/src/frontend/components/ui/Tooltip/Tooltip.tsx
+++ b/src/frontend/components/ui/Tooltip/Tooltip.tsx
@@ -1,7 +1,22 @@
 'use client';
 
-import { useEffect, useRef, useState, type PointerEvent, type ReactNode } from 'react';
+import {
+    useEffect,
+    useLayoutEffect,
+    useRef,
+    useState,
+    type CSSProperties,
+    type PointerEvent,
+    type ReactNode
+} from 'react';
 import styles from './Tooltip.module.css';
+
+/**
+ * Minimum horizontal gap between the tooltip and the viewport edges. Picks
+ * up just enough breathing room so the tooltip never visually butts against
+ * a window border but stays close to the trigger when one edge is tight.
+ */
+const VIEWPORT_PADDING_PX = 8;
 
 /**
  * Tooltip props interface defining trigger and content configuration.
@@ -32,6 +47,13 @@ interface TooltipProps {
  * overflow constraints (like table headers with horizontal scroll) to
  * prevent clipping.
  *
+ * Horizontal viewport clamping: after the tooltip mounts the layout effect
+ * measures it via `getBoundingClientRect()` and, if it would overflow the
+ * viewport on either side, sets `--tooltip-shift-x` on the content element
+ * so CSS shifts the tooltip back inside (and the arrow stays anchored to
+ * the trigger). Trigger-centered tooltips near a screen edge would
+ * otherwise be clipped or pushed off-screen.
+ *
  * @example
  * ```tsx
  * <Tooltip content="Click to refresh data">
@@ -41,7 +63,9 @@ interface TooltipProps {
  */
 export function Tooltip({ content, children, placement = 'top' }: TooltipProps) {
     const [isVisible, setIsVisible] = useState(false);
+    const [shiftX, setShiftX] = useState(0);
     const triggerRef = useRef<HTMLSpanElement | null>(null);
+    const contentRef = useRef<HTMLSpanElement | null>(null);
 
     function handlePointerEnter(event: PointerEvent<HTMLSpanElement>) {
         if (event.pointerType === 'mouse') {
@@ -74,6 +98,41 @@ export function Tooltip({ content, children, placement = 'top' }: TooltipProps) 
         return () => document.removeEventListener('pointerdown', handleDocumentPointerDown);
     }, [isVisible]);
 
+    // Measure the rendered tooltip against the viewport and shift it inward
+    // if either edge would clip. Runs in `useLayoutEffect` so the corrected
+    // position is in place before the browser paints — measuring after paint
+    // would briefly show the tooltip clipped. Re-runs when `content`
+    // changes since the rendered width depends on it.
+    useLayoutEffect(() => {
+        if (!isVisible) {
+            setShiftX(0);
+            return;
+        }
+        const el = contentRef.current;
+        if (!el) return;
+        // Measure with shift cleared so each pass starts from the
+        // trigger-centered position rather than the previous offset.
+        el.style.setProperty('--tooltip-shift-x', '0px');
+        const rect = el.getBoundingClientRect();
+        const viewportWidth = document.documentElement.clientWidth;
+        const overflowLeft = Math.max(0, VIEWPORT_PADDING_PX - rect.left);
+        const overflowRight = Math.max(
+            0,
+            rect.right - (viewportWidth - VIEWPORT_PADDING_PX)
+        );
+        // `overflowLeft - overflowRight` is the net inward nudge: positive
+        // when the left edge overflows (shift right), negative when the
+        // right edge overflows (shift left). When the tooltip is wider
+        // than the available room both sides overflow and we bias left,
+        // which keeps the tooltip's leading text visible.
+        setShiftX(overflowLeft - overflowRight);
+    }, [isVisible, content]);
+
+    const contentStyle =
+        shiftX !== 0
+            ? ({ ['--tooltip-shift-x']: `${shiftX}px` } as CSSProperties)
+            : undefined;
+
     return (
         <span
             ref={triggerRef}
@@ -85,8 +144,10 @@ export function Tooltip({ content, children, placement = 'top' }: TooltipProps) 
             {children}
             {isVisible && (
                 <span
+                    ref={contentRef}
                     role="tooltip"
                     className={`${styles.content} ${placement === 'bottom' ? styles.content_bottom : ''}`}
+                    style={contentStyle}
                 >
                     {content}
                     <span className={`${styles.arrow} ${placement === 'bottom' ? styles.arrow_bottom : ''}`} />

--- a/src/frontend/components/ui/Tooltip/Tooltip.tsx
+++ b/src/frontend/components/ui/Tooltip/Tooltip.tsx
@@ -102,30 +102,54 @@ export function Tooltip({ content, children, placement = 'top' }: TooltipProps) 
     // if either edge would clip. Runs in `useLayoutEffect` so the corrected
     // position is in place before the browser paints — measuring after paint
     // would briefly show the tooltip clipped. Re-runs when `content`
-    // changes since the rendered width depends on it.
+    // changes since the rendered width depends on it, and re-runs on window
+    // resize so a tooltip that stays open through a viewport change does
+    // not become stale.
     useLayoutEffect(() => {
         if (!isVisible) {
             setShiftX(0);
             return;
         }
-        const el = contentRef.current;
-        if (!el) return;
-        // Measure with shift cleared so each pass starts from the
-        // trigger-centered position rather than the previous offset.
-        el.style.setProperty('--tooltip-shift-x', '0px');
-        const rect = el.getBoundingClientRect();
-        const viewportWidth = document.documentElement.clientWidth;
-        const overflowLeft = Math.max(0, VIEWPORT_PADDING_PX - rect.left);
-        const overflowRight = Math.max(
-            0,
-            rect.right - (viewportWidth - VIEWPORT_PADDING_PX)
-        );
-        // `overflowLeft - overflowRight` is the net inward nudge: positive
-        // when the left edge overflows (shift right), negative when the
-        // right edge overflows (shift left). When the tooltip is wider
-        // than the available room both sides overflow and we bias left,
-        // which keeps the tooltip's leading text visible.
-        setShiftX(overflowLeft - overflowRight);
+
+        function updateShift() {
+            const el = contentRef.current;
+            if (!el) return;
+            // Measure with shift cleared so each pass starts from the
+            // trigger-centered position rather than the previous offset.
+            el.style.setProperty('--tooltip-shift-x', '0px');
+            const rect = el.getBoundingClientRect();
+            const viewportWidth = document.documentElement.clientWidth;
+            const overflowLeft = Math.max(0, VIEWPORT_PADDING_PX - rect.left);
+            const overflowRight = Math.max(
+                0,
+                rect.right - (viewportWidth - VIEWPORT_PADDING_PX)
+            );
+            // Bias left: a left-edge overflow always wins, shifting right
+            // so the leading text becomes visible. When only the right
+            // edge overflows, shift left just enough to clear it, but
+            // never further than the available room on the left — that
+            // way the tooltip's start stays on-screen even when the
+            // tooltip is wider than the viewport.
+            let nextShift = 0;
+            if (overflowLeft > 0) {
+                nextShift = overflowLeft;
+            } else if (overflowRight > 0) {
+                const maxShiftLeft = Math.max(0, rect.left - VIEWPORT_PADDING_PX);
+                nextShift = -Math.min(overflowRight, maxShiftLeft);
+            }
+            // Write the final shift to the DOM imperatively, then sync
+            // React state. The imperative write matters: if `nextShift`
+            // equals the current `shiftX` state, `setShiftX` bails out
+            // without re-rendering, so React's inline-style branch (which
+            // only emits the property when `shiftX !== 0`) would otherwise
+            // leave the DOM stuck at the `0px` reset above.
+            el.style.setProperty('--tooltip-shift-x', `${nextShift}px`);
+            setShiftX(nextShift);
+        }
+
+        updateShift();
+        window.addEventListener('resize', updateShift);
+        return () => window.removeEventListener('resize', updateShift);
     }, [isVisible, content]);
 
     const contentStyle =


### PR DESCRIPTION
## Summary

Trigger-centered tooltips near the left or right edge of the viewport were clipped or pushed off-screen — the `transform: translateX(-50%)` centering takes no account of available space.

After mount the component now measures the rendered tooltip with `getBoundingClientRect()` in a `useLayoutEffect` and, when either edge overflows the viewport (minus an 8px breathing-room pad), sets `--tooltip-shift-x` on the content element. The CSS folds that variable into the existing `translateX(-50%)` so the tooltip body slides inward, while the arrow applies the opposite sign and stays anchored to the trigger. When both edges overflow (tooltip wider than the available room) we bias left so the leading text remains visible. The shift resets to `0px` on each pass so measurements always start from the trigger-centered position.