### PR TITLE
Add widget zone registry under modules/widgets/

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -59,3 +59,14 @@ export type {
 } from './hooks/index.js';
 export { HookAbortError, isHookAbortError } from './hooks/index.js';
 export type { IHeadFragment, HeadFragmentTag, ISsrHeadContext } from './ssr/index.js';
+export type {
+    IZoneDescriptor,
+    IDefineZoneOptions,
+    ZoneHost,
+    ZoneLayout,
+    ZoneRegisterDisposer,
+    IZoneRegistry,
+    IZoneSnapshot,
+    IZoneSnapshotRecord,
+    IPluginZones
+} from './widget-zones/index.js';

--- a/packages/types/src/observer/IPluginContext.ts
+++ b/packages/types/src/observer/IPluginContext.ts
@@ -21,6 +21,7 @@ import type { IUserService } from '../user/IUserService.js';
 import type { IServiceRegistry } from '../services/IServiceRegistry.js';
 import type { ISignatureService } from '../services/ISignatureService.js';
 import type { IPluginHooks } from '../hooks/IPluginHooks.js';
+import type { IPluginZones } from '../widget-zones/IPluginZones.js';
 import { ISystemLogService } from '../system-log/ISystemLogService.js';
 
 /**
@@ -173,6 +174,36 @@ export interface IPluginContext {
      * ```
      */
     hooks: IPluginHooks;
+
+    /**
+     * Plugin-scoped zone facade for declaring widget injection points
+     * inside the plugin's own pages.
+     *
+     * Zones are physical injection points where widgets render. Core
+     * zones (e.g. `main-after`, `ticker-after`) are declared by the
+     * platform; plugins can declare additional zones that other plugins
+     * can target with widget placements. Zone declarations must happen
+     * during the plugin lifecycle (`install` / `enable` / `init`);
+     * registering from a request handler throws.
+     *
+     * Plugins do not need to redeclare core zones — they reach those by
+     * string id from widget placements. This facade is exclusively for
+     * declaring *new* zones the plugin owns.
+     *
+     * @example
+     * ```typescript
+     * init: async (context) => {
+     *     context.zones.register({
+     *         id: 'whales:detail-sidebar',
+     *         label: 'Whale detail sidebar',
+     *         description: 'Right-side panel on individual whale pages.',
+     *         host: 'plugin',
+     *         layout: 'vertical'
+     *     });
+     * }
+     * ```
+     */
+    zones: IPluginZones;
 
     /** Structured logger scoped to the plugin for consistent telemetry */
     logger: ISystemLogService;

--- a/packages/types/src/widget-zones/IPluginZones.ts
+++ b/packages/types/src/widget-zones/IPluginZones.ts
@@ -1,0 +1,78 @@
+/**
+ * @fileoverview Per-plugin zone facade exposed via IPluginContext.
+ *
+ * Plugins never touch the global `IZoneRegistry` directly. They receive
+ * an `IPluginZones` instance scoped to their plugin id, which constructs
+ * descriptors via `defineZone` on the plugin's behalf, tags every
+ * registration with the plugin id, enforces the lifecycle window
+ * (registration permitted only while the facade is open), and collects
+ * disposers so the plugin loader can drop every declared zone on
+ * `disable()` without the plugin tracking them by hand.
+ *
+ * Mirrors the shape of `IPluginHooks` so plugin code learns one pattern
+ * for participating in extension surfaces.
+ *
+ * @module types/widget-zones/IPluginZones
+ */
+
+import type { IDefineZoneOptions, ZoneRegisterDisposer } from './IZoneDescriptor.js';
+
+/**
+ * Plugin-scoped view of the zone registry. Surfaced as `context.zones`
+ * in the plugin context.
+ */
+export interface IPluginZones {
+    /**
+     * Declare a zone owned by this plugin.
+     *
+     * Plugins declare zones to expose injection points inside their own
+     * pages — for example, a whale tracker plugin declaring
+     * `whale-detail:sidebar` so other plugins can place widgets there.
+     * Core zones are declared by the platform and reachable to placements
+     * by string id; plugins do not redeclare them.
+     *
+     * Registration is only valid during the plugin lifecycle
+     * (`install` / `enable` / `init`). Calling it from a request handler
+     * throws — there is no mid-request mutation of the zone catalog.
+     *
+     * If a zone with the same id is already registered to a different
+     * plugin, the call throws. The disposer returned removes only this
+     * plugin's claim; if the plugin re-registers later, the same id is
+     * available again.
+     *
+     * @param options - Zone configuration. The descriptor is constructed
+     *   on the plugin's behalf with the plugin id tagged automatically.
+     * @returns Disposer that removes this specific registration. The
+     *   loader tracks disposers per plugin so calling `disable()` on the
+     *   plugin removes every zone it owns — the disposer is exposed for
+     *   finer-grained control but is not required for correctness.
+     *
+     * @example
+     * ```typescript
+     * init: async (context: IPluginContext) => {
+     *     context.zones.register({
+     *         id: 'whales:detail-sidebar',
+     *         label: 'Whale detail sidebar',
+     *         description: 'Right-side panel on individual whale pages.',
+     *         host: 'plugin',
+     *         layout: 'vertical'
+     *     });
+     * }
+     * ```
+     */
+    register(options: IDefineZoneOptions): ZoneRegisterDisposer;
+
+    /**
+     * Close the lifecycle window without disposing declared zones.
+     *
+     * Called by the platform after `install` / `enable` / `init` finish,
+     * so any later `register()` attempt throws instead of silently
+     * extending the plugin's zone surface. Zones stay registered for the
+     * plugin's enabled lifetime — only the open flag flips.
+     *
+     * Idempotent: calling `seal()` on an already-sealed facade is a
+     * no-op. Disable/uninstall paths instead invoke the implementation's
+     * bulk-dispose method, which both seals and drops every zone.
+     */
+    seal(): void;
+}

--- a/packages/types/src/widget-zones/IZoneDescriptor.ts
+++ b/packages/types/src/widget-zones/IZoneDescriptor.ts
@@ -1,0 +1,97 @@
+/**
+ * @fileoverview Typed descriptor for a declared widget zone.
+ *
+ * A zone is a physical injection point in the rendered UI — somewhere in
+ * the markup a layout calls `<WidgetZone descriptor={...} />` and the
+ * runtime pulls in every placement targeting that zone. Zone descriptors
+ * are the single source of truth for what zones exist; the runtime
+ * placement service refuses to accept a placement whose zone id is not
+ * in the descriptor registry.
+ *
+ * Descriptors are minted by `defineZone(...)`, which tracks them in a
+ * module-local set so the runtime registry can refuse forged descriptors.
+ * Plugins do not import `defineZone` directly — they call
+ * `context.zones.register(options)` and the facade constructs the
+ * descriptor internally tagged with the plugin id. Core declarations
+ * live in a central `ZONES` object so layouts can reference them by
+ * typed identifier instead of string.
+ *
+ * @module types/widget-zones/IZoneDescriptor
+ */
+
+/**
+ * The layout context a zone is rendered inside. Drives admin-UI grouping
+ * and operator expectations about which pages the zone reaches; the
+ * actual rendering site is still owned by whichever layout calls
+ * `<WidgetZone>`, so this is metadata, not enforcement.
+ *
+ * - `'site'`: rendered by the root layout — reaches every route the root
+ *   layout serves.
+ * - `'core'`: rendered by the `(core)` route-group layout — front-of-house
+ *   pages only.
+ * - `'plugin'`: rendered inside a plugin page wrapper.
+ * - `'admin'`: rendered on admin / system pages. Reserved for future use.
+ */
+export type ZoneHost = 'site' | 'core' | 'plugin' | 'admin';
+
+/**
+ * Visual layout hint for the admin placement editor and the renderer.
+ *
+ * - `'vertical'`: widgets stack top-to-bottom (default for content zones).
+ * - `'horizontal'`: widgets sit side-by-side (used for sidebars and
+ *   navigation accessories).
+ * - `'grid'`: widgets flow into a responsive grid (dashboard zones).
+ */
+export type ZoneLayout = 'vertical' | 'horizontal' | 'grid';
+
+/**
+ * Immutable descriptor for a single zone. Returned by `defineZone` and
+ * stored in the runtime registry. Layouts reference the descriptor's
+ * `id` when calling `<WidgetZone>`; admin tools render `label` and
+ * `description` directly.
+ *
+ * The descriptor is frozen on construction. Mutating it raises a runtime
+ * error and breaks the identity check the registry performs at
+ * registration time.
+ */
+export interface IZoneDescriptor {
+    /** Dotted, fully qualified id — e.g. `main-after`, `whale-detail:sidebar`. */
+    readonly id: string;
+    /** Short label rendered in admin UIs (zone palette, placement editor). */
+    readonly label: string;
+    /** Sentence-length description shown on hover and in the admin timeline. */
+    readonly description: string;
+    /** Layout context the zone is rendered inside. */
+    readonly host: ZoneHost;
+    /** Visual layout hint. */
+    readonly layout: ZoneLayout;
+}
+
+/**
+ * Initialisation options accepted by `defineZone`.
+ *
+ * Plugins pass the same shape to `context.zones.register(...)` — the
+ * facade constructs the descriptor on their behalf so plugin code never
+ * imports `defineZone` directly.
+ */
+export interface IDefineZoneOptions {
+    /** Dotted, fully qualified id. Must be unique across the process. */
+    id: string;
+    /** Short label for admin UIs. */
+    label: string;
+    /** Sentence-length description. */
+    description: string;
+    /** Layout context. */
+    host: ZoneHost;
+    /** Visual layout hint. Defaults to `'vertical'` when omitted. */
+    layout?: ZoneLayout;
+}
+
+/**
+ * Disposer returned from zone registration. Calling it removes the zone
+ * from the runtime registry — placements targeting the removed zone
+ * resolve to "zone unavailable" and the renderer skips them, but does
+ * not crash. Plugin-owned zones are bulk-disposed by the plugin loader
+ * on `disable()`; the disposer is exposed for finer-grained control.
+ */
+export type ZoneRegisterDisposer = () => void;

