### PR TITLE
Fix menu icon rendering and wire styling.compact through

### DIFF
--- a/src/frontend/components/layout/MenuNav/MenuNav.module.scss
+++ b/src/frontend/components/layout/MenuNav/MenuNav.module.scss
@@ -45,6 +45,25 @@
     overflow: visible;
 }
 
+/**
+ * Compact variant — tighter spacing and smaller text.
+ *
+ * Driven by the namespace config `styling.compact` toggle. Tightens
+ * the inter-tab gap and drops padding / font-size one step on the
+ * curated t-shirt scale for descendant tab and category buttons.
+ * Token tier stays on use-case semantics and curated primitives.
+ */
+.nav--compact {
+    gap: var(--gap-xs);
+
+    .tab,
+    .categoryButton,
+    .subcategoryButton {
+        padding: var(--padding-xs) var(--padding-sm);
+        font-size: var(--font-size-caption);
+    }
+}
+
 .tab {
     padding: var(--padding-sm) var(--padding-md);
     background: transparent;

--- a/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
@@ -573,7 +573,12 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
         );
     };
 
-    const navClassName = `${styles.nav} ${hasInitialized ? styles['nav--initialized'] : ''}`;
+    const isCompact = menuConfig.styling?.compact ?? false;
+    const navClassName = [
+        styles.nav,
+        hasInitialized ? styles['nav--initialized'] : '',
+        isCompact ? styles['nav--compact'] : ''
+    ].filter(Boolean).join(' ');
 
     // Always render PriorityNav to maintain consistent single-row layout.
     // The fallback wrapped layout caused vertical overflow during loading,

--- a/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
@@ -150,6 +150,7 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
     const iconsEnabled = menuConfig.icons?.enabled ?? true;
     const iconPosition: IconPosition = (menuConfig.icons?.position as IconPosition) ?? 'left';
     const showLabelsConfigured = menuConfig.styling?.showLabels ?? true;
+    const isCompact = menuConfig.styling?.compact ?? false;
     // `MenuNodeIcon` uses `next/dynamic({ ssr: false })`, so the icon
     // glyph renders nothing during SSR, nothing during the first client
     // paint, and nothing for no-JS users. Keeping labels visible until
@@ -538,11 +539,22 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
 
         const position = getDropdownPosition();
 
