### PR TITLE
Make every themable surface actually theme

### DIFF
--- a/docs/frontend/ui/ui-accessibility.md
+++ b/docs/frontend/ui/ui-accessibility.md
@@ -27,15 +27,32 @@ Buttons, links, lists, and navigation landmarks communicate purpose to assistive
 
 ## Focus Management
 
-All interactive elements must have visible focus states. The design system provides these automatically for `<button>`, `<input>`, and `<a>` elements.
+All interactive elements must have visible focus states. The design system provides these automatically for `<button>`, `<input>`, and `<a>` via the global `:focus-visible` outline in `globals.scss`.
 
-For custom interactive elements, ensure `focus-visible` is styled:
+When a component overrides the focus style — to swap the outline for a box-shadow ring, change the border color, or fit a custom shape — gate the rule on `:focus-visible`, not `:focus`. `:focus` fires for both keyboard tabbing and mouse clicks; mouse clicks should not leave a lingering focus ring. `:focus-visible` fires only when the browser determines focus came from keyboard navigation or assistive tech.
+
+```scss
+/* CORRECT — keyboard-only focus ring */
+.my_input:focus-visible {
+    outline: none;
+    border-color: var(--input-border-focus);
+    box-shadow: var(--input-shadow-focus);
+}
+
+/* WRONG — fires on mouse clicks too, leaves visual noise after activation */
+.my_input:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--color-primary-alpha-30);
+}
+```
+
+For custom interactive elements that don't get focus for free, add `tabIndex={0}`, handle keyboard activation in `onKeyDown`, and style with `:focus-visible`:
 
 ```tsx
 <div
     role="button"
     tabIndex={0}
-    className="custom-interactive"
+    className={styles.custom_interactive}
     onKeyDown={handleKeyDown}
 >
     Custom Element

--- a/docs/frontend/ui/ui-design-token-layers.md
+++ b/docs/frontend/ui/ui-design-token-layers.md
@@ -33,6 +33,67 @@ Component CSS reaches for tokens in this order:
 
 If no token in tiers 1–3 fits, **flag the gap so a use-case-named semantic can be added**. Don't silently drop to a forbidden foundation primitive.
 
+## Layer 2 Composition Rules
+
+Layer 2 tokens must derive from theme-controlled tokens. Literal values short-circuit the cascade — a theme override of `--color-primary` cannot reach surfaces whose tokens bake in literal blue.
+
+**No literals in themable Layer 2 tokens.** Any semantic token a theme is expected to override — colors, gradients, shadows tinted by brand — must compose from `--color-primary` (or sibling brand tokens) via `var()`, the alpha ladder, or `color-mix()`. Literal `rgba(…)` and hex values survive in `semantic-tokens.scss` only on tokens that should *not* theme: status base colors (`--color-danger: #ff6f7d` is the source of truth), dark backdrop primitives, fully neutral whites/blacks.
+
+**No half-derived tokens.** A token that mixes `var(--color-primary)` with a literal stop (e.g., `linear-gradient(135deg, var(--color-primary), #6da3ff)`) themes the derived half and freezes the literal half. The result is a visible color shear when the theme remaps primary. Derive every stop from theme-controlled values; use `color-mix(in srgb, var(--color-primary) 70%, white)` for a lighter variant.
+
+**No duplicate token names across layers.** Defining the same token in both `primitives.scss` and `semantic-tokens.scss` creates dead code — the later file wins the cascade silently. Semantic-named tokens belong in Layer 2; raw scales in Layer 1. A token name may appear only once in the source tree.
+
+### Alpha Ladder
+
+Brand-tinted overlays — focus rings, hover washes, badge backgrounds, gradient stops — consume `--color-primary` at fixed opacities. Express the ladder once in Layer 2; downstream consumers reference it:
+
+```scss
+--color-primary-alpha-10: color-mix(in srgb, var(--color-primary) 8%, transparent);
+--color-primary-alpha-15: color-mix(in srgb, var(--color-primary) 15%, transparent);
+--color-primary-alpha-18: color-mix(in srgb, var(--color-primary) 18%, transparent);
+--color-primary-alpha-30: color-mix(in srgb, var(--color-primary) 28%, transparent);
+--color-primary-alpha-38: color-mix(in srgb, var(--color-primary) 38%, transparent);
+```
+
+Identical ladders exist for `--color-success-alpha-*`, `--color-danger-alpha-*`, `--color-warning-alpha-*`. Adding a new alpha step is a Layer 2 edit, not a per-call decision.
+
+### color-mix() for Theme-Aware Variants
+
+When a token needs a variant of a brand color and no alpha-ladder entry fits, derive it inline:
+
+```scss
+/* Lighter primary for gradient sheen */
+--button-primary-background: linear-gradient(135deg, var(--color-primary), color-mix(in srgb, var(--color-primary) 70%, white));
+
+/* Primary at 25% opacity for colored drop-shadow */
+--button-primary-shadow: 0 20px 36px color-mix(in srgb, var(--color-primary) 25%, transparent);
+```
+
+`color-mix(in srgb, …)` is supported across all evergreen browsers since early 2023. Prefer it over hand-computed rgba values whose RGB triple decouples from `--color-primary` and stops themable.
+
+### Text-Contrast Companions
+
+Brand colors that appear as solid surfaces (primary, future on-secondary) pair with a `--color-on-X` token for the text/icon color drawn on top. Themes override `--color-on-X` whenever their brand value's luminance crosses the contrast threshold — a dark primary needs light on-primary, a light primary needs dark.
+
+This is distinct from `--color-X-text`, which is calibrated for text on `--color-X-alpha-*` washes, not on solid X. `--color-danger-text: #ffc1c8` reads correctly on the muted danger overlay; the same token would fail contrast against solid `--color-danger`. Two different concerns, two different tokens.
+
+```scss
+--color-on-primary: #0b1020;        /* dark text on default light-blue primary */
+--button-primary-color: var(--color-on-primary);
+```
+
+Add `--color-on-X` for additional brand colors only when a real surface needs one — preemptive tokens accumulate unused.
+
+### Intentional Literal Exceptions
+
+Three categories of literal colors are legitimate and should *not* be forced through the token system:
+
+1. **Functional fixed colors.** QR-code backgrounds (`#ffffff`), barcode foregrounds — colors required for the artifact to be scanned or read by external systems. Themes must not change them.
+2. **Data-visualization palettes.** Heatmap green→red gradients, chart series colors that encode data semantics rather than brand identity. The mapping is part of the data, not the theme.
+3. **Plugin-local design tokens.** A plugin with its own bounded palette (five-elements colors, ranking medal hues) should declare them as plugin-local CSS variables on the component (`--bazi-element-wood`, `--leaderboard-medal-gold`) and consume through `var()`. The plugin owns its design tokens; the core theme system does not try to override them.
+
+Declare the intent in a comment so the next audit reads it as deliberate, not as a missed leak.
+
 ## Size-Variant Convention
 
 Component-scoped semantic tokens that vary by density use the `xs | sm | md | lg` suffix uniformly. Buttons expose `--button-padding-xs/sm/md/lg`, `--button-font-size-xs/sm/md/lg`, `--button-height-xs/sm/md/lg`. Cards expose `--card-padding-xs/sm/md/lg`. Inputs expose `--input-padding` and `--input-padding-sm` (dense inline variant). When adding a new component-scoped density, extend the same four-step ladder rather than inventing a parallel scale — callers then pick the step that matches the visual weight they need, and responsive rules swap tokens instead of redefining them.
