### PR TITLE
Move AI tool contract types into core

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delphian/tronrelic-types",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Core type definitions for the TronRelic platform",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/types/src/ai-tools/IAiAssistantService.ts
+++ b/packages/types/src/ai-tools/IAiAssistantService.ts
@@ -1,0 +1,99 @@
+/**
+ * @file IAiAssistantService.ts
+ *
+ * Public service interface for an AI Assistant plugin. Consuming plugins
+ * discover this service at runtime via the shared service registry and use
+ * it to register tools, submit programmatic queries, or both.
+ */
+
+import type { IAiTool } from './IAiTool.js';
+import type { IAiQueryOptions } from './IAiQueryOptions.js';
+import type { IAiQueryResult } from './IAiQueryResult.js';
+import type { IModelInfo } from './IModelInfo.js';
+
+/**
+ * Service interface for an AI Assistant plugin.
+ *
+ * Discovered at runtime through the service registry:
+ * ```typescript
+ * const ai = context.services.get<IAiAssistantService>('ai-assistant');
+ * if (ai) {
+ *     // Register tools for the model
+ *     ai.registerTool(myTool);
+ *
+ *     // Submit a programmatic query using configured defaults
+ *     const result = await ai.ask('How many transactions in the last hour?');
+ *
+ *     // Submit a query with explicit overrides
+ *     const result = await ai.query({
+ *         prompt: 'Analyze {%system-status%}',
+ *         maxTokens: 8192,
+ *         includeTools: false
+ *     });
+ * }
+ * ```
+ *
+ * Consuming plugins should always guard against the service being unavailable,
+ * since the AI Assistant plugin may be disabled.
+ */
+export interface IAiAssistantService {
+    /**
+     * Register a tool for the model to use during AI-assisted queries.
+     *
+     * @param tool - Tool definition including name, schema, and handler.
+     * @throws If a tool with the same name is already registered.
+     */
+    registerTool(tool: IAiTool): void;
+
+    /**
+     * Remove a previously registered tool by name.
+     *
+     * @param name - The tool name to unregister.
+     * @returns `true` if the tool was found and removed, `false` otherwise.
+     */
+    unregisterTool(name: string): boolean;
+
+    /**
+     * List all currently registered tools.
+     *
+     * @returns Array of registered tool definitions.
+     */
+    listTools(): IAiTool[];
+
+    /**
+     * Execute a non-streaming AI query with explicit parameter overrides.
+     *
+     * Only `prompt` is required. Omitted parameters fall back to the
+     * configured defaults from the AI Assistant settings tab. Registered
+     * (enabled) tools are included unless `includeTools` is set to false.
+     * Template variables are expanded unless `expandVariables` is false.
+     *
+     * @param options - Query options with prompt and optional overrides.
+     * @returns Complete response with text, model, stop reason, and usage.
+     * @throws On API failures, missing API key, or invalid configuration.
+     */
+    query(options: IAiQueryOptions): Promise<IAiQueryResult>;
+
+    /**
+     * Convenience wrapper: submit a prompt using all configured defaults.
+     *
+     * Equivalent to `query({ prompt })`.
+     *
+     * @param prompt - The natural language prompt to send to the model.
+     * @returns Complete response with text, model, stop reason, and usage.
+     * @throws On API failures, missing API key, or invalid configuration.
+     */
+    ask(prompt: string): Promise<IAiQueryResult>;
+
+    /**
+     * Retrieve the list of available models from the Anthropic API.
+     *
+     * Paginates through the Models API, merges static token limit metadata,
+     * and returns results sorted alphabetically by display name. Results are
+     * cached internally for subsequent lookups.
+     *
+     * @returns Array of model info objects with id, display name, and token limits.
+     * @throws On API failures or missing API key configuration.
+     */
+    listModels(): Promise<IModelInfo[]>;
+}

