### PR TITLE
Tighten WalletButton and BlockTicker density

### DIFF
--- a/src/frontend/app/primitives.scss
+++ b/src/frontend/app/primitives.scss
@@ -147,6 +147,7 @@
     --button-height-sm: 34px;
     --button-height-md: 42px;
     --button-height-lg: 50px;
+    --icon-size-xs: 14px;
     --icon-size-sm: 18px;
     --icon-size-md: 20px;
     --icon-size-lg: 24px;

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -131,6 +131,7 @@
 
     /* Icon Button - Padding around icon */
     --icon-button-padding: var(--spacing-4);
+    --icon-button-padding-touch: var(--spacing-5); /* 0.75rem - WCAG dense-UI minimum with --icon-size-xs */
 
     /* Icon Button - Size Variants (icon + padding on both sides) */
     --icon-button-size-sm: calc(var(--icon-size-sm) + var(--icon-button-padding) * 2);

--- a/src/frontend/components/layout/BlockTicker/BlockTicker.module.scss
+++ b/src/frontend/components/layout/BlockTicker/BlockTicker.module.scss
@@ -18,10 +18,11 @@
     display: flex;
     align-items: center;
     gap: var(--spacing-10);
-    padding: var(--spacing-4) var(--container-padding-desktop);
+    padding: var(--padding-xs) var(--container-padding-desktop);
     width: min($breakpoint-tablet, 100%);
     margin: 0 auto;
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-caption);
+    line-height: var(--line-height-tight);
     overflow-x: auto;
     scrollbar-width: none;
 }
@@ -61,7 +62,7 @@
 /* Responsive adjustments */
 @media (max-width: $breakpoint-tablet) {
     .container {
-        padding: var(--spacing-4) var(--container-padding-tablet);
+        padding: var(--padding-xs) var(--container-padding-tablet);
         gap: var(--spacing-7);
     }
 }
@@ -69,9 +70,8 @@
 /* Note: 640px is component-specific, not a standard breakpoint */
 @media (max-width: 640px) {
     .container {
-        padding: var(--spacing-4) var(--container-padding-mobile);
+        padding: var(--padding-xs) var(--container-padding-mobile);
         gap: var(--spacing-5);
-        font-size: var(--font-size-xs);
     }
 
     .separator {

--- a/src/frontend/modules/user/components/WalletButton/WalletButton.module.scss
+++ b/src/frontend/modules/user/components/WalletButton/WalletButton.module.scss
@@ -23,7 +23,7 @@
     font-weight: var(--button-font-weight);
     font-size: var(--button-font-size-sm);
     padding: var(--button-padding-sm);
-    border-radius: var(--radius-md);
+    border-radius: var(--button-border-radius);
     display: inline-flex;
     align-items: center;
     gap: var(--button-gap);
@@ -56,8 +56,8 @@
  * TronLink logo with subtle glow effect and minimal border treatment.
  */
 .wallet_icon {
-    width: 14px;
-    height: 14px;
+    width: var(--icon-size-xs);
+    height: var(--icon-size-xs);
     border-radius: var(--radius-xs);
     border: var(--border-width-thin) solid var(--color-border);
     filter: drop-shadow(0 0 var(--spacing-4) var(--color-primary-alpha-38));
@@ -133,7 +133,7 @@
     }
 
     .connect_btn {
-        padding: var(--spacing-3);
+        padding: var(--icon-button-padding-touch);
     }
 }
 

--- a/src/frontend/modules/user/components/WalletButton/WalletButton.module.scss
+++ b/src/frontend/modules/user/components/WalletButton/WalletButton.module.scss
@@ -20,13 +20,13 @@
     background: linear-gradient(135deg, var(--color-primary-alpha-30), var(--color-primary-alpha-18));
     border: var(--border-width-medium) solid var(--color-primary);
     color: var(--color-text);
-    font-weight: var(--font-weight-semibold);
-    font-size: var(--font-size-base);
-    padding: var(--spacing-3) var(--spacing-9) var(--spacing-3) var(--spacing-8);
-    border-radius: var(--radius-full);
+    font-weight: var(--button-font-weight);
+    font-size: var(--button-font-size-sm);
+    padding: var(--button-padding-sm);
+    border-radius: var(--radius-md);
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-5);
+    gap: var(--button-gap);
     cursor: pointer;
     transition: all var(--transition-base);
     box-shadow: var(--button-primary-shadow);
@@ -56,8 +56,8 @@
  * TronLink logo with subtle glow effect and minimal border treatment.
  */
 .wallet_icon {
-    width: var(--icon-size-sm);
-    height: var(--icon-size-sm);
+    width: 14px;
+    height: 14px;
     border-radius: var(--radius-xs);
     border: var(--border-width-thin) solid var(--color-border);
     filter: drop-shadow(0 0 var(--spacing-4) var(--color-primary-alpha-38));
@@ -133,7 +133,7 @@
     }
 
     .connect_btn {
-        padding: var(--spacing-3) var(--spacing-5);
+        padding: var(--spacing-3);
     }
 }
 

--- a/src/frontend/modules/user/components/WalletButton/WalletButton.tsx
+++ b/src/frontend/modules/user/components/WalletButton/WalletButton.tsx
@@ -37,11 +37,11 @@ import { useWallet } from '../../hooks/useWallet';
 import styles from './WalletButton.module.scss';
 
 /**
- * Truncates a wallet address to show first 6 and last 4 characters.
- * Example: TRSbL...N8Mq
+ * Truncates a wallet address to show first 3 and last 3 characters.
+ * Example: TRS…8Mq
  */
 function truncateWallet(address: string) {
-    return `${address.slice(0, 6)}…${address.slice(-4)}`;
+    return `${address.slice(0, 3)}…${address.slice(-3)}`;
 }
 
 /**
@@ -193,7 +193,7 @@ export function WalletButton() {
             aria-label="Login"
         >
             {isConnecting ? (
-                <Loader2 size={18} className={styles.spinner} />
+                <Loader2 size={14} className={styles.spinner} />
             ) : (
                 <img
                     src="/images/tronlink/tronlink-64x64.jpg"


### PR DESCRIPTION
## Summary

Compact the header strip so the wallet button and block ticker share a tighter visual rhythm.

- `WalletButton` adopts button-specific semantic tokens (`--button-padding-sm`, `--button-gap`, `--button-font-size-sm`), shrinks the wallet icon to 14px, and truncates addresses to 3…3 characters.
- `BlockTicker` switches container padding to `--padding-xs`, font size to `--font-size-caption`, and line-height to `--line-height-tight` so it matches the new button height.