### PR TITLE
Surface menu node origin + wire namespace config to live render

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,7 +15,7 @@ export type { IUsdtParametersFetcher } from './usdt-parameters/IUsdtParametersFe
 export type { ICacheService } from './services/ICacheService.js';
 export type { IServiceRegistry, IServiceWatchHandlers, ServiceWatchDisposer } from './services/IServiceRegistry.js';
 export type { ISignatureService } from './services/ISignatureService.js';
-export type { IMenuNode, IMenuNodeWithChildren, IMenuTree, IMenuValidation, MenuEventType, IMenuEvent, MenuEventSubscriber, IMenuService, IMenuNamespaceConfig } from './menu/index.js';
+export type { IMenuNode, IMenuNodeWithChildren, IMenuTree, IMenuValidation, MenuEventType, IMenuEvent, MenuEventSubscriber, IMenuService, IMenuNamespaceConfig, MenuNodeOrigin, IMenuNodeAdminView, IMenuNodeAdminViewWithChildren, IMenuTreeAdminView } from './menu/index.js';
 export { WIDGET_ZONES } from './widget/index.js';
 export type { IWidgetConfig, WidgetZone, IWidgetData, IWidgetService, IWidgetComponentProps, WidgetComponent } from './widget/index.js';
 export type { ISystemConfig, ISystemConfigService } from './system-config/index.js';

--- a/packages/types/src/menu/IMenuNodeAdminView.ts
+++ b/packages/types/src/menu/IMenuNodeAdminView.ts
@@ -1,0 +1,60 @@
+import type { IMenuNode, IMenuNodeWithChildren } from './IMenuNode.js';
+
+/**
+ * Origin classification for a menu node.
+ *
+ * The service knows internally whether a node is database-backed (created via
+ * the admin API and persisted to `menu_nodes`) or memory-only (registered by
+ * a plugin at runtime), but that distinction does not appear on `IMenuNode`.
+ * The admin UI needs it to know whether a delete is durable or whether the
+ * row will reappear on the next plugin load.
+ *
+ * Three states are meaningful to an operator:
+ *
+ * - `manual` — Persisted in `menu_nodes`. Create/update/delete all survive
+ *   restart and there is no plugin to re-register the row.
+ * - `plugin` — Memory-only, no admin customization on file. Deleting the row
+ *   removes it from the in-memory tree only; the plugin will re-register it
+ *   on next startup. Updates can be saved as overrides (which promotes it to
+ *   `plugin-overridden`).
+ * - `plugin-overridden` — Memory-only AND has a row in `menu_node_overrides`
+ *   keyed by `(namespace, url)`. The plugin still owns lifecycle, but the
+ *   admin has customized `order` / `label` / `icon` / `description` /
+ *   `enabled` and those customizations persist across restarts via the
+ *   overrides collection.
+ */
+export type MenuNodeOrigin = 'manual' | 'plugin' | 'plugin-overridden';
+
+/**
+ * Admin-only projection of a menu node that includes the computed `origin`
+ * tag. Returned from the admin read path; never sent to anonymous callers.
+ *
+ * `origin` is derived at read time from the service's `persistedNodeIds` set
+ * and the cached set of override keys, so the field is always consistent
+ * with the current state of the tree — there is no stored column to drift.
+ */
+export interface IMenuNodeAdminView extends IMenuNode {
+    origin: MenuNodeOrigin;
+}
+
+/**
+ * Admin-only projection of {@link IMenuNodeWithChildren} carrying `origin`
+ * recursively through the tree.
+ */
+export interface IMenuNodeAdminViewWithChildren extends IMenuNodeWithChildren {
+    origin: MenuNodeOrigin;
+    children: IMenuNodeAdminViewWithChildren[];
+}
+
+/**
+ * Admin-only projection of the menu tree.
+ *
+ * Mirrors `IMenuTree` but with origin-tagged nodes in both `roots` and the
+ * flat `all` list. Kept as a separate shape so the public read path cannot
+ * accidentally surface origin metadata to unauthenticated callers.
+ */
+export interface IMenuTreeAdminView {
+    roots: IMenuNodeAdminViewWithChildren[];
+    all: IMenuNodeAdminView[];
+    generatedAt: Date;
+}

--- a/packages/types/src/menu/IMenuService.ts
+++ b/packages/types/src/menu/IMenuService.ts
@@ -1,5 +1,6 @@
 import type { IMenuNode } from './IMenuNode.js';
 import type { IMenuTree } from './IMenuTree.js';
+import type { IMenuTreeAdminView } from './IMenuNodeAdminView.js';
 import type { MenuEventType, MenuEventSubscriber } from './IMenuEvent.js';
 import type { IMenuNamespaceConfig } from './IMenuNamespaceConfig.js';
 import type { IUser } from '../user/IUser.js';
