### PR TITLE
fix(system/hooks): remove dead token guard blocking snapshot fetch

### DIFF
--- a/src/frontend/app/(core)/system/hooks/page.tsx
+++ b/src/frontend/app/(core)/system/hooks/page.tsx
@@ -88,7 +88,6 @@ export default function HooksAdminPage() {
     const [loading, setLoading] = useState<boolean>(true);
 
     useEffect(() => {
-        if (!token) return;
         let aborted = false;
         const ctrl = new AbortController();
 


### PR DESCRIPTION
## Summary

The `/system/hooks` admin page never loaded its snapshot — the spinner stayed on "Loading hook snapshot…" forever. The effect guarded the fetch on `if (!token) return;`, but `useSystemAuth` was migrated to cookie-based admin auth and now returns `token: ''` permanently. The empty string is falsy, the effect short-circuited, and the fetch never fired.

Dropping the guard lets the same-origin fetch proceed; the empty `x-admin-token` header is harmless because `requireAdmin` falls back to the signed `tronrelic_uid` cookie, which is the pattern every other `/system/*` page already uses (`UsersMonitor`, `PagesTab`, etc.).

The runtime-config console warning the user observed alongside this bug is unrelated — that warning logs once from `SocketBridge`/plugin loaders before SSR config arrives, and the hooks page never calls `getRuntimeConfig()`.