### PR TITLE
Add providerId to IAiAssistantService.registerTool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12683,7 +12683,7 @@
     },
     "packages/types": {
       "name": "@delphian/tronrelic-types",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -12721,7 +12721,7 @@
     },
     "src/plugins/trp-ai-assistant/packages/types": {
       "name": "@delphian/trp-ai-assistant-types",
-      "version": "1.2.4",
+      "version": "2.0.2",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.3.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delphian/tronrelic-types",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "description": "Core type definitions for the TronRelic platform",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delphian/tronrelic-types",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Core type definitions for the TronRelic platform",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/types/src/ai-tools/IAiAssistantService.ts
+++ b/packages/types/src/ai-tools/IAiAssistantService.ts
@@ -18,8 +18,9 @@ import type { IModelInfo } from './IModelInfo.js';
  * ```typescript
  * const ai = context.services.get<IAiAssistantService>('ai-assistant');
  * if (ai) {
- *     // Register tools for the model
- *     ai.registerTool(myTool);
+ *     // Register tools for the model — pass your plugin's manifest id so
+ *     // the admin UI can group tools by their source.
+ *     ai.registerTool(myTool, 'my-plugin');
  *
  *     // Submit a programmatic query using configured defaults
  *     const result = await ai.ask('How many transactions in the last hour?');

--- a/packages/types/src/ai-tools/IAiAssistantService.ts
+++ b/packages/types/src/ai-tools/IAiAssistantService.ts
@@ -40,10 +40,18 @@ export interface IAiAssistantService {
     /**
      * Register a tool for the model to use during AI-assisted queries.
      *
+     * `providerId` attributes the tool to a plugin or module so the admin UI
+     * can group tools by their source. Pass your plugin's manifest id (e.g.
+     * `'telegram-bot'`); omit only for legacy callers — the registry will tag
+     * those as `'unknown'`. Attribution is captured at registration time, not
+     * inferred from the tool name.
+     *
      * @param tool - Tool definition including name, schema, and handler.
+     * @param providerId - Plugin/module id that owns this tool (e.g. the
+     *                     caller's `manifest.id`). Defaults to `'unknown'`.
      * @throws If a tool with the same name is already registered.
      */
-    registerTool(tool: IAiTool): void;
+    registerTool(tool: IAiTool, providerId?: string): void;
 
     /**
      * Remove a previously registered tool by name.

--- a/packages/types/src/ai-tools/IAiQueryOptions.ts
+++ b/packages/types/src/ai-tools/IAiQueryOptions.ts
@@ -65,9 +65,6 @@ export interface IAiQueryOptions {
     /** Whether to include thinking blocks in the final response text. Falls back to configured default. */
     persistThinking?: boolean;
 
-    /** Whether to format DB query template variable output as YAML. Default: false. */
-    formatAsYaml?: boolean;
-
     /** Execution mode for history tracking. Default: 'programmatic'. Use 'stream' for admin UI queries. */
     mode?: 'stream' | 'programmatic';
 


### PR DESCRIPTION
## Summary

- Extends `IAiAssistantService.registerTool` with an optional `providerId` so the AI Assistant admin Tools page can group registered tools by the plugin or module that owns them. Existing callers keep working — the tool registry tags them as `'unknown'`. Documented on the interface so plugin authors discover it from the public contract.
- Removes the unused `formatAsYaml` option from `IAiQueryOptions`; no consumer in the workspace referenced it.
- Bumps `@delphian/tronrelic-types` to 1.2.0 to publish the additive `providerId` parameter and the unused-field removal.