--- a/packages/types/src/ai-tools/IAiQueryOptions.ts
+++ b/packages/types/src/ai-tools/IAiQueryOptions.ts
@@ -1,0 +1,90 @@
+/**
+ * @file IAiQueryOptions.ts
+ *
+ * Low-level query options for programmatic AI requests via the service
+ * registry. Every field except `prompt` is optional and falls back to
+ * the configured defaults in the AI Assistant settings tab.
+ */
+
+import type { IAiTool } from './IAiTool.js';
+
+/**
+ * Options for a non-streaming AI query submitted through
+ * {@link IAiAssistantService.query}.
+ *
+ * Only `prompt` is required. Omitted parameters resolve from the
+ * AI Assistant's stored config so external consumers do not need to
+ * know the admin's API key, model preference, or token budgets.
+ *
+ * @example
+ * ```typescript
+ * // Minimal — uses all configured defaults
+ * const result = await ai.query({ prompt: 'Summarize recent transactions' });
+ *
+ * // Override specific parameters
+ * const result = await ai.query({
+ *     prompt: 'Analyze {%system-status%}',
+ *     maxTokens: 8192,
+ *     thinkingBudget: 4000,
+ *     includeTools: false
+ * });
+ * ```
+ */
+export interface IAiQueryOptions {
+    /** The user's natural language prompt. Required. */
+    prompt: string;
+
+    /** Override the system prompt. Falls back to configured default. */
+    systemPrompt?: string;
+
+    /** Override the Anthropic API key. Falls back to configured default. */
+    apiKey?: string;
+
+    /** Override the Claude model identifier. Falls back to configured default. */
+    model?: string;
+
+    /** Override maximum output tokens. Falls back to configured default. */
+    maxTokens?: number;
+
+    /**
+     * Override the query timeout in milliseconds. Falls back to the
+     * AI Assistant's configured `timeoutMs`. Enforced via
+     * AbortController on the underlying HTTP request.
+     */
+    timeoutMs?: number;
+
+    /** Override extended thinking budget. 0 disables thinking. Falls back to configured default. */
+    thinkingBudget?: number;
+
+    /** Override maximum tool-use round-trips (1-50). Falls back to configured default. */
+    maxToolRounds?: number;
+
+    /** Override 1M context window flag. Falls back to configured default. */
+    extendedContext?: boolean;
+
+    /** Whether to include thinking blocks in the final response text. Falls back to configured default. */
+    persistThinking?: boolean;
+
+    /** Whether to format DB query template variable output as YAML. Default: false. */
+    formatAsYaml?: boolean;
+
+    /** Execution mode for history tracking. Default: 'programmatic'. Use 'stream' for admin UI queries. */
+    mode?: 'stream' | 'programmatic';
+
+    /** Whether to expand {%variable%} template patterns in the prompt. Default: true. */
+    expandVariables?: boolean;
+
+    /** Whether to include registered (enabled) tools in the request. Default: true. */
+    includeTools?: boolean;
+
+    /** Additional one-off tools to include alongside registered tools for this query only. */
+    additionalTools?: IAiTool[];
+
+    /**
+     * Client-generated UUID for WebSocket streaming. When provided,
+     * text deltas and completion events are emitted to this room so
+     * a subscribed client can display the response in real time.
+     * When omitted, the query runs silently with no WebSocket output.
+     */
+    queryId?: string;
+}