--- a/packages/types/src/widget-zones/IZoneRegistry.ts
+++ b/packages/types/src/widget-zones/IZoneRegistry.ts
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview Global widget zone registry interface.
+ *
+ * The zone registry stores every declared zone — core declarations made
+ * via `defineZone` at module load and plugin declarations made through
+ * the per-plugin facade — and serves the introspection snapshot consumed
+ * by the `/api/admin/system/zones` endpoint. There is one instance per
+ * process, constructed during bootstrap and threaded into plugin
+ * contexts the same way the hook registry is.
+ *
+ * Plugins do not call the registry directly. They receive an
+ * `IPluginZones` facade scoped to their plugin id which tags every
+ * registration and tracks disposers for lifecycle cleanup.
+ *
+ * @module types/widget-zones/IZoneRegistry
+ */
+
+import type { IZoneDescriptor, IDefineZoneOptions, ZoneRegisterDisposer, ZoneHost } from './IZoneDescriptor.js';
+
+/**
+ * Introspection record for a single registered zone. Surfaced through
+ * the admin endpoint so the placement editor can render the available
+ * zones alongside their owner and registration time.
+ */
+export interface IZoneSnapshotRecord {
+    /** Dotted id from the descriptor. */
+    readonly id: string;
+    /** Short label. */
+    readonly label: string;
+    /** Sentence-length description. */
+    readonly description: string;
+    /** Layout context. */
+    readonly host: ZoneHost;
+    /** Visual layout hint. */
+    readonly layout: 'vertical' | 'horizontal' | 'grid';
+    /** Plugin id that declared the zone, or `'core'`. */
+    readonly pluginId: string;
+    /** ISO-8601 timestamp the zone was registered with the runtime. */
+    readonly registeredAt: string;
+    /**
+     * Best-effort source location captured at registration time. May be
+     * `null` when the runtime cannot resolve a callsite — for example
+     * when the zone is declared via `defineZone` at module load and the
+     * registry auto-populates it on construction.
+     */
+    readonly source: string | null;
+}
+
+/**
+ * Top-level introspection payload returned from `snapshot()` and served
+ * by the admin endpoint. Zones are grouped by host so the placement
+ * editor can render the catalog organised by rendering context.
+ */
+export interface IZoneSnapshot {
+    /** Tracks in display order, one per zone host. */
+    readonly tracks: ReadonlyArray<{
+        readonly id: ZoneHost;
+        readonly label: string;
+        readonly zones: ReadonlyArray<IZoneSnapshotRecord>;
+    }>;
+}
+
+/**
+ * Process-wide zone registry. Implementations are responsible for
+ * storing declared zones, enforcing the descriptor-identity check,
+ * detecting cross-plugin conflicts, and producing the snapshot consumed
+ * by introspection.
+ */
+export interface IZoneRegistry {
+    /**
+     * Register a declared zone.
+     *
+     * Core declarations are typically auto-populated by the registry
+     * constructor from the descriptors `defineZone` has tracked at
+     * module load. Plugin declarations flow through the per-plugin
+     * facade, which calls `register` with the plugin's id.
+     *
+     * The descriptor must have been produced by `defineZone`; the
+     * runtime tracks every minted descriptor and refuses forged
+     * objects. If a zone with the same id is already registered to a
+     * different plugin, the call throws — zones are owned exclusively
+     * by their declaring component.
+     *
+     * @param pluginId - Plugin (or `'core'`) declaring the zone.
+     * @param descriptor - Zone descriptor produced by `defineZone`.
+     * @returns Disposer that removes the zone from the registry.
+     */
+    register(pluginId: string, descriptor: IZoneDescriptor): ZoneRegisterDisposer;
+
+    /**
+     * Drop every zone declared by the given plugin.
+     *
+     * Called when a plugin is disabled or uninstalled. Core zones are
+     * never affected — `'core'` ownership is not subject to bulk
+     * disposal.
+     *
+     * @param pluginId - Plugin whose zones should be removed.
+     * @returns Count of zones removed.
+     */
+    disposeForPlugin(pluginId: string): number;
+
+    /**
+     * Check whether a zone id is currently registered.
+     *
+     * Used by the placement service to validate widget placements at
+     * creation time. A placement targeting an unknown zone is rejected
+     * by the API; at SSR resolution time, an unknown zone causes the
+     * placement to be skipped silently so a plugin disable does not
+     * crash the page.
+     *
+     * @param zoneId - Zone id to check.
+     * @returns True if the zone is registered.
+     */
+    has(zoneId: string): boolean;
+
+    /**
+     * Retrieve the registered descriptor for a zone, with ownership
+     * metadata. Returns `undefined` when no zone with that id is
+     * registered.
+     *
+     * @param zoneId - Zone id to look up.
+     * @returns Snapshot record or `undefined`.
+     */
+    get(zoneId: string): IZoneSnapshotRecord | undefined;
+
+    /**
+     * Produce the introspection snapshot consumed by the admin endpoint.
+     *
+     * The snapshot enumerates every registered zone grouped by host so
+     * the placement editor can render the catalog without re-grouping.
+     *
+     * @returns Structured payload ready for JSON serialization.
+     */
+    snapshot(): IZoneSnapshot;
+}
+
+// Re-export the options type so consumers importing IZoneRegistry can
+// reach IDefineZoneOptions without a separate import.
+export type { IDefineZoneOptions };

--- a/packages/types/src/widget-zones/index.ts
+++ b/packages/types/src/widget-zones/index.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Public type surface for the widget zone system.
+ *
+ * Re-exports the descriptor, registry, and per-plugin facade types so
+ * consumers can import them from a single barrel.
+ *
+ * Zones are physical injection points where widgets render. Core zones
+ * (e.g. `main-after`) are declared at module load in the backend's
+ * widget module; plugins declare additional zones through the
+ * per-plugin facade exposed on `context.zones`.
+ *
+ * @module types/widget-zones
+ */
+
+export type {
+    IZoneDescriptor,
+    IDefineZoneOptions,
+    ZoneHost,
+    ZoneLayout,
+    ZoneRegisterDisposer
+} from './IZoneDescriptor.js';
+
+export type {
+    IZoneRegistry,
+    IZoneSnapshot,
+    IZoneSnapshotRecord
+} from './IZoneRegistry.js';
+
+export type { IPluginZones } from './IPluginZones.js';

--- a/src/backend/api/middleware/rate-limit.ts
+++ b/src/backend/api/middleware/rate-limit.ts
@@ -12,3 +12,45 @@ export function createRateLimiter({ windowSeconds, maxRequests, keyPrefix }: { w
     next();
   };
 }
+
+/**
+ * Default rate-limit settings for admin endpoints.
+ *
+ * 60-second window, 60 requests per IP — the same shape used by the
+ * other rate-limited core routes (tokens, transactions, energy) and
+ * the existing admin precedent at MenuModule's /manage route. Bounds
+ * brute-force cost against the `requireAdmin` auth path while leaving
+ * plenty of headroom for legitimate operator usage.
+ */
+const ADMIN_RATE_LIMIT_WINDOW_SECONDS = 60;
+const ADMIN_RATE_LIMIT_MAX_REQUESTS = 60;
+
+/**
+ * Build a per-IP rate limiter using the platform-default admin
+ * settings.
+ *
+ * New admin endpoints should chain this in front of `requireAdmin` so
+ * the brute-force cost against the auth gate is bounded and CodeQL's
+ * `js/missing-rate-limiting` rule sees rate-limiting before
+ * authorization in the middleware stack. CodeQL pattern-matches
+ * `express-rate-limit` and similar packages; it does not recognize
+ * the in-house limiter, so the alert still fires and is dismissed
+ * with the project's standard rationale.
+ *
+ * The `keyPrefix` argument identifies the endpoint's rate-limit
+ * bucket. Different admin endpoints share the same window and max
+ * but separate buckets, so one noisy admin tool does not starve
+ * another from the same IP.
+ *
+ * @param keyPrefix - Endpoint-specific bucket prefix (e.g.
+ *   `'system-zones'`, `'menu-manage'`).
+ * @returns Express middleware that consumes one slot per request and
+ *   responds 429 when the bucket is exhausted.
+ */
+export function createAdminRateLimiter(keyPrefix: string) {
+  return createRateLimiter({
+    windowSeconds: ADMIN_RATE_LIMIT_WINDOW_SECONDS,
+    maxRequests: ADMIN_RATE_LIMIT_MAX_REQUESTS,
+    keyPrefix
+  });
+}

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -31,6 +31,7 @@ import { LogsModule } from './modules/logs/index.js';
 import { DatabaseModule } from './modules/database/index.js';
 import { ClickHouseModule } from './modules/clickhouse/index.js';
 import { PagesModule } from './modules/pages/index.js';
+import { WidgetsModule, ZoneRegistry } from './modules/widgets/index.js';
 import { UserModule } from './modules/user/index.js';
 import { AddressLabelsModule } from './modules/address-labels/index.js';
 import { ToolsModule } from './modules/tools/index.js';
@@ -44,7 +45,7 @@ import { UsdtParametersService } from './modules/usdt-parameters/usdt-parameters
 import { createApiRouter } from './api/routes/index.js';
 import { PluginManagerService } from './services/plugin-manager.service.js';
 import type { Express } from 'express';
-import type { IDatabaseService, IMenuService, IMenuNode, IPluginManifest, IServiceRegistry, IHookRegistry } from '@/types';
+import type { IDatabaseService, IMenuService, IMenuNode, IPluginManifest, IServiceRegistry, IHookRegistry, IZoneRegistry } from '@/types';
 import axios from 'axios';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -142,7 +143,7 @@ async function bootstrap(): Promise<void> {
             await logger.waitUntilInitialized();
             // Pass scheduler to plugins for context.scheduler injection
             const scheduler = ctx.modules.scheduler.getSchedulerService();
-            await loadPlugins(ctx.coreDatabase, scheduler, ctx.serviceRegistry, ctx.hookRegistry);
+            await loadPlugins(ctx.coreDatabase, scheduler, ctx.serviceRegistry, ctx.hookRegistry, ctx.zoneRegistry);
         } catch (pluginError) {
             logger.error({ pluginError, stack: pluginError instanceof Error ? pluginError.stack : undefined }, 'Plugin initialization failed');
         }