@@ -108,6 +169,24 @@ Container queries are preferred over viewport media queries; reserve `@media` fo
 ## Theme Customization
 
 Themes override semantic tokens via custom CSS attached to a `[data-theme="UUID"]` selector — no source-file changes needed. Themes persist in MongoDB and apply via SSR injection. See [ui-theme.md](./ui-theme.md) before creating or modifying a theme.
+
+## Auditing Token Compliance
+
+Drift accumulates quietly. A periodic grep catches most of it:
+
+```bash
+# Layer 3/4 — color literals in component and plugin code
+grep -rnE 'rgba?\(|#[0-9a-fA-F]{6}' \
+    src/frontend/components src/frontend/modules src/frontend/features src/plugins \
+    --include="*.scss" 2>/dev/null \
+    | grep -vE 'var\(--|/\*|//'
+
+# Layer 2 — blue/cyan literals that should derive from --color-primary/secondary
+grep -nE 'rgba?\(([0-9]+,\s*){2}(2[0-9]{2}|1[5-9][0-9])' \
+    src/frontend/app/semantic-tokens.scss
+```
+
+Hits are either real violations (replace with semantic tokens, the alpha ladder, or `color-mix()`) or intentional literals from the exception carveout above. The latter should already carry an explaining comment; if they don't, add one and consider whether a plugin-local variable would be cleaner.
 
 ## Further Reading
 