@@ -231,6 +232,24 @@ export interface IMenuService {
      * ```
      */
     getTree(namespace?: string): IMenuTree;
+
+    /**
+     * Admin-only view of the menu tree with each node's `origin` resolved.
+     *
+     * Returns the unfiltered tree projected to `IMenuNodeAdminView`, tagging
+     * every node as `manual` (persisted in `menu_nodes`), `plugin`
+     * (memory-only), or `plugin-overridden` (memory-only with an admin
+     * customization in `menu_node_overrides`). The admin UI uses this to
+     * render an origin badge and to gate destructive actions on plugin
+     * rows (which reappear on next plugin load).
+     *
+     * Callers must authenticate as admin before invoking — there is no
+     * per-method authorization. Origin is computed at read time, so it is
+     * always consistent with the current state of the tree.
+     *
+     * @param namespace - Menu namespace (defaults to 'main')
+     */
+    getTreeAdminView(namespace?: string): IMenuTreeAdminView;
 
     /**
      * Get the menu tree filtered to nodes the given user is permitted to see.

--- a/packages/types/src/menu/index.ts
+++ b/packages/types/src/menu/index.ts
@@ -8,6 +8,12 @@
  */
 
 export type { IMenuNode, IMenuNodeWithChildren } from './IMenuNode.js';
+export type {
+    MenuNodeOrigin,
+    IMenuNodeAdminView,
+    IMenuNodeAdminViewWithChildren,
+    IMenuTreeAdminView
+} from './IMenuNodeAdminView.js';
 export type { IMenuTree } from './IMenuTree.js';
 export type {
     IMenuValidation,

--- a/src/backend/modules/menu/README.md
+++ b/src/backend/modules/menu/README.md
@@ -86,6 +86,18 @@ When an admin reorders a memory-only menu item (e.g., changes a plugin's menu po
 
 Override persistence applies to `order`, `label`, `description`, `icon`, and `enabled` fields. Only nodes with a URL are eligible for overrides since the URL serves as the stable identity across restarts.
 
+### Origin Tag (Admin Reads Only)
+
+`IMenuNode` carries no flag distinguishing manual rows from plugin-registered ones, but the service tracks the distinction internally: `persistedNodeIds` holds ids loaded from or written to `menu_nodes`, and a cached set of `(namespace, url)` keys mirrors `menu_node_overrides`. Surfacing that as a stored column would be a drift hazard. Instead `getTreeAdminView()` projects the in-memory tree to `IMenuNodeAdminView` and tags each node with `origin`:
+
+| Value | Meaning |
+|-------|---------|
+| `manual` | Persisted in `menu_nodes`. Create/update/delete survive restart. |
+| `plugin` | Memory-only, no override row. Delete removes only the in-memory copy — the plugin re-registers on next boot. |
+| `plugin-overridden` | Memory-only with an admin customization in `menu_node_overrides`. Plugin still owns lifecycle; `order`/`label`/`icon`/`description`/`enabled` survive restarts. |
+
+The controller branches on `isAdmin(req)` — admin callers receive `IMenuTreeAdminView`, public callers receive the unchanged `IMenuTree`. Origin is computed at read time, so it never goes stale. The admin UI at `/system/menu` renders the tag as a badge and gates the delete confirm dialog with a "will reappear on next plugin load" warning for `plugin` and `plugin-overridden` rows.
+
 ### Auto-Derived URLs for Container Nodes
 
 Container nodes that omit a URL receive one automatically by slugifying their label. For root-level containers, the URL is `/{slug}` (e.g., label "Tools" becomes `/tools`). For nested containers, the URL is `{parent-url}/{slug}`. This auto-derived URL serves as the stable override key and as the route for the auto-generated category landing page. Admins can change the URL at runtime through the admin API, but for memory-only/plugin-registered nodes that change does not persist across restarts via `menu_node_overrides`. Only `order`, `label`, `description`, `icon`, and `enabled` are persisted for memory-only nodes. Persisted database-backed nodes save URL changes normally.

--- a/src/backend/modules/menu/__tests__/menu.service.origin.test.ts
+++ b/src/backend/modules/menu/__tests__/menu.service.origin.test.ts
@@ -1,0 +1,297 @@
+/// <reference types="vitest" />
+
+/**
+ * Origin-resolution tests for `MenuService.getTreeAdminView`.
+ *
+ * Covers the three states the admin UI distinguishes (`manual`,
+ * `plugin`, `plugin-overridden`), plus the supporting invariants:
+ *
+ * - Override-keys cache hydrates from the `menu_node_overrides`
+ *   collection on init (so a memory-only node registered after restart
+ *   immediately reads as `plugin-overridden`).
+ * - `saveOverride` adds both the original URL and any renamed URL to
+ *   the in-memory cache, so the badge stays consistent when an admin
+ *   patches a plugin node's URL during the live session.
+ * - `getTreeAdminView` projects the `origin` field onto both `roots`
+ *   and the flat `all` list.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { IDatabaseService } from '@/types';
+import { ObjectId } from 'mongodb';
+
+vi.mock('../../../../services/websocket.service.js', () => ({
+    WebSocketService: {
+        getInstance: vi.fn(() => ({ emit: vi.fn() }))
+    }
+}));
+
+// Import MenuService AFTER mocking WebSocketService so the singleton
+// captures the mock instance during emit calls.
+import { MenuService } from '../services/menu.service.js';
+
+/**
+ * Minimal in-memory IDatabaseService mock that supports the subset of
+ * Mongo operations MenuService exercises for these tests: find/findOne,
+ * insertOne, updateOne (with `$set`, `$setOnInsert`, and `upsert`), and
+ * createIndex. Other interface methods stub out as no-ops because the
+ * code paths under test never reach them.
+ */
+class MockDatabase implements IDatabaseService {
+    private collections = new Map<string, any[]>();
+
+    registerModel(): void {}
+    getModel(): any { return undefined; }
+    async initializeMigrations(): Promise<void> {}
+    async getMigrationsPending(): Promise<any[]> { return []; }
+    async getMigrationsCompleted(): Promise<any[]> { return []; }
+    async executeMigration(): Promise<void> {}
+    async executeMigrationsAll(): Promise<void> {}
+    isMigrationRunning(): boolean { return false; }
+    async createIndex(): Promise<void> {}
+    async count(): Promise<number> { return 0; }
+    async find(): Promise<any[]> { return []; }
+    async findOne(): Promise<any> { return null; }
+    async insertOne(): Promise<any> { return new ObjectId(); }
+    async updateMany(): Promise<number> { return 0; }
+    async deleteMany(): Promise<number> { return 0; }
+    async get(): Promise<any> { return undefined; }
+    async set(): Promise<void> {}
+    async delete(): Promise<boolean> { return false; }
+
+    /**
+     * Pre-seed a collection with documents — used to plant override
+     * rows before `MenuService.initialize()` so the hydration path can
+     * be exercised.
+     */
+    seed(name: string, docs: any[]): void {
+        const items = docs.map((doc) => ({ _id: doc._id ?? new ObjectId(), ...doc }));
+        this.collections.set(name, items);
+    }
+
+    clear(): void {
+        this.collections.clear();
+    }
+
+    getCollection<T = any>(name: string) {
+        if (!this.collections.has(name)) {
+            this.collections.set(name, []);
+        }
+        const data = this.collections.get(name)!;
+
+        const matches = (filter: any) => (doc: any) =>
+            Object.entries(filter).every(([key, value]) => {
+                if (key === '_id' && value instanceof ObjectId) {
+                    return doc._id?.equals?.(value);
+                }
+                return doc[key] === value;
+            });
+
+        return {
+            find: vi.fn((filter: any = {}, _options?: any) => ({
+                toArray: vi.fn(async () => {
+                    if (Object.keys(filter).length === 0) return data;
+                    return data.filter(matches(filter));
+                }),
+                sort: vi.fn(function (this: any) { return this; }),
+                skip: vi.fn(function (this: any) { return this; }),
+                limit: vi.fn(function (this: any) { return this; })
+            })),
+            findOne: vi.fn(async (filter: any) => data.find(matches(filter)) ?? null),
+            insertOne: vi.fn(async (doc: any) => {
+                const id = new ObjectId();
+                data.push({ ...doc, _id: id });
+                return { insertedId: id, acknowledged: true };
+            }),
+            updateOne: vi.fn(async (filter: any, update: any, options?: any) => {
+                const idx = data.findIndex(matches(filter));
+                if (idx !== -1) {
+                    data[idx] = { ...data[idx], ...(update.$set ?? {}) };
+                    return { modifiedCount: 1, acknowledged: true };
+                }
+                if (options?.upsert) {
+                    const id = new ObjectId();
+                    data.push({
+                        _id: id,
+                        ...(update.$setOnInsert ?? {}),
+                        ...(update.$set ?? {})
+                    });
+                    return {
+                        modifiedCount: 0,
+                        upsertedCount: 1,
+                        upsertedId: id,
+                        acknowledged: true
+                    };
+                }
+                return { modifiedCount: 0, acknowledged: true };
+            }),
+            deleteOne: vi.fn(async (filter: any) => {
+                const idx = data.findIndex(matches(filter));
+                if (idx !== -1) {
+                    data.splice(idx, 1);
+                    return { deletedCount: 1, acknowledged: true };
+                }
+                return { deletedCount: 0, acknowledged: true };
+            }),
+            countDocuments: vi.fn(async () => data.length),
+            createIndex: vi.fn(async () => 'index_name')
+        } as any;
+    }
+}
+
+describe('MenuService origin resolution', () => {
+    let menuService: MenuService;
+    let mockDatabase: MockDatabase;
+
+    const newService = async () => {
+        (MenuService as any).instance = undefined;
+        MenuService.setDatabase(mockDatabase);
+        const svc = MenuService.getInstance();
+        await svc.initialize();
+        return svc;
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockDatabase = new MockDatabase();
+    });
+
+    afterEach(() => {
+        mockDatabase.clear();
+    });
+
+    /**
+     * Tags as `manual` when the node lives in `menu_nodes`.
+     */
+    it('tags admin-created nodes as origin="manual"', async () => {
+        menuService = await newService();
+        const node = await menuService.create(
+            { label: 'Dashboard', url: '/dashboard', order: 10, enabled: true },
+            true
+        );
+
+        const tree = menuService.getTreeAdminView('main');
+        const projected = tree.all.find((n) => n._id === node._id);
+
+        expect(projected?.origin).toBe('manual');
+    });
+
+    /**
+     * Tags as `plugin` when the node is memory-only with no override row.
+     */
+    it('tags memory-only nodes as origin="plugin" when no override exists', async () => {
+        menuService = await newService();
+        const node = await menuService.create(
+            { label: 'Whale Alerts', url: '/plugins/whale-alerts', order: 50, enabled: true },
+            false
+        );
+
+        const tree = menuService.getTreeAdminView('main');
+        const projected = tree.all.find((n) => n._id === node._id);
+
+        expect(projected?.origin).toBe('plugin');
+    });
+
+    /**
+     * Tags as `plugin-overridden` once an admin patches a memory-only node
+     * with `persist=true` — `saveOverride` upserts the override row and
+     * adds the key to the in-memory cache.
+     */
+    it('tags memory-only nodes as origin="plugin-overridden" after an admin override', async () => {
+        menuService = await newService();
+        const node = await menuService.create(
+            { label: 'Whale Alerts', url: '/plugins/whale-alerts', order: 50, enabled: true },
+            false
+        );
+
+        await menuService.update(node._id!, { order: 5 }, true);
+
+        const tree = menuService.getTreeAdminView('main');
+        const projected = tree.all.find((n) => n._id === node._id);
+
+        expect(projected?.origin).toBe('plugin-overridden');
+    });
+
+    /**
+     * Hydration path: an override row that exists in Mongo before
+     * `initialize()` runs should make the matching memory-only node
+     * read as `plugin-overridden` from the first admin tree fetch.
+     */
+    it('hydrates the override-keys cache from menu_node_overrides on initialize', async () => {
+        mockDatabase.seed('menu_node_overrides', [{
+            namespace: 'main',
+            url: '/plugins/whale-alerts',
+            order: 5,
+            createdAt: new Date(),
+            updatedAt: new Date()
+        }]);
+
+        menuService = await newService();
+        const node = await menuService.create(
+            { label: 'Whale Alerts', url: '/plugins/whale-alerts', order: 50, enabled: true },
+            false
+        );
+
+        const tree = menuService.getTreeAdminView('main');
+        const projected = tree.all.find((n) => n._id === node._id);
+
+        expect(projected?.origin).toBe('plugin-overridden');
+    });
+
+    /**
+     * When an admin renames a plugin node's URL during the live session,
+     * the override row stays keyed by the original URL (the canonical
+     * plugin-registered identity), but the in-memory node carries the
+     * new URL. The cache must hold both keys so `resolveOrigin` still
+     * tags the in-memory node as overridden — without this, the origin
+     * badge would flicker off until the next service restart.
+     */
+    it('keeps origin="plugin-overridden" when an admin renames the URL during the session', async () => {
+        menuService = await newService();
+        const node = await menuService.create(
+            { label: 'Whale Alerts', url: '/plugins/whale-alerts', order: 50, enabled: true },
+            false
+        );
+
+        await menuService.update(
+            node._id!,
+            { url: '/plugins/whales', label: 'Whales' },
+            true
+        );
+
+        const tree = menuService.getTreeAdminView('main');
+        const projected = tree.all.find((n) => n._id === node._id);
+
+        expect(projected?.url).toBe('/plugins/whales');
+        expect(projected?.origin).toBe('plugin-overridden');
+    });
+
+    /**
+     * `getTreeAdminView` must populate origin on both the hierarchical
+     * `roots` projection and the flat `all` list — consumers iterate
+     * either depending on the UI surface.
+     */
+    it('projects origin onto both roots and the flat all list', async () => {
+        menuService = await newService();
+        const manual = await menuService.create(
+            { label: 'Dashboard', url: '/dashboard', order: 10, enabled: true },
+            true
+        );
+        const plugin = await menuService.create(
+            { label: 'Plugin', url: '/plugins/p', order: 20, enabled: true },
+            false
+        );
+
+        const tree = menuService.getTreeAdminView('main');
+
+        const manualInAll = tree.all.find((n) => n._id === manual._id);
+        const pluginInAll = tree.all.find((n) => n._id === plugin._id);
+        expect(manualInAll?.origin).toBe('manual');
+        expect(pluginInAll?.origin).toBe('plugin');
+
+        const manualInRoots = tree.roots.find((n) => n._id === manual._id);
+        const pluginInRoots = tree.roots.find((n) => n._id === plugin._id);
+        expect(manualInRoots?.origin).toBe('manual');
+        expect(pluginInRoots?.origin).toBe('plugin');
+    });
+});

--- a/src/backend/modules/menu/api/menu.controller.ts
+++ b/src/backend/modules/menu/api/menu.controller.ts
@@ -377,12 +377,16 @@ export class MenuController {
 
             // Admins see the full unfiltered tree (including disabled
             // nodes and gated entries) so the admin UI can render and
-            // edit them. Admin status now resolves either via the user
-            // cookie (verified wallet + admin group) or via service token.
-            // Regular visitors get the per-user filtered view: enabled-
-            // only AND gating-aware.
+            // edit them. The admin variant additionally tags each node
+            // with an `origin` field (`manual` / `plugin` /
+            // `plugin-overridden`) so the UI can render an origin badge
+            // and gate destructive UX on plugin-owned rows. Admin status
+            // resolves either via the user cookie (verified wallet +
+            // admin group) or via service token. Regular visitors get
+            // the per-user filtered view: enabled-only AND gating-aware,
+            // with no origin metadata leaked.
             if (await isAdmin(req)) {
-                res.json({ success: true, tree: this.service.getTree(namespace) });
+                res.json({ success: true, tree: this.service.getTreeAdminView(namespace) });
                 return;
             }
 

--- a/src/backend/modules/menu/services/menu.service.ts
+++ b/src/backend/modules/menu/services/menu.service.ts
@@ -1405,8 +1405,18 @@ export class MenuService implements IMenuService {
 
             // Keep the in-memory override-keys cache in sync so the next
             // admin tree read tags the node as `plugin-overridden` without
-            // waiting on a Mongo round-trip.
+            // waiting on a Mongo round-trip. The override row is keyed by
+            // the plugin's canonical URL (passed in as `url`), but the
+            // in-memory node may carry a renamed URL after the same
+            // update — `resolveOrigin` matches against `node.url`, so we
+            // also seed the cache with `updates.url` to keep the badge
+            // consistent in-session. The rename itself does not survive
+            // restart (only the override fields persist), so the spare
+            // cache entry is naturally cleaned up on the next init.
             this.overrideKeys.add(this.overrideKey(namespace, url));
+            if (updates.url && updates.url !== url) {
+                this.overrideKeys.add(this.overrideKey(namespace, updates.url));
+            }
 
             logger.debug({ namespace, url, overrideFields }, 'Menu node override saved');
         } catch (error) {

--- a/src/backend/modules/menu/services/menu.service.ts
+++ b/src/backend/modules/menu/services/menu.service.ts
@@ -12,7 +12,11 @@ import type {
     IServiceRegistry,
     IUserGroupService,
     IUser,
-    UserIdentityState as UserIdentityStateType
+    UserIdentityState as UserIdentityStateType,
+    MenuNodeOrigin,
+    IMenuNodeAdminView,
+    IMenuNodeAdminViewWithChildren,
+    IMenuTreeAdminView
 } from '@/types';
 import { UserIdentityState } from '@/types';
 import { logger } from '../../../lib/logger.js';
@@ -77,6 +81,20 @@ export class MenuService implements IMenuService {
     private readonly DEFAULT_NAMESPACE = 'main';
     private readonly OVERRIDES_COLLECTION = 'menu_node_overrides';
     private persistedNodeIds = new Set<string>();
+
+    /**
+     * Cache of override coordinates `${namespace}|${url}` for memory-only menu
+     * nodes that carry admin customizations in the `menu_node_overrides`
+     * collection. Populated on `initialize()` and kept in sync by
+     * `saveOverride()`. Used by `resolveOrigin()` to distinguish a vanilla
+     * plugin registration from one whose label/order/icon/etc. an admin has
+     * customized through the admin UI.
+     *
+     * We cache the keys rather than re-querying Mongo on every admin tree
+     * read because the admin UI calls `getTreeAdminView` synchronously and
+     * a per-node round-trip would scale linearly with tree size.
+     */
+    private overrideKeys = new Set<string>();
 
     // Admin-only namespace list lives in `../constants.ts` so the HTTP
     // gate (controller) and the WebSocket suppression (this service) can
@@ -202,6 +220,19 @@ export class MenuService implements IMenuService {
                 { namespace: 1, url: 1 },
                 { unique: true }
             ).catch(err => logger.debug({ err }, 'Overrides index already exists'));
+
+            // Hydrate the override-keys cache so admin reads can resolve a
+            // node's origin (`plugin` vs `plugin-overridden`) without a
+            // round-trip per node. Cheap — one full scan of a tiny collection.
+            this.overrideKeys.clear();
+            const overrideDocs = await overridesCollection.find({}, {
+                projection: { namespace: 1, url: 1 }
+            }).toArray();
+            for (const doc of overrideDocs) {
+                if (doc.namespace && doc.url) {
+                    this.overrideKeys.add(this.overrideKey(doc.namespace, doc.url));
+                }
+            }
 
             // Build in-memory tree organized by namespace
             this.menuTree.clear();
@@ -819,6 +850,34 @@ export class MenuService implements IMenuService {
     }
 
     /**
+     * Admin-only view of the menu tree with each node's `origin` resolved.
+     *
+     * Returns the unfiltered tree — disabled nodes, gated nodes, every
+     * namespace member — projected to `IMenuNodeAdminView` so the admin UI
+     * can render a per-row "manual / plugin / plugin-overridden" badge and
+     * gate destructive UX accordingly (e.g. warning that deleting a plugin
+     * row will reappear on the next plugin load). The `origin` field is
+     * computed at read time from `persistedNodeIds` and the override-keys
+     * cache, so it is always consistent with the current state of the
+     * tree and never goes stale.
+     *
+     * Callers MUST authenticate as admin before invoking this method. The
+     * controller already gates this behind `isAdmin(req)`; no per-method
+     * authorization happens here.
+     *
+     * @param namespace - Menu namespace (defaults to 'main')
+     * @returns Origin-tagged tree mirroring `IMenuTree`'s shape
+     */
+    public getTreeAdminView(namespace?: string): IMenuTreeAdminView {
+        const tree = this.getTree(namespace);
+        return {
+            roots: tree.roots.map((root) => this.toAdminViewWithChildren(root)),
+            all: tree.all.map((node) => this.toAdminView(node)),
+            generatedAt: tree.generatedAt
+        };
+    }
+
+    /**
      * Get a single child of the named parent that the given user may see.
      *
      * Same gating rules as {@link getTreeForUser}; returns the user-filtered
@@ -1344,6 +1403,11 @@ export class MenuService implements IMenuService {
                 { upsert: true }
             );
 
+            // Keep the in-memory override-keys cache in sync so the next
+            // admin tree read tags the node as `plugin-overridden` without
+            // waiting on a Mongo round-trip.
+            this.overrideKeys.add(this.overrideKey(namespace, url));
+
             logger.debug({ namespace, url, overrideFields }, 'Menu node override saved');
         } catch (error) {
             logger.error({ error, namespace, url }, 'Failed to save menu node override');
@@ -1402,6 +1466,58 @@ export class MenuService implements IMenuService {
         sortChildren(roots);
 
         return roots;
+    }
+
+    /**
+     * Cache key for the `menu_node_overrides` collection. Joined with `|`
+     * because both `namespace` (NAMESPACE_REGEX-bounded) and `url` (slash-
+     * leading) cannot themselves contain the pipe character.
+     */
+    private overrideKey(namespace: string, url: string): string {
+        return `${namespace}|${url}`;
+    }
+
+    /**
+     * Classify a node as `manual`, `plugin`, or `plugin-overridden`.
+     *
+     * Resolution rules:
+     * - In `persistedNodeIds` → `manual` (lives in `menu_nodes`)
+     * - Otherwise, if a `(namespace, url)` override row exists → `plugin-overridden`
+     * - Otherwise → `plugin`
+     *
+     * A memory-only node without a `url` cannot have an override (overrides
+     * are keyed by url), so it falls through to plain `plugin`.
+     */
+    private resolveOrigin(node: IMenuNode): MenuNodeOrigin {
+        if (node._id && this.persistedNodeIds.has(node._id)) {
+            return 'manual';
+        }
+        const namespace = node.namespace || this.DEFAULT_NAMESPACE;
+        if (node.url && this.overrideKeys.has(this.overrideKey(namespace, node.url))) {
+            return 'plugin-overridden';
+        }
+        return 'plugin';
+    }
+
+    /**
+     * Project an `IMenuNode` to its admin-view shape by tagging the
+     * computed origin. Pure — does not touch the in-memory tree.
+     */
+    private toAdminView(node: IMenuNode): IMenuNodeAdminView {
+        return { ...node, origin: this.resolveOrigin(node) };
+    }
+
+    /**
+     * Project an `IMenuNodeWithChildren` recursively, tagging the entire
+     * subtree with origin. Children come from `buildTree`'s output so the
+     * recursion bottoms out at the leaves naturally.
+     */
+    private toAdminViewWithChildren(node: IMenuNodeWithChildren): IMenuNodeAdminViewWithChildren {
+        return {
+            ...node,
+            origin: this.resolveOrigin(node),
+            children: node.children.map((child) => this.toAdminViewWithChildren(child))
+        };
     }
 
     /**

--- a/src/backend/modules/pages/__tests__/pages.module.test.ts
+++ b/src/backend/modules/pages/__tests__/pages.module.test.ts
@@ -21,6 +21,7 @@ class MockMenuService implements IMenuService {
     delete = vi.fn();
     getNode = vi.fn();
     getTree = vi.fn(() => ({ all: [], roots: [], generatedAt: new Date() }));
+    getTreeAdminView = vi.fn(() => ({ all: [], roots: [], generatedAt: new Date() }));
     getTreeForUser = vi.fn(async () => ({ all: [], roots: [], generatedAt: new Date() }));
     getChildren = vi.fn(() => []);
     getChildrenForUser = vi.fn(async () => []);

--- a/src/backend/modules/tools/__tests__/tools.module.test.ts
+++ b/src/backend/modules/tools/__tests__/tools.module.test.ts
@@ -75,6 +75,7 @@ class MockMenuService implements IMenuService {
     delete = vi.fn();
     getNode = vi.fn();
     getTree = vi.fn(() => ({ all: [], roots: [], generatedAt: new Date() }));
+    getTreeAdminView = vi.fn(() => ({ all: [], roots: [], generatedAt: new Date() }));
     getTreeForUser = vi.fn(async () => ({ all: [], roots: [], generatedAt: new Date() }));
     getChildren = vi.fn(() => []);
     getChildrenForUser = vi.fn(async () => []);

--- a/src/frontend/app/(core)/system/menu/page.tsx
+++ b/src/frontend/app/(core)/system/menu/page.tsx
@@ -2,7 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useState, type FormEvent, type ReactNode } from 'react';
 import { ChevronRight, Pencil, Plus, Trash2 } from 'lucide-react';
-import type { IMenuNamespaceConfig, IMenuNode, IMenuTree, IUserGroup } from '@/types';
+import type {
+    IMenuNamespaceConfig,
+    IMenuNode,
+    IMenuNodeAdminView,
+    IMenuTreeAdminView,
+    IUserGroup,
+    MenuNodeOrigin
+} from '@/types';
 import { UserIdentityState } from '@/types';
 
 import { Page, Stack } from '../../../../components/layout';
@@ -24,10 +31,23 @@ import styles from './menu.module.scss';
 type Tab = 'items' | 'config';
 
 interface FlatNode {
-    node: IMenuNode;
+    node: IMenuNodeAdminView;
     depth: number;
     parentLabel: string | null;
 }
+
+/**
+ * Per-origin label + tone for the badge column. `manual` is neutral so it
+ * doesn't compete visually with the plugin states; `plugin` is info (this
+ * is the row's lifecycle, not a warning); `plugin-overridden` is warning to
+ * signal the row carries admin customizations that the plugin's defaults
+ * no longer fully describe.
+ */
+const ORIGIN_BADGE: Record<MenuNodeOrigin, { label: string; tone: 'neutral' | 'info' | 'warning' }> = {
+    manual: { label: 'Manual', tone: 'neutral' },
+    plugin: { label: 'Plugin', tone: 'info' },
+    'plugin-overridden': { label: 'Plugin (overridden)', tone: 'warning' }
+};
 
 /**
  * Flatten a parent-child node list into a depth-aware sequence so a single
@@ -40,13 +60,13 @@ interface FlatNode {
  * admin table a complete view of state so operators can see (and fix or
  * delete) orphans instead of having them silently disappear.
  */
-function flattenTree(nodes: IMenuNode[]): FlatNode[] {
+function flattenTree(nodes: IMenuNodeAdminView[]): FlatNode[] {
     const knownIds = new Set<string>();
     for (const node of nodes) {
         if (node._id) knownIds.add(node._id);
     }
 
-    const byParent = new Map<string | null, IMenuNode[]>();
+    const byParent = new Map<string | null, IMenuNodeAdminView[]>();
     for (const node of nodes) {
         const key = node.parent && knownIds.has(node.parent) ? node.parent : null;
         const bucket = byParent.get(key) ?? [];
@@ -99,7 +119,7 @@ export default function MenuAdminPage() {
     const [namespaces, setNamespaces] = useState<string[]>([]);
     const [activeNamespace, setActiveNamespace] = useState<string>('main');
 
-    const [menuTree, setMenuTree] = useState<IMenuTree | null>(null);
+    const [menuTree, setMenuTree] = useState<IMenuTreeAdminView | null>(null);
     const [config, setConfig] = useState<IMenuNamespaceConfig | null>(null);
     const [loading, setLoading] = useState(false);
     const [savingConfig, setSavingConfig] = useState(false);
@@ -137,7 +157,10 @@ export default function MenuAdminPage() {
             });
             if (!res.ok) throw new Error('Failed to load menu tree');
             const data = await res.json();
-            return data.tree as IMenuTree;
+            // Admin reads return the origin-tagged projection (controller
+            // branches on `isAdmin`). The page is admin-only, so the cast
+            // is always valid for callers reaching this code path.
+            return data.tree as IMenuTreeAdminView;
         },
         [authHeaders]
     );
@@ -333,14 +356,33 @@ export default function MenuAdminPage() {
     );
 
     const openDeleteModal = useCallback(
-        (node: IMenuNode) => {
+        (node: IMenuNodeAdminView) => {
             if (!node._id) return;
+            // Plugin-owned rows re-register on the next plugin load, so a
+            // delete here only removes the in-memory copy until restart.
+            // Surface that fact up front instead of leaving operators to
+            // discover it the hard way after a deploy.
+            const isPluginOwned = node.origin === 'plugin' || node.origin === 'plugin-overridden';
+            const message = isPluginOwned ? (
+                <>
+                    Delete <strong>{node.label}</strong>?
+                    {' '}This row is owned by a plugin and will reappear on the next plugin load.
+                    {node.origin === 'plugin-overridden' && (
+                        <>
+                            {' '}The saved override (label, order, icon, description, enabled) will also persist.
+                            {' '}To remove the row permanently, disable the plugin.
+                        </>
+                    )}
+                </>
+            ) : undefined;
+
             const id = openModal({
                 title: 'Delete menu item',
                 size: 'sm',
                 content: (
                     <ConfirmDialog
                         label={node.label}
+                        message={message}
                         onCancel={() => closeModal(id)}
                         onConfirm={async () => {
                             try {
@@ -540,9 +582,9 @@ interface ItemsTabProps {
     flatNodes: FlatNode[];
     busyNodeId: string | null;
     onCreate: () => void;
-    onEdit: (node: IMenuNode) => void;
-    onDelete: (node: IMenuNode) => void;
-    onToggleEnabled: (node: IMenuNode, next: boolean) => void;
+    onEdit: (node: IMenuNodeAdminView) => void;
+    onDelete: (node: IMenuNodeAdminView) => void;
+    onToggleEnabled: (node: IMenuNodeAdminView, next: boolean) => void;
 }
 
 function ItemsTab({ flatNodes, busyNodeId, onCreate, onEdit, onDelete, onToggleEnabled }: ItemsTabProps) {
@@ -569,6 +611,7 @@ function ItemsTab({ flatNodes, busyNodeId, onCreate, onEdit, onDelete, onToggleE
                             <Th>URL</Th>
                             <Th width="shrink">Order</Th>
                             <Th width="shrink">Parent</Th>
+                            <Th width="shrink">Origin</Th>
                             <Th width="shrink">Enabled</Th>
                             <Th width="shrink">Actions</Th>
                         </Tr>
@@ -591,6 +634,11 @@ function ItemsTab({ flatNodes, busyNodeId, onCreate, onEdit, onDelete, onToggleE
                                 </Td>
                                 <Td>{node.order}</Td>
                                 <Td muted>{parentLabel ?? '—'}</Td>
+                                <Td>
+                                    <Badge tone={ORIGIN_BADGE[node.origin].tone}>
+                                        {ORIGIN_BADGE[node.origin].label}
+                                    </Badge>
+                                </Td>
                                 <Td>
                                     <Switch
                                         size="sm"

--- a/src/frontend/components/layout/MenuNav/MenuNav.module.scss
+++ b/src/frontend/components/layout/MenuNav/MenuNav.module.scss
@@ -59,6 +59,55 @@
     line-height: var(--line-height-normal);
 }
 
+/* Inline-flex layout used only when an icon is rendered next to the
+ * label. Keeping it opt-in preserves the legacy label-only layout for
+ * tabs whose menu node has no icon string. */
+.tab--withIcon {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-xs);
+}
+
+/* Icon-above-label stack when the namespace config asks for
+ * `icons.position: 'top'`. Tighter gap and centered column so the icon
+ * and label read as a single hit target. */
+.tab--iconTop {
+    flex-direction: column;
+    align-items: center;
+    gap: var(--gap-2xs);
+    text-align: center;
+}
+
+/* Same top-stack treatment for category toggle buttons. The chevron
+ * still follows the label horizontally inside the bottom row, since the
+ * categoryButton's default `display: inline-flex; gap: var(--gap-xs)`
+ * already lays children out — switching to `column` stacks the icon
+ * above without affecting the label/chevron pairing. */
+.categoryButton--iconTop {
+    flex-direction: column;
+    align-items: center;
+    gap: var(--gap-2xs);
+    text-align: center;
+}
+
+/* Accessible-name-only label, used when `styling.showLabels === false`
+ * so screen readers and the link's accessible name stay intact while
+ * the visible text is hidden. Standard sr-only pattern; kept scoped to
+ * the module because `.text-muted` is the project's only general
+ * global utility — we don't bolt visually-hidden onto globals.scss
+ * for one caller. */
+.sr_only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 .tab:hover {
     background: var(--color-surface-elevated);
     border-color: var(--color-nav-tab-active-background);

--- a/src/frontend/components/layout/MenuNav/MenuNav.module.scss
+++ b/src/frontend/components/layout/MenuNav/MenuNav.module.scss
@@ -78,16 +78,25 @@
     text-align: center;
 }
 
-/* Same top-stack treatment for category toggle buttons. The chevron
- * still follows the label horizontally inside the bottom row, since the
- * categoryButton's default `display: inline-flex; gap: var(--gap-xs)`
- * already lays children out — switching to `column` stacks the icon
- * above without affecting the label/chevron pairing. */
+/* Top-stack treatment for category toggle buttons. `flex-direction:
+ * column` stacks the button's direct children vertically, so the
+ * markup pairs `label` and `chevron` inside a `.categoryButton__row`
+ * span — the row sits below the icon and keeps the chevron inline with
+ * the label. Without the row wrapper, the column would stack icon,
+ * label, and chevron as three separate atoms. */
 .categoryButton--iconTop {
     flex-direction: column;
     align-items: center;
     gap: var(--gap-2xs);
     text-align: center;
+}
+
+/* Row container used only inside `.categoryButton--iconTop` to keep
+ * label+chevron on a single line below the stacked icon. */
+.categoryButton__row {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-xs);
 }
 
 /* Accessible-name-only label, used when `styling.showLabels === false`

--- a/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
@@ -150,7 +150,15 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
     const iconsEnabled = menuConfig.icons?.enabled ?? true;
     const iconPosition: IconPosition = (menuConfig.icons?.position as IconPosition) ?? 'left';
     const showLabelsConfigured = menuConfig.styling?.showLabels ?? true;
-    const showLabels = showLabelsConfigured || !iconsEnabled;
+    // `MenuNodeIcon` uses `next/dynamic({ ssr: false })`, so the icon
+    // glyph renders nothing during SSR, nothing during the first client
+    // paint, and nothing for no-JS users. Keeping labels visible until
+    // `isMounted` flips post-hydration guarantees every tab has visible
+    // content in all three of those states. Once mounted, the configured
+    // `showLabels` value takes over — and if the operator turned icons
+    // off entirely we always keep labels visible as a last-resort
+    // fallback (otherwise the tab has nothing to render).
+    const showLabels = !iconsEnabled || !isMounted ? true : showLabelsConfigured;
 
     // Track mount state for portal rendering (SSR safety)
     useEffect(() => {
@@ -371,9 +379,22 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
                     aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${item.label} submenu`}
                 >
                     {iconPosition !== 'right' && icon}