--- a/packages/types/src/ai-tools/IAiQueryResult.ts
+++ b/packages/types/src/ai-tools/IAiQueryResult.ts
@@ -19,8 +19,16 @@ export interface IAiQueryResult {
     /** Model that was used for this query. */
     model: string;
 
-    /** Why the response ended: 'end_turn', 'max_tokens', or 'tool_use' (round limit hit). */
-    stopReason: string;
+    /**
+     * Why the response ended. Mirrors Anthropic's `StopReason` union:
+     * - `end_turn` — model naturally completed
+     * - `max_tokens` — hit the output token budget
+     * - `stop_sequence` — matched a configured stop sequence
+     * - `tool_use` — pausing to invoke a tool (or tool-use round limit hit)
+     * - `pause_turn` — long-running turn paused for continuation
+     * - `refusal` — model declined to respond
+     */
+    stopReason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'tool_use' | 'pause_turn' | 'refusal';
 
     /** Token usage summed across all tool-use rounds. */
     usage: {

--- a/packages/types/src/ai-tools/IAiQueryResult.ts
+++ b/packages/types/src/ai-tools/IAiQueryResult.ts
@@ -1,0 +1,42 @@
+/**
+ * @file IAiQueryResult.ts
+ *
+ * Result of a non-streaming AI query executed through
+ * {@link IAiAssistantService.query} or {@link IAiAssistantService.ask}.
+ */
+
+/**
+ * The complete result of a programmatic AI query.
+ *
+ * Returned by both `query()` and `ask()` on `IAiAssistantService`.
+ * Token usage is summed across all tool-use rounds when tools are
+ * invoked during the conversation.
+ */
+export interface IAiQueryResult {
+    /** The complete text response from the model. */
+    responseText: string;
+
+    /** Model that was used for this query. */
+    model: string;
+
+    /** Why the response ended: 'end_turn', 'max_tokens', or 'tool_use' (round limit hit). */
+    stopReason: string;
+
+    /** Token usage summed across all tool-use rounds. */
+    usage: {
+        inputTokens: number;
+        outputTokens: number;
+        /**
+         * Tokens written to Anthropic's prompt cache during this query.
+         * Non-zero on the round that first populates the cache. Optional
+         * because older records and non-streaming paths may omit it.
+         */
+        cacheCreationInputTokens?: number;
+        /**
+         * Tokens served from Anthropic's prompt cache (priced at ~10% of
+         * `inputTokens`). Non-zero rounds here are the signal that caching
+         * is working on this tool-use loop.
+         */
+        cacheReadInputTokens?: number;
+    };
+}

--- a/packages/types/src/ai-tools/IAiTool.ts
+++ b/packages/types/src/ai-tools/IAiTool.ts
@@ -1,0 +1,108 @@
+/**
+ * @file IAiTool.ts
+ *
+ * Defines the shape of a tool that can be registered with an AI Assistant
+ * service. Consuming plugins import this interface to build tools that an
+ * AI model can invoke during AI-assisted queries.
+ *
+ * Aligns with the Anthropic tool-use specification:
+ * - Tool names must match ^[a-zA-Z0-9_-]{1,64}$
+ * - Input schemas follow JSON Schema with top-level type 'object'
+ * - Descriptions should be detailed (see JSDoc on each field)
+ */
+
+/** Regex pattern for valid Anthropic tool names. */
+export const AI_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+
+/**
+ * JSON Schema definition for a tool's input parameters.
+ *
+ * Sent to the model so it knows what arguments to provide when invoking
+ * the tool. Follows Anthropic's tool-use specification which requires
+ * the top-level type to be 'object'.
+ */
+export interface IAiToolInputSchema {
+    /** Must be 'object' per Anthropic tool-use spec. */
+    type: 'object';
+    /** Property definitions keyed by parameter name. Each value is a JSON Schema object. */
+    properties: Record<string, unknown>;
+    /** Parameter names that must be provided. Anthropic recommends explicit required arrays. */
+    required?: string[];
+    /**
+     * Human-readable description of the parameters object as a whole.
+     * Helps the model understand the overall shape of the expected input.
+     */
+    description?: string;
+    /**
+     * When false, signals to the model that only the declared properties are valid.
+     * Anthropic recommends setting this to false to prevent the model from
+     * inventing extra parameters not defined in properties.
+     * @default false
+     */
+    additionalProperties?: boolean;
+}
+
+/**
+ * A tool that can be registered with the AI Assistant for the model to invoke.
+ *
+ * Tools enable the model to call back into the system during a conversation,
+ * execute a function, receive the result, and continue its response with
+ * that context.
+ *
+ * **Anthropic best practices for tool definitions:**
+ * - **name** — Alphanumeric with hyphens and underscores, max 64 characters.
+ *   Must match `^[a-zA-Z0-9_-]{1,64}$`.
+ * - **description** — Provide detailed descriptions explaining what the tool
+ *   does, when it should be used, what each parameter means, and any
+ *   important limitations. This is the most important factor in tool
+ *   performance — the model relies on the description to decide when and
+ *   how to use the tool.
+ * - **inputSchema** — Define all expected parameters with types and
+ *   descriptions. Set `additionalProperties: false` to prevent the model
+ *   from inventing parameters. Mark truly required fields in `required`.
+ *
+ * @example
+ * ```typescript
+ * const priceTool: IAiTool = {
+ *     name: 'get-energy-prices',
+ *     description:
+ *         'Fetches current TRON energy market prices from all providers. ' +
+ *         'Use when the user asks about energy costs, rental pricing, or ' +
+ *         'market comparisons. Returns an array of provider objects with ' +
+ *         'price_per_unit (in SUN), duration, and provider name. ' +
+ *         'Does NOT include historical prices — only current listings.',
+ *     inputSchema: {
+ *         type: 'object',
+ *         description: 'Optional filters for the price query',
+ *         properties: {
+ *             duration: {
+ *                 type: 'string',
+ *                 description: 'Filter by rental duration (e.g., "1h", "1d", "3d"). Omit for all durations.'
+ *             }
+ *         },
+ *         required: [],
+ *         additionalProperties: false
+ *     },
+ *     handler: async (input) => {
+ *         return await marketService.getPrices(input.duration as string);
+ *     }
+ * };
+ * ```
+ */
+export interface IAiTool {
+    /**
+     * Unique tool name. Must match `^[a-zA-Z0-9_-]{1,64}$`.
+     * Alphanumeric characters, hyphens, and underscores only.
+     */
+    name: string;
+    /**
+     * Detailed description shown to the model. This is the most important factor
+     * in tool performance. Explain what the tool does, when to use it,
+     * what each parameter means, and any limitations or requirements.
+     */
+    description: string;
+    /** JSON Schema defining the tool's expected input parameters. */
+    inputSchema: IAiToolInputSchema;
+    /** Async handler executed server-side when the model invokes this tool. */
+    handler: (input: Record<string, unknown>) => Promise<unknown>;
+}

--- a/packages/types/src/ai-tools/IModelInfo.ts
+++ b/packages/types/src/ai-tools/IModelInfo.ts
@@ -1,0 +1,18 @@
+/**
+ * Model metadata combining Anthropic Models API data with static token limits.
+ *
+ * The API provides id, display_name, and created_at. Token limits are
+ * merged from a static lookup since the Models API does not expose them.
+ */
+export interface IModelInfo {
+    /** Model identifier (e.g., 'claude-sonnet-4-5-20250514'). */
+    id: string;
+    /** Human-readable model name. */
+    display_name: string;
+    /** Maximum output tokens the model can generate per request. */
+    max_tokens?: number;
+    /** Maximum input context window in tokens. */
+    input_token_limit?: number;
+    /** ISO timestamp of when the model was created. */
+    created_at?: string;
+}

--- a/packages/types/src/ai-tools/index.ts
+++ b/packages/types/src/ai-tools/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @file index.ts
+ *
+ * Barrel for AI tool interfaces shared across the TronRelic platform.
+ *
+ * These types describe the contract between an AI Assistant plugin and any
+ * plugin that wants to expose tools to the model. They are platform-owned
+ * so that tool-providing plugins do not have to depend on the AI Assistant
+ * plugin's own types package to publish a tool.
+ */
+
+export type { IAiTool, IAiToolInputSchema } from './IAiTool.js';
+export { AI_TOOL_NAME_PATTERN } from './IAiTool.js';
+export type { IAiAssistantService } from './IAiAssistantService.js';
+export type { IAiQueryOptions } from './IAiQueryOptions.js';
+export type { IAiQueryResult } from './IAiQueryResult.js';
+export type { IModelInfo } from './IModelInfo.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -35,3 +35,5 @@ export type { ITronGridService, ITronGridAccountResponse, ITronGridAccountPermis
 export type { IBlockStats, IBlock, IBlockchainService, ITransactionTimeseriesPoint } from './blockchain/index.js';
 export type { IAddressLabel, IResolvedAddressLabel, AddressCategory, AddressLabelSourceType, ITronAddressMetadata, IAddressLabelService, ICreateAddressLabelInput, IUpdateAddressLabelInput, IAddressLabelFilter, IAddressLabelImportResult, IAddressLabelListResult } from './address-label/index.js';
 export type { IToolsService, IAddressConversionResult, IAddressValidationResult } from './tools/index.js';
+export type { IAiTool, IAiToolInputSchema, IAiAssistantService, IAiQueryOptions, IAiQueryResult, IModelInfo } from './ai-tools/index.js';
+export { AI_TOOL_NAME_PATTERN } from './ai-tools/index.js';


### PR DESCRIPTION
## Summary

Promotes the cross-plugin AI-tool surface — `IAiTool`, `IAiToolInputSchema`, `AI_TOOL_NAME_PATTERN`, `IAiAssistantService`, `IAiQueryOptions`, `IAiQueryResult`, `IModelInfo` — from `trp-ai-assistant`'s private types package into `@delphian/tronrelic-types` under `packages/types/src/ai-tools/`.

Tool-providing plugins (trp-bazi-fortune, trp-files, trp-image-gen, trp-memo-tracker, etc.) can now import this contract directly from the platform's core types package and drop their dependency on `@delphian/trp-ai-assistant-types`.

Bumps `@delphian/tronrelic-types` to 1.1.0.

## Companion changes

- `delphian/trp-ai-assistant` — deletes the moved files from `src/shared/types/`, switches internal imports over to `@delphian/tronrelic-types`, and ships `@delphian/trp-ai-assistant-types` 2.0.0 with the breaking removal of the moved surface.
- `delphian/trp-bazi-fortune`, `delphian/trp-files`, `delphian/trp-image-gen`, `delphian/trp-memo-tracker` — swap the import specifier and drop the `@delphian/trp-ai-assistant-types` dependency.

The plugin PRs depend on `@delphian/tronrelic-types@1.1.0` being published before they can resolve their bumped floors at install time.