### PR TITLE
Split menu admin read off /api/menu to /api/menu/manage

### DIFF
--- a/src/backend/modules/menu/MenuModule.ts
+++ b/src/backend/modules/menu/MenuModule.ts
@@ -19,6 +19,7 @@ import { MenuController } from './api/menu.controller.js';
 import { MAIN_SYSTEM_CONTAINER_ID } from './constants.js';
 import { Router as ExpressRouter } from 'express';
 import { requireAdmin } from '../../api/middleware/admin-auth.js';
+import { createRateLimiter } from '../../api/middleware/rate-limit.js';
 import { userContextMiddleware } from '../../api/middleware/user-context.js';
 
 /**
@@ -301,7 +302,16 @@ export class MenuModule implements IModule<IMenuModuleDependencies> {
         // Admin management read — origin-tagged, includes disabled and gated
         // rows. Distinct from `GET /` (the universal navigation read) so
         // privilege never changes the shape of the navigation tree.
-        router.get('/manage', requireAdmin, this.controller.getManageView);
+        // Rate-limited per-IP using the same 60s/60req shape as the other
+        // rate-limited core routes (tokens, transactions) to satisfy
+        // CodeQL's missing-rate-limiting rule and bound brute-force cost
+        // against the `requireAdmin` token check.
+        const manageRateLimiter = createRateLimiter({
+            windowSeconds: 60,
+            maxRequests: 60,
+            keyPrefix: 'menu-manage'
+        });
+        router.get('/manage', manageRateLimiter, requireAdmin, this.controller.getManageView);
 
         // Admin-only routes (mutating operations require authentication)
         router.post('/', requireAdmin, this.controller.create);

--- a/src/backend/modules/menu/MenuModule.ts
+++ b/src/backend/modules/menu/MenuModule.ts
@@ -298,6 +298,11 @@ export class MenuModule implements IModule<IMenuModuleDependencies> {
         router.get('/namespace/:namespace/config', this.controller.getNamespaceConfig);
         router.get('/', userContextMiddleware, this.controller.getTree);
 
+        // Admin management read — origin-tagged, includes disabled and gated
+        // rows. Distinct from `GET /` (the universal navigation read) so
+        // privilege never changes the shape of the navigation tree.
+        router.get('/manage', requireAdmin, this.controller.getManageView);
+
         // Admin-only routes (mutating operations require authentication)
         router.post('/', requireAdmin, this.controller.create);
         router.patch('/:id', requireAdmin, this.controller.update);

--- a/src/backend/modules/menu/README.md
+++ b/src/backend/modules/menu/README.md
@@ -231,7 +231,7 @@ the server returns the filtered view.
 
 ## REST API Reference
 
-Read endpoints are public so the frontend can render navigation without an admin token; mutating endpoints require `ADMIN_API_TOKEN` via `x-admin-token` or `Authorization: Bearer`. See [system-api.md](../../../../docs/system/system-api.md) for complete authentication patterns.
+Navigation reads are public — the frontend chrome fetches them without an admin token, with per-user gating applied from the `tronrelic_uid` cookie. The admin management read (`GET /api/menu/manage`) and every mutating endpoint go through `requireAdmin`, which accepts either the cookie path (verified wallet + admin group) or `ADMIN_API_TOKEN` via `x-admin-token` / `Authorization: Bearer`. See [system-api.md](../../../../docs/system/system-api.md) for complete authentication patterns.
 
 **Public (no auth):**
 

--- a/src/backend/modules/menu/README.md
+++ b/src/backend/modules/menu/README.md
@@ -96,7 +96,7 @@ Override persistence applies to `order`, `label`, `description`, `icon`, and `en
 | `plugin` | Memory-only, no override row. Delete removes only the in-memory copy — the plugin re-registers on next boot. |
 | `plugin-overridden` | Memory-only with an admin customization in `menu_node_overrides`. Plugin still owns lifecycle; `order`/`label`/`icon`/`description`/`enabled` survive restarts. |
 
-The controller branches on `isAdmin(req)` — admin callers receive `IMenuTreeAdminView`, public callers receive the unchanged `IMenuTree`. Origin is computed at read time, so it never goes stale. The admin UI at `/system/menu` renders the tag as a badge and gates the delete confirm dialog with a "will reappear on next plugin load" warning for `plugin` and `plugin-overridden` rows.
+The origin-tagged projection is served exclusively from `GET /api/menu/manage`, a `requireAdmin`-gated endpoint. `GET /api/menu` is the universal navigation read and never changes shape based on caller privilege — every visitor, admin or not, gets the same per-user filtered, enabled-only tree. Splitting reads this way keeps the navigation chrome consistent for admin operators and confines disabled / gated rows to the editing surface where they belong. Origin is computed at read time, so it never goes stale. The admin UI at `/system/menu` renders the tag as a badge and gates the delete confirm dialog with a "will reappear on next plugin load" warning for `plugin` and `plugin-overridden` rows.
 
 ### Auto-Derived URLs for Container Nodes
 
@@ -246,6 +246,7 @@ Read endpoints are public so the frontend can render navigation without an admin
 
 | Endpoint | Method | Purpose | Key Fields |
 |----------|--------|---------|------------|
+| `/api/menu/manage` | GET | Origin-tagged tree for the menu admin UI — includes disabled and gated rows | Query: `namespace` (optional, defaults to 'main') |
 | `/api/menu` | POST | Create persisted menu node | Body: `label` (required), `description`, `url`, `icon`, `order`, `parent`, `enabled`, `allowedIdentityStates`, `requiresGroups`, `requiresAdmin` |
 | `/api/menu/:id` | PATCH | Update menu node | Body: any fields to update |
 | `/api/menu/:id` | DELETE | Delete menu node | Does **not** cascade — children become orphans unless a `before:delete` subscriber handles them |

--- a/src/backend/modules/menu/api/menu.controller.ts
+++ b/src/backend/modules/menu/api/menu.controller.ts
@@ -325,17 +325,24 @@ export class MenuController {
     constructor(private readonly service: MenuService) {}
 
     /**
-     * Get the complete menu tree structure.
+     * Get the user-visible menu tree for the navigation chrome.
      *
-     * Returns hierarchical representation of all menu nodes organized by parent-child
-     * relationships. Root nodes are in the `roots` array, each potentially containing
-     * nested children. The `all` array provides a flat list for quick lookups.
+     * Returns the hierarchical menu projected through the cookie-resolved
+     * visitor's gating: nodes with `enabled: false` are stripped, and per-node
+     * gating fields (`allowedIdentityStates`, `requiresGroups`, `requiresAdmin`)
+     * narrow the tree to what this visitor may see. Admins receive the same
+     * shape as everyone else — the origin-tagged management view lives at
+     * `GET /api/menu/manage`. Root nodes are in the `roots` array, each
+     * potentially containing nested children; the `all` array provides a
+     * flat list for quick lookups.
      *
      * **Route:** GET /api/menu
      *
-     * **Authentication:** Public (no authentication required)
+     * **Authentication:** Public — `userContextMiddleware` resolves the
+     *                     `tronrelic_uid` cookie so per-user gating applies.
+     *                     Anonymous callers see only ungated nodes.
      *
-     * **Response:**
+     * **Response:** (shape after filtering; concrete fields depend on caller's identity)
      * ```json
      * {
      *   "success": true,
@@ -405,6 +412,9 @@ export class MenuController {
      * **Route:** GET /api/menu/manage
      *
      * **Authentication:** Requires admin (via `requireAdmin` middleware).
+     *
+     * @param req - Express request object
+     * @param res - Express response object
      */
     getManageView = async (req: Request, res: Response) => {
         try {

--- a/src/backend/modules/menu/api/menu.controller.ts
+++ b/src/backend/modules/menu/api/menu.controller.ts
@@ -375,24 +375,50 @@ export class MenuController {
 
             if (await denyIfAdminNamespace(req, res, namespace)) return;
 
-            // Admins see the full unfiltered tree (including disabled
-            // nodes and gated entries) so the admin UI can render and
-            // edit them. The admin variant additionally tags each node
-            // with an `origin` field (`manual` / `plugin` /
-            // `plugin-overridden`) so the UI can render an origin badge
-            // and gate destructive UX on plugin-owned rows. Admin status
-            // resolves either via the user cookie (verified wallet +
-            // admin group) or via service token. Regular visitors get
-            // the per-user filtered view: enabled-only AND gating-aware,
-            // with no origin metadata leaked.
-            if (await isAdmin(req)) {
-                res.json({ success: true, tree: this.service.getTreeAdminView(namespace) });
-                return;
-            }
-
+            // Universal navigation read: every caller — admin or not —
+            // receives the same per-user filtered, enabled-only tree.
+            // Admins do not get a privileged shape here; the admin
+            // management surface lives at `GET /api/menu/manage`. Node
+            // visibility is controlled exclusively by per-node gating
+            // (`allowedIdentityStates`, `requiresGroups`, `requiresAdmin`).
             const user = (req as Request & { user?: IUser }).user;
             const filtered = await this.service.getTreeForUser(namespace, user);
             res.json({ success: true, tree: publicTreeView(filtered) });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Failed to get menu tree';
+            res.status(500).json({ success: false, error: message });
+        }
+    };
+
+    /**
+     * Admin management read: full origin-tagged tree.
+     *
+     * Returns every node in the namespace — including disabled rows and
+     * gated entries — with each node tagged `manual` / `plugin` /
+     * `plugin-overridden` so the admin UI can render origin badges and
+     * gate destructive actions on plugin-owned rows.
+     *
+     * Distinct from `GET /api/menu` by design. The navigation read is
+     * universal and gated only by per-node permissions; this endpoint
+     * is the menu-editing surface, not a privileged navigation view.
+     *
+     * **Route:** GET /api/menu/manage
+     *
+     * **Authentication:** Requires admin (via `requireAdmin` middleware).
+     */
+    getManageView = async (req: Request, res: Response) => {
+        try {
+            const rawNamespace = req.query.namespace;
+            const namespace = typeof rawNamespace === 'string' && rawNamespace.length > 0
+                ? rawNamespace
+                : undefined;
+
+            if (namespace !== undefined && !NAMESPACE_REGEX.test(namespace)) {
+                res.status(400).json({ success: false, error: 'Invalid namespace' });
+                return;
+            }
+
+            res.json({ success: true, tree: this.service.getTreeAdminView(namespace) });
         } catch (error) {
             const message = error instanceof Error ? error.message : 'Failed to get menu tree';
             res.status(500).json({ success: false, error: message });

--- a/src/frontend/app/(core)/system/menu/page.tsx
+++ b/src/frontend/app/(core)/system/menu/page.tsx
@@ -164,14 +164,14 @@ export default function MenuAdminPage() {
 
     const fetchTree = useCallback(
         async (namespace: string) => {
-            const res = await fetch(`/api/menu?namespace=${encodeURIComponent(namespace)}`, {
+            const res = await fetch(`/api/menu/manage?namespace=${encodeURIComponent(namespace)}`, {
                 headers: authHeaders
             });
             if (!res.ok) throw new Error('Failed to load menu tree');
             const data = await res.json();
-            // Admin reads return the origin-tagged projection (controller
-            // branches on `isAdmin`). The page is admin-only, so the cast
-            // is always valid for callers reaching this code path.
+            // `/api/menu/manage` returns the origin-tagged projection.
+            // The route is `requireAdmin`-gated so the cast is always
+            // valid for callers reaching this code path.
             return data.tree as IMenuTreeAdminView;
         },
         [authHeaders]


### PR DESCRIPTION
## Summary

`GET /api/menu` previously branched on `isAdmin(req)` and returned the unfiltered origin-tagged tree to admin callers. The SSR navbar fetcher forwards the visitor's cookie, so admins received the admin shape in their main navigation too — disabled rows (e.g. an Overview entry whose override carried `enabled: false`) surfaced under the System container anyway.

Navigation reads are now universal: every caller, admin or not, receives the same per-user filtered, enabled-only tree. The origin-tagged projection moves to a dedicated `GET /api/menu/manage` endpoint gated by `requireAdmin` and consumed by the `/system/menu` admin page. Privilege no longer changes the shape of the navigation tree; node visibility is controlled exclusively by per-node gating fields (`allowedIdentityStates`, `requiresGroups`, `requiresAdmin`).

## Changes

- `menu.controller.ts` — `getTree` drops the admin branch; new `getManageView` handler returns `getTreeAdminView` output for the manage route.
- `MenuModule.ts` — registers `GET /api/menu/manage` behind `requireAdmin`.
- `app/(core)/system/menu/page.tsx` — admin page fetches from `/api/menu/manage`.
- `modules/menu/README.md` — origin-tag and REST sections updated to reflect the split.