@@ -213,12 +214,14 @@ interface BootstrapContext {
     menuService: IMenuService;
     serviceRegistry: IServiceRegistry;
     hookRegistry: IHookRegistry;
+    zoneRegistry: IZoneRegistry;
     modules: {
         database: DatabaseModule;
         clickhouse: ClickHouseModule;
         menu: MenuModule;
         logs: LogsModule;
         pages: PagesModule;
+        widgets: WidgetsModule;
         user: UserModule;
         addressLabels: AddressLabelsModule;
         tools: ToolsModule;
@@ -286,6 +289,13 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     // both are available to the plugin loader.
     const hookRegistry = new HookRegistry(logger);
 
+    // Zone registry is process-wide infrastructure for the widget system —
+    // core zone descriptors declared at module load (see modules/widgets/
+    // zones/descriptors.ts) auto-populate on construction. Threaded into
+    // both the WidgetsModule (for admin introspection) and the plugin loader
+    // (for the per-plugin facade exposed on context.zones).
+    const zoneRegistry = new ZoneRegistry(logger);
+
     // Register shared infrastructure on the service registry so modules and
     // plugins can discover them via late-binding DI instead of importing
     // concrete classes.
@@ -298,10 +308,11 @@ async function bootstrapInit(): Promise<BootstrapContext> {
 
     const cacheService = new CacheService(getRedisClient(), coreDatabase);
 
-    const sharedDeps = { database: coreDatabase, cacheService, menuService, serviceRegistry, hookRegistry, app };
+    const sharedDeps = { database: coreDatabase, cacheService, menuService, serviceRegistry, hookRegistry, zoneRegistry, app };
 
     const logsModule = new LogsModule();
     const pagesModule = new PagesModule();
+    const widgetsModule = new WidgetsModule();
     const userModule = new UserModule();
     const addressLabelsModule = new AddressLabelsModule();
     const toolsModule = new ToolsModule();
@@ -309,6 +320,7 @@ async function bootstrapInit(): Promise<BootstrapContext> {
 
     await logsModule.init({ pinoLogger, database: coreDatabase, app });
     await pagesModule.init(sharedDeps);
+    await widgetsModule.init(sharedDeps);
     await schedulerModule.init({ database: coreDatabase, menuService, app });
     const schedulerService = schedulerModule.getSchedulerService();
     await userModule.init({ ...sharedDeps, scheduler: schedulerService, systemConfig: SystemConfigService.getInstance(), clickhouse });
@@ -323,12 +335,14 @@ async function bootstrapInit(): Promise<BootstrapContext> {
         menuService,
         serviceRegistry,
         hookRegistry,
+        zoneRegistry,
         modules: {
             database: databaseModule,
             clickhouse: clickHouseModule,
             menu: menuModule,
             logs: logsModule,
             pages: pagesModule,
+            widgets: widgetsModule,
             user: userModule,
             addressLabels: addressLabelsModule,
             tools: toolsModule,
@@ -359,6 +373,7 @@ async function bootstrapRun(ctx: BootstrapContext): Promise<void> {
     await modules.menu.run();
     await modules.logs.run();
     await modules.pages.run();
+    await modules.widgets.run();
     await modules.user.run();
     await modules.addressLabels.run();
     await modules.tools.run();

--- a/src/backend/loaders/plugins.ts
+++ b/src/backend/loaders/plugins.ts
@@ -234,11 +234,14 @@ export async function loadPlugins(
                 pluginLogger.info('✓ Loaded plugin (no init hook)');
             }
 
-            // Seal the lifecycle window. Handlers stay registered for
-            // the plugin's enabled lifetime; subsequent register() calls
+            // Seal the lifecycle windows on both per-plugin facades.
+            // Handlers and zone declarations stay registered for the
+            // plugin's enabled lifetime; subsequent register() calls
             // (e.g. inside request handlers) now throw, matching the
-            // contract documented in system-hooks.md.
+            // contract enforced by every other activation path in
+            // PluginManagerService.
             loaded.hooks.seal();
+            loaded.zones.seal();
 
             // Register widgets if defined
             if (plugin.widgets && plugin.widgets.length > 0) {

--- a/src/backend/loaders/plugins.ts
+++ b/src/backend/loaders/plugins.ts
@@ -1,7 +1,8 @@
 import axios from 'axios';
 import mongoose from 'mongoose';
-import type { IPluginContext, IPlugin, IDatabaseService, ISchedulerService, IServiceRegistry, IHookRegistry } from '@/types';
+import type { IPluginContext, IPlugin, IDatabaseService, ISchedulerService, IServiceRegistry, IHookRegistry, IZoneRegistry } from '@/types';
 import { PluginHooks } from '../hooks/index.js';
+import { PluginZones } from '../modules/widgets/index.js';
 import { logger } from '../lib/logger.js';
 import { BlockchainObserverService } from '../services/blockchain-observer/index.js';
 import { BaseObserver, BaseBatchObserver, BaseBlockObserver } from '../modules/blockchain/observers/index.js';
@@ -65,7 +66,8 @@ export async function loadPlugins(
     database: IDatabaseService,
     scheduler: ISchedulerService | null,
     serviceRegistry: IServiceRegistry,
-    hookRegistry: IHookRegistry
+    hookRegistry: IHookRegistry,
+    zoneRegistry: IZoneRegistry
 ): Promise<void> {
     await logger.waitUntilInitialized();
 
@@ -77,6 +79,7 @@ export async function loadPlugins(
     const metadataService = PluginMetadataService.getInstance();
     const pluginManager = PluginManagerService.getInstance();
     pluginManager.setHookRegistry(hookRegistry);
+    pluginManager.setZoneRegistry(zoneRegistry);
     const observerService = BlockchainObserverService.getInstance();
 
     logger.info(`Discovered ${pluginList.length} plugins`);
@@ -94,6 +97,7 @@ export async function loadPlugins(
     const chainParametersService = ChainParametersService.getInstance();
     const usdtParametersService = UsdtParametersService.getInstance();
     const widgetService = WidgetService.getInstance(logger);
+    widgetService.setZoneRegistry(zoneRegistry);
     const tronGridClient = TronGridClient.getInstance();
     // Ensure BlockchainService has database injected before getInstance() (may already be set by jobs/index.ts)
     BlockchainService.setDependencies(database);
@@ -150,6 +154,11 @@ export async function loadPlugins(
             // disabled or uninstalled.
             const pluginHooks = new PluginHooks(plugin.manifest.id, hookRegistry, pluginLogger);
 
+            // Per-plugin zone facade. Same lifecycle and disposal model as
+            // hooks — zones declared during install/enable/init are dropped
+            // when the plugin is disabled or uninstalled.
+            const pluginZones = new PluginZones(plugin.manifest.id, zoneRegistry, pluginLogger);
+
             // Create plugin context with injected dependencies
             const context: IPluginContext = {
                 http: httpClient,
@@ -175,11 +184,12 @@ export async function loadPlugins(
                 signatureService: new SignatureService(tronWebInstance),
                 services: serviceRegistry,
                 hooks: pluginHooks,
+                zones: pluginZones,
                 logger: pluginLogger
             };
 
             // Register plugin in the manager (does not initialize)
-            pluginManager.registerPlugin(plugin, context, pluginHooks);
+            pluginManager.registerPlugin(plugin, context, pluginHooks, pluginZones);
 
             pluginLogger.debug('Plugin discovered and registered');
         } catch (error) {

--- a/src/backend/modules/widgets/WidgetsModule.ts
+++ b/src/backend/modules/widgets/WidgetsModule.ts
@@ -1,0 +1,117 @@
+/**
+ * @fileoverview Widget module — IModule implementation.
+ *
+ * Owns the widget-zone subsystem in PR 1: receives the bootstrap-owned
+ * `ZoneRegistry` instance via dependency injection, mounts the admin
+ * introspection endpoint at `/api/admin/system/zones`. Future PRs add
+ * the widget-type registry, placement persistence, and the SSR
+ * resolution pipeline to this same module so all widget concerns live
+ * in one tree.
+ *
+ * The zone registry itself is constructed in `bootstrapInit` alongside
+ * the hook registry — the module does not own its lifecycle. This
+ * mirrors the hook-registry pattern: the registry is process-wide
+ * infrastructure shared between the plugin loader and the module that
+ * exposes it.
+ *
+ * @module backend/modules/widgets/WidgetsModule
+ */
+
+import type { Express, Router } from 'express';
+import type {
+    IModule,
+    IModuleMetadata,
+    IZoneRegistry,
+    ISystemLogService
+} from '@/types';
+import { logger } from '../../lib/logger.js';
+import { requireAdmin } from '../../api/middleware/admin-auth.js';
+import { ZonesController } from './api/zones.controller.js';
+import { createZonesAdminRouter } from './api/zones.routes.js';
+
+/**
+ * Dependencies required by the widgets module.
+ *
+ * `zoneRegistry` is constructed in `bootstrapInit` and threaded through
+ * `sharedDeps` so both this module and the plugin loader receive the
+ * same instance.
+ */
+export interface IWidgetsModuleDependencies {
+    /** Shared process-wide zone registry. */
+    zoneRegistry: IZoneRegistry;
+    /** Express app for admin route mounting. */
+    app: Express;
+}
+
+/**
+ * Widgets module class.
+ *
+ * Lifecycle:
+ * - `init()` — store dependencies, construct admin controller.
+ * - `run()` — mount the admin zone introspection router.
+ */
+export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
+    readonly metadata: IModuleMetadata = {
+        id: 'widgets',
+        name: 'Widgets',
+        version: '1.0.0',
+        description: 'Widget zone registry, widget type catalog, and placement persistence.'
+    };
+
+    private zoneRegistry!: IZoneRegistry;
+    private app!: Express;
+    private zonesController!: ZonesController;
+
+    private readonly logger: ISystemLogService = logger.child({ module: 'widgets' });
+
+    /**
+     * Initialise the module.
+     *
+     * @param dependencies - Injected dependencies.
+     * @throws Error if any dependency is missing.
+     */
+    async init(dependencies: IWidgetsModuleDependencies): Promise<void> {
+        this.logger.info('Initializing widgets module...');
+
+        if (!dependencies.zoneRegistry) {
+            throw new Error('WidgetsModule requires zoneRegistry dependency');
+        }
+        if (!dependencies.app) {
+            throw new Error('WidgetsModule requires app dependency');
+        }
+
+        this.zoneRegistry = dependencies.zoneRegistry;
+        this.app = dependencies.app;
+
+        this.zonesController = new ZonesController(this.zoneRegistry, this.logger);
+
+        this.logger.info('Widgets module initialized');
+    }
+
+    /**
+     * Activate the module — mount the admin zone introspection router.
+     */
+    async run(): Promise<void> {
+        this.logger.info('Running widgets module...');
+
+        const adminRouter: Router = createZonesAdminRouter(this.zonesController);
+        this.app.use('/api/admin/system/zones', requireAdmin, adminRouter);
+        this.logger.info('Zone introspection router mounted at /api/admin/system/zones');
+
+        this.logger.info('Widgets module running');
+    }
+
+    /**
+     * Accessor for the zone registry, exposed for tests and tooling
+     * that need to reach the registry through the module instance.
+     *
+     * @returns The registry passed into `init`.
+     * @throws Error when called before `init()`.
+     */
+    getZoneRegistry(): IZoneRegistry {
+        if (!this.zoneRegistry) {
+            throw new Error('WidgetsModule not initialized - call init() first');
+        }
+        return this.zoneRegistry;
+    }
+}

--- a/src/backend/modules/widgets/WidgetsModule.ts
+++ b/src/backend/modules/widgets/WidgetsModule.ts
@@ -26,6 +26,7 @@ import type {
 } from '@/types';
 import { logger } from '../../lib/logger.js';
 import { requireAdmin } from '../../api/middleware/admin-auth.js';
+import { createAdminRateLimiter } from '../../api/middleware/rate-limit.js';
 import { ZonesController } from './api/zones.controller.js';
 import { createZonesAdminRouter } from './api/zones.routes.js';
 
@@ -90,12 +91,18 @@ export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
 
     /**
      * Activate the module — mount the admin zone introspection router.
+     *
+     * The platform-default admin rate limiter runs before `requireAdmin`
+     * so the brute-force cost against the auth gate is bounded per IP
+     * (60 req / 60s). Matches the MenuModule `/manage` precedent and
+     * satisfies CodeQL's `js/missing-rate-limiting` rule.
      */
     async run(): Promise<void> {
         this.logger.info('Running widgets module...');
 
         const adminRouter: Router = createZonesAdminRouter(this.zonesController);
-        this.app.use('/api/admin/system/zones', requireAdmin, adminRouter);
+        const rateLimiter = createAdminRateLimiter('system-zones');
+        this.app.use('/api/admin/system/zones', rateLimiter, requireAdmin, adminRouter);
         this.logger.info('Zone introspection router mounted at /api/admin/system/zones');
 
         this.logger.info('Widgets module running');

--- a/src/backend/modules/widgets/__tests__/zones.test.ts
+++ b/src/backend/modules/widgets/__tests__/zones.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { ISystemLogService, IZoneDescriptor } from '@/types';
 import {
     defineZone,
+    forgetZone,
     isKnownZone,
     listKnownZones,
     __resetKnownZonesForTests,
@@ -255,17 +256,95 @@ describe('ZoneRegistry.disposeForPlugin', () => {
         expect(registry.has('test.plugin-a-2')).toBe(false);
     });
 
+    it('forgets disposed zones from KNOWN_ZONES so subsequent defineZone calls mint fresh descriptors', () => {
+        const desc = defineZone({ id: 'test.forget', label: 'F', description: '', host: 'plugin' });
+        registry.register('plugin-a', desc);
+
+        registry.disposeForPlugin('plugin-a');
+
+        expect(listKnownZones().map(d => d.id)).not.toContain('test.forget');
+        const fresh = defineZone({ id: 'test.forget', label: 'F2', description: '', host: 'plugin' });
+        expect(fresh).not.toBe(desc);
+        expect(fresh.label).toBe('F2');
+    });
+
     it('never removes core-owned zones', () => {
         const removed = registry.disposeForPlugin(RESERVED_PLUGIN_ID);
 
         expect(removed).toBe(0);
         expect(registry.has('test.core')).toBe(true);
+        expect(listKnownZones().map(d => d.id)).toContain('test.core');
     });
 
     it('returns zero when the plugin owns no zones', () => {
         const removed = registry.disposeForPlugin('phantom-plugin');
 
         expect(removed).toBe(0);
+    });
+});
+
+describe('Plugin re-enable cycle', () => {
+    let logger: MockLogger;
+    let registry: ZoneRegistry;
+
+    beforeEach(() => {
+        __resetKnownZonesForTests();
+        logger = new MockLogger();
+        registry = new ZoneRegistry(logger);
+    });
+
+    it('lets a plugin re-declare zones after disposeForPlugin clears them', () => {
+        const facade = new PluginZones('plugin-x', registry, logger);
+        facade.register({
+            id: 'test.re-enable',
+            label: 'Re-enable',
+            description: '',
+            host: 'plugin'
+        });
+        expect(registry.has('test.re-enable')).toBe(true);
+
+        // Mimic PluginManagerService.disposeZones on plugin disable.
+        facade.closeAndDisposeAll();
+        registry.disposeForPlugin('plugin-x');
+
+        // Mimic PluginManagerService.rearmZones on the next enable.
+        const reFacade = new PluginZones('plugin-x', registry, logger);
+        expect(() => reFacade.register({
+            id: 'test.re-enable',
+            label: 'Re-enable',
+            description: '',
+            host: 'plugin'
+        })).not.toThrow();
+        expect(registry.has('test.re-enable')).toBe(true);
+        expect(registry.get('test.re-enable')?.pluginId).toBe('plugin-x');
+    });
+
+    it('forgets the zone when a single registration disposer fires', () => {
+        const facade = new PluginZones('plugin-x', registry, logger);
+        const dispose = facade.register({
+            id: 'test.single-dispose',
+            label: 'D',
+            description: '',
+            host: 'plugin'
+        });
+
+        dispose();
+
+        expect(listKnownZones().map(d => d.id)).not.toContain('test.single-dispose');
+        expect(() => defineZone({
+            id: 'test.single-dispose',
+            label: 'Fresh',
+            description: '',
+            host: 'plugin'
+        })).not.toThrow();
+    });
+
+    it('exports forgetZone as a primitive of define-zone', () => {
+        defineZone({ id: 'test.manual-forget', label: 'M', description: '', host: 'plugin' });
+
+        expect(forgetZone('test.manual-forget')).toBe(true);
+        expect(forgetZone('test.manual-forget')).toBe(false);
+        expect(listKnownZones().map(d => d.id)).not.toContain('test.manual-forget');
     });
 });
 

--- a/src/backend/modules/widgets/__tests__/zones.test.ts
+++ b/src/backend/modules/widgets/__tests__/zones.test.ts
@@ -1,0 +1,412 @@
+/// <reference types="vitest" />
+
+/**
+ * @fileoverview Unit tests for the widget-zone subsystem.
+ *
+ * Covers descriptor minting and identity tracking (`defineZone`), the
+ * runtime registry's auto-population, registration, conflict detection,
+ * snapshot shape, and the per-plugin facade's lifecycle window and
+ * disposer ledger. Mirrors the hook system test conventions so the two
+ * registry pairs read consistently.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ISystemLogService, IZoneDescriptor } from '@/types';
+import {
+    defineZone,
+    isKnownZone,
+    listKnownZones,
+    __resetKnownZonesForTests,
+    ZoneRegistry,
+    PluginZones,
+    RESERVED_PLUGIN_ID
+} from '../zones/index.js';
+
+/**
+ * Minimal `ISystemLogService` implementation for assertions on warn /
+ * info / debug call sites without booting the real Pino-backed logger.
+ * Mirrors the mock used by the hook system tests.
+ */
+class MockLogger implements ISystemLogService {
+    public level = 'info';
+    public fatal = vi.fn();
+    public error = vi.fn();
+    public warn = vi.fn();
+    public info = vi.fn();
+    public debug = vi.fn();
+    public trace = vi.fn();
+    public child = vi.fn((_bindings: Record<string, unknown>): ISystemLogService => {
+        return this;
+    });
+
+    public async initialize() {}
+    public async saveLog() {}
+    public async getLogs() {
+        return { logs: [], total: 0, page: 1, limit: 50, totalPages: 0, hasNextPage: false, hasPrevPage: false };
+    }
+    public async markAsResolved() {}
+    public async cleanup() { return 0; }
+    public async getStatistics() { return { total: 0, byLevel: {} as any, byService: {}, unresolved: 0 }; }
+    public async getLogById() { return null; }
+    public async markAsUnresolved() { return null; }
+    public async deleteAllLogs() { return 0; }
+    public async getStats() { return { total: 0, byLevel: {} as any, resolved: 0, unresolved: 0 }; }
+    public async waitUntilInitialized() {}
+}
+
+describe('defineZone', () => {
+    beforeEach(() => __resetKnownZonesForTests());
+
+    it('produces a frozen descriptor tracked by the runtime', () => {
+        const desc = defineZone({
+            id: 'test.alpha',
+            label: 'Alpha',
+            description: 'alpha zone',
+            host: 'core'
+        });
+
+        expect(desc.id).toBe('test.alpha');
+        expect(Object.isFrozen(desc)).toBe(true);
+        expect(isKnownZone(desc)).toBe(true);
+        expect(listKnownZones().map(d => d.id)).toEqual(['test.alpha']);
+    });
+
+    it('defaults layout to vertical when omitted', () => {
+        const desc = defineZone({
+            id: 'test.layout',
+            label: 'Layout default',
+            description: 'no layout passed',
+            host: 'core'
+        });
+
+        expect(desc.layout).toBe('vertical');
+    });
+
+    it('preserves explicit layout values', () => {
+        const desc = defineZone({
+            id: 'test.grid',
+            label: 'Grid',
+            description: 'grid layout',
+            host: 'core',
+            layout: 'grid'
+        });
+
+        expect(desc.layout).toBe('grid');
+    });
+
+    it('rejects duplicate ids', () => {
+        defineZone({
+            id: 'test.dup',
+            label: 'First',
+            description: 'first',
+            host: 'core'
+        });
+
+        expect(() => defineZone({
+            id: 'test.dup',
+            label: 'Second',
+            description: 'second',
+            host: 'core'
+        })).toThrow(/Duplicate zone descriptor id/);
+    });
+
+    it('does not consider a hand-rolled object known', () => {
+        const fake: IZoneDescriptor = {
+            id: 'test.fake',
+            label: 'Fake',
+            description: '',
+            host: 'core',
+            layout: 'vertical'
+        };
+
+        expect(isKnownZone(fake)).toBe(false);
+    });
+
+    it('listKnownZones returns descriptors sorted by id', () => {
+        defineZone({ id: 'test.gamma', label: 'G', description: '', host: 'core' });
+        defineZone({ id: 'test.alpha', label: 'A', description: '', host: 'core' });
+        defineZone({ id: 'test.beta', label: 'B', description: '', host: 'core' });
+
+        expect(listKnownZones().map(d => d.id)).toEqual(['test.alpha', 'test.beta', 'test.gamma']);
+    });
+});
+
+describe('ZoneRegistry construction', () => {
+    let logger: MockLogger;
+
+    beforeEach(() => {
+        __resetKnownZonesForTests();
+        logger = new MockLogger();
+    });
+
+    it('auto-populates with every descriptor tracked at construction time as core-owned', () => {
+        defineZone({ id: 'test.preload-a', label: 'A', description: '', host: 'site' });
+        defineZone({ id: 'test.preload-b', label: 'B', description: '', host: 'core' });
+
+        const registry = new ZoneRegistry(logger);
+
+        expect(registry.has('test.preload-a')).toBe(true);
+        expect(registry.has('test.preload-b')).toBe(true);
+        expect(registry.get('test.preload-a')?.pluginId).toBe(RESERVED_PLUGIN_ID);
+        expect(registry.get('test.preload-b')?.pluginId).toBe(RESERVED_PLUGIN_ID);
+    });
+
+    it('starts empty when no descriptors have been declared', () => {
+        const registry = new ZoneRegistry(logger);
+        const snapshot = registry.snapshot();
+
+        const totalZones = snapshot.tracks.reduce((sum, t) => sum + t.zones.length, 0);
+        expect(totalZones).toBe(0);
+        expect(snapshot.tracks.map(t => t.id)).toEqual(['site', 'core', 'plugin', 'admin']);
+    });
+});
+
+describe('ZoneRegistry.register', () => {
+    let logger: MockLogger;
+    let registry: ZoneRegistry;
+
+    beforeEach(() => {
+        __resetKnownZonesForTests();
+        logger = new MockLogger();
+        registry = new ZoneRegistry(logger);
+    });
+
+    it('rejects an empty pluginId', () => {
+        const desc = defineZone({ id: 'test.alpha', label: 'A', description: '', host: 'core' });
+
+        expect(() => registry.register('', desc)).toThrow(/non-empty pluginId/);
+    });
+
+    it('rejects a descriptor not produced by defineZone', () => {
+        const fake: IZoneDescriptor = {
+            id: 'test.fake',
+            label: 'Fake',
+            description: '',
+            host: 'core',
+            layout: 'vertical'
+        };
+
+        expect(() => registry.register('my-plugin', fake)).toThrow(/was not produced by defineZone/);
+    });
+
+    it('accepts a plugin registration and surfaces it in the snapshot', () => {
+        const desc = defineZone({
+            id: 'test.plugin-zone',
+            label: 'Plugin Zone',
+            description: 'declared by a plugin',
+            host: 'plugin'
+        });
+
+        registry.register('my-plugin', desc);
+
+        expect(registry.has('test.plugin-zone')).toBe(true);
+        const record = registry.get('test.plugin-zone');
+        expect(record?.pluginId).toBe('my-plugin');
+        expect(record?.host).toBe('plugin');
+        expect(record?.label).toBe('Plugin Zone');
+    });
+
+    it('refuses to overwrite a zone declared by a different plugin', () => {
+        const desc = defineZone({ id: 'test.conflict', label: 'C', description: '', host: 'plugin' });
+        registry.register('plugin-a', desc);
+
+        expect(() => registry.register('plugin-b', desc)).toThrow(/already declared by 'plugin-a'/);
+    });
+
+    it('allows the same plugin to re-register its own zone', () => {
+        const desc = defineZone({ id: 'test.reregister', label: 'R', description: '', host: 'plugin' });
+        registry.register('plugin-a', desc);
+
+        expect(() => registry.register('plugin-a', desc)).not.toThrow();
+    });
+
+    it('returns a disposer that removes the zone', () => {
+        const desc = defineZone({ id: 'test.dispose', label: 'D', description: '', host: 'plugin' });
+        const dispose = registry.register('my-plugin', desc);
+
+        expect(registry.has('test.dispose')).toBe(true);
+        dispose();
+        expect(registry.has('test.dispose')).toBe(false);
+    });
+});
+
+describe('ZoneRegistry.disposeForPlugin', () => {
+    let logger: MockLogger;
+    let registry: ZoneRegistry;
+
+    beforeEach(() => {
+        __resetKnownZonesForTests();
+        // Pre-declare a core zone so it lives in the registry from construction.
+        defineZone({ id: 'test.core', label: 'Core', description: '', host: 'core' });
+        logger = new MockLogger();
+        registry = new ZoneRegistry(logger);
+    });
+
+    it('drops every zone owned by the plugin', () => {
+        const a = defineZone({ id: 'test.plugin-a-1', label: 'A1', description: '', host: 'plugin' });
+        const b = defineZone({ id: 'test.plugin-a-2', label: 'A2', description: '', host: 'plugin' });
+        registry.register('plugin-a', a);
+        registry.register('plugin-a', b);
+
+        const removed = registry.disposeForPlugin('plugin-a');
+
+        expect(removed).toBe(2);
+        expect(registry.has('test.plugin-a-1')).toBe(false);
+        expect(registry.has('test.plugin-a-2')).toBe(false);
+    });
+
+    it('never removes core-owned zones', () => {
+        const removed = registry.disposeForPlugin(RESERVED_PLUGIN_ID);
+
+        expect(removed).toBe(0);
+        expect(registry.has('test.core')).toBe(true);
+    });
+
+    it('returns zero when the plugin owns no zones', () => {
+        const removed = registry.disposeForPlugin('phantom-plugin');
+
+        expect(removed).toBe(0);
+    });
+});
+
+describe('ZoneRegistry.snapshot', () => {
+    let logger: MockLogger;
+
+    beforeEach(() => {
+        __resetKnownZonesForTests();
+        logger = new MockLogger();
+    });
+
+    it('groups zones by host and emits every host track even when empty', () => {
+        defineZone({ id: 'test.site', label: 'S', description: '', host: 'site' });
+        defineZone({ id: 'test.core', label: 'C', description: '', host: 'core' });
+        const registry = new ZoneRegistry(logger);
+
+        const snapshot = registry.snapshot();
+
+        const siteTrack = snapshot.tracks.find(t => t.id === 'site');
+        const coreTrack = snapshot.tracks.find(t => t.id === 'core');
+        const pluginTrack = snapshot.tracks.find(t => t.id === 'plugin');
+        const adminTrack = snapshot.tracks.find(t => t.id === 'admin');
+
+        expect(siteTrack?.zones.map(z => z.id)).toEqual(['test.site']);
+        expect(coreTrack?.zones.map(z => z.id)).toEqual(['test.core']);
+        expect(pluginTrack?.zones).toEqual([]);
+        expect(adminTrack?.zones).toEqual([]);
+    });
+
+    it('sorts zones within a track by id', () => {
+        defineZone({ id: 'test.zeta', label: 'Z', description: '', host: 'core' });
+        defineZone({ id: 'test.alpha', label: 'A', description: '', host: 'core' });
+        defineZone({ id: 'test.beta', label: 'B', description: '', host: 'core' });
+        const registry = new ZoneRegistry(logger);
+
+        const snapshot = registry.snapshot();
+        const coreTrack = snapshot.tracks.find(t => t.id === 'core');
+
+        expect(coreTrack?.zones.map(z => z.id)).toEqual(['test.alpha', 'test.beta', 'test.zeta']);
+    });
+
+    it('serializes registeredAt as an ISO-8601 string', () => {
+        defineZone({ id: 'test.time', label: 'T', description: '', host: 'core' });
+        const registry = new ZoneRegistry(logger);
+
+        const record = registry.get('test.time');
+
+        expect(record?.registeredAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    });
+});
+
+describe('PluginZones facade', () => {
+    let logger: MockLogger;
+    let registry: ZoneRegistry;
+
+    beforeEach(() => {
+        __resetKnownZonesForTests();
+        logger = new MockLogger();
+        registry = new ZoneRegistry(logger);
+    });
+
+    it('tags zone declarations with the plugin id', () => {
+        const facade = new PluginZones('plugin-x', registry, logger);
+
+        facade.register({
+            id: 'test.facade-tagged',
+            label: 'Tagged',
+            description: '',
+            host: 'plugin'
+        });
+
+        expect(registry.get('test.facade-tagged')?.pluginId).toBe('plugin-x');
+    });
+
+    it('refuses to register after seal()', () => {
+        const facade = new PluginZones('plugin-x', registry, logger);
+        facade.seal();
+
+        expect(() => facade.register({
+            id: 'test.after-seal',
+            label: 'X',
+            description: '',
+            host: 'plugin'
+        })).toThrow(/lifecycle window closed/);
+    });
+
+    it('refuses to register after closeAndDisposeAll()', () => {
+        const facade = new PluginZones('plugin-x', registry, logger);
+        facade.closeAndDisposeAll();
+
+        expect(() => facade.register({
+            id: 'test.after-close',
+            label: 'X',
+            description: '',
+            host: 'plugin'
+        })).toThrow(/lifecycle window closed/);
+    });
+
+    it('seal() is idempotent and does not dispose registrations', () => {
+        const facade = new PluginZones('plugin-x', registry, logger);
+        facade.register({
+            id: 'test.survives-seal',
+            label: 'S',
+            description: '',
+            host: 'plugin'
+        });
+        facade.seal();
+        facade.seal();
+
+        expect(registry.has('test.survives-seal')).toBe(true);
+    });
+
+    it('closeAndDisposeAll() drops every zone the facade owns and returns the count', () => {
+        const facade = new PluginZones('plugin-x', registry, logger);
+        facade.register({ id: 'test.bulk-1', label: '1', description: '', host: 'plugin' });
+        facade.register({ id: 'test.bulk-2', label: '2', description: '', host: 'plugin' });
+        facade.register({ id: 'test.bulk-3', label: '3', description: '', host: 'plugin' });
+
+        const removed = facade.closeAndDisposeAll();
+
+        expect(removed).toBe(3);
+        expect(registry.has('test.bulk-1')).toBe(false);
+        expect(registry.has('test.bulk-2')).toBe(false);
+        expect(registry.has('test.bulk-3')).toBe(false);
+    });
+
+    it('individual disposers do not double-dispose during closeAndDisposeAll', () => {
+        const facade = new PluginZones('plugin-x', registry, logger);
+        const dispose = facade.register({
+            id: 'test.double-dispose',
+            label: 'D',
+            description: '',
+            host: 'plugin'
+        });
+
+        dispose();
+        const removed = facade.closeAndDisposeAll();
+
+        // The first dispose removed the entry from the facade's set, so the
+        // bulk dispose finds nothing left to drop.
+        expect(removed).toBe(0);
+        expect(registry.has('test.double-dispose')).toBe(false);
+    });
+});

--- a/src/backend/modules/widgets/api/zones.controller.ts
+++ b/src/backend/modules/widgets/api/zones.controller.ts
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Admin controller for widget-zone introspection.
+ *
+ * Serves the registry's snapshot to the `/system/widgets` admin
+ * placement editor (forthcoming). The snapshot enumerates every
+ * declared zone grouped by host, with ownership and registration
+ * metadata — the same shape `HooksController` produces for hooks.
+ *
+ * @module backend/modules/widgets/api/zones.controller
+ */
+
+import type { Request, Response } from 'express';
+import type { IZoneRegistry, ISystemLogService } from '@/types';
+
+/**
+ * Admin endpoint controller. Read-only — placement CRUD lands in PR 2.
+ */
+export class ZonesController {
+    /**
+     * Construct the controller.
+     *
+     * @param registry - Shared process-wide zone registry.
+     * @param logger - Scoped logger.
+     */
+    constructor(
+        private readonly registry: IZoneRegistry,
+        private readonly logger: ISystemLogService
+    ) {}
+
+    /**
+     * Return the current zone snapshot.
+     *
+     * Always succeeds — empty registries return tracks with empty zone
+     * arrays so the admin UI can render its host scaffold unconditionally.
+     *
+     * @param _req - Express request (unused).
+     * @param res - Express response.
+     */
+    getSnapshot = (_req: Request, res: Response): void => {
+        const snapshot = this.registry.snapshot();
+        res.json(snapshot);
+    };
+}

--- a/src/backend/modules/widgets/api/zones.routes.ts
+++ b/src/backend/modules/widgets/api/zones.routes.ts
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Router factory for the zone-introspection admin
+ * endpoint.
+ *
+ * Single read-only `GET /` route returning the registry snapshot.
+ * Caller mounts the router under `/api/admin/system/zones` with the
+ * `requireAdmin` middleware applied at mount time, so the router
+ * itself stays unauthenticated.
+ *
+ * @module backend/modules/widgets/api/zones.routes
+ */
+
+import { Router } from 'express';
+import type { ZonesController } from './zones.controller.js';
+
+/**
+ * Build the zone admin router. Mounted by `WidgetsModule.run()`.
+ *
+ * @param controller - Controller with the request handlers bound.
+ * @returns Express router with the snapshot route attached.
+ */
+export function createZonesAdminRouter(controller: ZonesController): Router {
+    const router = Router();
+    router.get('/', controller.getSnapshot);
+
+    return router;
+}

--- a/src/backend/modules/widgets/index.ts
+++ b/src/backend/modules/widgets/index.ts
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Widgets module public API.
+ *
+ * Exposes the module class, its dependency interface, and the zone
+ * subsystem barrel so consumers (bootstrap, plugin loader, layouts,
+ * tests) can import everything they need from one path.
+ *
+ * @module backend/modules/widgets
+ */
+
+export { WidgetsModule } from './WidgetsModule.js';
+export type { IWidgetsModuleDependencies } from './WidgetsModule.js';
+
+export {
+    defineZone,
+    isKnownZone,
+    listKnownZones,
+    __resetKnownZonesForTests,
+    ZONES,
+    ZoneRegistry,
+    PluginZones,
+    RESERVED_PLUGIN_ID
+} from './zones/index.js';
+export type { Zones } from './zones/index.js';
+
+export { ZonesController } from './api/zones.controller.js';
+export { createZonesAdminRouter } from './api/zones.routes.js';

--- a/src/backend/modules/widgets/index.ts
+++ b/src/backend/modules/widgets/index.ts
@@ -13,6 +13,7 @@ export type { IWidgetsModuleDependencies } from './WidgetsModule.js';
 
 export {
     defineZone,
+    forgetZone,
     isKnownZone,
     listKnownZones,
     __resetKnownZonesForTests,

--- a/src/backend/modules/widgets/zones/define-zone.ts
+++ b/src/backend/modules/widgets/zones/define-zone.ts
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview defineZone factory for producing typed zone descriptors.
+ *
+ * `defineZone` is the only sanctioned way to construct an `IZoneDescriptor`.
+ * Every descriptor it produces is tracked in a module-local set so the
+ * runtime registry can reject registration of any descriptor that was
+ * not minted here — preventing plugins from forging zones the runtime
+ * does not recognise. Plugins do not import this function directly;
+ * they call `context.zones.register(options)` and the facade invokes
+ * `defineZone` on their behalf.
+ *
+ * @module backend/modules/widgets/zones/define-zone
+ */
+
+import type { IZoneDescriptor, IDefineZoneOptions } from '@/types';
+
+/**
+ * Tracked set of every descriptor minted by `defineZone` in this process.
+ *
+ * Keyed by id so the runtime can reject duplicate ids and look up the
+ * descriptor for snapshot generation without coupling to the shape of
+ * the central `ZONES` const.
+ */
+const KNOWN_ZONES: Map<string, IZoneDescriptor> = new Map();
+
+/**
+ * Construct a frozen, runtime-tracked zone descriptor.
+ *
+ * Layouts reference core zones by typed identifier — e.g.
+ * `<WidgetZone descriptor={ZONES.mainAfter} />`. Plugin zones are
+ * constructed transparently by the per-plugin facade, so plugin code
+ * never invokes this function directly.
+ *
+ * @param options - Descriptor configuration. Defaults to
+ *   `layout: 'vertical'` when omitted.
+ * @returns Frozen descriptor tracked in the known-zone set.
+ * @throws Error if a descriptor with the same id was already defined.
+ */
+export function defineZone(options: IDefineZoneOptions): IZoneDescriptor {
+    if (KNOWN_ZONES.has(options.id)) {
+        throw new Error(`Duplicate zone descriptor id: '${options.id}'. Zone ids must be unique across the process.`);
+    }
+
+    const descriptor: IZoneDescriptor = Object.freeze({
+        id: options.id,
+        label: options.label,
+        description: options.description,
+        host: options.host,
+        layout: options.layout ?? 'vertical'
+    });
+
+    KNOWN_ZONES.set(options.id, descriptor);
+
+    return descriptor;
+}
+
+/**
+ * Test whether a descriptor was produced by `defineZone` in this process.
+ *
+ * The runtime registry calls this to refuse registration of fabricated
+ * descriptors that bypass the central constructor.
+ *
+ * @param descriptor - Candidate descriptor.
+ * @returns True if the descriptor is tracked.
+ */
+export function isKnownZone(descriptor: IZoneDescriptor): boolean {
+    const tracked = KNOWN_ZONES.get(descriptor.id);
+    const result = tracked === descriptor;
+
+    return result;
+}
+
+/**
+ * Snapshot every descriptor known to the process, in stable id order.
+ *
+ * Used by the runtime registry's constructor to auto-populate core
+ * declarations made via `defineZone` at module load — descriptors are
+ * registered as `'core'`-owned without needing an explicit register
+ * call site.
+ *
+ * @returns Array of descriptors, sorted by id.
+ */
+export function listKnownZones(): ReadonlyArray<IZoneDescriptor> {
+    const list = Array.from(KNOWN_ZONES.values()).sort((a, b) => a.id.localeCompare(b.id));
+
+    return list;
+}
+
+/**
+ * Drop every tracked descriptor.
+ *
+ * Test-only utility. Production code never invokes this — descriptors
+ * are defined once at module load and persist for the process lifetime.
+ */
+export function __resetKnownZonesForTests(): void {
+    KNOWN_ZONES.clear();
+
+    return;
+}

--- a/src/backend/modules/widgets/zones/define-zone.ts
+++ b/src/backend/modules/widgets/zones/define-zone.ts
@@ -71,6 +71,30 @@ export function isKnownZone(descriptor: IZoneDescriptor): boolean {
 }
 
 /**
+ * Forget a tracked descriptor.
+ *
+ * Called by the runtime registry when a zone is disposed — either
+ * through a single registration's disposer or through bulk
+ * `disposeForPlugin` cleanup — so a future `defineZone` call with the
+ * same id mints a fresh descriptor with fresh metadata rather than
+ * returning a stale cached entry. Without this, a disable → re-enable
+ * cycle would trip the duplicate-id guard the next time the plugin
+ * declares its zones.
+ *
+ * No caller currently holds descriptor references across a
+ * `disposeForPlugin` boundary, so dropping the cache entry does not
+ * invalidate any live identity check. Core zones are not subject to
+ * this path — `ZoneRegistry.disposeForPlugin` short-circuits on the
+ * reserved `'core'` plugin id.
+ *
+ * @param id - Zone id to forget.
+ * @returns True if the descriptor was tracked and removed.
+ */
+export function forgetZone(id: string): boolean {
+    return KNOWN_ZONES.delete(id);
+}
+
+/**
  * Snapshot every descriptor known to the process, in stable id order.
  *
  * Used by the runtime registry's constructor to auto-populate core

--- a/src/backend/modules/widgets/zones/descriptors.ts
+++ b/src/backend/modules/widgets/zones/descriptors.ts
@@ -1,0 +1,113 @@
+/**
+ * @fileoverview Central declared-zone registry.
+ *
+ * This file is the single source of truth for every widget zone the
+ * platform ships out of the box. Adding a new zone requires editing
+ * this file and adding a corresponding `<WidgetZone>` call site in a
+ * layout — descriptors and render sites must move together so the
+ * registry stays honest about what zones actually exist on the page.
+ *
+ * Plugins declare additional zones through `context.zones.register(...)`
+ * rather than editing this file. Their zones are runtime-only and
+ * scoped to the plugin's lifecycle.
+ *
+ * Style:
+ *
+ * - Group keys by host (`site` / `core` / `plugin`).
+ * - Use camelCase keys.
+ * - Ids match the strings layouts pass to `<WidgetZone>` exactly.
+ *
+ * @see {@link ../../../../docs/plugins/plugins-widget-zones.md} for the
+ *   conceptual contract: zone hosts, placement model, and SSR resolution.
+ * @module backend/modules/widgets/zones/descriptors
+ */
+
+import { defineZone } from './define-zone.js';
+
+/**
+ * Declared core zones, organised by host. Core modules and layout files
+ * import this object directly to reference zones by typed identifier
+ * instead of string literal. Plugins reach the same runtime descriptors
+ * through `context.zones` — they reference core zones by id from widget
+ * placement records rather than by importing this object.
+ */
+export const ZONES = {
+    /**
+     * Rendered by the root layout (`src/frontend/app/layout.tsx`) below
+     * the block ticker and above the main page content. Reaches every
+     * route the root layout serves, so widgets placed here appear on
+     * core, plugin, and admin pages alike. Operators typically scope
+     * placements with route filters to avoid showing ticker-adjacent
+     * widgets in the admin surface.
+     */
+    tickerAfter: defineZone({
+        id: 'ticker-after',
+        label: 'Below the block ticker',
+        description:
+            'Rendered in the root layout below the block ticker. Reaches every route the root layout serves.',
+        host: 'site',
+        layout: 'vertical'
+    }),
+
+    /**
+     * Rendered above the page content inside the `(core)` route-group
+     * layout — front-of-house pages only (`/`, `/u/[address]`, etc.).
+     * Useful for banners and alerts that should appear on consumer
+     * pages without leaking into plugin pages or the admin surface.
+     */
+    mainBefore: defineZone({
+        id: 'main-before',
+        label: 'Above main content',
+        description:
+            'Above the primary page content inside the (core) route group. Front-of-house pages only.',
+        host: 'core',
+        layout: 'vertical'
+    }),
+
+    /**
+     * Rendered below the page content inside the `(core)` route-group
+     * layout. Common destination for feeds, summaries, and related-
+     * content widgets on front-of-house pages.
+     */
+    mainAfter: defineZone({
+        id: 'main-after',
+        label: 'Below main content',
+        description:
+            'Below the primary page content inside the (core) route group. Common destination for feeds and related-content widgets.',
+        host: 'core',
+        layout: 'vertical'
+    }),
+
+    /**
+     * Rendered above an individual plugin page by the
+     * `PluginPageWithZones` wrapper. Enables cross-plugin injection
+     * around a plugin's own page without modifying that plugin.
+     */
+    pluginContentBefore: defineZone({
+        id: 'plugin-content:before',
+        label: 'Plugin page — before',
+        description:
+            'Above the rendered plugin page. Enables cross-plugin injection around plugin pages.',
+        host: 'plugin',
+        layout: 'vertical'
+    }),
+
+    /**
+     * Rendered below an individual plugin page by the
+     * `PluginPageWithZones` wrapper.
+     */
+    pluginContentAfter: defineZone({
+        id: 'plugin-content:after',
+        label: 'Plugin page — after',
+        description:
+            'Below the rendered plugin page. Enables cross-plugin injection around plugin pages.',
+        host: 'plugin',
+        layout: 'vertical'
+    })
+} as const;
+
+/**
+ * Type alias re-exported for ergonomic imports at core call sites that
+ * want the full shape of the declared zone catalog.
+ */
+export type Zones = typeof ZONES;

--- a/src/backend/modules/widgets/zones/index.ts
+++ b/src/backend/modules/widgets/zones/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @fileoverview Widget zone subsystem barrel.
+ *
+ * Public exports for the zone subsystem — the `defineZone` constructor,
+ * the core `ZONES` catalog, the runtime `ZoneRegistry`, and the
+ * per-plugin `PluginZones` facade. Consumed by `WidgetsModule`, the
+ * plugin loader, and core layout files that need to reference zones by
+ * typed identifier.
+ *
+ * @module backend/modules/widgets/zones
+ */
+
+export {
+    defineZone,
+    isKnownZone,
+    listKnownZones,
+    __resetKnownZonesForTests
+} from './define-zone.js';
+export { ZONES } from './descriptors.js';
+export type { Zones } from './descriptors.js';
+export { ZoneRegistry, RESERVED_PLUGIN_ID } from './zone-registry.js';
+export { PluginZones } from './plugin-zones.js';

--- a/src/backend/modules/widgets/zones/index.ts
+++ b/src/backend/modules/widgets/zones/index.ts
@@ -12,6 +12,7 @@
 
 export {
     defineZone,
+    forgetZone,
     isKnownZone,
     listKnownZones,
     __resetKnownZonesForTests

--- a/src/backend/modules/widgets/zones/plugin-zones.ts
+++ b/src/backend/modules/widgets/zones/plugin-zones.ts
@@ -1,0 +1,121 @@
+/**
+ * @fileoverview Per-plugin zone facade.
+ *
+ * Each plugin receives an `IPluginZones` instance wrapping the shared
+ * `ZoneRegistry`. The facade constructs descriptors via `defineZone`
+ * on the plugin's behalf, tags every registration with the plugin id,
+ * enforces the lifecycle window (registration permitted only while the
+ * facade is open), and collects disposers so the plugin loader can
+ * drop every declared zone on `disable()` without each plugin tracking
+ * them by hand.
+ *
+ * Mirrors `PluginHooks` so plugin authors learn one pattern for
+ * participating in extension surfaces.
+ *
+ * @module backend/modules/widgets/zones/plugin-zones
+ */
+
+import type {
+    IDefineZoneOptions,
+    IPluginZones,
+    IZoneRegistry,
+    ZoneRegisterDisposer,
+    ISystemLogService
+} from '@/types';
+import { defineZone } from './define-zone.js';
+
+/**
+ * Concrete per-plugin facade. One instance per plugin per process.
+ */
+export class PluginZones implements IPluginZones {
+    /** Disposers for every zone registered through this facade. */
+    private readonly disposers: Set<ZoneRegisterDisposer> = new Set();
+
+    /** Whether registration is still permitted. */
+    private open: boolean = true;
+
+    /**
+     * Construct a facade scoped to a plugin.
+     *
+     * @param pluginId - Owning plugin id, used to tag every registration.
+     * @param registry - Shared process-wide zone registry.
+     * @param logger - Plugin-scoped logger.
+     */
+    constructor(
+        private readonly pluginId: string,
+        private readonly registry: IZoneRegistry,
+        private readonly logger: ISystemLogService
+    ) {}
+
+    /**
+     * Declare a zone owned by this plugin.
+     *
+     * Constructs the descriptor through `defineZone` and registers it
+     * with the shared registry tagged with this plugin's id. Plugins do
+     * not import `defineZone` directly — passing options here is the
+     * only sanctioned plugin path.
+     *
+     * @param options - Zone configuration.
+     * @returns Disposer that removes this specific registration. The
+     *   facade also tracks it internally so `closeAndDisposeAll` removes
+     *   it without the plugin retaining the reference.
+     * @throws Error if the lifecycle window has closed or the zone id
+     *   is already claimed.
+     */
+    register(options: IDefineZoneOptions): ZoneRegisterDisposer {
+        if (!this.open) {
+            throw new Error(
+                `Plugin '${this.pluginId}' attempted to declare zone '${options.id}' ` +
+                `after its lifecycle window closed. Zone registration is permitted only ` +
+                `during install/enable/init — declare zones at startup, not inside ` +
+                `request handlers.`
+            );
+        }
+
+        const descriptor = defineZone(options);
+        const disposer = this.registry.register(this.pluginId, descriptor);
+        const wrapped: ZoneRegisterDisposer = () => {
+            this.disposers.delete(wrapped);
+            disposer();
+        };
+        this.disposers.add(wrapped);
+
+        return wrapped;
+    }
+
+    /**
+     * Close the lifecycle window without disposing declared zones.
+     *
+     * Called by the platform after install/enable/init finish so any
+     * later `register()` attempt throws. Idempotent.
+     */
+    seal(): void {
+        this.open = false;
+    }
+
+    /**
+     * Close the facade and drop every zone it owns.
+     *
+     * Invoked by the plugin loader on `disable()` and `uninstall()`.
+     * After this returns, subsequent `register()` calls throw.
+     *
+     * @returns Count of zones removed.
+     */
+    closeAndDisposeAll(): number {
+        this.open = false;
+        const snapshot = Array.from(this.disposers);
+        this.disposers.clear();
+        for (const dispose of snapshot) {
+            try {
+                dispose();
+            } catch (err) {
+                this.logger.warn(
+                    { err, pluginId: this.pluginId },
+                    'Zone disposer threw during plugin disable'
+                );
+            }
+        }
+
+        return snapshot.length;
+    }
+}

--- a/src/backend/modules/widgets/zones/zone-registry.ts
+++ b/src/backend/modules/widgets/zones/zone-registry.ts
@@ -1,0 +1,272 @@
+/**
+ * @fileoverview Runtime widget zone registry implementation.
+ *
+ * Concrete `IZoneRegistry` backed by a Map of zone id → registered
+ * entry. Auto-populates from descriptors `defineZone` has tracked at
+ * module load (core zones), accepts plugin-declared zones through
+ * `register(...)`, validates the descriptor-identity check that proves
+ * a descriptor was minted via `defineZone`, and produces the snapshot
+ * consumed by the `/api/admin/system/zones` endpoint.
+ *
+ * Mirrors `HookRegistry` in shape and semantics — see
+ * `src/backend/hooks/hook-registry.ts` for the pattern.
+ *
+ * @see {@link ../../../../docs/plugins/plugins-widget-zones.md} for the
+ *   conceptual contract.
+ * @module backend/modules/widgets/zones/zone-registry
+ */
+
+import type {
+    IZoneDescriptor,
+    IZoneRegistry,
+    IZoneSnapshot,
+    IZoneSnapshotRecord,
+    ZoneHost,
+    ZoneRegisterDisposer,
+    ISystemLogService
+} from '@/types';
+import { isKnownZone, listKnownZones } from './define-zone.js';
+
+const RESERVED_PLUGIN_ID = 'core';
+
+/**
+ * Display labels and order for each zone host, used by the admin
+ * snapshot. Hosts not in this list will not appear in the snapshot —
+ * adding a new host requires extending this table.
+ */
+const HOST_TRACKS: ReadonlyArray<{ id: ZoneHost; label: string }> = [
+    { id: 'site', label: 'Site-wide' },
+    { id: 'core', label: 'Core pages' },
+    { id: 'plugin', label: 'Plugin pages' },
+    { id: 'admin', label: 'Admin pages' }
+];
+
+interface IRegisteredZone {
+    readonly descriptor: IZoneDescriptor;
+    readonly pluginId: string;
+    readonly registeredAt: number;
+    readonly source: string | null;
+}
+
+/**
+ * Map-backed zone registry. One instance per process; constructed
+ * during bootstrap, threaded into the plugin context via the per-plugin
+ * facade, and queried by `WidgetService` validation and the admin
+ * introspection endpoint.
+ */
+export class ZoneRegistry implements IZoneRegistry {
+    /** Registered zones keyed by zone id. */
+    private readonly zones: Map<string, IRegisteredZone> = new Map();
+
+    /**
+     * Construct a registry.
+     *
+     * Auto-populates from every descriptor `defineZone` has tracked up
+     * to this moment, tagging each with `pluginId: 'core'`. Subsequent
+     * plugin-declared zones flow in via `register(pluginId, descriptor)`.
+     *
+     * @param logger - System logger used for registration and disposal
+     *   diagnostics.
+     */
+    constructor(private readonly logger: ISystemLogService) {
+        const now = Date.now();
+        for (const descriptor of listKnownZones()) {
+            this.zones.set(descriptor.id, {
+                descriptor,
+                pluginId: RESERVED_PLUGIN_ID,
+                registeredAt: now,
+                source: null
+            });
+        }
+
+        this.logger.debug(
+            { coreZoneCount: this.zones.size },
+            'Zone registry initialised with core descriptors'
+        );
+    }
+
+    /**
+     * Register a declared zone owned by the given plugin (or core).
+     *
+     * Validates that the descriptor was minted by `defineZone` and that
+     * no other component has already claimed the id. Returns a disposer
+     * that removes the zone from the registry — plugin disposers are
+     * collected by the per-plugin facade so `disable()` drops them in
+     * bulk.
+     *
+     * @param pluginId - Plugin id (or `'core'`) registering the zone.
+     * @param descriptor - Descriptor minted by `defineZone`.
+     * @returns Disposer that removes the registration.
+     * @throws Error if the descriptor is unknown or the zone is already
+     *   claimed by a different plugin.
+     */
+    register(pluginId: string, descriptor: IZoneDescriptor): ZoneRegisterDisposer {
+        if (!pluginId || typeof pluginId !== 'string') {
+            throw new Error('Zone registration requires a non-empty pluginId.');
+        }
+        if (!descriptor || typeof descriptor.id !== 'string') {
+            throw new Error('Zone registration requires a valid descriptor.');
+        }
+        if (!isKnownZone(descriptor)) {
+            throw new Error(
+                `Zone descriptor '${descriptor.id}' was not produced by defineZone. ` +
+                `Construct it through the central factory before registering.`
+            );
+        }
+
+        const existing = this.zones.get(descriptor.id);
+        if (existing && existing.pluginId !== pluginId) {
+            throw new Error(
+                `Zone '${descriptor.id}' is already declared by '${existing.pluginId}'. ` +
+                `Zone ids are exclusive to their declaring component.`
+            );
+        }
+
+        const record: IRegisteredZone = {
+            descriptor,
+            pluginId,
+            registeredAt: Date.now(),
+            source: captureRegistrationSource()
+        };
+
+        this.zones.set(descriptor.id, record);
+
+        this.logger.debug(
+            { zoneId: descriptor.id, pluginId, host: descriptor.host },
+            'Zone registered'
+        );
+
+        return () => {
+            const cur = this.zones.get(descriptor.id);
+            if (!cur || cur !== record) return;
+            this.zones.delete(descriptor.id);
+            this.logger.debug({ zoneId: descriptor.id, pluginId }, 'Zone unregistered');
+        };
+    }
+
+    /**
+     * Remove every zone declared by the given plugin.
+     *
+     * Core-owned zones (`pluginId === 'core'`) are never affected;
+     * bulk disposal is plugin-scoped only.
+     *
+     * @param pluginId - Plugin whose zones should be removed.
+     * @returns Count of zones removed.
+     */
+    disposeForPlugin(pluginId: string): number {
+        if (pluginId === RESERVED_PLUGIN_ID) {
+            return 0;
+        }
+        let removed = 0;
+        for (const [id, entry] of this.zones) {
+            if (entry.pluginId === pluginId) {
+                this.zones.delete(id);
+                removed++;
+            }
+        }
+        if (removed > 0) {
+            this.logger.info({ pluginId, removed }, 'Zones disposed for plugin');
+        }
+
+        return removed;
+    }
+
+    /**
+     * Check whether a zone id is registered.
+     *
+     * @param zoneId - Zone id to check.
+     * @returns True if registered.
+     */
+    has(zoneId: string): boolean {
+        return this.zones.has(zoneId);
+    }
+
+    /**
+     * Retrieve the snapshot record for a single zone.
+     *
+     * @param zoneId - Zone id to look up.
+     * @returns Snapshot record or `undefined`.
+     */
+    get(zoneId: string): IZoneSnapshotRecord | undefined {
+        const entry = this.zones.get(zoneId);
+        if (!entry) return undefined;
+
+        return toSnapshotRecord(entry);
+    }
+
+    /**
+     * Produce the introspection snapshot consumed by the admin endpoint.
+     *
+     * Groups every registered zone by host so the placement editor
+     * renders the catalog without re-grouping. Empty hosts appear in
+     * the snapshot to keep the timeline shape stable across deployments.
+     *
+     * @returns Structured payload ready for JSON serialization.
+     */
+    snapshot(): IZoneSnapshot {
+        const byHost: Map<ZoneHost, IZoneSnapshotRecord[]> = new Map();
+        for (const track of HOST_TRACKS) {
+            byHost.set(track.id, []);
+        }
+
+        for (const entry of this.zones.values()) {
+            const bucket = byHost.get(entry.descriptor.host);
+            if (!bucket) continue;
+            bucket.push(toSnapshotRecord(entry));
+        }
+
+        const tracks = HOST_TRACKS.map(track => ({
+            id: track.id,
+            label: track.label,
+            zones: (byHost.get(track.id) ?? []).sort((a, b) => a.id.localeCompare(b.id))
+        }));
+
+        return { tracks };
+    }
+}
+
+/**
+ * Render a registered entry as a snapshot record. Pure mapping with no
+ * registry dependency so callers can reuse it inside tests.
+ *
+ * @param entry - Internal registered-zone record.
+ * @returns Public snapshot shape.
+ */
+function toSnapshotRecord(entry: IRegisteredZone): IZoneSnapshotRecord {
+    return {
+        id: entry.descriptor.id,
+        label: entry.descriptor.label,
+        description: entry.descriptor.description,
+        host: entry.descriptor.host,
+        layout: entry.descriptor.layout,
+        pluginId: entry.pluginId,
+        registeredAt: new Date(entry.registeredAt).toISOString(),
+        source: entry.source
+    };
+}
+
+/**
+ * Best-effort source-file capture from a stack trace, skipping frames
+ * inside the registry itself and node_modules. Returns `null` when the
+ * trace is missing or unparseable — the admin UI tolerates `null` and
+ * renders the registration without a deep link.
+ *
+ * @returns A `file:line:col` string or `null`.
+ */
+function captureRegistrationSource(): string | null {
+    const stack = new Error().stack;
+    if (!stack) return null;
+    const lines = stack.split('\n');
+    for (let i = 2; i < lines.length; i++) {
+        const line = lines[i].trim();
+        if (line.includes('/widgets/zones/') || line.includes('node_modules')) continue;
+        const match = line.match(/\((.+:\d+:\d+)\)/) || line.match(/at (.+:\d+:\d+)$/);
+        if (match) {
+            return match[1];
+        }
+    }
+
+    return null;
+}
+
+export { RESERVED_PLUGIN_ID };

--- a/src/backend/modules/widgets/zones/zone-registry.ts
+++ b/src/backend/modules/widgets/zones/zone-registry.ts
@@ -25,7 +25,7 @@ import type {
     ZoneRegisterDisposer,
     ISystemLogService
 } from '@/types';
-import { isKnownZone, listKnownZones } from './define-zone.js';
+import { forgetZone, isKnownZone, listKnownZones } from './define-zone.js';
 
 const RESERVED_PLUGIN_ID = 'core';
 
@@ -140,6 +140,7 @@ export class ZoneRegistry implements IZoneRegistry {
             const cur = this.zones.get(descriptor.id);
             if (!cur || cur !== record) return;
             this.zones.delete(descriptor.id);
+            forgetZone(descriptor.id);
             this.logger.debug({ zoneId: descriptor.id, pluginId }, 'Zone unregistered');
         };
     }
@@ -161,6 +162,7 @@ export class ZoneRegistry implements IZoneRegistry {
         for (const [id, entry] of this.zones) {
             if (entry.pluginId === pluginId) {
                 this.zones.delete(id);
+                forgetZone(id);
                 removed++;
             }
         }

--- a/src/backend/services/plugin-manager.service.ts
+++ b/src/backend/services/plugin-manager.service.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import type { IPlugin, IPluginContext, IPluginManifest, IHookRegistry } from '@/types';
+import type { IPlugin, IPluginContext, IPluginManifest, IHookRegistry, IZoneRegistry } from '@/types';
 import { PluginMetadataService } from './plugin-metadata.service.js';
 import { PluginDatabaseService } from '../modules/database/index.js';
 import { PluginApiService } from './plugin-api.service.js';
@@ -8,6 +8,7 @@ import { BaseObserver } from '../modules/blockchain/observers/BaseObserver.js';
 import { WebSocketService } from './websocket.service.js';
 import { logger } from '../lib/logger.js';
 import { PluginHooks } from '../hooks/index.js';
+import { PluginZones } from '../modules/widgets/index.js';
 
 /**
  * Lifecycle event payloads emitted by PluginManagerService.
@@ -37,6 +38,7 @@ interface ILoadedPlugin {
     context: IPluginContext;
     manifest: IPluginManifest;
     hooks: PluginHooks;
+    zones: PluginZones;
 }
 
 /**
@@ -52,6 +54,7 @@ export class PluginManagerService {
     private metadataService: PluginMetadataService;
     private events: EventEmitter = new EventEmitter();
     private hookRegistry: IHookRegistry | null = null;
+    private zoneRegistry: IZoneRegistry | null = null;
 
     private constructor() {
         this.metadataService = PluginMetadataService.getInstance();
@@ -68,6 +71,19 @@ export class PluginManagerService {
      */
     public setHookRegistry(registry: IHookRegistry): void {
         this.hookRegistry = registry;
+    }
+
+    /**
+     * Inject the process-wide zone registry.
+     *
+     * Called once during bootstrap from the plugin loader. The registry
+     * is used to rebuild a plugin's zone facade after it has been
+     * disabled and to dispose zone declarations in bulk as a safety net.
+     *
+     * @param registry - Shared zone registry instance.
+     */
+    public setZoneRegistry(registry: IZoneRegistry): void {
+        this.zoneRegistry = registry;
     }
 
     /**
@@ -144,13 +160,21 @@ export class PluginManagerService {
      * @param hooks - Per-plugin hook facade tied to this context, used by
      *   disable/uninstall paths to close the lifecycle window and drop
      *   every handler the plugin has registered.
+     * @param zones - Per-plugin zone facade. Same lifecycle and bulk-
+     *   disposal contract as the hooks facade.
      */
-    public registerPlugin(plugin: IPlugin, context: IPluginContext, hooks: PluginHooks): void {
+    public registerPlugin(
+        plugin: IPlugin,
+        context: IPluginContext,
+        hooks: PluginHooks,
+        zones: PluginZones
+    ): void {
         this.loadedPlugins.set(plugin.manifest.id, {
             plugin,
             context,
             manifest: plugin.manifest,
-            hooks
+            hooks,
+            zones
         });
     }
 
@@ -210,6 +234,53 @@ export class PluginManagerService {
     }
 
     /**
+     * Rebuild a plugin's zone facade and rebind it to the live context.
+     *
+     * Called immediately before re-entering a plugin's install/enable/
+     * init path so the plugin sees an open lifecycle window for
+     * `context.zones.register(...)` calls. The previous facade (if any)
+     * is closed and its zones disposed, then a fresh facade replaces
+     * `context.zones`.
+     *
+     * @param loaded - Loaded plugin record.
+     */
+    private rearmZones(loaded: ILoadedPlugin): void {
+        if (!this.zoneRegistry) {
+            return;
+        }
+        try {
+            loaded.zones.closeAndDisposeAll();
+        } catch (err) {
+            logger.warn({ err, pluginId: loaded.manifest.id }, 'Zone facade dispose threw during rearm');
+        }
+        this.zoneRegistry.disposeForPlugin(loaded.manifest.id);
+        const fresh = new PluginZones(loaded.manifest.id, this.zoneRegistry, loaded.context.logger);
+        loaded.zones = fresh;
+        loaded.context.zones = fresh;
+    }
+
+    /**
+     * Close a plugin's zone facade and drop every zone it owns.
+     *
+     * Called after a plugin's disable hook completes so any zones
+     * declared during init/enable are removed from the registry
+     * regardless of whether the plugin code remembered to dispose them
+     * itself.
+     *
+     * @param loaded - Loaded plugin record.
+     */
+    private disposeZones(loaded: ILoadedPlugin): void {
+        try {
+            loaded.zones.closeAndDisposeAll();
+        } catch (err) {
+            logger.warn({ err, pluginId: loaded.manifest.id }, 'Zone facade dispose threw');
+        }
+        if (this.zoneRegistry) {
+            this.zoneRegistry.disposeForPlugin(loaded.manifest.id);
+        }
+    }
+
+    /**
      * Get all loaded plugin manifests.
      *
      * @returns Array of plugin manifests for all discovered plugins
@@ -242,9 +313,11 @@ export class PluginManagerService {
                 return { success: false, message: 'Plugin metadata not found' };
             }
 
-            // Rebind a fresh hook facade so the plugin's install/enable/init
-            // path sees an open lifecycle window.
+            // Rebind fresh per-plugin facades so the plugin's install/
+            // enable/init path sees open lifecycle windows for hooks and
+            // zones.
             this.rearmHooks(loaded);
+            this.rearmZones(loaded);
 
             // Run install hook if not already installed
             if (!metadata.installed && plugin.install) {
@@ -265,10 +338,12 @@ export class PluginManagerService {
                 await plugin.init(context);
             }
 
-            // Seal the lifecycle window. Subsequent register() attempts
-            // (e.g. inside request handlers) now throw — handlers
-            // registered during install/enable/init stay live.
+            // Seal the lifecycle windows. Subsequent register() attempts
+            // (e.g. inside request handlers) now throw — handlers and
+            // zone declarations registered during install/enable/init
+            // stay live.
             loaded.hooks.seal();
+            loaded.zones.seal();
 
             // Mark as enabled in database
             await this.metadataService.markEnabled(pluginId);
@@ -324,10 +399,11 @@ export class PluginManagerService {
         }
 
         try {
-            // Close the plugin's hook facade and drop every handler it
-            // registered, regardless of whether the plugin's disable hook
-            // remembered to call disposers itself.
+            // Close the plugin's per-plugin facades and drop every
+            // registration they hold, regardless of whether the plugin's
+            // disable hook remembered to call disposers itself.
             this.disposeHooks(loaded);
+            this.disposeZones(loaded);
 
             // Mark as disabled in database
             await this.metadataService.markDisabled(pluginId);
@@ -381,13 +457,15 @@ export class PluginManagerService {
                 return { success: false, message: 'Plugin is already installed' };
             }
 
-            // Rearm the hook facade so the install hook may register
-            // handlers. A previous disable/uninstall cycle leaves the
-            // facade closed (closeAndDisposeAll flips it shut), and the
-            // install lifecycle window is one of the three points where
-            // context.hooks.register(...) is allowed — reinstall and
-            // upgrade flows depend on this being a fresh facade.
+            // Rearm the per-plugin facades so the install hook may
+            // register handlers and declare zones. A previous disable/
+            // uninstall cycle leaves the facades closed, and the install
+            // lifecycle window is one of the three points where
+            // context.hooks.register(...) and context.zones.register(...)
+            // are allowed — reinstall and upgrade flows depend on these
+            // being fresh facades.
             this.rearmHooks(loaded);
+            this.rearmZones(loaded);
 
             // Run install hook if defined
             if (plugin.install) {
@@ -395,9 +473,10 @@ export class PluginManagerService {
                 await plugin.install(context);
             }
 
-            // Seal the install lifecycle window. The next enable cycle
-            // will rearm the facade before plugin.enable/init runs.
+            // Seal the install lifecycle windows. The next enable cycle
+            // will rearm the facades before plugin.enable/init runs.
             loaded.hooks.seal();
+            loaded.zones.seal();
 
             // Mark as installed in database
             await this.metadataService.markInstalled(pluginId);
@@ -519,9 +598,10 @@ export class PluginManagerService {
                 return { success: false, message: 'Plugin is already enabled' };
             }
 
-            // Rebind a fresh hook facade so the plugin's enable/init path
-            // sees an open lifecycle window.
+            // Rebind fresh per-plugin facades so the plugin's enable/
+            // init path sees open lifecycle windows for hooks and zones.
             this.rearmHooks(loaded);
+            this.rearmZones(loaded);
 
             // Run enable hook if defined
             if (plugin.enable) {
@@ -535,8 +615,9 @@ export class PluginManagerService {
                 await plugin.init(context);
             }
 
-            // Seal the lifecycle window now that enable+init have run.
+            // Seal the lifecycle windows now that enable+init have run.
             loaded.hooks.seal();
+            loaded.zones.seal();
 
             // Mark as enabled in database
             await this.metadataService.markEnabled(pluginId);
@@ -601,10 +682,11 @@ export class PluginManagerService {
         }
 
         try {
-            // Close the plugin's hook facade and drop every handler it
-            // registered, regardless of whether the plugin's disable hook
-            // remembered to call disposers itself.
+            // Close the plugin's per-plugin facades and drop every
+            // registration they hold, regardless of whether the plugin's
+            // disable hook remembered to call disposers itself.
             this.disposeHooks(loaded);
+            this.disposeZones(loaded);
 
             // Mark as disabled in database
             await this.metadataService.markDisabled(pluginId);

--- a/src/backend/services/widget/__tests__/widget.service.test.ts
+++ b/src/backend/services/widget/__tests__/widget.service.test.ts
@@ -136,12 +136,11 @@ describe('WidgetService', () => {
 
         it('should not warn on valid zones', async () => {
             const validZones = [
+                'ticker-after',
                 'main-before',
                 'main-after',
                 'plugin-content:before',
-                'plugin-content:after',
-                'sidebar-top',
-                'sidebar-bottom'
+                'plugin-content:after'
             ];
             for (const zone of validZones) {
                 await service.register(
@@ -151,6 +150,18 @@ describe('WidgetService', () => {
             }
 
             expect(mockLogger.warn).not.toHaveBeenCalled();
+        });
+
+        it('should warn on sidebar zones (no render sites — divergent from legacy WIDGET_ZONES)', async () => {
+            await service.register(
+                createWidget({ id: 'sidebar-widget', zone: 'sidebar-top' as any }),
+                'plugin'
+            );
+
+            expect(mockLogger.warn).toHaveBeenCalledWith(
+                'Widget registered with unknown zone',
+                expect.objectContaining({ zone: 'sidebar-top' })
+            );
         });
     });
 

--- a/src/backend/services/widget/widget.service.ts
+++ b/src/backend/services/widget/widget.service.ts
@@ -11,16 +11,17 @@ import type {
  * been injected yet — covers test paths that instantiate the service
  * without bootstrap wiring. Production always overrides this via
  * `setZoneRegistry(...)` immediately after bootstrap constructs the
- * registry.
+ * registry, so this set's job is to mirror the registry's declared
+ * core zones (see `modules/widgets/zones/descriptors.ts`) and nothing
+ * more — divergence would have widgets warn-or-not depending on
+ * whether the registry happened to be wired.
  */
 const FALLBACK_VALID_ZONES = new Set([
     'ticker-after',
     'main-before',
     'main-after',
     'plugin-content:before',
-    'plugin-content:after',
-    'sidebar-top',
-    'sidebar-bottom'
+    'plugin-content:after'
 ]);
 
 /**

--- a/src/backend/services/widget/widget.service.ts
+++ b/src/backend/services/widget/widget.service.ts
@@ -2,11 +2,18 @@ import type {
     IWidgetService,
     IWidgetConfig,
     IWidgetData,
-    ISystemLogService
+    ISystemLogService,
+    IZoneRegistry
 } from '@/types';
 
-/** Valid widget zone names for validation. */
-const VALID_ZONES = new Set([
+/**
+ * Fallback set used for zone validation when no `IZoneRegistry` has
+ * been injected yet — covers test paths that instantiate the service
+ * without bootstrap wiring. Production always overrides this via
+ * `setZoneRegistry(...)` immediately after bootstrap constructs the
+ * registry.
+ */
+const FALLBACK_VALID_ZONES = new Set([
     'ticker-after',
     'main-before',
     'main-after',
@@ -50,6 +57,7 @@ export class WidgetService implements IWidgetService {
     private static instance: WidgetService;
     private widgets: Map<string, IWidgetConfig> = new Map();
     private logger: ISystemLogService;
+    private zoneRegistry: IZoneRegistry | null = null;
 
     /**
      * Private constructor enforcing singleton pattern with dependency injection.
@@ -58,6 +66,37 @@ export class WidgetService implements IWidgetService {
      */
     private constructor(logger: ISystemLogService) {
         this.logger = logger;
+    }
+
+    /**
+     * Inject the process-wide zone registry.
+     *
+     * Called once during bootstrap after the registry is constructed so
+     * that subsequent widget registrations can validate `config.zone`
+     * against the live set of declared zones — including plugin-declared
+     * zones that the hardcoded fallback set could not anticipate.
+     *
+     * @param registry - Shared zone registry instance.
+     */
+    public setZoneRegistry(registry: IZoneRegistry): void {
+        this.zoneRegistry = registry;
+    }
+
+    /**
+     * Test whether a zone id is currently known.
+     *
+     * Prefers the injected `IZoneRegistry`; falls back to the hardcoded
+     * set when the registry has not been wired (e.g. unit tests
+     * instantiating the singleton directly).
+     *
+     * @param zone - Zone id to check.
+     * @returns True if the zone is known.
+     */
+    private isKnownZone(zone: string): boolean {
+        if (this.zoneRegistry) {
+            return this.zoneRegistry.has(zone);
+        }
+        return FALLBACK_VALID_ZONES.has(zone);
     }
 
     /**
@@ -91,13 +130,15 @@ export class WidgetService implements IWidgetService {
      * @returns Promise that resolves when registration is complete
      */
     public async register(config: IWidgetConfig, pluginId: string): Promise<void> {
-        // Validate zone name
-        if (!VALID_ZONES.has(config.zone)) {
+        // Validate zone name against the live registry (preferred) or
+        // the hardcoded fallback set when the registry has not been
+        // wired. Unknown zones produce a warning but do not block
+        // registration — the warning is diagnostic, not authoritative.
+        if (!this.isKnownZone(config.zone)) {
             this.logger.warn('Widget registered with unknown zone', {
                 widgetId: config.id,
                 pluginId,
-                zone: config.zone,
-                validZones: Array.from(VALID_ZONES)
+                zone: config.zone
             });
         }
 


### PR DESCRIPTION
## Summary

- Introduces a typed widget-zone registry mirroring the hook system: `defineZone` constructor with identity tracking, runtime `ZoneRegistry`, per-plugin `PluginZones` facade scoped to lifecycle, and an admin introspection endpoint at `/api/admin/system/zones`.
- Core zones (`ticker-after`, `main-before`, `main-after`, `plugin-content:before`, `plugin-content:after`) are declared in `modules/widgets/zones/descriptors.ts` and auto-populated as core-owned. Plugins declare additional zones via `context.zones.register(...)`, tagged with the plugin id and bulk-disposed on disable/uninstall through new `rearmZones`/`disposeZones` helpers in `PluginManagerService`.
- New `WidgetsModule` under `src/backend/modules/widgets/` owns the admin introspection route. `WidgetService.register` now validates zones against the live registry through a `setZoneRegistry` setter, falling back to the hardcoded set when unwired.
- First of three PRs implementing the widget type/placement split. PR 2 adds widget types plus Mongo-persisted placements; PR 3 adds the placement editor and removes the legacy widget service.

## Why now

Today's widget system bakes the placement decision (zone, routes, order) into plugin code, so adding a widget to a new route is a build-and-deploy event and operators have no UI to compose widget pages. The placement model split begins here by establishing the zone registry as the foundation. The registry also doubles as a fix for a leak in the existing system — `widgetService.unregisterAll(pluginId)` is never called by the plugin manager today, so plugin widgets leak past disable; the new facade pattern picks up the same disposer-ledger semantics the hook system already uses.

## Notes

- IPluginContext gains a `zones: IPluginZones` field. Existing plugin code reads context structurally; the new field does not break consumers.
- WidgetsModule mounts between Pages and User in both `bootstrapInit` and `bootstrapRun`.
- Zone runtime tests: 26 passing. Existing widget service tests: 26 passing. Hook tests: 27 passing. Full backend suite: 853 passing, 1 skipped.