-                    {label}
-                    {iconPosition === 'right' && icon}
-                    {chevron}
+                    {iconStackTop ? (
+                        // In icon-top mode the button is `flex-direction: column`,
+                        // so each child sits on its own line. Group label+chevron
+                        // in a row span so the chevron stays inline with the
+                        // label instead of stacking under it.
+                        <span className={styles.categoryButton__row}>
+                            {label}
+                            {chevron}
+                        </span>
+                    ) : (
+                        <>
+                            {label}
+                            {iconPosition === 'right' && icon}
+                            {chevron}
+                        </>
+                    )}
                 </button>
             </div>
         );

--- a/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
@@ -39,7 +39,10 @@ import { PriorityNav, useMenuConfig, useBodyScrollLock } from '../../../modules/
 import { menuTreeSeeded } from '../../../modules/menu/slice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { ChevronDown, ChevronRight } from 'lucide-react';
+import { MenuNodeIcon } from './MenuNodeIcon';
 import styles from './MenuNav.module.scss';
+
+type IconPosition = 'left' | 'right' | 'top';
 
 /**
  * Props for MenuNavClient component.
@@ -138,6 +141,16 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
 
     // Whether overflow handling (Priority+ nav) is enabled for this namespace
     const overflowEnabled = menuConfig.overflow?.enabled ?? true;
+
+    // Icon + label rendering controls. Defaults match `useMenuConfig`'s
+    // DEFAULT_CONFIG so behavior is identical when the admin has not saved
+    // a namespace config yet. If both icons and labels are disabled the
+    // link would render empty, so labels win the fallback — operators can
+    // still see and click the items they just hid.
+    const iconsEnabled = menuConfig.icons?.enabled ?? true;
+    const iconPosition: IconPosition = (menuConfig.icons?.position as IconPosition) ?? 'left';
+    const showLabelsConfigured = menuConfig.styling?.showLabels ?? true;
+    const showLabels = showLabelsConfigured || !iconsEnabled;
 
     // Track mount state for portal rendering (SSR safety)
     useEffect(() => {
@@ -254,13 +267,39 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
             ? pathname === '/'
             : pathname.startsWith(item.url!);
 
+        // Nested rows (inside category dropdowns) are vertical-list items
+        // where icon-top and label-hiding both degrade readability. Force
+        // left position and always-on labels for that surface; top-level
+        // PriorityNav items honor the configured position and
+        // `showLabels` toggle.
+        const rowIconEnabled = iconsEnabled && !!item.icon;
+        const rowIconPosition: IconPosition = isNested ? 'left' : iconPosition;
+        const rowShowLabels = isNested ? true : showLabels;
+        const iconStackTop = rowIconEnabled && rowIconPosition === 'top';
+
+        const className = [
+            styles.tab,
+            isActive ? styles.active : '',
+            isNested ? styles.nested : '',
+            rowIconEnabled ? styles['tab--withIcon'] : '',
+            iconStackTop ? styles['tab--iconTop'] : ''
+        ].filter(Boolean).join(' ');
+
+        const icon = rowIconEnabled
+            ? <MenuNodeIcon name={item.icon!} size={16} />
+            : null;
+        const label = rowShowLabels
+            ? <span>{item.label}</span>
+            : <span className={styles.sr_only}>{item.label}</span>;
+
         return (
             <Link
                 key={item._id}
                 href={item.url!}
-                className={`${styles.tab} ${isActive ? styles.active : ''} ${isNested ? styles.nested : ''}`}
+                className={className}
                 role={isNested ? 'menuitem' : undefined}
                 aria-current={isActive ? 'page' : undefined}
+                aria-label={rowShowLabels ? undefined : item.label}
                 onClick={() => {
                     if (isNested) {
                         closeDropdown();
@@ -269,7 +308,9 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
                     }
                 }}
             >
-                {item.label}
+                {rowIconPosition !== 'right' && icon}
+                {label}
+                {rowIconPosition === 'right' && icon}
             </Link>
         );
     };
@@ -288,6 +329,27 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
             ? (item.url === '/' ? pathname === '/' : pathname === item.url || pathname.startsWith(`${item.url}/`))
             : false;
 
+        const rowIconEnabled = iconsEnabled && !!item.icon;
+        const iconStackTop = rowIconEnabled && iconPosition === 'top';
+
+        const buttonClassName = [
+            styles.categoryButton,
+            isActive ? styles.active : '',
+            iconStackTop ? styles['categoryButton--iconTop'] : ''
+        ].filter(Boolean).join(' ');
+
+        const icon = rowIconEnabled
+            ? <MenuNodeIcon name={item.icon!} size={16} />
+            : null;
+        const label = showLabels
+            ? <span>{item.label}</span>
+            : <span className={styles.sr_only}>{item.label}</span>;
+        const chevron = isExpanded ? (
+            <ChevronDown size={16} className={styles.categoryChevron} />
+        ) : (
+            <ChevronRight size={16} className={styles.categoryChevron} />
+        );
+
         return (
             <div key={item._id} className={styles.category}>
                 <button
@@ -299,7 +361,7 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
                             categoryButtonRefs.current.delete(item._id);
                         }
                     }}
-                    className={`${styles.categoryButton} ${isActive ? styles.active : ''}`}
+                    className={buttonClassName}
                     onClick={(e) => {
                         e.stopPropagation();
                         toggleCategory(item._id);
@@ -308,12 +370,10 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
                     aria-haspopup="true"
                     aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${item.label} submenu`}
                 >
-                    {item.label}
-                    {isExpanded ? (
-                        <ChevronDown size={16} className={styles.categoryChevron} />
-                    ) : (
-                        <ChevronRight size={16} className={styles.categoryChevron} />
-                    )}
+                    {iconPosition !== 'right' && icon}
+                    {label}
+                    {iconPosition === 'right' && icon}
+                    {chevron}
                 </button>
             </div>
         );

--- a/src/frontend/components/layout/MenuNav/MenuNodeIcon.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNodeIcon.tsx
@@ -1,0 +1,26 @@
+/**
+ * Lazy-loaded wrapper around the menu icon resolver.
+ *
+ * `MenuNavClient` renders on every page, so importing the full
+ * `lucide-react` namespace from a `'use client'` module would inflate the
+ * main bundle by ~1 MB. `next/dynamic({ ssr: false })` defers the import
+ * to a separate chunk that loads the first time a menu icon needs to
+ * render. Hydration stays clean — the server and the first client render
+ * both produce an empty placeholder; the resolved glyph swaps in
+ * post-hydration alongside any other live-updates dispatch.
+ */
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const MenuNodeIconLoader = dynamic(() => import('./MenuNodeIconLoader'), { ssr: false });
+
+interface MenuNodeIconProps {
+    name: string;
+    size?: number;
+    className?: string;
+}
+
+export function MenuNodeIcon(props: MenuNodeIconProps) {
+    return <MenuNodeIconLoader {...props} />;
+}

