### PR TITLE
fix(frontend/plugin-context): defer ApiClient baseUrl read until first request

### DIFF
--- a/src/frontend/lib/frontendPluginContext.tsx
+++ b/src/frontend/lib/frontendPluginContext.tsx
@@ -59,10 +59,24 @@ import { getRuntimeConfig } from './runtimeConfig';
  * service-token path for CI/scripts that don't run in a browser).
  */
 class ApiClient implements IApiClient {
-    private baseUrl: string;
+    private _baseUrl: string | null = null;
 
-    constructor() {
-        this.baseUrl = getRuntimeConfig().apiUrl;
+    /**
+     * Resolved API base URL, cached after first access.
+     *
+     * Why a lazy getter: `FrontendPluginContextProvider` instantiates
+     * `ApiClient` inside a `useMemo` factory, which Next.js runs during
+     * the SSR pass of every client component. `getRuntimeConfig()`
+     * throws when `typeof window === 'undefined'`, so resolving the URL
+     * in the constructor crashed every page render. Deferring to first
+     * request guarantees we only consult `window.__RUNTIME_CONFIG__`
+     * on the client, after hydration, where it is defined.
+     */
+    private get baseUrl(): string {
+        if (this._baseUrl === null) {
+            this._baseUrl = getRuntimeConfig().apiUrl;
+        }
+        return this._baseUrl;
     }
 
     /**


### PR DESCRIPTION
## Summary

Production was returning HTTP 500 on every page after the latest `:production` deploy. The frontend container logs showed:

> `Error: getRuntimeConfig() can only be called client-side. ... at new E (...) digest: '2330706434'`

`ApiClient.constructor` (in `src/frontend/lib/frontendPluginContext.tsx:64-66`) called `getRuntimeConfig().apiUrl` synchronously. `getRuntimeConfig` throws when `typeof window === 'undefined'`. `FrontendPluginContextProvider`'s `useMemo` factory ran `new ApiClient()` on every render — and Next.js client components still server-render to produce SSR HTML, so the throw aborted every page render sitewide.

The fix replaces the eager constructor field with a lazy-cached getter. The base URL is only resolved on the first `request()` call, which always fires from client-side code after hydration. The class is now side-effect-free to instantiate, matching what the surrounding hook machinery already assumes.

## Why a lazy getter rather than switching `useMemo` → `useState`

Both `useMemo` and `useState` lazy initializers run during the SSR pass for client components. Switching hook alone would not have fixed the throw — the SSR-safety boundary is `useEffect`, a `typeof window` guard, or removing the side effect from the synchronous code path entirely. We chose the last option here as the smallest correct diff.

`FrontendPluginContextProvider` should still move from `useMemo` to `useState(() => new ...)` for `api`/`websocket` per React's "instance creation" canon — `useMemo` is a perf hint, not a semantic guarantee, and future React versions may discard memoized values. Filing as a follow-up rather than bundling into this hotfix.