--- a/docs/frontend/ui/ui-design-token-layers.md
+++ b/docs/frontend/ui/ui-design-token-layers.md
@@ -48,10 +48,10 @@ Layer 2 tokens must derive from theme-controlled tokens. Literal values short-ci
 Brand-tinted overlays — focus rings, hover washes, badge backgrounds, gradient stops — consume `--color-primary` at fixed opacities. Express the ladder once in Layer 2; downstream consumers reference it:
 
 ```scss
---color-primary-alpha-10: color-mix(in srgb, var(--color-primary) 8%, transparent);
+--color-primary-alpha-10: color-mix(in srgb, var(--color-primary) 10%, transparent);
 --color-primary-alpha-15: color-mix(in srgb, var(--color-primary) 15%, transparent);
 --color-primary-alpha-18: color-mix(in srgb, var(--color-primary) 18%, transparent);
---color-primary-alpha-30: color-mix(in srgb, var(--color-primary) 28%, transparent);
+--color-primary-alpha-30: color-mix(in srgb, var(--color-primary) 30%, transparent);
 --color-primary-alpha-38: color-mix(in srgb, var(--color-primary) 38%, transparent);
 ```
 

--- a/docs/plugins/plugins-frontend-context-styling.md
+++ b/docs/plugins/plugins-frontend-context-styling.md
@@ -47,6 +47,37 @@ export function MyPluginPage({ context }: { context: IFrontendPluginContext }) {
 
 Multi-word identifiers use underscores (`styles.market_card`) so dot-notation works. See [ui-scss-modules.md](../frontend/ui/ui-scss-modules.md) for token tiers and naming.
 
+## Status Colors and Brand-Tinted Overlays
+
+Do not introduce a parallel status palette. Core publishes the canonical danger/success/warning/info families through semantic tokens; plugin status surfaces (alerts, badges, monitor cards) must reference them so they theme consistently. Hardcoding Tailwind palette numbers (`rgba(239, 68, 68, …)` for red, `rgba(34, 197, 94, …)` for green) creates a parallel design system that themes cannot reach.
+
+| Need | Token | Companion alphas |
+|------|-------|------------------|
+| Brand accent | `--color-primary` | `--color-primary-alpha-10/15/18/30/38` |
+| Success / online | `--color-success` | `--color-success-alpha-18/45`, `--color-success-text` |
+| Warning / stale | `--color-warning` | `--color-warning-alpha-15/40`, `--color-warning-text` |
+| Danger / failed | `--color-danger` | `--color-danger-alpha-18/50`, `--color-danger-text` |
+| Secondary accent | `--color-secondary` | — |
+| Focused input | — | `--input-border-focus`, `--input-shadow-focus` |
+
+Use alpha companions for tinted overlays (card backgrounds, badge fills, border accents) and `-text` variants for readable text on those overlays.
+
+```scss
+/* CORRECT — uses core's danger family; themes propagate */
+.warning_alert {
+    background: var(--color-danger-alpha-18);
+    border: var(--border-width-thin) solid var(--color-danger-alpha-50);
+}
+
+/* WRONG — parallel palette, frozen at default red */
+.warning_alert {
+    background: rgba(239, 68, 68, 0.1);
+    border: var(--border-width-thin) solid rgba(239, 68, 68, 0.3);
+}
+```
+
+For lighter/darker variants outside the published ladder, derive with `color-mix()`: `color-mix(in srgb, var(--color-primary) 70%, white)`. See [ui-design-token-layers.md](../frontend/ui/ui-design-token-layers.md#layer-2-composition-rules) for the complete rule set.
+
 ## SSR + Live Updates
 
 Visible plugin UI must render fully on the server with real data, then hydrate for live updates. No loading spinner on initial paint.

--- a/docs/plugins/plugins-system-architecture.md
+++ b/docs/plugins/plugins-system-architecture.md
@@ -44,7 +44,7 @@ Source mode couples every plugin to core's webpack and blocks per-plugin build i
 
 ### What core still owns in compiled mode
 
-Externals (`react`, `next/*`, `lucide-react`, `@delphian/tronrelic-types`, etc.) resolve through core's hoisted `node_modules` so there is one React instance at runtime. SCSS Modules are still compiled by core's webpack via the `/src/plugins/` include extension in `next.config.mjs:113-151` — only the TypeScript compile moves into the plugin. A new plugin version still requires rebuilding the core Docker image because `plugins.generated.ts` imports the entry statically at `next build` time.
+Externals (`react`, `next/*`, `lucide-react`, `@delphian/tronrelic-types`, etc.) resolve through core's hoisted `node_modules` so there is one React instance at runtime. SCSS Modules are still compiled by core's webpack via the `/src/plugins/` include extension in `next.config.mjs:113-151` — only the TypeScript compile moves into the plugin. SCSS edits in `src/frontend/**/*.scss` propagate automatically through `next dev` because core reads from source; the `copy-frontend-assets.mjs` step mirrors them into `dist/frontend/` only when `npm run build:frontend` runs, so production consumers of `dist/` see stale SCSS until then. A new plugin version still requires rebuilding the core Docker image because `plugins.generated.ts` imports the entry statically at `next build` time.
 
 ### Required compiled-mode files
 

--- a/src/frontend/app/primitives.scss
+++ b/src/frontend/app/primitives.scss
@@ -67,27 +67,15 @@
     --container-padding-tablet: 1.5rem;    /* 24px */
     --container-padding-desktop: 3rem;     /* 48px */
 
-    /* Color Tokens - Background & Surfaces */
+    /* Color Tokens - Background */
     --color-background: #03060f;
-    --color-surface: rgba(12, 18, 34, 0.88);
-    --color-surface-muted: rgba(9, 14, 26, 0.78);
-    --color-surface-accent: linear-gradient(135deg, rgba(44, 123, 255, 0.22), rgba(78, 47, 255, 0.18));
-
-    /* Color Tokens - Borders */
-    --color-border: rgba(120, 180, 255, 0.14);
-    --color-border-strong: rgba(120, 180, 255, 0.25);
 
     /* Color Tokens - Brand & Semantic */
     --color-primary: #4b8cff;
     --color-primary-strong: #246bff;
-    --color-secondary: #3fd1ff;
     --color-success: #57d48c;
     --color-warning: #ffc857;
     --color-danger: #ff6f7d;
-
-    /* Color Tokens - Text */
-    --color-text-muted: rgba(226, 234, 255, 0.64);
-    --color-text-subtle: rgba(226, 234, 255, 0.44);
 
     /* Shadow Tokens */
     --shadow-sm: 0 8px 18px rgba(7, 15, 30, 0.35);

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -90,16 +90,16 @@
     --button-font-size-lg: var(--font-size-lg);              /* 1.05rem */
 
     /* Button - Primary Variant */
-    --button-primary-background: linear-gradient(135deg, var(--color-primary), #6da3ff);
-    --button-primary-color: #0b1020;
-    --button-primary-shadow: 0 20px 36px rgba(58, 110, 255, 0.25);
-    --button-primary-shadow-hover: 0 28px 52px rgba(58, 110, 255, 0.32);
+    --button-primary-background: linear-gradient(135deg, var(--color-primary), color-mix(in srgb, var(--color-primary) 70%, white));
+    --button-primary-color: var(--color-on-primary);
+    --button-primary-shadow: 0 20px 36px color-mix(in srgb, var(--color-primary) 25%, transparent);
+    --button-primary-shadow-hover: 0 28px 52px color-mix(in srgb, var(--color-primary) 32%, transparent);
 
     /* Button - Secondary Variant */
-    --button-secondary-background: rgba(79, 140, 255, 0.14);
-    --button-secondary-background-hover: rgba(79, 140, 255, 0.22);
-    --button-secondary-color: #eaf0ff;
-    --button-secondary-border: rgba(79, 140, 255, 0.4);
+    --button-secondary-background: var(--color-primary-alpha-15);
+    --button-secondary-background-hover: var(--color-primary-alpha-30);
+    --button-secondary-color: var(--color-text);
+    --button-secondary-border: var(--color-primary-alpha-38);
 
     /* Button - Ghost Variant */
     --button-ghost-background: transparent;
@@ -225,9 +225,9 @@
     --badge-border-width: var(--border-width-thin);    /* 1px */
 
     /* Badge - Neutral Variant */
-    --badge-neutral-background: rgba(118, 164, 255, 0.22);
-    --badge-neutral-color: #bcd7ff;
-    --badge-neutral-border: rgba(118, 164, 255, 0.4);
+    --badge-neutral-background: color-mix(in srgb, var(--color-text) 12%, transparent);
+    --badge-neutral-color: var(--color-text);
+    --badge-neutral-border: color-mix(in srgb, var(--color-text) 24%, transparent);
 
     /* Badge - Success Variant */
     --badge-success-background: rgba(87, 212, 140, 0.18);
@@ -245,9 +245,9 @@
     --badge-danger-border: rgba(255, 111, 125, 0.45);
 
     /* Badge - Info Variant (primary-tinted for active/in-progress status) */
-    --badge-info-background: rgba(79, 140, 255, 0.15);
-    --badge-info-color: #bcd7ff;
-    --badge-info-border: rgba(79, 140, 255, 0.4);
+    --badge-info-background: var(--color-primary-alpha-15);
+    --badge-info-color: var(--color-text);
+    --badge-info-border: var(--color-primary-alpha-38);
 
     /* ========================================================================
      * INPUT COMPONENT TOKENS
@@ -255,7 +255,7 @@
 
     /* Input - Base Properties */
     --input-background: rgba(3, 6, 15, 0.9);
-    --input-border: var(--border-width-thin) solid rgba(110, 160, 255, 0.18);
+    --input-border: var(--border-width-thin) solid var(--color-primary-alpha-18);
     --input-border-radius: var(--radius-sm);
     --input-padding: var(--spacing-5) var(--spacing-7); /* 0.75rem 1rem */
     --input-padding-sm: var(--spacing-1) var(--spacing-2); /* 0.25rem 0.35rem — dense filter/search/inline inputs */
@@ -264,8 +264,8 @@
                         box-shadow var(--transition-base);
 
     /* Input - Focus State */
-    --input-border-focus: rgba(110, 160, 255, 0.48);
-    --input-shadow-focus: 0 0 0 3px rgba(79, 140, 255, 0.24);
+    --input-border-focus: color-mix(in srgb, var(--color-primary) 48%, transparent);
+    --input-shadow-focus: 0 0 0 3px var(--color-primary-alpha-30);
 
     /* Input - Ghost Variant */
     --input-ghost-background: transparent;
@@ -283,7 +283,7 @@
 
     /* Modal - Dialog */
     --modal-dialog-background: rgba(10, 15, 26, 0.96);
-    --modal-dialog-border: var(--border-width-thin) solid rgba(120, 180, 255, 0.16);
+    --modal-dialog-border: var(--border-width-thin) solid var(--color-border-strong);
     --modal-dialog-border-radius: var(--radius-lg);
     --modal-dialog-shadow: var(--shadow-lg);
     --modal-dialog-max-height: min(90vh, 720px);
@@ -329,7 +329,7 @@
     --toast-success-border: rgba(87, 212, 140, 0.4);
     --toast-warning-border: rgba(255, 200, 87, 0.45);
     --toast-danger-border: rgba(255, 111, 125, 0.45);
-    --toast-info-border: rgba(120, 180, 255, 0.35);
+    --toast-info-border: var(--color-primary-alpha-38);
 
     /* Toast - Actions */
     --toast-action-background: rgba(255, 255, 255, 0.08);
@@ -431,17 +431,17 @@
     --table-cell-border: var(--border-width-thin) solid rgba(255, 255, 255, 0.05);
 
     /* Table - Row Hover */
-    --table-row-background-hover: rgba(79, 140, 255, 0.08);
+    --table-row-background-hover: var(--color-primary-alpha-10);
     --table-row-transition: background-color var(--transition-base);
 
     /* ========================================================================
      * FOCUS STATE TOKENS (Global)
      * ======================================================================== */
 
-    --focus-outline-color: rgba(124, 155, 255, 0.95);
+    --focus-outline-color: var(--color-focus);
     --focus-outline-width: 2px;
     --focus-outline-offset: 3px;
-    --focus-shadow: 0 0 0 4px rgba(124, 155, 255, 0.24);
+    --focus-shadow: 0 0 0 4px var(--color-focus-alpha-25);
 
     /* ========================================================================
      * DIVIDER TOKENS
@@ -486,11 +486,17 @@
     --color-text-subtle: #7a8499;                 /* Tertiary text */
 
     /* Primary Color Alphas */
-    --color-primary-alpha-10: rgba(79, 140, 255, 0.08);
-    --color-primary-alpha-15: rgba(79, 140, 255, 0.15);
-    --color-primary-alpha-18: rgba(79, 140, 255, 0.18);
-    --color-primary-alpha-30: rgba(79, 140, 255, 0.28);
-    --color-primary-alpha-38: rgba(79, 140, 255, 0.38);
+    --color-primary-alpha-10: color-mix(in srgb, var(--color-primary) 8%, transparent);
+    --color-primary-alpha-15: color-mix(in srgb, var(--color-primary) 15%, transparent);
+    --color-primary-alpha-18: color-mix(in srgb, var(--color-primary) 18%, transparent);
+    --color-primary-alpha-30: color-mix(in srgb, var(--color-primary) 28%, transparent);
+    --color-primary-alpha-38: color-mix(in srgb, var(--color-primary) 38%, transparent);
+
+    /* Text Contrast Companions
+     * Foreground color paired with each brand color for use as text/icon on top
+     * of that color's solid surface. Themes override when the brand value's
+     * luminance demands the opposite end of the contrast scale. */
+    --color-on-primary: #0b1020;
 
     /* Surface Colors */
     --color-surface: rgba(20, 28, 48, 0.88);      /* Card/surface background */
@@ -505,8 +511,8 @@
     --color-border-strong: rgba(255, 255, 255, 0.12);
 
     /* Focus Colors */
-    --color-focus: rgba(124, 155, 255, 0.95);
-    --color-focus-alpha-25: rgba(124, 155, 255, 0.24);
+    --color-focus: var(--color-primary);
+    --color-focus-alpha-25: color-mix(in srgb, var(--color-focus) 24%, transparent);
 
     /* Warning Color Alphas */
     --color-warning-alpha-15: rgba(255, 200, 87, 0.15);
@@ -530,10 +536,10 @@
      * GRADIENT TOKENS
      * ======================================================================== */
 
-    --gradient-primary: linear-gradient(135deg, rgba(79, 140, 255, 0.38), rgba(79, 140, 255, 0.18));
-    --gradient-meter: linear-gradient(90deg, rgba(124, 155, 255, 0.9), rgba(101, 217, 165, 0.9));
+    --gradient-primary: linear-gradient(135deg, var(--color-primary-alpha-38), var(--color-primary-alpha-18));
+    --gradient-meter: linear-gradient(90deg, color-mix(in srgb, var(--color-primary) 90%, transparent), color-mix(in srgb, var(--color-success) 90%, transparent));
     --gradient-body-background: radial-gradient(circle at 0% -20%, var(--color-primary-alpha-18), transparent 45%),
-                                radial-gradient(circle at 90% 0%, rgba(63, 209, 255, 0.14), transparent 60%),
+                                radial-gradient(circle at 90% 0%, color-mix(in srgb, var(--color-secondary) 14%, transparent), transparent 60%),
                                 linear-gradient(140deg, rgba(14, 21, 38, 0.85), rgba(6, 10, 20, 0.96));
 
     /* ========================================================================
@@ -561,7 +567,7 @@
     --segmented-control-button-padding: var(--spacing-3) var(--spacing-7); /* 0.45rem 0.9rem */
     --segmented-control-button-font-size: var(--font-size-sm);
     --segmented-control-active-background: var(--gradient-primary);
-    --segmented-control-active-color: #f7fbff;
+    --segmented-control-active-color: var(--color-text);
 
     /* ========================================================================
      * METER/PROGRESS TOKENS

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -486,10 +486,10 @@
     --color-text-subtle: #7a8499;                 /* Tertiary text */
 
     /* Primary Color Alphas */
-    --color-primary-alpha-10: color-mix(in srgb, var(--color-primary) 8%, transparent);
+    --color-primary-alpha-10: color-mix(in srgb, var(--color-primary) 10%, transparent);
     --color-primary-alpha-15: color-mix(in srgb, var(--color-primary) 15%, transparent);
     --color-primary-alpha-18: color-mix(in srgb, var(--color-primary) 18%, transparent);
-    --color-primary-alpha-30: color-mix(in srgb, var(--color-primary) 28%, transparent);
+    --color-primary-alpha-30: color-mix(in srgb, var(--color-primary) 30%, transparent);
     --color-primary-alpha-38: color-mix(in srgb, var(--color-primary) 38%, transparent);
 
     /* Text Contrast Companions
@@ -512,7 +512,7 @@
 
     /* Focus Colors */
     --color-focus: var(--color-primary);
-    --color-focus-alpha-25: color-mix(in srgb, var(--color-focus) 24%, transparent);
+    --color-focus-alpha-25: color-mix(in srgb, var(--color-focus) 25%, transparent);
 
     /* Warning Color Alphas */
     --color-warning-alpha-15: rgba(255, 200, 87, 0.15);
@@ -540,7 +540,7 @@
     --gradient-meter: linear-gradient(90deg, color-mix(in srgb, var(--color-primary) 90%, transparent), color-mix(in srgb, var(--color-success) 90%, transparent));
     --gradient-body-background: radial-gradient(circle at 0% -20%, var(--color-primary-alpha-18), transparent 45%),
                                 radial-gradient(circle at 90% 0%, color-mix(in srgb, var(--color-secondary) 14%, transparent), transparent 60%),
-                                linear-gradient(140deg, rgba(14, 21, 38, 0.85), rgba(6, 10, 20, 0.96));
+                                linear-gradient(140deg, color-mix(in srgb, var(--color-background) 85%, transparent), color-mix(in srgb, var(--color-background) 96%, transparent));
 
     /* ========================================================================
      * CHIP/PILL TOKENS

--- a/src/frontend/components/layout/BlockTicker/BlockTicker.module.scss
+++ b/src/frontend/components/layout/BlockTicker/BlockTicker.module.scss
@@ -56,7 +56,7 @@
 .separator {
     width: var(--border-width-thin);
     height: var(--spacing-7);
-    background: rgba(120, 180, 255, 0.2);
+    background: var(--color-primary-alpha-18);
 }
 
 /* Responsive adjustments */

--- a/src/frontend/features/blockchain/components/CurrentBlock/CurrentBlock.module.scss
+++ b/src/frontend/features/blockchain/components/CurrentBlock/CurrentBlock.module.scss
@@ -119,15 +119,15 @@
     height: 28px;
     border: none;
     border-radius: var(--radius-sm);
-    background: rgba(255, 255, 255, 0.05);
-    color: rgba(255, 255, 255, 0.6);
+    background: var(--color-surface-elevated);
+    color: var(--color-text-muted);
     cursor: pointer;
     transition: all var(--transition-base);
 }
 
 .expand_toggle:hover {
-    background: rgba(255, 255, 255, 0.1);
-    color: rgba(255, 255, 255, 0.9);
+    background: var(--color-border-strong);
+    color: var(--color-text);
 }
 
 .expand_toggle_expanded {
@@ -164,7 +164,7 @@
     gap: var(--spacing-7);
     margin-top: var(--spacing-7);
     padding-top: var(--spacing-7);
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-top: var(--border-width-thin) solid var(--color-border-strong);
     animation: slideDown 0.2s ease-out;
 }
 
@@ -207,8 +207,8 @@
 
 .mini_stat_card {
     padding: var(--spacing-4);
-    background: rgba(255, 255, 255, 0.02);
-    border: var(--border-width-thin) solid rgba(255, 255, 255, 0.05);
+    background: var(--color-surface-elevated);
+    border: var(--border-width-thin) solid var(--color-border);
     border-radius: var(--radius-sm);
     display: flex;
     flex-direction: column;
@@ -244,10 +244,10 @@
 .period_selector {
     display: flex;
     gap: var(--spacing-2);
-    background: rgba(255, 255, 255, 0.03);
+    background: var(--color-surface-elevated);
     padding: 0.2rem;
     border-radius: var(--radius-sm);
-    border: var(--border-width-thin) solid rgba(255, 255, 255, 0.08);
+    border: var(--border-width-thin) solid var(--color-border-strong);
 }
 
 .period_button {
@@ -255,7 +255,7 @@
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-medium);
     background: transparent;
-    color: rgba(255, 255, 255, 0.5);
+    color: var(--color-text-subtle);
     border: none;
     border-radius: 3px;
     cursor: pointer;
@@ -263,8 +263,8 @@
 }
 
 .period_button:hover {
-    background: rgba(255, 255, 255, 0.05);
-    color: rgba(255, 255, 255, 0.7);
+    background: var(--color-border-strong);
+    color: var(--color-text-muted);
 }
 
 .period_button_active {


### PR DESCRIPTION
## Summary

- Re-derive every Layer 2 token from `--color-primary` via the alpha ladder and `color-mix()`; the cascade is now intact end-to-end. Theme overrides propagate to buttons, inputs, badges, modals, toasts, focus rings, gradients, and the body backdrop instead of stopping at `--color-primary` itself.
- Delete 8 dead duplicate primitives that `semantic-tokens.scss` silently overrode (`--color-surface*`, `--color-border*`, `--color-text-muted/subtle`, `--color-secondary`, plus the dead `--color-surface-accent` gradient).
- Tokenize 13 literal rgba values in `BlockTicker.module.scss` and `CurrentBlock.module.scss`. Introduce `--color-on-primary` so the only remaining literal text color (`#0b1020` on primary buttons) becomes themable.

## Documentation

- New section in `ui-design-token-layers.md`: **Layer 2 Composition Rules** (no literals in themable tokens, no half-derived tokens, no duplicate names across layers), the **Alpha Ladder** pattern, **color-mix() for Theme-Aware Variants**, **Text-Contrast Companions**, the **Intentional Literal Exceptions** carveout, and an **Auditing Token Compliance** grep recipe.
- `ui-accessibility.md`: prescribe `:focus-visible` over `:focus` for custom focus rings, with CORRECT/WRONG SCSS examples.
- `plugins-frontend-context-styling.md`: status-color cheatsheet so plugin authors stop building parallel red/green/amber palettes.
- `plugins-system-architecture.md`: clarify that source SCSS edits propagate through `next dev` but `dist/frontend/*.scss` stays stale until `npm run build:frontend` runs.

## Why now

Every literal value the audit removed had been actively short-circuiting `[data-theme="…"]` overrides. A theme could change `--color-primary` to bronze and the page backdrop would still cast cyan, focus rings would stay cool blue, primary buttons would interpolate from bronze to hardcoded sky-blue. The fix is mostly mechanical; the doc additions make the rules enforceable in review going forward.