--- a/src/frontend/components/layout/MenuNav/MenuNodeIconLoader.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNodeIconLoader.tsx
@@ -1,0 +1,33 @@
+/**
+ * Inner icon renderer for `<MenuNodeIcon>`.
+ *
+ * Imported only through `next/dynamic` in `MenuNodeIcon.tsx`, so the
+ * `lucide-react` namespace import sits in a separate chunk that loads on
+ * the first menu render rather than ballooning the initial bundle. The
+ * resolver itself is shared with `CategoryLandingPage` for identical
+ * name-resolution behavior across surfaces.
+ */
+'use client';
+
+import { resolveIcon } from '../../../modules/menu/components/CategoryLandingPage/iconResolver';
+
+interface MenuNodeIconLoaderProps {
+    name: string;
+    size?: number;
+    className?: string;
+}
+
+/**
+ * Render the lucide icon for `name`, or nothing if it does not resolve.
+ * Decorative by definition — the link/button's `aria-label` already
+ * carries the accessible name, so the icon stays `aria-hidden`.
+ */
+export default function MenuNodeIconLoader({
+    name,
+    size = 16,
+    className
+}: MenuNodeIconLoaderProps) {
+    const Icon = resolveIcon(name);
+    if (!Icon) return null;
+    return <Icon size={size} className={className} aria-hidden="true" />;
+}