+        // The portal lives under <body>, outside the <nav> that carries the
+        // compact class — descendant selectors anchored on `.nav--compact`
+        // would never match the dropdown contents. Tagging the dropdown root
+        // and the backdrop with the same compact class brings the rule scope
+        // into the portal so `.subcategoryButton` and other dropdown rows
+        // honor `styling.compact`.
+        const dropdownClassName = [styles.categoryDropdown, isCompact ? styles['nav--compact'] : '']
+            .filter(Boolean).join(' ');
+        const backdropClassName = [styles.categoryBackdrop, isCompact ? styles['nav--compact'] : '']
+            .filter(Boolean).join(' ');
+
         return createPortal(
             <>
                 {/* Backdrop - prevents interaction with page behind sheet */}
                 <div
-                    className={styles.categoryBackdrop}
+                    className={backdropClassName}
                     aria-hidden="true"
                     onClick={closeDropdown}
                     onTouchMove={(e) => e.preventDefault()}
@@ -550,7 +562,7 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
                 {/* Dropdown panel */}
                 <div
                     ref={dropdownRef}
-                    className={styles.categoryDropdown}
+                    className={dropdownClassName}
                     role="menu"
                     aria-label={`${expandedCategory.label} submenu`}
                     style={{
@@ -573,7 +585,6 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
         );
     };
 
-    const isCompact = menuConfig.styling?.compact ?? false;
     const navClassName = [
         styles.nav,
         hasInitialized ? styles['nav--initialized'] : '',

--- a/src/frontend/modules/menu/components/CategoryLandingPage/iconResolver.tsx
+++ b/src/frontend/modules/menu/components/CategoryLandingPage/iconResolver.tsx
@@ -32,6 +32,18 @@ const NON_ICON_EXPORTS = new Set(['icons', 'Icon', 'createLucideIcon']);
  * @returns The LucideIcon component or undefined if not found
  */
 export function resolveIcon(name: string): LucideIcon | undefined {
+    // Predicate mirrors `isRenderableLucideExport` in
+    // `components/ui/IconPickerModal/IconPickerModal.tsx` so both surfaces
+    // accept the same set: picker can never offer a name the resolver
+    // would later reject (or vice versa). If the predicate is extended
+    // there, mirror the change here.
+
+    // Icon exports start with an uppercase letter; everything else
+    // (e.g. `createLucideIcon`, `icons`) is a utility.
+    if (!/^[A-Z]/.test(name)) {
+        return undefined;
+    }
+
     if (NON_ICON_EXPORTS.has(name) || name.startsWith('Lucide') || name.endsWith('Icon')) {
         return undefined;
     }
@@ -40,14 +52,21 @@ export function resolveIcon(name: string): LucideIcon | undefined {
 
     // lucide-react ≥ 0.300 wraps every icon in `React.forwardRef(...)`, whose
     // result is a `ForwardRefExoticComponent` — `typeof` reports `'object'`,
-    // not `'function'`. A plain `typeof === 'function'` guard rejects every
-    // icon and silently returns undefined, so menu nav and category landing
-    // pages render no icons at all. Accept both shapes: function components
-    // (legacy) and exotic component objects (forwardRef / memo wrappers).
+    // not `'function'`. Accept both shapes: function components (legacy)
+    // and exotic component objects (forwardRef / memo wrappers).
     if (candidate == null) {
         return undefined;
     }
     if (typeof candidate !== 'function' && typeof candidate !== 'object') {
+        return undefined;
+    }
+
+    // Lucide icons carry a `displayName: string` set by `createLucideIcon`.
+    // Non-component exports that happen to be objects (utility helpers,
+    // future additions) will not, so requiring it closes the
+    // non-renderable-cast risk Copilot flagged.
+    const component = candidate as { displayName?: unknown };
+    if (typeof component.displayName !== 'string') {
         return undefined;
     }
 

--- a/src/frontend/modules/menu/components/CategoryLandingPage/iconResolver.tsx
+++ b/src/frontend/modules/menu/components/CategoryLandingPage/iconResolver.tsx
@@ -38,7 +38,16 @@ export function resolveIcon(name: string): LucideIcon | undefined {
 
     const candidate = (LucideIcons as Record<string, unknown>)[name];
 
-    if (typeof candidate !== 'function') {
+    // lucide-react ≥ 0.300 wraps every icon in `React.forwardRef(...)`, whose
+    // result is a `ForwardRefExoticComponent` — `typeof` reports `'object'`,
+    // not `'function'`. A plain `typeof === 'function'` guard rejects every
+    // icon and silently returns undefined, so menu nav and category landing
+    // pages render no icons at all. Accept both shapes: function components
+    // (legacy) and exotic component objects (forwardRef / memo wrappers).
+    if (candidate == null) {
+        return undefined;
+    }
+    if (typeof candidate !== 'function' && typeof candidate !== 'object') {
         return undefined;
     }
 


### PR DESCRIPTION
## Summary

Two independent bugs in the main menu rendering path, both pre-dating the recent endpoint split:

**Icons never rendered.** `resolveIcon` (`src/frontend/modules/menu/components/CategoryLandingPage/iconResolver.tsx`) gated on `typeof candidate === 'function'`, but lucide-react ≥ 0.300 wraps every icon in `React.forwardRef(...)` — a `ForwardRefExoticComponent` whose `typeof` is `'object'`. Every icon name silently resolved to `undefined`, so `MenuNodeIcon` rendered `null` regardless of the namespace `icons.enabled` toggle. The guard now accepts both function components (legacy) and exotic component objects (forwardRef / memo wrappers).

**Compact mode was a no-op.** `IMenuNamespaceConfig.styling.compact` was declared in the types, persisted through the admin UI, and broadcast over WebSocket — but no frontend consumer ever read it. Now `MenuNavClient` reads `menuConfig.styling?.compact`, applies a `nav--compact` class on the `<nav>`, and an SCSS rule drops the inter-tab gap and tab / categoryButton padding + font-size one step on the curated t-shirt scale.

## Changes

- `iconResolver.tsx` — accept `typeof === 'object'` in addition to `'function'` for forwardRef-wrapped icons.
- `MenuNavClient.tsx` — derive `isCompact` from `menuConfig.styling?.compact` and append the modifier class.
- `MenuNav.module.scss` — `.nav--compact` selector tightening descendant tab and category button spacing.