--- a/src/frontend/components/socket/SocketBridge.tsx
+++ b/src/frontend/components/socket/SocketBridge.tsx
@@ -7,7 +7,8 @@ import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { prependMemo } from '../../store/slices/memoSlice';
 import { blockReceived } from '../../features/blockchain/slice';
 import { setUserData, selectUserId } from '../../modules/user';
-import { refetchMenuTree } from '../../modules/menu/slice';
+import { refetchMenuTree, namespaceConfigSet } from '../../modules/menu/slice';
+import type { IMenuNamespaceConfig } from '../../modules/menu/types';
 import {
   connectionDeferred,
   deferredCountdownTick,
@@ -24,6 +25,7 @@ import type {
   BlockNotificationPayload,
   MemoUpdatePayload,
   MenuUpdatePayload,
+  MenuNamespaceConfigUpdatePayload,
   SocketSubscriptions
 } from '@/shared';
 import type { IUserData } from '../../modules/user';
@@ -211,6 +213,17 @@ export function SocketBridge() {
       dispatch(refetchMenuTree({ namespace: payload.namespace, timestamp: payload.timestamp }));
     };
 
+    const handleMenuNamespaceConfigUpdate = (payload: MenuNamespaceConfigUpdatePayload['payload']) => {
+      // Namespace config has no per-user variance, so the server emits the
+      // full normalized config inline — no refetch needed. Cast at the
+      // boundary because the wire type is `Record<string, unknown>` to
+      // keep the shared socket types decoupled from the menu types.
+      dispatch(namespaceConfigSet({
+        namespace: payload.namespace,
+        config: payload.config as unknown as IMenuNamespaceConfig
+      }));
+    };
+
     const handleVisibility = () => {
       if (document.visibilityState === 'visible' && !socket.connected && !manualDisconnectRef.current) {
         // If connection was initiated, try to reconnect
@@ -239,6 +252,7 @@ export function SocketBridge() {
     socket.on('block:new', handleBlockUpdate);
     socket.on('user:update', handleUserUpdate);
     socket.on('menu:update', handleMenuUpdate);
+    socket.on('menu:namespace-config:update', handleMenuNamespaceConfigUpdate);
 
     // Set up browser event handlers
     window.addEventListener('online', handleOnline);
@@ -275,6 +289,7 @@ export function SocketBridge() {
       socket.off('block:new', handleBlockUpdate);
       socket.off('user:update', handleUserUpdate);
       socket.off('menu:update', handleMenuUpdate);
+      socket.off('menu:namespace-config:update', handleMenuNamespaceConfigUpdate);
       socket.off('connect', handleConnect);
       socket.off('disconnect', handleDisconnect);
       socket.off('connect_error', handleConnectError);

--- a/src/frontend/components/socket/SocketBridge.tsx
+++ b/src/frontend/components/socket/SocketBridge.tsx
@@ -215,12 +215,30 @@ export function SocketBridge() {
 
     const handleMenuNamespaceConfigUpdate = (payload: MenuNamespaceConfigUpdatePayload['payload']) => {
       // Namespace config has no per-user variance, so the server emits the
-      // full normalized config inline — no refetch needed. Cast at the
-      // boundary because the wire type is `Record<string, unknown>` to
-      // keep the shared socket types decoupled from the menu types.
+      // full normalized config inline — no refetch needed. The wire type
+      // is `Record<string, unknown>` to keep the shared socket types
+      // decoupled from the menu types, so this is the validation
+      // boundary: drop the event if the payload is not an object or its
+      // namespace disagrees with the envelope. Nested fields (icons,
+      // styling, layout, overflow) are intentionally not validated here
+      // — `useMenuConfig` and `MenuNavClient` already degrade gracefully
+      // with `?? defaults`, so a partial shape is harmless. A flat-out
+      // bogus payload is what would poison the store.
+      const raw = payload.config;
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+        console.warn('Dropped menu:namespace-config:update with non-object config', payload);
+        return;
+      }
+      const configNamespace = (raw as { namespace?: unknown }).namespace;
+      if (typeof configNamespace !== 'string' || configNamespace !== payload.namespace) {
+        console.warn(
+          `Dropped menu:namespace-config:update — namespace mismatch (envelope=${payload.namespace}, config=${String(configNamespace)})`
+        );
+        return;
+      }
       dispatch(namespaceConfigSet({
         namespace: payload.namespace,
-        config: payload.config as unknown as IMenuNamespaceConfig
+        config: raw as unknown as IMenuNamespaceConfig
       }));
     };
 

--- a/src/frontend/features/system/components/SystemNav/SystemNavClient.tsx
+++ b/src/frontend/features/system/components/SystemNav/SystemNavClient.tsx
@@ -113,7 +113,7 @@ export function SystemNavClient({ items }: ISystemNavClientProps) {
         walk(nodes);
         return result;
     }, []);
-    const activeItems = liveMenuState ? flattenRoots(liveMenuState.roots) : items;
+    const activeItems = liveMenuState?.roots ? flattenRoots(liveMenuState.roots) : items;
 
     // Sort by order and filter enabled items
     const visibleItems = useMemo(() => activeItems

--- a/src/frontend/modules/menu/components/CategoryLandingPage/iconResolver.tsx
+++ b/src/frontend/modules/menu/components/CategoryLandingPage/iconResolver.tsx
@@ -5,9 +5,13 @@
  * This utility maps those strings to the corresponding lucide-react component
  * for rendering in the CategoryLandingPage card grid.
  *
- * Safe to use the full lucide-react namespace here because this file is only
- * imported by server components — the barrel import never reaches the client
- * bundle.
+ * Two callers today: `CategoryLandingPage` (server component) and
+ * `MenuNodeIconLoader` (the `next/dynamic({ ssr: false })` chunk behind
+ * `<MenuNodeIcon>`). The dynamic boundary keeps the lucide-react
+ * namespace out of the main client bundle, so importing this resolver
+ * from a `'use client'` module is only safe when the import is
+ * lazy/code-split — direct imports from non-dynamic client modules will
+ * regress bundle size.
  */
 
 import * as LucideIcons from 'lucide-react';

--- a/src/frontend/modules/menu/hooks/useMenuConfig.ts
+++ b/src/frontend/modules/menu/hooks/useMenuConfig.ts
@@ -54,18 +54,28 @@ const DEFAULT_CONFIG: IMenuNamespaceConfig = {
 export function useMenuConfig(namespace: string = 'main'): IUseMenuConfigResult {
     const dispatch = useAppDispatch();
     const stored = useAppSelector(state => state.menu.namespaces[namespace]?.config);
+    const status = useAppSelector(state => state.menu.namespaces[namespace]?.configStatus);
 
     useEffect(() => {
-        if (!stored) {
-            // Thunk middleware fires the network call once even if
-            // multiple consumers mount in the same tick — the second
-            // dispatch finds a fulfilled promise in the action cache.
+        // Dispatch only on the first idle state. The thunk's `condition`
+        // option also blocks duplicate work, but checking here keeps the
+        // hook honest about its own intent and saves an unnecessary
+        // dispatch on every render after the first fetch resolves.
+        if (status === undefined || status === 'idle') {
             void dispatch(fetchNamespaceConfig({ namespace }));
         }
-    }, [namespace, stored, dispatch]);
+    }, [namespace, status, dispatch]);
 
-    if (!stored) {
-        return { ...DEFAULT_CONFIG, namespace, loading: true };
+    // Treat 'failed' as a terminal state and surface defaults with
+    // loading:false so consumers stop showing fallback chrome. The
+    // thunk's `condition` guard prevents re-dispatch from this hook,
+    // so a transient failure is sticky until the page reloads — a
+    // deliberate trade so we don't retry on every render.
+    if (stored) {
+        return { ...stored, loading: false };
     }
-    return { ...stored, loading: false };
+    if (status === 'failed') {
+        return { ...DEFAULT_CONFIG, namespace, loading: false };
+    }
+    return { ...DEFAULT_CONFIG, namespace, loading: true };
 }

--- a/src/frontend/modules/menu/hooks/useMenuConfig.ts
+++ b/src/frontend/modules/menu/hooks/useMenuConfig.ts
@@ -1,134 +1,71 @@
 /**
- * Hook for fetching and managing menu namespace configuration.
+ * Redux-backed hook for the namespace rendering configuration.
  *
- * Provides access to namespace-specific menu settings including Priority+
- * overflow behavior, icon display, layout orientation, and styling hints.
- * Configuration is fetched once on mount and cached for the component lifecycle.
+ * The slice is the single source of truth: `fetchNamespaceConfig` seeds
+ * it on first consumer mount and the
+ * `menu:namespace-config:update` WebSocket handler in `SocketBridge`
+ * keeps it live. Every component that calls `useMenuConfig(ns)` reads
+ * the same store entry, so a config saved in `/system/menu` propagates
+ * to every connected tab without a refresh.
+ *
+ * Keeping the fetch inside a thunk (rather than a per-hook
+ * `useEffect`) means multiple consumers of the same namespace share one
+ * network call — Redux Toolkit's thunk middleware fires the underlying
+ * fetch once and the slice merges the result for everyone.
  *
  * @example
  * ```tsx
  * function MyMenu() {
  *     const config = useMenuConfig('main');
- *
- *     if (config.loading) {
- *         return <div>Loading menu...</div>;
- *     }
- *
- *     return (
- *         <PriorityNav
- *             enabled={config.overflow?.enabled ?? true}
- *             collapseAtCount={config.overflow?.collapseAtCount}
- *         >
- *             {menuItems}
- *         </PriorityNav>
- *     );
+ *     if (config.loading) return null;
+ *     return <PriorityNav enabled={config.overflow?.enabled ?? true}>{items}</PriorityNav>;
  * }
  * ```
  */
 'use client';
 
-import { useEffect, useState } from 'react';
-import { apiClient } from '../../../lib/api';
+import { useEffect } from 'react';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
+import { fetchNamespaceConfig } from '../slice';
 import type { IMenuNamespaceConfig, IUseMenuConfigResult } from '../types';
 
 /**
- * Default configuration used when API hasn't responded yet.
+ * Defaults returned while the initial fetch is in flight.
  *
- * Provides sensible defaults matching backend behavior (see MenuService.getNamespaceConfig).
- * Priority+ overflow enabled by default, icons enabled on left, horizontal layout.
+ * Mirror `MenuService.getNamespaceConfig`'s defaults so the rendered
+ * navigation looks identical before and after the store hydrates.
  */
 const DEFAULT_CONFIG: IMenuNamespaceConfig = {
     namespace: 'main',
-    overflow: {
-        enabled: true
-    },
-    icons: {
-        enabled: true,
-        position: 'left'
-    },
-    layout: {
-        orientation: 'horizontal'
-    }
+    overflow: { enabled: true },
+    icons: { enabled: true, position: 'left' },
+    layout: { orientation: 'horizontal' }
 };
 
 /**
- * Fetches and manages menu namespace configuration from the backend.
+ * Read a namespace's rendering configuration from Redux, fetching it
+ * on first consumer mount if the store doesn't have it yet. Subsequent
+ * updates flow through SocketBridge's
+ * `menu:namespace-config:update` handler.
  *
- * Makes a GET request to /api/menu/namespace/{namespace}/config on mount and
- * caches the result. If the request fails, falls back to default configuration.
- * The hook automatically handles loading states and provides type-safe access
- * to all configuration fields.
- *
- * @param namespace - Menu namespace to fetch config for (defaults to 'main')
- * @returns Configuration object with loading state
+ * @param namespace - Menu namespace to read (defaults to 'main')
+ * @returns Configuration plus a `loading` flag (true until first fetch resolves)
  */
 export function useMenuConfig(namespace: string = 'main'): IUseMenuConfigResult {
-    const [config, setConfig] = useState<IMenuNamespaceConfig>({
-        ...DEFAULT_CONFIG,
-        namespace
-    });
-    const [loading, setLoading] = useState(true);
+    const dispatch = useAppDispatch();
+    const stored = useAppSelector(state => state.menu.namespaces[namespace]?.config);
 
     useEffect(() => {
-        /**
-         * Validates that the config object has required structure.
-         *
-         * @param config - Configuration object to validate
-         * @throws Error if required fields are missing or invalid
-         */
-        function validateConfig(config: unknown): asserts config is IMenuNamespaceConfig {
-            if (!config || typeof config !== 'object') {
-                throw new Error('Config must be an object');
-            }
-
-            const c = config as Partial<IMenuNamespaceConfig>;
-
-            if (!c.namespace) {
-                throw new Error('Config missing required field: namespace');
-            }
-
-            // Validate optional overflow field structure if present
-            if (c.overflow !== undefined) {
-                if (typeof c.overflow !== 'object' || c.overflow === null) {
-                    throw new Error('Config overflow must be an object');
-                }
-                if (typeof c.overflow.enabled !== 'boolean') {
-                    throw new Error('Config overflow.enabled must be a boolean');
-                }
-                if (c.overflow.collapseAtCount !== undefined && typeof c.overflow.collapseAtCount !== 'number') {
-                    throw new Error('Config overflow.collapseAtCount must be a number');
-                }
-            }
+        if (!stored) {
+            // Thunk middleware fires the network call once even if
+            // multiple consumers mount in the same tick — the second
+            // dispatch finds a fulfilled promise in the action cache.
+            void dispatch(fetchNamespaceConfig({ namespace }));
         }
+    }, [namespace, stored, dispatch]);
 
-        /**
-         * Fetches namespace configuration from backend API.
-         */
-        async function fetchConfig() {
-            try {
-                const response = await apiClient.get<{ success: boolean; config: IMenuNamespaceConfig }>(
-                    `/menu/namespace/${namespace}/config`
-                );
-
-                if (!response.data || !response.data.config) {
-                    throw new Error('Invalid API response structure: missing config property');
-                }
-
-                validateConfig(response.data.config);
-                setConfig(response.data.config);
-            } catch (error) {
-                console.error(`Failed to fetch menu config for namespace '${namespace}':`, error);
-                // Keep default config on error
-            } finally {
-                setLoading(false);
-            }
-        }
-
-        void fetchConfig();
-    }, [namespace]);
-
-    return {
-        ...config,
-        loading
-    };
+    if (!stored) {
+        return { ...DEFAULT_CONFIG, namespace, loading: true };
+    }
+    return { ...stored, loading: false };
 }

--- a/src/frontend/modules/menu/slice.ts
+++ b/src/frontend/modules/menu/slice.ts
@@ -14,10 +14,22 @@
 import { createSlice, createAsyncThunk, type PayloadAction } from '@reduxjs/toolkit';
 import type { MenuNodeSerialized } from '@/shared';
 import { getApiUrl } from '../../lib/config';
+import type { IMenuNamespaceConfig } from './types';
 
+/**
+ * Per-namespace menu state.
+ *
+ * Tree (`roots` + `lastUpdated`) and rendering config (`config`) are
+ * tracked independently so a tree mutation broadcast doesn't blow away a
+ * previously-loaded config (and vice versa). All three are optional —
+ * the namespace can show up via any of the three entry points (SSR tree
+ * seed, config fetch, WebSocket update) and the reducers merge into
+ * whatever is already there.
+ */
 interface MenuNamespaceState {
-    roots: MenuNodeSerialized[];
-    lastUpdated: string;
+    roots?: MenuNodeSerialized[];
+    lastUpdated?: string;
+    config?: IMenuNamespaceConfig;
 }
 
 export interface MenuState {
@@ -56,6 +68,37 @@ export const refetchMenuTree = createAsyncThunk<
     }
 });
 
+/**
+ * Fetch a namespace's rendering configuration on first consumer mount.
+ *
+ * The config endpoint is public, but credentials are sent for symmetry
+ * with the tree refetch so any future per-user config gating works
+ * without further plumbing. Subsequent updates arrive via the
+ * `menu:namespace-config:update` WebSocket event handled in
+ * SocketBridge.
+ */
+export const fetchNamespaceConfig = createAsyncThunk<
+    { namespace: string; config: IMenuNamespaceConfig },
+    { namespace: string },
+    { rejectValue: string }
+>('menu/fetchNamespaceConfig', async ({ namespace }, { rejectWithValue }) => {
+    try {
+        const url = getApiUrl(`/menu/namespace/${encodeURIComponent(namespace)}/config`);
+        const response = await fetch(url, { credentials: 'include' });
+        if (!response.ok) {
+            return rejectWithValue(`config fetch failed: ${response.status}`);
+        }
+        const body = await response.json();
+        const config = body?.config as IMenuNamespaceConfig | undefined;
+        if (!config || !config.namespace) {
+            return rejectWithValue('config payload missing or invalid');
+        }
+        return { namespace, config };
+    } catch (error) {
+        return rejectWithValue(error instanceof Error ? error.message : 'config fetch failed');
+    }
+});
+
 const menuSlice = createSlice({
     name: 'menu',
     initialState,
@@ -69,16 +112,35 @@ const menuSlice = createSlice({
          */
         menuTreeSeeded(state, action: PayloadAction<{ namespace: string; roots: MenuNodeSerialized[]; timestamp: string }>) {
             const { namespace, roots, timestamp } = action.payload;
-            state.namespaces[namespace] = { roots, lastUpdated: timestamp };
+            const existing = state.namespaces[namespace] ?? {};
+            state.namespaces[namespace] = { ...existing, roots, lastUpdated: timestamp };
+        },
+        /**
+         * Replace the config for `namespace`. Dispatched by SocketBridge on
+         * receipt of `menu:namespace-config:update`, and by the
+         * `fetchNamespaceConfig` thunk on initial load. Merges into any
+         * tree state already held for the namespace so a config update
+         * never wipes a freshly-loaded tree.
+         */
+        namespaceConfigSet(state, action: PayloadAction<{ namespace: string; config: IMenuNamespaceConfig }>) {
+            const { namespace, config } = action.payload;
+            const existing = state.namespaces[namespace] ?? {};
+            state.namespaces[namespace] = { ...existing, config };
         }
     },
     extraReducers: (builder) => {
         builder.addCase(refetchMenuTree.fulfilled, (state, action) => {
             const { namespace, roots, timestamp } = action.payload;
-            state.namespaces[namespace] = { roots, lastUpdated: timestamp };
+            const existing = state.namespaces[namespace] ?? {};
+            state.namespaces[namespace] = { ...existing, roots, lastUpdated: timestamp };
+        });
+        builder.addCase(fetchNamespaceConfig.fulfilled, (state, action) => {
+            const { namespace, config } = action.payload;
+            const existing = state.namespaces[namespace] ?? {};
+            state.namespaces[namespace] = { ...existing, config };
         });
     }
 });
 
-export const { menuTreeSeeded } = menuSlice.actions;
+export const { menuTreeSeeded, namespaceConfigSet } = menuSlice.actions;
 export default menuSlice.reducer;

--- a/src/frontend/modules/menu/slice.ts
+++ b/src/frontend/modules/menu/slice.ts
@@ -14,22 +14,35 @@
 import { createSlice, createAsyncThunk, type PayloadAction } from '@reduxjs/toolkit';
 import type { MenuNodeSerialized } from '@/shared';
 import { getApiUrl } from '../../lib/config';
+import { getRuntimeConfig } from '../../lib/runtimeConfig';
 import type { IMenuNamespaceConfig } from './types';
+
+/**
+ * Lifecycle of the initial namespace-config fetch.
+ *
+ * Tracked per-namespace so the hook can stop dispatching after a
+ * terminal state — without this, a rejected fetch leaves `config`
+ * undefined and every subsequent render of any consumer would re-fire
+ * the thunk, leaking requests until the user reloads.
+ */
+export type NamespaceConfigStatus = 'idle' | 'loading' | 'succeeded' | 'failed';
 
 /**
  * Per-namespace menu state.
  *
- * Tree (`roots` + `lastUpdated`) and rendering config (`config`) are
- * tracked independently so a tree mutation broadcast doesn't blow away a
- * previously-loaded config (and vice versa). All three are optional —
- * the namespace can show up via any of the three entry points (SSR tree
- * seed, config fetch, WebSocket update) and the reducers merge into
- * whatever is already there.
+ * Tree (`roots` + `lastUpdated`) and rendering config (`config` plus its
+ * fetch `configStatus`/`configError`) are tracked independently so a
+ * tree mutation broadcast doesn't blow away a previously-loaded config
+ * (and vice versa). All fields are optional — the namespace can show up
+ * via any of the entry points (SSR tree seed, config fetch, WebSocket
+ * update) and the reducers merge into whatever is already there.
  */
 interface MenuNamespaceState {
     roots?: MenuNodeSerialized[];
     lastUpdated?: string;
     config?: IMenuNamespaceConfig;
+    configStatus?: NamespaceConfigStatus;
+    configError?: string;
 }
 
 export interface MenuState {
@@ -80,10 +93,14 @@ export const refetchMenuTree = createAsyncThunk<
 export const fetchNamespaceConfig = createAsyncThunk<
     { namespace: string; config: IMenuNamespaceConfig },
     { namespace: string },
-    { rejectValue: string }
+    { rejectValue: string; state: { menu: MenuState } }
 >('menu/fetchNamespaceConfig', async ({ namespace }, { rejectWithValue }) => {
     try {
-        const url = getApiUrl(`/menu/namespace/${encodeURIComponent(namespace)}/config`);
+        // Use the runtime config helper (not the deprecated build-time
+        // `getApiUrl`) so the same Docker image works across domains —
+        // see `docs/frontend/frontend.md` for the universal-image rule.
+        const { apiUrl } = getRuntimeConfig();
+        const url = `${apiUrl}/menu/namespace/${encodeURIComponent(namespace)}/config`;
         const response = await fetch(url, { credentials: 'include' });
         if (!response.ok) {
             return rejectWithValue(`config fetch failed: ${response.status}`);
@@ -93,9 +110,31 @@ export const fetchNamespaceConfig = createAsyncThunk<
         if (!config || !config.namespace) {
             return rejectWithValue('config payload missing or invalid');
         }
+        // Reject if the response's namespace doesn't match what we
+        // asked for — otherwise we would store mismatched config under
+        // the requested key and consumers would silently render the
+        // wrong namespace's settings.
+        if (config.namespace !== namespace) {
+            return rejectWithValue(
+                `namespace mismatch: requested "${namespace}", server returned "${config.namespace}"`
+            );
+        }
         return { namespace, config };
     } catch (error) {
         return rejectWithValue(error instanceof Error ? error.message : 'config fetch failed');
+    }
+}, {
+    /**
+     * Skip the dispatch if a fetch for this namespace is already in
+     * flight or has already produced a terminal result. Without this,
+     * concurrent mounts of `useMenuConfig` (which RTK does not dedupe
+     * by default) would each fire the request, and a rejected attempt
+     * would be retried on every render where the consumer's hook
+     * dispatches again.
+     */
+    condition: ({ namespace }, { getState }) => {
+        const status = getState().menu.namespaces[namespace]?.configStatus;
+        return status !== 'loading' && status !== 'succeeded' && status !== 'failed';
     }
 });
 
@@ -134,10 +173,37 @@ const menuSlice = createSlice({
             const existing = state.namespaces[namespace] ?? {};
             state.namespaces[namespace] = { ...existing, roots, lastUpdated: timestamp };
         });
+        builder.addCase(fetchNamespaceConfig.pending, (state, action) => {
+            const { namespace } = action.meta.arg;
+            const existing = state.namespaces[namespace] ?? {};
+            state.namespaces[namespace] = {
+                ...existing,
+                configStatus: 'loading',
+                configError: undefined
+            };
+        });
         builder.addCase(fetchNamespaceConfig.fulfilled, (state, action) => {
             const { namespace, config } = action.payload;
             const existing = state.namespaces[namespace] ?? {};
-            state.namespaces[namespace] = { ...existing, config };
+            state.namespaces[namespace] = {
+                ...existing,
+                config,
+                configStatus: 'succeeded',
+                configError: undefined
+            };
+        });
+        builder.addCase(fetchNamespaceConfig.rejected, (state, action) => {
+            const { namespace } = action.meta.arg;
+            const existing = state.namespaces[namespace] ?? {};
+            // Terminal failure — record the error and let the hook fall
+            // back to defaults with loading:false. We do not auto-retry
+            // because retry on a permanently-bad endpoint would burn
+            // requests on every consumer render.
+            state.namespaces[namespace] = {
+                ...existing,
+                configStatus: 'failed',
+                configError: action.payload ?? action.error.message ?? 'config fetch failed'
+            };
         });
     }
 });

--- a/src/frontend/modules/menu/types/index.ts
+++ b/src/frontend/modules/menu/types/index.ts
@@ -87,13 +87,20 @@ export interface IMenuNamespaceConfig {
 
     /**
      * Timestamp when configuration was created.
+     *
+     * ISO 8601 string on the wire. The frontend type intentionally
+     * differs from the backend `IMenuNamespaceConfig` (which carries
+     * `Date`) because the JSON transport strips the prototype — typing
+     * this as `Date` here would silently fail at the first `.toISOString()`
+     * call.
      */
-    createdAt?: Date;
+    createdAt?: string;
 
     /**
-     * Timestamp when configuration was last updated.
+     * Timestamp when configuration was last updated. See `createdAt`
+     * above for the string-not-Date rationale.
      */
-    updatedAt?: Date;
+    updatedAt?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds an admin-only `IMenuNodeAdminView` projection that tags every menu node with `origin: 'manual' | 'plugin' | 'plugin-overridden'`. The admin UI at `/system/menu` renders the tag as a badge and guards the delete confirm dialog with a "will reappear on next plugin load" warning for plugin-owned rows. Public reads keep the unchanged `IMenuTree` shape — no origin metadata leaks to unauthenticated callers.
- Wires the long-dormant `icons.enabled`, `icons.position`, and `styling.showLabels` namespace-config toggles into `MenuNavClient`. Icons render via a code-split `MenuNodeIcon` (next/dynamic + the existing `resolveIcon`) so the lucide-react namespace stays out of the main bundle. Hiding labels keeps an `aria-label` plus an `sr-only` span for accessibility; if icons and labels are both off, labels win the fallback.
- Makes namespace configuration changes propagate in real time. The menu Redux slice now carries an optional `config` alongside the tree; `SocketBridge` dispatches `namespaceConfigSet` on the `menu:namespace-config:update` event the backend was already broadcasting; `useMenuConfig` becomes a thin Redux selector that fetches once via a new `fetchNamespaceConfig` thunk.