### PR TITLE
Split widgets into types + placements; route legacy WidgetService through both

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -70,3 +70,22 @@ export type {
     IZoneSnapshotRecord,
     IPluginZones
 } from './widget-zones/index.js';
+export type {
+    IWidgetType,
+    IDefineWidgetTypeOptions,
+    WidgetDataFetcher,
+    WidgetTypeRegisterDisposer,
+    IWidgetTypeRegistry,
+    IWidgetTypeSnapshot,
+    IWidgetTypeSnapshotRecord,
+    IPluginWidgetTypes
+} from './widget-types/index.js';
+export type {
+    IWidgetPlacement,
+    IPlacementInput,
+    IPluginPlacementInput,
+    PlacementSource,
+    IPlacementService,
+    IPlacementListFilter,
+    IPlacementPatch
+} from './widget-placements/index.js';

--- a/packages/types/src/observer/IPluginContext.ts
+++ b/packages/types/src/observer/IPluginContext.ts
@@ -22,6 +22,7 @@ import type { IServiceRegistry } from '../services/IServiceRegistry.js';
 import type { ISignatureService } from '../services/ISignatureService.js';
 import type { IPluginHooks } from '../hooks/IPluginHooks.js';
 import type { IPluginZones } from '../widget-zones/IPluginZones.js';
+import type { IPluginWidgetTypes } from '../widget-types/IPluginWidgetTypes.js';
 import { ISystemLogService } from '../system-log/ISystemLogService.js';
 
 /**
@@ -204,6 +205,39 @@ export interface IPluginContext {
      * ```
      */
     zones: IPluginZones;
+
+    /**
+     * Plugin-scoped widget-type facade for declaring renderable
+     * widgets the operator can place across zones.
+     *
+     * Each registered type contributes a single SSR data fetcher and
+     * is paired with a frontend component built into the plugin's
+     * widget bundle (keyed by the type id). Placements — the records
+     * that decide *where* a type appears — are managed independently
+     * via the legacy widget-service compatibility shim (which creates
+     * one plugin-source placement per registered type) and, in
+     * future, via an operator-facing admin UI.
+     *
+     * Type declarations must happen during the plugin lifecycle
+     * (`install` / `enable` / `init`); registering from a request
+     * handler throws.
+     *
+     * @example
+     * ```typescript
+     * init: async (context) => {
+     *     context.widgetTypes.register({
+     *         id: 'whale-alerts:recent',
+     *         label: 'Recent Whale Activity',
+     *         description: 'Latest large transactions on TRON network.',
+     *         defaultDataFetcher: async () => {
+     *             const cache = await context.database.findOne('feed', {});
+     *             return { transactions: cache?.items ?? [] };
+     *         }
+     *     });
+     * }
+     * ```
+     */
+    widgetTypes: IPluginWidgetTypes;
 
     /** Structured logger scoped to the plugin for consistent telemetry */
     logger: ISystemLogService;

--- a/packages/types/src/widget-placements/IPlacementService.ts
+++ b/packages/types/src/widget-placements/IPlacementService.ts
@@ -1,0 +1,140 @@
+/**
+ * @fileoverview Widget placement service interface.
+ *
+ * `IPlacementService` owns the placement collection — CRUD operations
+ * plus the route-based query the resolver uses to populate SSR. The
+ * legacy widget-service compatibility shim calls
+ * `ensurePluginPlacement` on plugin enable and `softDisableForPlugin`
+ * on plugin disable; the admin API surface (future PR) drives the
+ * generic CRUD methods.
+ *
+ * Soft-disable semantics: plugin-source placements with `enabled:
+ * false` survive plugin disable, preserving operator customisations
+ * to `order` / `routes` / `title` for the next re-enable. Hard delete
+ * is reserved for operator action via admin UI.
+ *
+ * @module types/widget-placements/IPlacementService
+ */
+
+import type {
+    IWidgetPlacement,
+    IPlacementInput,
+    IPluginPlacementInput
+} from './IWidgetPlacement.js';
+
+/**
+ * Filter accepted by `list`. Future admin UI will narrow listings by
+ * zone, plugin, or source.
+ */
+export interface IPlacementListFilter {
+    zoneId?: string;
+    pluginId?: string;
+    source?: 'plugin' | 'operator';
+    enabledOnly?: boolean;
+}
+
+/**
+ * Patch shape for `update`. Any subset of operator-editable fields.
+ */
+export interface IPlacementPatch {
+    zoneId?: string;
+    routes?: string[];
+    order?: number;
+    title?: string;
+    instanceConfig?: Record<string, unknown>;
+    enabled?: boolean;
+}
+
+/**
+ * Process-wide placement service. One implementation per process,
+ * created during `WidgetsModule.init()` with the injected
+ * `IDatabaseService`.
+ */
+export interface IPlacementService {
+    /**
+     * Ensure a plugin-source placement exists for the given plugin +
+     * widget-type combination. On first call, creates a placement
+     * with all input fields and `enabled: true`. On subsequent calls
+     * (e.g. plugin re-enable after disable), finds the existing row
+     * and sets `enabled: true` without overwriting other fields —
+     * operator customisations to `order` / `routes` / `title` survive.
+     *
+     * Called by the legacy widget-service compatibility shim during
+     * plugin install / enable / init.
+     *
+     * @param input - Plugin placement parameters.
+     * @returns The resulting placement record (created or re-enabled).
+     */
+    ensurePluginPlacement(input: IPluginPlacementInput): Promise<IWidgetPlacement>;
+
+    /**
+     * Soft-disable every plugin-source placement for the given plugin
+     * by setting `enabled: false`. Operator-source placements are
+     * untouched. Called by `PluginManagerService` on plugin disable
+     * and uninstall.
+     *
+     * @param pluginId - Plugin whose placements should be disabled.
+     * @returns Count of placements modified.
+     */
+    softDisableForPlugin(pluginId: string): Promise<number>;
+
+    /**
+     * Find all placements relevant to the given route, sorted by
+     * `(zoneId asc, order asc)`. Includes only `enabled: true` rows.
+     * Route matching is exact: an empty `routes` array matches every
+     * route; otherwise the route must appear in the array.
+     *
+     * @param route - Request path the host derived from the URL.
+     * @returns Matching placements in deterministic render order.
+     */
+    findByRoute(route: string): Promise<ReadonlyArray<IWidgetPlacement>>;
+
+    /**
+     * Create a new placement. Operator-source by default unless
+     * `source` is provided. Used by the admin API.
+     *
+     * @param input - Full placement input.
+     * @param options - Source discriminator and optional plugin id.
+     * @returns The created record.
+     */
+    create(
+        input: IPlacementInput,
+        options?: { source?: 'plugin' | 'operator'; pluginId?: string }
+    ): Promise<IWidgetPlacement>;
+
+    /**
+     * Update a placement's operator-editable fields by id.
+     *
+     * @param id - Placement id (stringified ObjectId).
+     * @param patch - Subset of editable fields.
+     * @returns The updated record, or `null` when no placement with
+     *   that id exists.
+     */
+    update(id: string, patch: IPlacementPatch): Promise<IWidgetPlacement | null>;
+
+    /**
+     * Permanently delete a placement by id. Reserved for operator
+     * action — plugin lifecycle uses {@link softDisableForPlugin}
+     * instead so customisations survive disable/re-enable.
+     *
+     * @param id - Placement id.
+     * @returns True when a row was removed; false when no match.
+     */
+    delete(id: string): Promise<boolean>;
+
+    /**
+     * Find a single placement by id.
+     *
+     * @param id - Placement id.
+     * @returns The record, or `null` when no match.
+     */
+    findById(id: string): Promise<IWidgetPlacement | null>;
+
+    /**
+     * List placements with optional filter. Used by the admin UI.
+     *
+     * @param filter - Optional narrow.
+     * @returns Placements in `(zoneId asc, order asc)` order.
+     */
+    list(filter?: IPlacementListFilter): Promise<ReadonlyArray<IWidgetPlacement>>;
+}

--- a/packages/types/src/widget-placements/IWidgetPlacement.ts
+++ b/packages/types/src/widget-placements/IWidgetPlacement.ts
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview Widget placement record shape.
+ *
+ * A widget placement is the operator-managed *instance* of a widget
+ * type at a particular zone, with optional route filtering and
+ * per-instance configuration. Plugin-source placements are
+ * automatically created/maintained by the legacy widget-service
+ * compatibility shim; operator-source placements are created via the
+ * admin API (forthcoming in a future PR).
+ *
+ * The split between widget *type* (code) and widget *placement* (data)
+ * is the structural change PR 2 introduces. Type code change → new
+ * deploy required. Placement change → operator action via admin UI,
+ * survives plugin disable/re-enable.
+ *
+ * @module types/widget-placements/IWidgetPlacement
+ */
+
+/**
+ * Discriminator distinguishing plugin-seeded placements from
+ * operator-created placements. Disable behaviour and admin-UI
+ * editability vary between the two.
+ *
+ * - `'plugin'` — Created via the legacy widget-service compatibility
+ *   shim when a plugin registers a widget. Soft-disabled (set
+ *   `enabled: false`) on plugin disable so operator customisations
+ *   to `order` / `routes` / `title` survive the disable/re-enable
+ *   cycle.
+ * - `'operator'` — Created via the admin API by a human operator.
+ *   Lifecycle is independent of any plugin's enable state.
+ */
+export type PlacementSource = 'plugin' | 'operator';
+
+/**
+ * Public-facing placement record. The Mongo document interface
+ * extends this with `_id`; the API surface uses the string `id` form.
+ */
+export interface IWidgetPlacement {
+    /** Stable identifier (stringified ObjectId for Mongo-backed rows). */
+    readonly id: string;
+    /** Widget-type id this placement renders. */
+    readonly typeId: string;
+    /** Zone id this placement targets. */
+    readonly zoneId: string;
+    /** Route filter — empty array matches every route. */
+    readonly routes: ReadonlyArray<string>;
+    /** Sort order within the zone (lower renders first). */
+    readonly order: number;
+    /** Optional heading rendered above the widget. */
+    readonly title?: string;
+    /**
+     * Per-instance configuration the widget type's data fetcher /
+     * component may consume. Validated against the type's
+     * `configSchema` if provided (admin UI concern, forthcoming).
+     */
+    readonly instanceConfig?: Record<string, unknown>;
+    /** Whether the placement currently renders. */
+    readonly enabled: boolean;
+    /** Source discriminator — see {@link PlacementSource}. */
+    readonly source: PlacementSource;
+    /** Plugin id that owns the placement when `source === 'plugin'`. */
+    readonly pluginId?: string;
+    /** ISO-8601 creation timestamp. */
+    readonly createdAt: string;
+    /** ISO-8601 last-update timestamp. */
+    readonly updatedAt: string;
+}
+
+/**
+ * Input shape for placement CRUD. The discriminator and timestamps
+ * are populated by the service; the caller supplies the rest.
+ */
+export interface IPlacementInput {
+    typeId: string;
+    zoneId: string;
+    routes: string[];
+    order?: number;
+    title?: string;
+    instanceConfig?: Record<string, unknown>;
+    enabled?: boolean;
+}
+
+/**
+ * Convenience input shape for plugin-source placements created via
+ * the legacy widget-service compatibility shim. Forces `source` and
+ * carries the owning plugin id.
+ */
+export interface IPluginPlacementInput extends IPlacementInput {
+    pluginId: string;
+}

--- a/packages/types/src/widget-placements/index.ts
+++ b/packages/types/src/widget-placements/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Public type surface for widget placement persistence.
+ *
+ * Re-exports the placement record, input shapes, and service contract
+ * so consumers can import them from a single barrel.
+ *
+ * @module types/widget-placements
+ */
+
+export type {
+    IWidgetPlacement,
+    IPlacementInput,
+    IPluginPlacementInput,
+    PlacementSource
+} from './IWidgetPlacement.js';
+
+export type {
+    IPlacementService,
+    IPlacementListFilter,
+    IPlacementPatch
+} from './IPlacementService.js';

--- a/packages/types/src/widget-types/IPluginWidgetTypes.ts
+++ b/packages/types/src/widget-types/IPluginWidgetTypes.ts
@@ -1,0 +1,85 @@
+/**
+ * @fileoverview Per-plugin widget-type facade exposed via IPluginContext.
+ *
+ * Plugins never touch the global `IWidgetTypeRegistry` directly. They
+ * receive an `IPluginWidgetTypes` instance scoped to their plugin id,
+ * which constructs descriptors via `defineWidgetType` on the plugin's
+ * behalf, tags every registration with the plugin id, enforces the
+ * lifecycle window (registration permitted only while the facade is
+ * open), and collects disposers so the plugin loader can drop every
+ * declared type on `disable()` without the plugin tracking them by
+ * hand.
+ *
+ * Mirrors the shape of `IPluginZones` and `IPluginHooks` so plugin
+ * code learns one pattern for participating in extension surfaces.
+ *
+ * @module types/widget-types/IPluginWidgetTypes
+ */
+
+import type {
+    IDefineWidgetTypeOptions,
+    WidgetTypeRegisterDisposer
+} from './IWidgetType.js';
+
+/**
+ * Plugin-scoped view of the widget-type registry. Surfaced as
+ * `context.widgetTypes` in the plugin context.
+ */
+export interface IPluginWidgetTypes {
+    /**
+     * Declare a widget type owned by this plugin.
+     *
+     * Plugins declare widget types to publish renderable widgets the
+     * operator can place across zones. Each type contributes a single
+     * SSR data fetcher (`defaultDataFetcher`); the resolver invokes
+     * the fetcher once per placement at render time.
+     *
+     * Registration is only valid during the plugin lifecycle
+     * (`install` / `enable` / `init`). Calling it from a request
+     * handler throws — there is no mid-request mutation of the
+     * widget-type catalog.
+     *
+     * If a type with the same id is already registered to a different
+     * plugin, the call throws. The disposer returned removes only
+     * this plugin's claim.
+     *
+     * @param options - Widget-type configuration. The descriptor is
+     *   constructed on the plugin's behalf with the plugin id tagged
+     *   automatically.
+     * @returns Disposer that removes this specific registration. The
+     *   loader tracks disposers per plugin so calling `disable()` on
+     *   the plugin removes every type it owns; the disposer is
+     *   exposed for finer-grained control but is not required for
+     *   correctness.
+     *
+     * @example
+     * ```typescript
+     * init: async (context: IPluginContext) => {
+     *     context.widgetTypes.register({
+     *         id: 'whale-alerts:recent',
+     *         label: 'Recent Whale Activity',
+     *         description: 'Latest large transactions on TRON network.',
+     *         defaultDataFetcher: async () => {
+     *             const cache = await context.database.findOne('feed', {});
+     *             return { transactions: cache?.items ?? [] };
+     *         }
+     *     });
+     * }
+     * ```
+     */
+    register(options: IDefineWidgetTypeOptions): WidgetTypeRegisterDisposer;
+
+    /**
+     * Close the lifecycle window without disposing declared types.
+     *
+     * Called by the platform after `install` / `enable` / `init`
+     * finish so any later `register()` attempt throws instead of
+     * silently extending the plugin's surface. Types stay registered
+     * for the plugin's enabled lifetime — only the open flag flips.
+     *
+     * Idempotent. Disable/uninstall paths instead invoke the
+     * implementation's bulk-dispose method, which both seals and
+     * drops every type.
+     */
+    seal(): void;
+}

--- a/packages/types/src/widget-types/IWidgetType.ts
+++ b/packages/types/src/widget-types/IWidgetType.ts
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview Typed descriptor for a declared widget type.
+ *
+ * A widget type is the *capability* a plugin ships — a renderable
+ * component plus the SSR data fetcher that produces its initial
+ * payload. Placements are operator-managed records that point at a
+ * widget type and decide where it appears, in what order, and with
+ * what optional instance configuration.
+ *
+ * Widget type descriptors are minted by `defineWidgetType(...)` which
+ * tracks them in a module-local set so the runtime registry can reject
+ * forged descriptors. Plugins do not import `defineWidgetType`
+ * directly; they call `context.widgetTypes.register(options)` and the
+ * facade constructs the descriptor on their behalf, tagging it with
+ * the plugin id.
+ *
+ * @module types/widget-types/IWidgetType
+ */
+
+/**
+ * SSR data fetcher signature shared between widget types and the
+ * legacy widget service. Receives the resolved route and any params
+ * extracted by the host (e.g. `{ address }` on `/u/[address]`) and
+ * returns the JSON-serialisable data the frontend component renders.
+ *
+ * Implementations must return quickly (under 5 s; the resolver enforces
+ * a Promise.race timeout) and should not throw — return an empty
+ * payload on internal error so a single failing widget cannot drag
+ * down the page.
+ */
+export type WidgetDataFetcher = (
+    route: string,
+    params: Record<string, string>
+) => Promise<unknown>;
+
+/**
+ * Immutable descriptor for a single widget type. Returned by
+ * `defineWidgetType` and stored in the runtime registry. The frontend
+ * widget component registry is keyed by `id`; placement records
+ * reference `id` via their `typeId` field.
+ *
+ * The descriptor is frozen on construction. Mutating it raises a
+ * runtime error and breaks the identity check the registry performs
+ * at registration time.
+ */
+export interface IWidgetType {
+    /** Dotted, fully qualified id — e.g. `whale-alerts:recent`. */
+    readonly id: string;
+    /** Short label rendered in admin UIs (palette, placement editor). */
+    readonly label: string;
+    /** Sentence-length description shown on hover and in admin tooling. */
+    readonly description: string;
+    /**
+     * Optional category for admin-UI palette grouping (e.g.
+     * `'analytics'`, `'social'`). Unused at runtime.
+     */
+    readonly category?: string;
+    /**
+     * SSR data fetcher invoked by the resolver. Receives the route
+     * and params extracted by the host and returns the JSON payload
+     * the frontend component renders.
+     */
+    readonly defaultDataFetcher: WidgetDataFetcher;
+    /**
+     * Optional schema describing the operator-editable instance
+     * configuration this widget type accepts. Reserved for the
+     * admin placement editor in a future PR; today the resolver
+     * does not forward instanceConfig anywhere, so this field is
+     * informational only.
+     */
+    readonly configSchema?: unknown;
+}
+
+/**
+ * Initialisation options accepted by `defineWidgetType`.
+ *
+ * Plugins pass the same shape to `context.widgetTypes.register(...)` —
+ * the facade constructs the descriptor on their behalf so plugin
+ * code never imports `defineWidgetType` directly.
+ */
+export interface IDefineWidgetTypeOptions {
+    /** Dotted, fully qualified id. Must be unique across the process. */
+    id: string;
+    /** Short label for admin UIs. */
+    label: string;
+    /** Sentence-length description. */
+    description: string;
+    /** Optional category for admin-UI palette grouping. */
+    category?: string;
+    /** SSR data fetcher. See {@link WidgetDataFetcher}. */
+    defaultDataFetcher: WidgetDataFetcher;
+    /** Optional instance-config schema. Informational in this PR. */
+    configSchema?: unknown;
+}
+
+/**
+ * Disposer returned from widget-type registration. Calling it removes
+ * the type from the runtime registry — placements pointing at the
+ * removed type resolve to "type unavailable" and the resolver skips
+ * them silently. Plugin-owned types are bulk-disposed by the plugin
+ * loader on `disable()`; the disposer is exposed for finer-grained
+ * control but not required for correctness.
+ */
+export type WidgetTypeRegisterDisposer = () => void;

--- a/packages/types/src/widget-types/IWidgetTypeRegistry.ts
+++ b/packages/types/src/widget-types/IWidgetTypeRegistry.ts
@@ -102,6 +102,29 @@ export interface IWidgetTypeRegistry {
     get(typeId: string): IWidgetType | undefined;
 
     /**
+     * Return the plugin id that currently owns the given widget-type
+     * id, or `undefined` when the id is not registered.
+     *
+     * Used by the legacy `WidgetService` compatibility shim to
+     * distinguish three cases when a plugin registers a widget:
+     *
+     * - Owner equals the current plugin — same-plugin re-registration
+     *   (hot reload). Skip the registry call to avoid the
+     *   `defineWidgetType` duplicate-id throw; the existing
+     *   descriptor stays in place.
+     * - Owner is `undefined` — fresh registration. Mint a descriptor
+     *   and register it.
+     * - Owner is some other plugin — cross-plugin id collision.
+     *   Refuse to create the placement to prevent the new plugin's
+     *   placement from silently inheriting the first plugin's
+     *   data fetcher.
+     *
+     * @param typeId - Type id to query.
+     * @returns Owning plugin id, or `undefined` if unregistered.
+     */
+    getOwnerPluginId(typeId: string): string | undefined;
+
+    /**
      * Produce the introspection snapshot consumed by the admin
      * endpoint. The snapshot groups every registered type by
      * declaring plugin.

--- a/packages/types/src/widget-types/IWidgetTypeRegistry.ts
+++ b/packages/types/src/widget-types/IWidgetTypeRegistry.ts
@@ -1,0 +1,110 @@
+/**
+ * @fileoverview Global widget-type registry interface.
+ *
+ * The widget-type registry stores every declared type — currently only
+ * plugin-declared (no core widget types exist) — and serves the
+ * introspection snapshot consumed by the `/api/admin/system/widget-types`
+ * endpoint. There is one instance per process, constructed during
+ * bootstrap and threaded into plugin contexts the same way the hook
+ * and zone registries are.
+ *
+ * Plugins do not call the registry directly. They receive an
+ * `IPluginWidgetTypes` facade scoped to their plugin id which tags
+ * every registration and tracks disposers for lifecycle cleanup.
+ *
+ * @module types/widget-types/IWidgetTypeRegistry
+ */
+
+import type { IWidgetType, WidgetTypeRegisterDisposer } from './IWidgetType.js';
+
+/**
+ * Introspection record for a single registered widget type.
+ */
+export interface IWidgetTypeSnapshotRecord {
+    /** Dotted id from the descriptor. */
+    readonly id: string;
+    /** Short label. */
+    readonly label: string;
+    /** Sentence-length description. */
+    readonly description: string;
+    /** Optional category for palette grouping. */
+    readonly category: string | null;
+    /** Plugin id that declared the type, or `'core'`. */
+    readonly pluginId: string;
+    /** ISO-8601 timestamp the type was registered with the runtime. */
+    readonly registeredAt: string;
+    /**
+     * Best-effort source location captured at registration time. May
+     * be `null` when the runtime cannot resolve a callsite.
+     */
+    readonly source: string | null;
+}
+
+/**
+ * Top-level introspection payload returned from `snapshot()` and
+ * served by the admin endpoint. Types are grouped by plugin so the
+ * placement editor can render the palette organised by source.
+ */
+export interface IWidgetTypeSnapshot {
+    /** Groups in display order, one per declaring plugin. */
+    readonly groups: ReadonlyArray<{
+        readonly pluginId: string;
+        readonly types: ReadonlyArray<IWidgetTypeSnapshotRecord>;
+    }>;
+}
+
+/**
+ * Process-wide widget-type registry. Implementations are responsible
+ * for storing declared types, enforcing the descriptor-identity check,
+ * detecting cross-plugin id conflicts, and producing the snapshot
+ * consumed by introspection.
+ */
+export interface IWidgetTypeRegistry {
+    /**
+     * Register a declared widget type.
+     *
+     * The descriptor must have been produced by `defineWidgetType`;
+     * the runtime tracks every minted descriptor and refuses forged
+     * objects. If a type with the same id is already registered to a
+     * different plugin, the call throws — type ids are exclusive to
+     * their declaring component.
+     *
+     * @param pluginId - Plugin (or `'core'`) declaring the type.
+     * @param descriptor - Descriptor minted by `defineWidgetType`.
+     * @returns Disposer that removes the type from the registry.
+     */
+    register(pluginId: string, descriptor: IWidgetType): WidgetTypeRegisterDisposer;
+
+    /**
+     * Drop every widget type declared by the given plugin.
+     *
+     * @param pluginId - Plugin whose types should be removed.
+     * @returns Count of types removed.
+     */
+    disposeForPlugin(pluginId: string): number;
+
+    /**
+     * Check whether a widget-type id is currently registered.
+     *
+     * @param typeId - Type id to check.
+     * @returns True if the type is registered.
+     */
+    has(typeId: string): boolean;
+
+    /**
+     * Retrieve the registered descriptor for a type by id. Returns
+     * `undefined` when no type with that id is registered. Used by
+     * the placement resolver to look up the data fetcher.
+     *
+     * @param typeId - Type id to look up.
+     * @returns Descriptor or `undefined`.
+     */
+    get(typeId: string): IWidgetType | undefined;
+
+    /**
+     * Produce the introspection snapshot consumed by the admin
+     * endpoint. The snapshot groups every registered type by
+     * declaring plugin.
+     */
+    snapshot(): IWidgetTypeSnapshot;
+}

--- a/packages/types/src/widget-types/index.ts
+++ b/packages/types/src/widget-types/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Public type surface for the widget-type system.
+ *
+ * Re-exports the descriptor, registry, and per-plugin facade types so
+ * consumers can import them from a single barrel.
+ *
+ * @module types/widget-types
+ */
+
+export type {
+    IWidgetType,
+    IDefineWidgetTypeOptions,
+    WidgetDataFetcher,
+    WidgetTypeRegisterDisposer
+} from './IWidgetType.js';
+
+export type {
+    IWidgetTypeRegistry,
+    IWidgetTypeSnapshot,
+    IWidgetTypeSnapshotRecord
+} from './IWidgetTypeRegistry.js';
+
+export type { IPluginWidgetTypes } from './IPluginWidgetTypes.js';

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -31,7 +31,7 @@ import { LogsModule } from './modules/logs/index.js';
 import { DatabaseModule } from './modules/database/index.js';
 import { ClickHouseModule } from './modules/clickhouse/index.js';
 import { PagesModule } from './modules/pages/index.js';
-import { WidgetsModule, ZoneRegistry } from './modules/widgets/index.js';
+import { WidgetsModule, ZoneRegistry, WidgetTypeRegistry } from './modules/widgets/index.js';
 import { UserModule } from './modules/user/index.js';
 import { AddressLabelsModule } from './modules/address-labels/index.js';
 import { ToolsModule } from './modules/tools/index.js';
@@ -45,7 +45,7 @@ import { UsdtParametersService } from './modules/usdt-parameters/usdt-parameters
 import { createApiRouter } from './api/routes/index.js';
 import { PluginManagerService } from './services/plugin-manager.service.js';
 import type { Express } from 'express';
-import type { IDatabaseService, IMenuService, IMenuNode, IPluginManifest, IServiceRegistry, IHookRegistry, IZoneRegistry } from '@/types';
+import type { IDatabaseService, IMenuService, IMenuNode, IPluginManifest, IServiceRegistry, IHookRegistry, IZoneRegistry, IWidgetTypeRegistry } from '@/types';
 import axios from 'axios';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -143,7 +143,7 @@ async function bootstrap(): Promise<void> {
             await logger.waitUntilInitialized();
             // Pass scheduler to plugins for context.scheduler injection
             const scheduler = ctx.modules.scheduler.getSchedulerService();
-            await loadPlugins(ctx.coreDatabase, scheduler, ctx.serviceRegistry, ctx.hookRegistry, ctx.zoneRegistry);
+            await loadPlugins(ctx.coreDatabase, scheduler, ctx.serviceRegistry, ctx.hookRegistry, ctx.zoneRegistry, ctx.widgetTypeRegistry);
         } catch (pluginError) {
             logger.error({ pluginError, stack: pluginError instanceof Error ? pluginError.stack : undefined }, 'Plugin initialization failed');
         }
@@ -215,6 +215,7 @@ interface BootstrapContext {
     serviceRegistry: IServiceRegistry;
     hookRegistry: IHookRegistry;
     zoneRegistry: IZoneRegistry;
+    widgetTypeRegistry: IWidgetTypeRegistry;
     modules: {
         database: DatabaseModule;
         clickhouse: ClickHouseModule;
@@ -296,6 +297,13 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     // (for the per-plugin facade exposed on context.zones).
     const zoneRegistry = new ZoneRegistry(logger);
 
+    // Widget-type registry stores the renderable widget types plugins
+    // declare via context.widgetTypes.register(...). Mirrors the zone
+    // registry's bootstrap-owned shape so the plugin loader's facade
+    // construction and WidgetsModule's placement resolver receive the
+    // same instance.
+    const widgetTypeRegistry = new WidgetTypeRegistry(logger);
+
     // Register shared infrastructure on the service registry so modules and
     // plugins can discover them via late-binding DI instead of importing
     // concrete classes.
@@ -308,7 +316,7 @@ async function bootstrapInit(): Promise<BootstrapContext> {
 
     const cacheService = new CacheService(getRedisClient(), coreDatabase);
 
-    const sharedDeps = { database: coreDatabase, cacheService, menuService, serviceRegistry, hookRegistry, zoneRegistry, app };
+    const sharedDeps = { database: coreDatabase, cacheService, menuService, serviceRegistry, hookRegistry, zoneRegistry, widgetTypeRegistry, app };
 
     const logsModule = new LogsModule();
     const pagesModule = new PagesModule();
@@ -336,6 +344,7 @@ async function bootstrapInit(): Promise<BootstrapContext> {
         serviceRegistry,
         hookRegistry,
         zoneRegistry,
+        widgetTypeRegistry,
         modules: {
             database: databaseModule,
             clickhouse: clickHouseModule,

--- a/src/backend/loaders/plugins.ts
+++ b/src/backend/loaders/plugins.ts
@@ -251,6 +251,7 @@ export async function loadPlugins(
             // PluginManagerService.
             loaded.hooks.seal();
             loaded.zones.seal();
+            loaded.widgetTypes.seal();
 
             // Register widgets if defined
             if (plugin.widgets && plugin.widgets.length > 0) {

--- a/src/backend/loaders/plugins.ts
+++ b/src/backend/loaders/plugins.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import mongoose from 'mongoose';
-import type { IPluginContext, IPlugin, IDatabaseService, ISchedulerService, IServiceRegistry, IHookRegistry, IZoneRegistry } from '@/types';
+import type { IPluginContext, IPlugin, IDatabaseService, ISchedulerService, IServiceRegistry, IHookRegistry, IZoneRegistry, IWidgetTypeRegistry } from '@/types';
 import { PluginHooks } from '../hooks/index.js';
-import { PluginZones } from '../modules/widgets/index.js';
+import { PluginZones, PluginWidgetTypes } from '../modules/widgets/index.js';
 import { logger } from '../lib/logger.js';
 import { BlockchainObserverService } from '../services/blockchain-observer/index.js';
 import { BaseObserver, BaseBatchObserver, BaseBlockObserver } from '../modules/blockchain/observers/index.js';
@@ -67,7 +67,8 @@ export async function loadPlugins(
     scheduler: ISchedulerService | null,
     serviceRegistry: IServiceRegistry,
     hookRegistry: IHookRegistry,
-    zoneRegistry: IZoneRegistry
+    zoneRegistry: IZoneRegistry,
+    widgetTypeRegistry: IWidgetTypeRegistry
 ): Promise<void> {
     await logger.waitUntilInitialized();
 
@@ -80,6 +81,7 @@ export async function loadPlugins(
     const pluginManager = PluginManagerService.getInstance();
     pluginManager.setHookRegistry(hookRegistry);
     pluginManager.setZoneRegistry(zoneRegistry);
+    pluginManager.setWidgetTypeRegistry(widgetTypeRegistry);
     const observerService = BlockchainObserverService.getInstance();
 
     logger.info(`Discovered ${pluginList.length} plugins`);
@@ -159,6 +161,12 @@ export async function loadPlugins(
             // when the plugin is disabled or uninstalled.
             const pluginZones = new PluginZones(plugin.manifest.id, zoneRegistry, pluginLogger);
 
+            // Per-plugin widget-type facade. Mirrors the zone facade —
+            // widget types declared during install/enable/init are
+            // disposed on disable, and the placement service's
+            // soft-disable path handles the matching placement rows.
+            const pluginWidgetTypes = new PluginWidgetTypes(plugin.manifest.id, widgetTypeRegistry, pluginLogger);
+
             // Create plugin context with injected dependencies
             const context: IPluginContext = {
                 http: httpClient,
@@ -185,11 +193,12 @@ export async function loadPlugins(
                 services: serviceRegistry,
                 hooks: pluginHooks,
                 zones: pluginZones,
+                widgetTypes: pluginWidgetTypes,
                 logger: pluginLogger
             };
 
             // Register plugin in the manager (does not initialize)
-            pluginManager.registerPlugin(plugin, context, pluginHooks, pluginZones);
+            pluginManager.registerPlugin(plugin, context, pluginHooks, pluginZones, pluginWidgetTypes);
 
             pluginLogger.debug('Plugin discovered and registered');
         } catch (error) {

--- a/src/backend/modules/widgets/WidgetsModule.ts
+++ b/src/backend/modules/widgets/WidgetsModule.ts
@@ -1,18 +1,22 @@
 /**
  * @fileoverview Widget module — IModule implementation.
  *
- * Owns the widget-zone subsystem in PR 1: receives the bootstrap-owned
- * `ZoneRegistry` instance via dependency injection, mounts the admin
- * introspection endpoint at `/api/admin/system/zones`. Future PRs add
- * the widget-type registry, placement persistence, and the SSR
- * resolution pipeline to this same module so all widget concerns live
- * in one tree.
+ * Owns three subsystems in PR 2: the widget-zone registry (PR 1
+ * scaffolding, still bootstrap-instantiated), the widget-type
+ * registry (also bootstrap-instantiated, plugin-declared types), and
+ * the new placement-persistence layer that records every operator-
+ * or plugin-source placement in MongoDB and resolves them at SSR
+ * time. The legacy `WidgetService` becomes a compatibility shim that
+ * delegates type registration and placement upsert/disable/fetch to
+ * this module's services, keeping every existing plugin working
+ * with no plugin-side code change.
  *
- * The zone registry itself is constructed in `bootstrapInit` alongside
- * the hook registry — the module does not own its lifecycle. This
- * mirrors the hook-registry pattern: the registry is process-wide
- * infrastructure shared between the plugin loader and the module that
- * exposes it.
+ * The registries (zones, widget types) are constructed in
+ * `bootstrapInit` and threaded through `sharedDeps` so the plugin
+ * loader's per-plugin facades and this module both receive the same
+ * instances. The placement service is module-owned because it needs
+ * the `IDatabaseService` injected via module DI and has no plugin-
+ * facing surface.
  *
  * @module backend/modules/widgets/WidgetsModule
  */
@@ -21,7 +25,9 @@ import type { Express, Router } from 'express';
 import type {
     IModule,
     IModuleMetadata,
+    IDatabaseService,
     IZoneRegistry,
+    IWidgetTypeRegistry,
     ISystemLogService
 } from '@/types';
 import { logger } from '../../lib/logger.js';
@@ -29,17 +35,26 @@ import { requireAdmin } from '../../api/middleware/admin-auth.js';
 import { createAdminRateLimiter } from '../../api/middleware/rate-limit.js';
 import { ZonesController } from './api/zones.controller.js';
 import { createZonesAdminRouter } from './api/zones.routes.js';
+import { PlacementService } from './placements/placement.service.js';
+import { PlacementResolver } from './placements/placement-resolver.js';
+import { WidgetService } from '../../services/widget/widget.service.js';
 
 /**
  * Dependencies required by the widgets module.
  *
- * `zoneRegistry` is constructed in `bootstrapInit` and threaded through
- * `sharedDeps` so both this module and the plugin loader receive the
- * same instance.
+ * `zoneRegistry` and `widgetTypeRegistry` are constructed in
+ * `bootstrapInit` and threaded through `sharedDeps` so both this
+ * module and the plugin loader receive the same instances. `database`
+ * is the platform-shared `IDatabaseService` the placement service
+ * uses for the `module_widgets_placements` collection.
  */
 export interface IWidgetsModuleDependencies {
     /** Shared process-wide zone registry. */
     zoneRegistry: IZoneRegistry;
+    /** Shared process-wide widget-type registry. */
+    widgetTypeRegistry: IWidgetTypeRegistry;
+    /** Database service for placement persistence. */
+    database: IDatabaseService;
     /** Express app for admin route mounting. */
     app: Express;
 }
@@ -48,25 +63,38 @@ export interface IWidgetsModuleDependencies {
  * Widgets module class.
  *
  * Lifecycle:
- * - `init()` — store dependencies, construct admin controller.
- * - `run()` — mount the admin zone introspection router.
+ * - `init()` — store deps, configure the `PlacementService`
+ *   singleton, construct the `PlacementResolver`, and wire the
+ *   legacy `WidgetService` compatibility shim so plugin registrations
+ *   route into the new infrastructure.
+ * - `run()` — mount the admin zone introspection router (PR 1).
+ *   Future PRs add placement-CRUD admin routes here.
  */
 export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
     readonly metadata: IModuleMetadata = {
         id: 'widgets',
         name: 'Widgets',
-        version: '1.0.0',
+        version: '2.0.0',
         description: 'Widget zone registry, widget type catalog, and placement persistence.'
     };
 
     private zoneRegistry!: IZoneRegistry;
+    private widgetTypeRegistry!: IWidgetTypeRegistry;
+    private database!: IDatabaseService;
     private app!: Express;
     private zonesController!: ZonesController;
+    private placementService!: PlacementService;
+    private placementResolver!: PlacementResolver;
 
     private readonly logger: ISystemLogService = logger.child({ module: 'widgets' });
 
     /**
      * Initialise the module.
+     *
+     * Wires the placement subsystem and the legacy `WidgetService`
+     * compatibility shim so that, by the time `loadPlugins(...)` runs,
+     * every plugin call to `context.widgetService.register(...)` is
+     * already routed into the new type/placement infrastructure.
      *
      * @param dependencies - Injected dependencies.
      * @throws Error if any dependency is missing.
@@ -77,14 +105,42 @@ export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
         if (!dependencies.zoneRegistry) {
             throw new Error('WidgetsModule requires zoneRegistry dependency');
         }
+        if (!dependencies.widgetTypeRegistry) {
+            throw new Error('WidgetsModule requires widgetTypeRegistry dependency');
+        }
+        if (!dependencies.database) {
+            throw new Error('WidgetsModule requires database dependency');
+        }
         if (!dependencies.app) {
             throw new Error('WidgetsModule requires app dependency');
         }
 
         this.zoneRegistry = dependencies.zoneRegistry;
+        this.widgetTypeRegistry = dependencies.widgetTypeRegistry;
+        this.database = dependencies.database;
         this.app = dependencies.app;
 
         this.zonesController = new ZonesController(this.zoneRegistry, this.logger);
+
+        PlacementService.setDependencies(this.database, this.logger);
+        this.placementService = PlacementService.getInstance();
+        this.placementResolver = new PlacementResolver(
+            this.placementService,
+            this.widgetTypeRegistry,
+            this.logger
+        );
+
+        // Wire the legacy `WidgetService` compatibility shim. The
+        // singleton was already constructed during the plugin loader
+        // setup, but its widget-type and placement back-ends only
+        // become populated here. Plugin registrations during
+        // `loadPlugins(...)` (which runs after every module's `run()`)
+        // therefore see the fully-wired shim.
+        const widgetService = WidgetService.getInstance(this.logger);
+        widgetService.setZoneRegistry(this.zoneRegistry);
+        widgetService.setWidgetTypeRegistry(this.widgetTypeRegistry);
+        widgetService.setPlacementService(this.placementService);
+        widgetService.setPlacementResolver(this.placementResolver);
 
         this.logger.info('Widgets module initialized');
     }
@@ -92,10 +148,11 @@ export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
     /**
      * Activate the module — mount the admin zone introspection router.
      *
-     * The platform-default admin rate limiter runs before `requireAdmin`
-     * so the brute-force cost against the auth gate is bounded per IP
-     * (60 req / 60s). Matches the MenuModule `/manage` precedent and
-     * satisfies CodeQL's `js/missing-rate-limiting` rule.
+     * The platform-default admin rate limiter runs before
+     * `requireAdmin` so the brute-force cost against the auth gate is
+     * bounded per IP (60 req / 60s). Matches the MenuModule `/manage`
+     * precedent and satisfies CodeQL's `js/missing-rate-limiting`
+     * rule.
      */
     async run(): Promise<void> {
         this.logger.info('Running widgets module...');
@@ -109,16 +166,45 @@ export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
     }
 
     /**
-     * Accessor for the zone registry, exposed for tests and tooling
-     * that need to reach the registry through the module instance.
-     *
-     * @returns The registry passed into `init`.
-     * @throws Error when called before `init()`.
+     * Accessor for the zone registry, exposed for tests and tooling.
      */
     getZoneRegistry(): IZoneRegistry {
         if (!this.zoneRegistry) {
             throw new Error('WidgetsModule not initialized - call init() first');
         }
         return this.zoneRegistry;
+    }
+
+    /**
+     * Accessor for the widget-type registry, exposed for tests and
+     * tooling.
+     */
+    getWidgetTypeRegistry(): IWidgetTypeRegistry {
+        if (!this.widgetTypeRegistry) {
+            throw new Error('WidgetsModule not initialized - call init() first');
+        }
+        return this.widgetTypeRegistry;
+    }
+
+    /**
+     * Accessor for the placement service, exposed for tests, admin
+     * tooling, and any forthcoming CRUD endpoints.
+     */
+    getPlacementService(): PlacementService {
+        if (!this.placementService) {
+            throw new Error('WidgetsModule not initialized - call init() first');
+        }
+        return this.placementService;
+    }
+
+    /**
+     * Accessor for the SSR placement resolver. The compat-shim widget
+     * service delegates `fetchWidgetsForRoute` here.
+     */
+    getPlacementResolver(): PlacementResolver {
+        if (!this.placementResolver) {
+            throw new Error('WidgetsModule not initialized - call init() first');
+        }
+        return this.placementResolver;
     }
 }

--- a/src/backend/modules/widgets/__tests__/placements.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.test.ts
@@ -1,0 +1,445 @@
+/// <reference types="vitest" />
+
+/**
+ * @fileoverview Unit tests for placement persistence and SSR
+ * resolution.
+ *
+ * Exercises `PlacementService` against the shared in-memory
+ * Mongo mock, `PlacementResolver` against stubbed registry +
+ * service implementations, and the pure `routeMatches` predicate.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type {
+    ISystemLogService,
+    IWidgetPlacement,
+    IWidgetType,
+    IWidgetTypeRegistry,
+    IPlacementService
+} from '@/types';
+import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+import { PlacementService } from '../placements/placement.service.js';
+import { PlacementResolver } from '../placements/placement-resolver.js';
+import { routeMatches } from '../placements/route-matcher.js';
+
+class MockLogger implements ISystemLogService {
+    public level = 'info';
+    public fatal = vi.fn();
+    public error = vi.fn();
+    public warn = vi.fn();
+    public info = vi.fn();
+    public debug = vi.fn();
+    public trace = vi.fn();
+    public child = vi.fn((_b: Record<string, unknown>): ISystemLogService => this);
+    public async initialize() {}
+    public async saveLog() {}
+    public async getLogs() {
+        return { logs: [], total: 0, page: 1, limit: 50, totalPages: 0, hasNextPage: false, hasPrevPage: false };
+    }
+    public async markAsResolved() {}
+    public async cleanup() { return 0; }
+    public async getStatistics() { return { total: 0, byLevel: {} as any, byService: {}, unresolved: 0 }; }
+    public async getLogById() { return null; }
+    public async markAsUnresolved() { return null; }
+    public async deleteAllLogs() { return 0; }
+    public async getStats() { return { total: 0, byLevel: {} as any, resolved: 0, unresolved: 0 }; }
+    public async waitUntilInitialized() {}
+}
+
+describe('routeMatches', () => {
+    it('matches every route when the filter is empty', () => {
+        expect(routeMatches([], '/')).toBe(true);
+        expect(routeMatches([], '/anything')).toBe(true);
+    });
+
+    it('matches exact strings only when the filter is populated', () => {
+        expect(routeMatches(['/', '/markets'], '/')).toBe(true);
+        expect(routeMatches(['/', '/markets'], '/markets')).toBe(true);
+        expect(routeMatches(['/'], '/markets')).toBe(false);
+        expect(routeMatches(['/'], '/u/TXyz')).toBe(false);
+    });
+});
+
+describe('PlacementService.ensurePluginPlacement', () => {
+    let logger: MockLogger;
+    let db: ReturnType<typeof createMockDatabaseService>;
+    let service: PlacementService;
+
+    beforeEach(() => {
+        logger = new MockLogger();
+        db = createMockDatabaseService();
+        PlacementService.__resetForTests();
+        PlacementService.setDependencies(db, logger);
+        service = PlacementService.getInstance();
+    });
+
+    it('creates a new placement when none exists', async () => {
+        const placement = await service.ensurePluginPlacement({
+            typeId: 'whale-alerts:recent',
+            zoneId: 'main-after',
+            routes: ['/'],
+            order: 20,
+            title: 'Recent Whales',
+            pluginId: 'whale-alerts'
+        });
+
+        expect(placement.typeId).toBe('whale-alerts:recent');
+        expect(placement.zoneId).toBe('main-after');
+        expect(placement.routes).toEqual(['/']);
+        expect(placement.order).toBe(20);
+        expect(placement.title).toBe('Recent Whales');
+        expect(placement.pluginId).toBe('whale-alerts');
+        expect(placement.source).toBe('plugin');
+        expect(placement.enabled).toBe(true);
+    });
+
+    it('defaults order to 100 when not provided', async () => {
+        const placement = await service.ensurePluginPlacement({
+            typeId: 'p:t',
+            zoneId: 'main-after',
+            routes: [],
+            pluginId: 'p'
+        });
+
+        expect(placement.order).toBe(100);
+    });
+
+    it('preserves operator customisations on re-enable', async () => {
+        const first = await service.ensurePluginPlacement({
+            typeId: 'p:t',
+            zoneId: 'main-after',
+            routes: ['/'],
+            order: 50,
+            title: 'Original',
+            pluginId: 'p'
+        });
+
+        // Simulate operator customisation
+        await service.update(first.id, { order: 5, routes: ['/dashboard'], title: 'Operator Override' });
+        await service.softDisableForPlugin('p');
+
+        // Re-enable — plugin code calls ensurePluginPlacement with its
+        // original defaults again.
+        const reenabled = await service.ensurePluginPlacement({
+            typeId: 'p:t',
+            zoneId: 'main-after',
+            routes: ['/'],
+            order: 50,
+            title: 'Original',
+            pluginId: 'p'
+        });
+
+        expect(reenabled.enabled).toBe(true);
+        expect(reenabled.order).toBe(5);
+        expect(reenabled.routes).toEqual(['/dashboard']);
+        expect(reenabled.title).toBe('Operator Override');
+    });
+
+    it('rejects calls without a pluginId', async () => {
+        await expect(
+            service.ensurePluginPlacement({
+                typeId: 'p:t',
+                zoneId: 'main-after',
+                routes: [],
+                pluginId: ''
+            })
+        ).rejects.toThrow(/requires a pluginId/);
+    });
+});
+
+describe('PlacementService.softDisableForPlugin', () => {
+    let logger: MockLogger;
+    let db: ReturnType<typeof createMockDatabaseService>;
+    let service: PlacementService;
+
+    beforeEach(() => {
+        logger = new MockLogger();
+        db = createMockDatabaseService();
+        PlacementService.__resetForTests();
+        PlacementService.setDependencies(db, logger);
+        service = PlacementService.getInstance();
+    });
+
+    it('flips enabled=false on every plugin-source row for the plugin', async () => {
+        await service.ensurePluginPlacement({ typeId: 'a:t', zoneId: 'main-after', routes: [], pluginId: 'a' });
+        await service.ensurePluginPlacement({ typeId: 'a:u', zoneId: 'main-after', routes: [], pluginId: 'a' });
+        await service.ensurePluginPlacement({ typeId: 'b:t', zoneId: 'main-after', routes: [], pluginId: 'b' });
+
+        const modified = await service.softDisableForPlugin('a');
+
+        expect(modified).toBe(2);
+        const aPlacements = await service.list({ pluginId: 'a' });
+        expect(aPlacements.every(p => p.enabled === false)).toBe(true);
+        const bPlacements = await service.list({ pluginId: 'b' });
+        expect(bPlacements.every(p => p.enabled === true)).toBe(true);
+    });
+
+    it('does not touch operator-source rows', async () => {
+        await service.ensurePluginPlacement({ typeId: 'a:t', zoneId: 'main-after', routes: [], pluginId: 'a' });
+        const op = await service.create(
+            { typeId: 'a:t', zoneId: 'main-after', routes: [] },
+            { source: 'operator' }
+        );
+
+        await service.softDisableForPlugin('a');
+
+        const operatorAfter = await service.findById(op.id);
+        expect(operatorAfter?.enabled).toBe(true);
+    });
+
+    it('returns zero when the plugin owns nothing', async () => {
+        const modified = await service.softDisableForPlugin('phantom');
+        expect(modified).toBe(0);
+    });
+});
+
+describe('PlacementService.findByRoute', () => {
+    let logger: MockLogger;
+    let db: ReturnType<typeof createMockDatabaseService>;
+    let service: PlacementService;
+
+    beforeEach(() => {
+        logger = new MockLogger();
+        db = createMockDatabaseService();
+        PlacementService.__resetForTests();
+        PlacementService.setDependencies(db, logger);
+        service = PlacementService.getInstance();
+    });
+
+    it('returns only enabled placements matching the route', async () => {
+        await service.ensurePluginPlacement({ typeId: 'a:home', zoneId: 'main-after', routes: ['/'], pluginId: 'a' });
+        await service.ensurePluginPlacement({ typeId: 'a:markets', zoneId: 'main-after', routes: ['/markets'], pluginId: 'a' });
+        await service.ensurePluginPlacement({ typeId: 'a:all', zoneId: 'main-after', routes: [], pluginId: 'a' });
+
+        // Disable one and ensure it doesn't surface
+        const markets = await service.list({ pluginId: 'a' });
+        const marketsRow = markets.find(p => p.typeId === 'a:markets')!;
+        await service.update(marketsRow.id, { enabled: false });
+
+        const homeResults = await service.findByRoute('/');
+        const homeIds = homeResults.map(p => p.typeId);
+        expect(homeIds).toContain('a:home');
+        expect(homeIds).toContain('a:all');
+        expect(homeIds).not.toContain('a:markets');
+    });
+});
+
+describe('PlacementService CRUD', () => {
+    let logger: MockLogger;
+    let db: ReturnType<typeof createMockDatabaseService>;
+    let service: PlacementService;
+
+    beforeEach(() => {
+        logger = new MockLogger();
+        db = createMockDatabaseService();
+        PlacementService.__resetForTests();
+        PlacementService.setDependencies(db, logger);
+        service = PlacementService.getInstance();
+    });
+
+    it('create defaults source=operator and enabled=true', async () => {
+        const placement = await service.create({
+            typeId: 't',
+            zoneId: 'main-after',
+            routes: ['/']
+        });
+
+        expect(placement.source).toBe('operator');
+        expect(placement.enabled).toBe(true);
+        expect(placement.pluginId).toBeUndefined();
+    });
+
+    it('create rejects plugin-source without pluginId', async () => {
+        await expect(
+            service.create(
+                { typeId: 't', zoneId: 'main-after', routes: [] },
+                { source: 'plugin' }
+            )
+        ).rejects.toThrow(/requires options\.pluginId/);
+    });
+
+    it('update preserves untouched fields', async () => {
+        const placement = await service.create({
+            typeId: 't',
+            zoneId: 'main-after',
+            routes: ['/'],
+            order: 50,
+            title: 'Original'
+        });
+        const updated = await service.update(placement.id, { order: 5 });
+
+        expect(updated?.order).toBe(5);
+        expect(updated?.zoneId).toBe('main-after');
+        expect(updated?.title).toBe('Original');
+        expect(updated?.routes).toEqual(['/']);
+    });
+
+    it('update returns null for unknown ids', async () => {
+        const result = await service.update('507f1f77bcf86cd799439011', { order: 5 });
+        expect(result).toBeNull();
+    });
+
+    it('update returns null for malformed ids', async () => {
+        const result = await service.update('not-an-objectid', { order: 5 });
+        expect(result).toBeNull();
+    });
+
+    it('delete removes the row', async () => {
+        const placement = await service.create({ typeId: 't', zoneId: 'main-after', routes: [] });
+        const removed = await service.delete(placement.id);
+
+        expect(removed).toBe(true);
+        expect(await service.findById(placement.id)).toBeNull();
+    });
+
+    it('list applies filters', async () => {
+        await service.create({ typeId: 'a', zoneId: 'main-after', routes: [] });
+        await service.create({ typeId: 'b', zoneId: 'main-before', routes: [] });
+        await service.create({ typeId: 'c', zoneId: 'main-after', routes: [], enabled: false });
+
+        const filtered = await service.list({ zoneId: 'main-after' });
+        expect(filtered.map(p => p.typeId).sort()).toEqual(['a', 'c']);
+
+        const enabled = await service.list({ zoneId: 'main-after', enabledOnly: true });
+        expect(enabled.map(p => p.typeId)).toEqual(['a']);
+    });
+});
+
+describe('PlacementResolver', () => {
+    let logger: MockLogger;
+    let typeRegistry: IWidgetTypeRegistry;
+    let placementService: IPlacementService;
+    let resolver: PlacementResolver;
+
+    const buildType = (id: string, fetcher: IWidgetType['defaultDataFetcher']): IWidgetType => ({
+        id,
+        label: id,
+        description: '',
+        defaultDataFetcher: fetcher
+    });
+
+    const buildPlacement = (overrides: Partial<IWidgetPlacement> = {}): IWidgetPlacement => ({
+        id: overrides.id ?? 'placement-1',
+        typeId: overrides.typeId ?? 'plugin:type',
+        zoneId: overrides.zoneId ?? 'main-after',
+        routes: overrides.routes ?? [],
+        order: overrides.order ?? 10,
+        title: overrides.title,
+        instanceConfig: overrides.instanceConfig,
+        enabled: overrides.enabled ?? true,
+        source: overrides.source ?? 'plugin',
+        pluginId: overrides.pluginId ?? 'plugin',
+        createdAt: overrides.createdAt ?? new Date().toISOString(),
+        updatedAt: overrides.updatedAt ?? new Date().toISOString()
+    });
+
+    beforeEach(() => {
+        logger = new MockLogger();
+        const types = new Map<string, IWidgetType>();
+        typeRegistry = {
+            register: vi.fn(),
+            disposeForPlugin: vi.fn(() => 0),
+            has: vi.fn((id: string) => types.has(id)),
+            get: vi.fn((id: string) => types.get(id)),
+            snapshot: vi.fn(() => ({ groups: [] }))
+        };
+        (typeRegistry as any).__types = types;
+        placementService = {
+            ensurePluginPlacement: vi.fn(),
+            softDisableForPlugin: vi.fn(),
+            findByRoute: vi.fn(async () => []),
+            create: vi.fn(),
+            update: vi.fn(),
+            delete: vi.fn(),
+            findById: vi.fn(),
+            list: vi.fn()
+        };
+        resolver = new PlacementResolver(placementService, typeRegistry, logger);
+    });
+
+    it('joins each placement to its type and runs the data fetcher', async () => {
+        (typeRegistry as any).__types.set('plugin:type', buildType('plugin:type', async () => ({ items: [1, 2] })));
+        (placementService.findByRoute as ReturnType<typeof vi.fn>).mockResolvedValue([
+            buildPlacement({ id: 'p-1', typeId: 'plugin:type', zoneId: 'main-after', order: 10 })
+        ]);
+
+        const result = await resolver.resolveForRoute('/', {});
+
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('plugin:type');
+        expect(result[0].zone).toBe('main-after');
+        expect(result[0].order).toBe(10);
+        expect(result[0].data).toEqual({ items: [1, 2] });
+    });
+
+    it('skips placements whose type is not registered', async () => {
+        (placementService.findByRoute as ReturnType<typeof vi.fn>).mockResolvedValue([
+            buildPlacement({ typeId: 'orphan:type' })
+        ]);
+
+        const result = await resolver.resolveForRoute('/', {});
+        expect(result).toEqual([]);
+    });
+
+    it('drops a placement whose fetcher times out', async () => {
+        (typeRegistry as any).__types.set(
+            'slow:type',
+            buildType('slow:type', () => new Promise(() => { /* never resolves */ }))
+        );
+        (placementService.findByRoute as ReturnType<typeof vi.fn>).mockResolvedValue([
+            buildPlacement({ typeId: 'slow:type' })
+        ]);
+
+        vi.useFakeTimers();
+        const pending = resolver.resolveForRoute('/', {});
+        await vi.advanceTimersByTimeAsync(5100);
+        const result = await pending;
+        vi.useRealTimers();
+
+        expect(result).toEqual([]);
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({
+                typeId: 'slow:type',
+                error: 'Widget fetch timeout'
+            }),
+            'Widget data fetch failed'
+        );
+    });
+
+    it('drops a placement whose fetcher returns non-serialisable data', async () => {
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        (typeRegistry as any).__types.set('circular:type', buildType('circular:type', async () => circular));
+        (placementService.findByRoute as ReturnType<typeof vi.fn>).mockResolvedValue([
+            buildPlacement({ typeId: 'circular:type' })
+        ]);
+
+        const result = await resolver.resolveForRoute('/', {});
+
+        expect(result).toEqual([]);
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({ typeId: 'circular:type' }),
+            'Widget returned non-serializable data'
+        );
+    });
+
+    it('sorts results by zone (alphabetical), then order', async () => {
+        // 'main-after' sorts before 'main-before' alphabetically, so
+        // the expected ordering joins zone-asc then order-asc within
+        // each zone.
+        (typeRegistry as any).__types.set('t1', buildType('t1', async () => 'a'));
+        (typeRegistry as any).__types.set('t2', buildType('t2', async () => 'b'));
+        (typeRegistry as any).__types.set('t3', buildType('t3', async () => 'c'));
+        (placementService.findByRoute as ReturnType<typeof vi.fn>).mockResolvedValue([
+            buildPlacement({ id: 'p1', typeId: 't1', zoneId: 'main-before', order: 50 }),
+            buildPlacement({ id: 'p2', typeId: 't2', zoneId: 'main-after', order: 5 }),
+            buildPlacement({ id: 'p3', typeId: 't3', zoneId: 'main-after', order: 100 })
+        ]);
+
+        const result = await resolver.resolveForRoute('/', {});
+
+        expect(result.map(r => r.id)).toEqual(['t2', 't3', 't1']);
+        expect(result.map(r => r.zone)).toEqual(['main-after', 'main-after', 'main-before']);
+        expect(result.map(r => r.order)).toEqual([5, 100, 50]);
+    });
+});

--- a/src/backend/modules/widgets/__tests__/placements.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.test.ts
@@ -341,6 +341,7 @@ describe('PlacementResolver', () => {
             disposeForPlugin: vi.fn(() => 0),
             has: vi.fn((id: string) => types.has(id)),
             get: vi.fn((id: string) => types.get(id)),
+            getOwnerPluginId: vi.fn((_id: string) => undefined),
             snapshot: vi.fn(() => ({ groups: [] }))
         };
         (typeRegistry as any).__types = types;

--- a/src/backend/modules/widgets/__tests__/widget-types.test.ts
+++ b/src/backend/modules/widgets/__tests__/widget-types.test.ts
@@ -1,0 +1,348 @@
+/// <reference types="vitest" />
+
+/**
+ * @fileoverview Unit tests for the widget-type subsystem.
+ *
+ * Mirrors the zone-subsystem tests: descriptor minting and identity
+ * tracking, runtime-registry register/dispose/conflict/snapshot
+ * semantics, per-plugin facade lifecycle window and disposer ledger,
+ * and the disable→re-enable cycle that exercises `forgetWidgetType`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ISystemLogService, IWidgetType } from '@/types';
+import {
+    defineWidgetType,
+    forgetWidgetType,
+    isKnownWidgetType,
+    listKnownWidgetTypes,
+    __resetKnownWidgetTypesForTests,
+    WidgetTypeRegistry,
+    PluginWidgetTypes,
+    RESERVED_PLUGIN_ID
+} from '../widget-types/index.js';
+
+class MockLogger implements ISystemLogService {
+    public level = 'info';
+    public fatal = vi.fn();
+    public error = vi.fn();
+    public warn = vi.fn();
+    public info = vi.fn();
+    public debug = vi.fn();
+    public trace = vi.fn();
+    public child = vi.fn((_b: Record<string, unknown>): ISystemLogService => this);
+    public async initialize() {}
+    public async saveLog() {}
+    public async getLogs() {
+        return { logs: [], total: 0, page: 1, limit: 50, totalPages: 0, hasNextPage: false, hasPrevPage: false };
+    }
+    public async markAsResolved() {}
+    public async cleanup() { return 0; }
+    public async getStatistics() { return { total: 0, byLevel: {} as any, byService: {}, unresolved: 0 }; }
+    public async getLogById() { return null; }
+    public async markAsUnresolved() { return null; }
+    public async deleteAllLogs() { return 0; }
+    public async getStats() { return { total: 0, byLevel: {} as any, resolved: 0, unresolved: 0 }; }
+    public async waitUntilInitialized() {}
+}
+
+const noopFetcher = async () => ({});
+
+describe('defineWidgetType', () => {
+    beforeEach(() => __resetKnownWidgetTypesForTests());
+
+    it('produces a frozen descriptor tracked by the runtime', () => {
+        const desc = defineWidgetType({
+            id: 'test.alpha',
+            label: 'Alpha',
+            description: 'alpha widget',
+            defaultDataFetcher: noopFetcher
+        });
+
+        expect(desc.id).toBe('test.alpha');
+        expect(Object.isFrozen(desc)).toBe(true);
+        expect(isKnownWidgetType(desc)).toBe(true);
+        expect(listKnownWidgetTypes().map(d => d.id)).toEqual(['test.alpha']);
+    });
+
+    it('rejects duplicate ids', () => {
+        defineWidgetType({ id: 'test.dup', label: 'A', description: '', defaultDataFetcher: noopFetcher });
+
+        expect(() => defineWidgetType({
+            id: 'test.dup',
+            label: 'B',
+            description: '',
+            defaultDataFetcher: noopFetcher
+        })).toThrow(/Duplicate widget-type descriptor id/);
+    });
+
+    it('does not consider a hand-rolled object known', () => {
+        const fake: IWidgetType = {
+            id: 'test.fake',
+            label: 'Fake',
+            description: '',
+            defaultDataFetcher: noopFetcher
+        };
+
+        expect(isKnownWidgetType(fake)).toBe(false);
+    });
+
+    it('listKnownWidgetTypes returns descriptors sorted by id', () => {
+        defineWidgetType({ id: 'test.gamma', label: 'G', description: '', defaultDataFetcher: noopFetcher });
+        defineWidgetType({ id: 'test.alpha', label: 'A', description: '', defaultDataFetcher: noopFetcher });
+        defineWidgetType({ id: 'test.beta', label: 'B', description: '', defaultDataFetcher: noopFetcher });
+
+        expect(listKnownWidgetTypes().map(d => d.id)).toEqual(['test.alpha', 'test.beta', 'test.gamma']);
+    });
+});
+
+describe('WidgetTypeRegistry.register', () => {
+    let logger: MockLogger;
+    let registry: WidgetTypeRegistry;
+
+    beforeEach(() => {
+        __resetKnownWidgetTypesForTests();
+        logger = new MockLogger();
+        registry = new WidgetTypeRegistry(logger);
+    });
+
+    it('rejects an empty pluginId', () => {
+        const desc = defineWidgetType({ id: 'test.alpha', label: 'A', description: '', defaultDataFetcher: noopFetcher });
+
+        expect(() => registry.register('', desc)).toThrow(/non-empty pluginId/);
+    });
+
+    it('rejects a descriptor not produced by defineWidgetType', () => {
+        const fake: IWidgetType = {
+            id: 'test.fake',
+            label: 'Fake',
+            description: '',
+            defaultDataFetcher: noopFetcher
+        };
+
+        expect(() => registry.register('plugin-a', fake)).toThrow(/was not produced by defineWidgetType/);
+    });
+
+    it('accepts a plugin registration and exposes the descriptor via get', () => {
+        const desc = defineWidgetType({
+            id: 'test.plugin-type',
+            label: 'Plugin Type',
+            description: 'declared by a plugin',
+            defaultDataFetcher: noopFetcher
+        });
+
+        registry.register('plugin-a', desc);
+
+        expect(registry.has('test.plugin-type')).toBe(true);
+        expect(registry.get('test.plugin-type')).toBe(desc);
+    });
+
+    it('refuses to overwrite a type declared by a different plugin', () => {
+        const desc = defineWidgetType({ id: 'test.conflict', label: 'C', description: '', defaultDataFetcher: noopFetcher });
+        registry.register('plugin-a', desc);
+
+        expect(() => registry.register('plugin-b', desc)).toThrow(/already declared by 'plugin-a'/);
+    });
+
+    it('allows the same plugin to re-register its own type', () => {
+        const desc = defineWidgetType({ id: 'test.reregister', label: 'R', description: '', defaultDataFetcher: noopFetcher });
+        registry.register('plugin-a', desc);
+
+        expect(() => registry.register('plugin-a', desc)).not.toThrow();
+    });
+
+    it('returns a disposer that removes the type and forgets it from the cache', () => {
+        const desc = defineWidgetType({ id: 'test.dispose', label: 'D', description: '', defaultDataFetcher: noopFetcher });
+        const dispose = registry.register('plugin-a', desc);
+
+        expect(registry.has('test.dispose')).toBe(true);
+        dispose();
+        expect(registry.has('test.dispose')).toBe(false);
+        expect(listKnownWidgetTypes().map(d => d.id)).not.toContain('test.dispose');
+    });
+});
+
+describe('WidgetTypeRegistry.disposeForPlugin', () => {
+    let logger: MockLogger;
+    let registry: WidgetTypeRegistry;
+
+    beforeEach(() => {
+        __resetKnownWidgetTypesForTests();
+        logger = new MockLogger();
+        registry = new WidgetTypeRegistry(logger);
+    });
+
+    it('drops every type owned by the plugin and forgets them from the cache', () => {
+        const a = defineWidgetType({ id: 'test.plugin-a-1', label: 'A1', description: '', defaultDataFetcher: noopFetcher });
+        const b = defineWidgetType({ id: 'test.plugin-a-2', label: 'A2', description: '', defaultDataFetcher: noopFetcher });
+        registry.register('plugin-a', a);
+        registry.register('plugin-a', b);
+
+        const removed = registry.disposeForPlugin('plugin-a');
+
+        expect(removed).toBe(2);
+        expect(registry.has('test.plugin-a-1')).toBe(false);
+        expect(registry.has('test.plugin-a-2')).toBe(false);
+        expect(listKnownWidgetTypes().map(d => d.id)).toEqual([]);
+    });
+
+    it('refuses to dispose core-owned types via disposeForPlugin', () => {
+        defineWidgetType({ id: 'test.core', label: 'C', description: '', defaultDataFetcher: noopFetcher });
+        // Core registration would be performed by a hypothetical core
+        // module (none today); we simulate it here.
+        registry.register(RESERVED_PLUGIN_ID, registry.get('test.core') ?? defineWidgetType({ id: 'test.core-2', label: '', description: '', defaultDataFetcher: noopFetcher }));
+
+        const removed = registry.disposeForPlugin(RESERVED_PLUGIN_ID);
+        expect(removed).toBe(0);
+    });
+
+    it('returns zero when the plugin owns no types', () => {
+        const removed = registry.disposeForPlugin('phantom-plugin');
+        expect(removed).toBe(0);
+    });
+});
+
+describe('WidgetTypeRegistry.snapshot', () => {
+    let logger: MockLogger;
+    let registry: WidgetTypeRegistry;
+
+    beforeEach(() => {
+        __resetKnownWidgetTypesForTests();
+        logger = new MockLogger();
+        registry = new WidgetTypeRegistry(logger);
+    });
+
+    it('groups types by plugin id and sorts groups + members', () => {
+        const aFoo = defineWidgetType({ id: 'plugin-a:foo', label: 'A foo', description: '', defaultDataFetcher: noopFetcher });
+        const aBar = defineWidgetType({ id: 'plugin-a:bar', label: 'A bar', description: '', defaultDataFetcher: noopFetcher });
+        const bBaz = defineWidgetType({ id: 'plugin-b:baz', label: 'B baz', description: '', defaultDataFetcher: noopFetcher });
+        registry.register('plugin-a', aFoo);
+        registry.register('plugin-a', aBar);
+        registry.register('plugin-b', bBaz);
+
+        const snapshot = registry.snapshot();
+
+        expect(snapshot.groups.map(g => g.pluginId)).toEqual(['plugin-a', 'plugin-b']);
+        expect(snapshot.groups[0].types.map(t => t.id)).toEqual(['plugin-a:bar', 'plugin-a:foo']);
+        expect(snapshot.groups[1].types.map(t => t.id)).toEqual(['plugin-b:baz']);
+    });
+
+    it('serializes registeredAt as an ISO-8601 string', () => {
+        const desc = defineWidgetType({ id: 'test.time', label: 'T', description: '', defaultDataFetcher: noopFetcher });
+        registry.register('plugin-a', desc);
+
+        const snapshot = registry.snapshot();
+        const record = snapshot.groups[0].types[0];
+
+        expect(record.registeredAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    });
+});
+
+describe('PluginWidgetTypes facade', () => {
+    let logger: MockLogger;
+    let registry: WidgetTypeRegistry;
+
+    beforeEach(() => {
+        __resetKnownWidgetTypesForTests();
+        logger = new MockLogger();
+        registry = new WidgetTypeRegistry(logger);
+    });
+
+    it('tags type declarations with the plugin id', () => {
+        const facade = new PluginWidgetTypes('plugin-x', registry, logger);
+
+        facade.register({
+            id: 'test.facade-tagged',
+            label: 'Tagged',
+            description: '',
+            defaultDataFetcher: noopFetcher
+        });
+
+        expect(registry.snapshot().groups[0].pluginId).toBe('plugin-x');
+    });
+
+    it('refuses to register after seal()', () => {
+        const facade = new PluginWidgetTypes('plugin-x', registry, logger);
+        facade.seal();
+
+        expect(() => facade.register({
+            id: 'test.after-seal',
+            label: '',
+            description: '',
+            defaultDataFetcher: noopFetcher
+        })).toThrow(/lifecycle window closed/);
+    });
+
+    it('seal() is idempotent and does not dispose registrations', () => {
+        const facade = new PluginWidgetTypes('plugin-x', registry, logger);
+        facade.register({
+            id: 'test.survives-seal',
+            label: 'S',
+            description: '',
+            defaultDataFetcher: noopFetcher
+        });
+        facade.seal();
+        facade.seal();
+
+        expect(registry.has('test.survives-seal')).toBe(true);
+    });
+
+    it('closeAndDisposeAll() drops every type the facade owns', () => {
+        const facade = new PluginWidgetTypes('plugin-x', registry, logger);
+        facade.register({ id: 'test.bulk-1', label: '1', description: '', defaultDataFetcher: noopFetcher });
+        facade.register({ id: 'test.bulk-2', label: '2', description: '', defaultDataFetcher: noopFetcher });
+
+        const removed = facade.closeAndDisposeAll();
+
+        expect(removed).toBe(2);
+        expect(registry.has('test.bulk-1')).toBe(false);
+        expect(registry.has('test.bulk-2')).toBe(false);
+    });
+});
+
+describe('Plugin re-enable cycle', () => {
+    let logger: MockLogger;
+    let registry: WidgetTypeRegistry;
+
+    beforeEach(() => {
+        __resetKnownWidgetTypesForTests();
+        logger = new MockLogger();
+        registry = new WidgetTypeRegistry(logger);
+    });
+
+    it('lets a plugin re-declare types after disposeForPlugin clears them', () => {
+        const facade = new PluginWidgetTypes('plugin-x', registry, logger);
+        facade.register({
+            id: 'test.re-enable',
+            label: 'Re-enable',
+            description: '',
+            defaultDataFetcher: noopFetcher
+        });
+        expect(registry.has('test.re-enable')).toBe(true);
+
+        facade.closeAndDisposeAll();
+        registry.disposeForPlugin('plugin-x');
+
+        const reFacade = new PluginWidgetTypes('plugin-x', registry, logger);
+        expect(() => reFacade.register({
+            id: 'test.re-enable',
+            label: 'Re-enable',
+            description: '',
+            defaultDataFetcher: noopFetcher
+        })).not.toThrow();
+        expect(registry.has('test.re-enable')).toBe(true);
+    });
+
+    it('exports forgetWidgetType as a primitive', () => {
+        defineWidgetType({
+            id: 'test.manual-forget',
+            label: 'M',
+            description: '',
+            defaultDataFetcher: noopFetcher
+        });
+
+        expect(forgetWidgetType('test.manual-forget')).toBe(true);
+        expect(forgetWidgetType('test.manual-forget')).toBe(false);
+        expect(listKnownWidgetTypes().map(d => d.id)).not.toContain('test.manual-forget');
+    });
+});

--- a/src/backend/modules/widgets/__tests__/widget-types.test.ts
+++ b/src/backend/modules/widgets/__tests__/widget-types.test.ts
@@ -137,6 +137,19 @@ describe('WidgetTypeRegistry.register', () => {
         expect(registry.get('test.plugin-type')).toBe(desc);
     });
 
+    it('exposes plugin ownership via getOwnerPluginId', () => {
+        const desc = defineWidgetType({
+            id: 'test.owned',
+            label: 'Owned',
+            description: '',
+            defaultDataFetcher: noopFetcher
+        });
+        registry.register('plugin-a', desc);
+
+        expect(registry.getOwnerPluginId('test.owned')).toBe('plugin-a');
+        expect(registry.getOwnerPluginId('test.unregistered')).toBeUndefined();
+    });
+
     it('refuses to overwrite a type declared by a different plugin', () => {
         const desc = defineWidgetType({ id: 'test.conflict', label: 'C', description: '', defaultDataFetcher: noopFetcher });
         registry.register('plugin-a', desc);

--- a/src/backend/modules/widgets/database/IWidgetPlacementDocument.ts
+++ b/src/backend/modules/widgets/database/IWidgetPlacementDocument.ts
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Mongo document interface for widget placements.
+ *
+ * The `module_widgets_placements` collection stores every placement
+ * record — both plugin-source (created via the legacy widget-service
+ * compatibility shim on plugin enable) and operator-source (created
+ * via the admin API in a future PR). The document interface mirrors
+ * `IWidgetPlacement` from the types package but with native Mongo
+ * types (`ObjectId`, `Date`).
+ *
+ * @see {@link ../../../../docs/system/system-database.md} for
+ *   database access patterns and the manual `module_*_*` collection
+ *   prefixing convention.
+ * @module backend/modules/widgets/database/IWidgetPlacementDocument
+ */
+
+import type { Types } from 'mongoose';
+import type { PlacementSource } from '@/types';
+
+/**
+ * Widget placement document as stored in MongoDB.
+ *
+ * Placements survive plugin disable/re-enable cycles because plugin
+ * lifecycle calls `softDisable` (flip `enabled: false`) rather than
+ * deleting rows. Operator customisations to `order`, `routes`,
+ * `title`, or `instanceConfig` therefore persist across plugin
+ * lifecycle events. Hard delete is reserved for the admin API.
+ */
+export interface IWidgetPlacementDocument {
+    _id: Types.ObjectId;
+    /** Widget-type id this placement renders. */
+    typeId: string;
+    /** Zone id this placement targets. */
+    zoneId: string;
+    /** Route filter — empty array matches every route. */
+    routes: string[];
+    /** Sort order within the zone (lower renders first). */
+    order: number;
+    /** Optional heading rendered above the widget. */
+    title?: string;
+    /** Per-instance configuration. */
+    instanceConfig?: Record<string, unknown>;
+    /** Whether the placement currently renders. */
+    enabled: boolean;
+    /** Source discriminator — plugin-seeded or operator-created. */
+    source: PlacementSource;
+    /** Plugin id that owns the placement when `source === 'plugin'`. */
+    pluginId?: string;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+/**
+ * Logical collection name used by the placement service. The
+ * `IDatabaseService` returns the physical collection
+ * `module_widgets_placements` via the module-prefix convention; the
+ * service itself supplies the prefixed name when calling
+ * `database.getCollection(...)`.
+ */
+export const WIDGET_PLACEMENT_COLLECTION = 'module_widgets_placements';

--- a/src/backend/modules/widgets/database/IWidgetPlacementDocument.ts
+++ b/src/backend/modules/widgets/database/IWidgetPlacementDocument.ts
@@ -14,7 +14,7 @@
  * @module backend/modules/widgets/database/IWidgetPlacementDocument
  */
 
-import type { Types } from 'mongoose';
+import type { ObjectId } from 'mongodb';
 import type { PlacementSource } from '@/types';
 
 /**
@@ -27,7 +27,7 @@ import type { PlacementSource } from '@/types';
  * lifecycle events. Hard delete is reserved for the admin API.
  */
 export interface IWidgetPlacementDocument {
-    _id: Types.ObjectId;
+    _id: ObjectId;
     /** Widget-type id this placement renders. */
     typeId: string;
     /** Zone id this placement targets. */

--- a/src/backend/modules/widgets/database/index.ts
+++ b/src/backend/modules/widgets/database/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @fileoverview Database layer barrel for the widgets module.
+ *
+ * @module backend/modules/widgets/database
+ */
+
+export type { IWidgetPlacementDocument } from './IWidgetPlacementDocument.js';
+export { WIDGET_PLACEMENT_COLLECTION } from './IWidgetPlacementDocument.js';

--- a/src/backend/modules/widgets/index.ts
+++ b/src/backend/modules/widgets/index.ts
@@ -1,9 +1,10 @@
 /**
  * @fileoverview Widgets module public API.
  *
- * Exposes the module class, its dependency interface, and the zone
- * subsystem barrel so consumers (bootstrap, plugin loader, layouts,
- * tests) can import everything they need from one path.
+ * Exposes the module class, its dependency interface, the zone and
+ * widget-type subsystems, and the placement persistence layer so
+ * consumers (bootstrap, plugin loader, layouts, the compat-shim
+ * widget service, tests) can import everything from one path.
  *
  * @module backend/modules/widgets
  */
@@ -23,6 +24,21 @@ export {
     RESERVED_PLUGIN_ID
 } from './zones/index.js';
 export type { Zones } from './zones/index.js';
+
+export {
+    defineWidgetType,
+    forgetWidgetType,
+    isKnownWidgetType,
+    listKnownWidgetTypes,
+    __resetKnownWidgetTypesForTests,
+    WidgetTypeRegistry,
+    PluginWidgetTypes
+} from './widget-types/index.js';
+
+export { PlacementService, PlacementResolver, routeMatches } from './placements/index.js';
+
+export type { IWidgetPlacementDocument } from './database/index.js';
+export { WIDGET_PLACEMENT_COLLECTION } from './database/index.js';
 
 export { ZonesController } from './api/zones.controller.js';
 export { createZonesAdminRouter } from './api/zones.routes.js';

--- a/src/backend/modules/widgets/migrations/001_create_widget_placements.ts
+++ b/src/backend/modules/widgets/migrations/001_create_widget_placements.ts
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Create the widget-placement collection and its
+ * supporting indexes.
+ *
+ * The new collection persists every widget placement — both
+ * plugin-source (created by the legacy widget-service compatibility
+ * shim) and operator-source (created by the admin API). Indexes back
+ * the three hot read paths: SSR resolution by route, bulk
+ * soft-disable by plugin id, and listing within a zone for the admin
+ * editor.
+ *
+ * Idempotent — re-running the migration finds the indexes already
+ * present and short-circuits to a no-op.
+ *
+ * @module backend/modules/widgets/migrations/001_create_widget_placements
+ */
+
+import type { IMigration, IMigrationContext } from '@/types';
+
+export const migration: IMigration = {
+    id: '001_create_widget_placements',
+    description:
+        'Create module_widgets_placements collection with indexes for route resolution, ' +
+        'plugin-scoped soft-disable, and zone-ordered admin listing.',
+    dependencies: [],
+
+    async up(context: IMigrationContext): Promise<void> {
+        const collection = 'module_widgets_placements';
+
+        // Read path: SSR resolver queries `{ enabled: true }` and
+        // sorts by `(zoneId, order)`. The compound index covers both.
+        await context.database.createIndex(
+            collection,
+            { enabled: 1, zoneId: 1, order: 1 },
+            { name: 'enabled_zone_order' }
+        );
+
+        // Bulk write path: `softDisableForPlugin` filters
+        // `{ pluginId, source, enabled }` to flip enabled flags. The
+        // compound index makes the filter selective without scanning
+        // operator placements.
+        await context.database.createIndex(
+            collection,
+            { pluginId: 1, source: 1, enabled: 1 },
+            { name: 'plugin_source_enabled' }
+        );
+
+        // Upsert filter for `ensurePluginPlacement`: unique on
+        // (typeId, pluginId) so the disable→enable cycle finds the
+        // existing row instead of creating a duplicate. Sparse so
+        // operator placements (which omit `pluginId`) are excluded
+        // from the unique constraint and can share a `typeId` freely.
+        await context.database.createIndex(
+            collection,
+            { typeId: 1, pluginId: 1 },
+            {
+                name: 'plugin_placement_identity',
+                unique: true,
+                sparse: true
+            }
+        );
+
+        // Listing index: admin UI lists placements by zone.
+        await context.database.createIndex(
+            collection,
+            { zoneId: 1, order: 1 },
+            { name: 'zone_order' }
+        );
+    }
+};

--- a/src/backend/modules/widgets/placements/index.ts
+++ b/src/backend/modules/widgets/placements/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Placement subsystem barrel.
+ *
+ * Public exports for placement persistence and SSR resolution.
+ *
+ * @module backend/modules/widgets/placements
+ */
+
+export { PlacementService } from './placement.service.js';
+export { PlacementResolver } from './placement-resolver.js';
+export { routeMatches } from './route-matcher.js';

--- a/src/backend/modules/widgets/placements/placement-resolver.ts
+++ b/src/backend/modules/widgets/placements/placement-resolver.ts
@@ -1,0 +1,171 @@
+/**
+ * @fileoverview SSR placement resolver.
+ *
+ * Joins matching placement records with their widget-type
+ * descriptors and runs each type's `defaultDataFetcher` in parallel
+ * with a 5-second timeout and a JSON-serialisability check. Returns
+ * the legacy `IWidgetData` shape so the existing frontend
+ * `WidgetZone` component renders without changes.
+ *
+ * Replaces the legacy `WidgetService.fetchWidgetsForRoute` while
+ * preserving its observable behaviour (parallel fetch, timeout per
+ * widget, failed widgets dropped silently with an error log, sorted
+ * by zone then order).
+ *
+ * @module backend/modules/widgets/placements/placement-resolver
+ */
+
+import type {
+    IPlacementService,
+    ISystemLogService,
+    IWidgetData,
+    IWidgetPlacement,
+    IWidgetTypeRegistry
+} from '@/types';
+
+/**
+ * Per-widget data-fetch timeout. Matches the legacy
+ * `WidgetService.fetchWidgetsForRoute` behaviour so plugin authors
+ * see no semantic change after the compat-shim migration.
+ */
+const TIMEOUT_MS = 5000;
+
+/**
+ * Pure resolver. No singleton — `WidgetsModule.init()` constructs one
+ * with the bootstrap-owned widget-type registry plus the
+ * module-owned placement service, and the compat-shim widget service
+ * delegates to it.
+ */
+export class PlacementResolver {
+    constructor(
+        private readonly placementService: IPlacementService,
+        private readonly widgetTypeRegistry: IWidgetTypeRegistry,
+        private readonly logger: ISystemLogService
+    ) {}
+
+    /**
+     * Resolve every widget that should render at the given route,
+     * with their SSR data already fetched.
+     *
+     * Behaviour matches the legacy
+     * `WidgetService.fetchWidgetsForRoute`: placements are joined to
+     * widget types in-memory, fetched in parallel with a 5-second
+     * timeout per fetch, JSON-serialisability is verified via a
+     * round-trip, failed fetches are dropped with an error log, and
+     * results are sorted by `(zoneId asc, order asc)`. Placements
+     * whose `typeId` is not currently registered (e.g. plugin
+     * disabled) are silently skipped.
+     *
+     * @param route - Request path resolved by the host.
+     * @param params - Route params extracted by the host (e.g.
+     *   `{ address }` on `/u/[address]`). Forwarded to each widget
+     *   type's data fetcher.
+     * @returns Widget data ready for the frontend, in render order.
+     */
+    async resolveForRoute(
+        route: string,
+        params: Record<string, string> = {}
+    ): Promise<IWidgetData[]> {
+        const placements = await this.placementService.findByRoute(route);
+        if (placements.length === 0) return [];
+
+        const results = await Promise.all(
+            placements.map(p => this.fetchOne(p, route, params))
+        );
+
+        const filtered = results.filter((w): w is IWidgetData => w !== null);
+        filtered.sort((a, b) => {
+            if (a.zone !== b.zone) return a.zone.localeCompare(b.zone);
+            return a.order - b.order;
+        });
+
+        this.logger.debug(
+            {
+                route,
+                placementCount: placements.length,
+                successCount: filtered.length,
+                failedCount: placements.length - filtered.length
+            },
+            'Resolved widgets for route'
+        );
+
+        return filtered;
+    }
+
+    /**
+     * Fetch a single placement's data with timeout + serialisability
+     * guards. Returns `null` when the type is not registered, the
+     * fetcher throws, the fetcher exceeds the timeout, or the
+     * returned data is not JSON-serialisable.
+     */
+    private async fetchOne(
+        placement: IWidgetPlacement,
+        route: string,
+        params: Record<string, string>
+    ): Promise<IWidgetData | null> {
+        const type = this.widgetTypeRegistry.get(placement.typeId);
+        if (!type) {
+            // Common case: plugin disabled or type unregistered.
+            // Skip silently — the placement row will be re-joined
+            // when the type re-registers on the next enable.
+            return null;
+        }
+
+        let timerId: NodeJS.Timeout | undefined;
+        try {
+            const timeoutPromise = new Promise<never>((_, reject) => {
+                timerId = setTimeout(() => reject(new Error('Widget fetch timeout')), TIMEOUT_MS);
+            });
+            const raw = await Promise.race([
+                type.defaultDataFetcher(route, params),
+                timeoutPromise
+            ]);
+            clearTimeout(timerId);
+
+            const data = this.validateSerializable(raw, placement.typeId);
+            if (data === null) return null;
+
+            return {
+                id: placement.typeId,
+                zone: placement.zoneId,
+                pluginId: placement.pluginId ?? type.id.split(':')[0] ?? 'unknown',
+                order: placement.order,
+                title: placement.title,
+                data
+            };
+        } catch (error) {
+            clearTimeout(timerId);
+            this.logger.error(
+                {
+                    typeId: placement.typeId,
+                    placementId: placement.id,
+                    pluginId: placement.pluginId,
+                    error: error instanceof Error ? error.message : String(error)
+                },
+                'Widget data fetch failed'
+            );
+            return null;
+        }
+    }
+
+    /**
+     * Verify the fetched data round-trips through `JSON.stringify` so
+     * the SSR payload is safe to embed in the response. Returns
+     * `null` on non-serialisable input (BigInt, circular refs,
+     * functions). Pure transform — does not mutate `data`.
+     */
+    private validateSerializable(data: unknown, typeId: string): unknown {
+        try {
+            return JSON.parse(JSON.stringify(data));
+        } catch (error) {
+            this.logger.error(
+                {
+                    typeId,
+                    error: error instanceof Error ? error.message : String(error)
+                },
+                'Widget returned non-serializable data'
+            );
+            return null;
+        }
+    }
+}

--- a/src/backend/modules/widgets/placements/placement-resolver.ts
+++ b/src/backend/modules/widgets/placements/placement-resolver.ts
@@ -125,10 +125,23 @@ export class PlacementResolver {
             const data = this.validateSerializable(raw, placement.typeId);
             if (data === null) return null;
 
+            // Resolve owning plugin id from the registry — the
+            // authoritative source — so operator placements (which
+            // omit `placement.pluginId`) and non-namespaced type ids
+            // both surface the correct frontend plugin context.
+            // Falls back to placement.pluginId only when the type
+            // isn't registered to anyone, which shouldn't happen
+            // because the type was just fetched from the registry
+            // above.
+            const owner =
+                this.widgetTypeRegistry.getOwnerPluginId(placement.typeId) ??
+                placement.pluginId ??
+                'unknown';
+
             return {
                 id: placement.typeId,
                 zone: placement.zoneId,
-                pluginId: placement.pluginId ?? type.id.split(':')[0] ?? 'unknown',
+                pluginId: owner,
                 order: placement.order,
                 title: placement.title,
                 data

--- a/src/backend/modules/widgets/placements/placement.service.ts
+++ b/src/backend/modules/widgets/placements/placement.service.ts
@@ -99,59 +99,49 @@ export class PlacementService implements IPlacementService {
             source: 'plugin' as PlacementSource
         };
 
-        // Find-then-(insert | re-enable). Atomicity is enforced by the
-        // unique sparse index on (typeId, pluginId) created in
-        // migration 001: a concurrent insert from a second process
-        // would fail and we'd fall back to the update branch on
-        // retry. In single-process tests there is no race; the
-        // pattern reads cleanly under both the production Mongo
-        // driver and the in-memory mock.
-        const existing = await collection.findOne(filter);
-        if (existing) {
-            await collection.updateOne(
-                { _id: existing._id },
-                { $set: { enabled: true, updatedAt: now } }
-            );
-            const refreshed = await collection.findOne({ _id: existing._id });
-            if (!refreshed) {
-                throw new Error(
-                    `ensurePluginPlacement: row vanished between update and reread for typeId='${input.typeId}', pluginId='${input.pluginId}'`
-                );
-            }
-            this.logger.debug(
-                { typeId: input.typeId, pluginId: input.pluginId, zoneId: input.zoneId },
-                'Plugin placement re-enabled (existing row)'
-            );
-            return toPublic(refreshed);
-        }
-
-        const doc: Omit<IWidgetPlacementDocument, '_id'> = {
-            typeId: input.typeId,
+        // Atomic upsert. `$set` applies on both insert and update so
+        // `enabled` and `updatedAt` always reflect the current call.
+        // `$setOnInsert` applies only on insert so operator
+        // customisations to `order`, `routes`, `title`, and
+        // `instanceConfig` survive plugin disable/re-enable cycles
+        // (the existing row is found by filter and only `enabled` +
+        // `updatedAt` are touched). The sparse unique index on
+        // (typeId, pluginId) created in migration 001 guarantees
+        // atomicity against concurrent enables from multiple
+        // processes: the second writer's $setOnInsert is dropped
+        // because the row already exists.
+        const setOnInsert: Partial<IWidgetPlacementDocument> = {
             zoneId: input.zoneId,
             routes: [...input.routes],
             order: input.order ?? DEFAULT_ORDER,
-            enabled: true,
             source: 'plugin',
-            pluginId: input.pluginId,
-            createdAt: now,
-            updatedAt: now
+            createdAt: now
         };
-        if (input.title !== undefined) doc.title = input.title;
-        if (input.instanceConfig !== undefined) doc.instanceConfig = input.instanceConfig;
+        if (input.title !== undefined) setOnInsert.title = input.title;
+        if (input.instanceConfig !== undefined) setOnInsert.instanceConfig = input.instanceConfig;
 
-        const result = await collection.insertOne(doc as IWidgetPlacementDocument);
-        const created = await collection.findOne({ _id: result.insertedId });
-        if (!created) {
+        await collection.updateOne(
+            filter,
+            {
+                $set: { enabled: true, updatedAt: now },
+                $setOnInsert: setOnInsert
+            },
+            { upsert: true }
+        );
+
+        const document = await collection.findOne(filter);
+        if (!document) {
             throw new Error(
-                `ensurePluginPlacement: insert succeeded but document could not be re-read for typeId='${input.typeId}', pluginId='${input.pluginId}'`
+                `ensurePluginPlacement: upsert succeeded but document could not be re-read for typeId='${input.typeId}', pluginId='${input.pluginId}'`
             );
         }
 
         this.logger.debug(
             { typeId: input.typeId, pluginId: input.pluginId, zoneId: input.zoneId },
-            'Plugin placement created'
+            'Plugin placement ensured'
         );
-        return toPublic(created);
+
+        return toPublic(document);
     }
 
     async softDisableForPlugin(pluginId: string): Promise<number> {
@@ -178,26 +168,27 @@ export class PlacementService implements IPlacementService {
 
     async findByRoute(route: string): Promise<ReadonlyArray<IWidgetPlacement>> {
         const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
-        // Fetch all enabled placements and filter route in-memory.
-        // The route-match grammar today is exact-string-or-empty-
-        // matches-all, which is awkward to express in a single
-        // index-friendly Mongo query; in-memory filtering of an
-        // `enabled: true` set is fast at the expected placement
-        // counts and keeps the matching rule in one place
-        // (`route-matcher.ts`).
+        // Push the route filter into Mongo. Empty `routes` matches
+        // every path; otherwise the exact path must appear in the
+        // array. The multikey index on `routes` (built implicitly on
+        // every array field) plus the compound
+        // `enabled_zone_order` index from migration 001 keeps the
+        // common SSR query cheap as placement counts grow. The
+        // pure `routeMatches` predicate in `route-matcher.ts`
+        // remains the canonical statement of the matching rule for
+        // any non-Mongo caller and for future grammar extension.
         const documents = await collection
-            .find({ enabled: true })
+            .find({
+                enabled: true,
+                $or: [
+                    { routes: { $size: 0 } },
+                    { routes: route }
+                ]
+            })
             .sort({ zoneId: 1, order: 1 })
             .toArray();
 
-        const matches: IWidgetPlacement[] = [];
-        for (const doc of documents) {
-            if (routeMatches(doc.routes ?? [], route)) {
-                matches.push(toPublic(doc));
-            }
-        }
-
-        return matches;
+        return documents.map(toPublic);
     }
 
     async create(
@@ -210,6 +201,13 @@ export class PlacementService implements IPlacementService {
 
         if (source === 'plugin' && !options.pluginId) {
             throw new Error("Plugin-source placement requires options.pluginId");
+        }
+        if (source === 'operator' && options.pluginId !== undefined) {
+            throw new Error(
+                "Operator-source placement must not carry a pluginId — pluginId is only " +
+                "meaningful when source='plugin', and the sparse unique index on " +
+                "(typeId, pluginId) would collide with future plugin registrations."
+            );
         }
 
         const doc: Omit<IWidgetPlacementDocument, '_id'> = {
@@ -224,7 +222,7 @@ export class PlacementService implements IPlacementService {
         };
         if (input.title !== undefined) doc.title = input.title;
         if (input.instanceConfig !== undefined) doc.instanceConfig = input.instanceConfig;
-        if (options.pluginId !== undefined) doc.pluginId = options.pluginId;
+        if (source === 'plugin' && options.pluginId !== undefined) doc.pluginId = options.pluginId;
 
         const result = await collection.insertOne(doc as IWidgetPlacementDocument);
         const created = await collection.findOne({ _id: result.insertedId });

--- a/src/backend/modules/widgets/placements/placement.service.ts
+++ b/src/backend/modules/widgets/placements/placement.service.ts
@@ -1,0 +1,307 @@
+/**
+ * @fileoverview Widget placement service implementation.
+ *
+ * Singleton that owns the `module_widgets_placements` collection.
+ * Plugin lifecycle invokes `ensurePluginPlacement` on enable and
+ * `softDisableForPlugin` on disable; the placement resolver queries
+ * `findByRoute` per SSR request; the admin API surface (forthcoming)
+ * uses `create` / `update` / `delete` / `list`.
+ *
+ * Soft-disable semantics: plugin-source placements with `enabled:
+ * false` remain in the database, preserving operator customisations
+ * to `order` / `routes` / `title` across the plugin's
+ * disable/re-enable cycle. Hard delete is reserved for operator
+ * action via the admin API.
+ *
+ * @module backend/modules/widgets/placements/placement.service
+ */
+
+import { ObjectId } from 'mongodb';
+import type {
+    IDatabaseService,
+    ISystemLogService,
+    IPlacementService,
+    IPlacementInput,
+    IPlacementListFilter,
+    IPlacementPatch,
+    IPluginPlacementInput,
+    IWidgetPlacement,
+    PlacementSource
+} from '@/types';
+import type { IWidgetPlacementDocument } from '../database/IWidgetPlacementDocument.js';
+import { WIDGET_PLACEMENT_COLLECTION } from '../database/IWidgetPlacementDocument.js';
+import { routeMatches } from './route-matcher.js';
+
+/**
+ * Default `order` applied when input omits one. Matches the legacy
+ * `WidgetService.register` behaviour (order defaulted to 100).
+ */
+const DEFAULT_ORDER = 100;
+
+/**
+ * Singleton placement service. Configured once during
+ * `WidgetsModule.init()` via `setDependencies` and consumed by the
+ * compat-shim widget service, the placement resolver, and the admin
+ * API surface.
+ */
+export class PlacementService implements IPlacementService {
+    private static instance: PlacementService;
+    private readonly database: IDatabaseService;
+    private readonly logger: ISystemLogService;
+
+    private constructor(database: IDatabaseService, logger: ISystemLogService) {
+        this.database = database;
+        this.logger = logger;
+    }
+
+    /**
+     * Configure the singleton's injected dependencies. Called once
+     * during `WidgetsModule.init()` with the bootstrap-owned
+     * `IDatabaseService` and the module-scoped logger.
+     */
+    public static setDependencies(database: IDatabaseService, logger: ISystemLogService): void {
+        if (!PlacementService.instance) {
+            PlacementService.instance = new PlacementService(database, logger);
+        }
+    }
+
+    /**
+     * Retrieve the configured singleton.
+     *
+     * @throws Error if `setDependencies` has not been called yet.
+     */
+    public static getInstance(): PlacementService {
+        if (!PlacementService.instance) {
+            throw new Error('PlacementService.setDependencies() must be called first');
+        }
+        return PlacementService.instance;
+    }
+
+    /**
+     * Test-only reset to clear the singleton between unit tests so a
+     * fresh injection can occur. Production never invokes this.
+     */
+    public static __resetForTests(): void {
+        // @ts-expect-error — clearing the private static for tests
+        PlacementService.instance = undefined;
+    }
+
+    async ensurePluginPlacement(input: IPluginPlacementInput): Promise<IWidgetPlacement> {
+        if (!input.pluginId) {
+            throw new Error('ensurePluginPlacement requires a pluginId');
+        }
+
+        const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
+        const now = new Date();
+        const filter = {
+            typeId: input.typeId,
+            pluginId: input.pluginId,
+            source: 'plugin' as PlacementSource
+        };
+
+        // Find-then-(insert | re-enable). Atomicity is enforced by the
+        // unique sparse index on (typeId, pluginId) created in
+        // migration 001: a concurrent insert from a second process
+        // would fail and we'd fall back to the update branch on
+        // retry. In single-process tests there is no race; the
+        // pattern reads cleanly under both the production Mongo
+        // driver and the in-memory mock.
+        const existing = await collection.findOne(filter);
+        if (existing) {
+            await collection.updateOne(
+                { _id: existing._id },
+                { $set: { enabled: true, updatedAt: now } }
+            );
+            const refreshed = await collection.findOne({ _id: existing._id });
+            if (!refreshed) {
+                throw new Error(
+                    `ensurePluginPlacement: row vanished between update and reread for typeId='${input.typeId}', pluginId='${input.pluginId}'`
+                );
+            }
+            this.logger.debug(
+                { typeId: input.typeId, pluginId: input.pluginId, zoneId: input.zoneId },
+                'Plugin placement re-enabled (existing row)'
+            );
+            return toPublic(refreshed);
+        }
+
+        const doc: Omit<IWidgetPlacementDocument, '_id'> = {
+            typeId: input.typeId,
+            zoneId: input.zoneId,
+            routes: [...input.routes],
+            order: input.order ?? DEFAULT_ORDER,
+            enabled: true,
+            source: 'plugin',
+            pluginId: input.pluginId,
+            createdAt: now,
+            updatedAt: now
+        };
+        if (input.title !== undefined) doc.title = input.title;
+        if (input.instanceConfig !== undefined) doc.instanceConfig = input.instanceConfig;
+
+        const result = await collection.insertOne(doc as IWidgetPlacementDocument);
+        const created = await collection.findOne({ _id: result.insertedId });
+        if (!created) {
+            throw new Error(
+                `ensurePluginPlacement: insert succeeded but document could not be re-read for typeId='${input.typeId}', pluginId='${input.pluginId}'`
+            );
+        }
+
+        this.logger.debug(
+            { typeId: input.typeId, pluginId: input.pluginId, zoneId: input.zoneId },
+            'Plugin placement created'
+        );
+        return toPublic(created);
+    }
+
+    async softDisableForPlugin(pluginId: string): Promise<number> {
+        if (!pluginId) {
+            throw new Error('softDisableForPlugin requires a pluginId');
+        }
+
+        const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
+        const result = await collection.updateMany(
+            { pluginId, source: 'plugin', enabled: true },
+            { $set: { enabled: false, updatedAt: new Date() } }
+        );
+
+        const modified = result.modifiedCount ?? 0;
+        if (modified > 0) {
+            this.logger.info(
+                { pluginId, modified },
+                'Plugin placements soft-disabled'
+            );
+        }
+
+        return modified;
+    }
+
+    async findByRoute(route: string): Promise<ReadonlyArray<IWidgetPlacement>> {
+        const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
+        // Fetch all enabled placements and filter route in-memory.
+        // The route-match grammar today is exact-string-or-empty-
+        // matches-all, which is awkward to express in a single
+        // index-friendly Mongo query; in-memory filtering of an
+        // `enabled: true` set is fast at the expected placement
+        // counts and keeps the matching rule in one place
+        // (`route-matcher.ts`).
+        const documents = await collection
+            .find({ enabled: true })
+            .sort({ zoneId: 1, order: 1 })
+            .toArray();
+
+        const matches: IWidgetPlacement[] = [];
+        for (const doc of documents) {
+            if (routeMatches(doc.routes ?? [], route)) {
+                matches.push(toPublic(doc));
+            }
+        }
+
+        return matches;
+    }
+
+    async create(
+        input: IPlacementInput,
+        options: { source?: PlacementSource; pluginId?: string } = {}
+    ): Promise<IWidgetPlacement> {
+        const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
+        const now = new Date();
+        const source: PlacementSource = options.source ?? 'operator';
+
+        if (source === 'plugin' && !options.pluginId) {
+            throw new Error("Plugin-source placement requires options.pluginId");
+        }
+
+        const doc: Omit<IWidgetPlacementDocument, '_id'> = {
+            typeId: input.typeId,
+            zoneId: input.zoneId,
+            routes: [...input.routes],
+            order: input.order ?? DEFAULT_ORDER,
+            enabled: input.enabled ?? true,
+            source,
+            createdAt: now,
+            updatedAt: now
+        };
+        if (input.title !== undefined) doc.title = input.title;
+        if (input.instanceConfig !== undefined) doc.instanceConfig = input.instanceConfig;
+        if (options.pluginId !== undefined) doc.pluginId = options.pluginId;
+
+        const result = await collection.insertOne(doc as IWidgetPlacementDocument);
+        const created = await collection.findOne({ _id: result.insertedId });
+        if (!created) {
+            throw new Error('Placement create succeeded but document could not be re-read');
+        }
+
+        return toPublic(created);
+    }
+
+    async update(id: string, patch: IPlacementPatch): Promise<IWidgetPlacement | null> {
+        if (!ObjectId.isValid(id)) return null;
+
+        const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
+        const setOps: Partial<IWidgetPlacementDocument> = { updatedAt: new Date() };
+        if (patch.zoneId !== undefined) setOps.zoneId = patch.zoneId;
+        if (patch.routes !== undefined) setOps.routes = [...patch.routes];
+        if (patch.order !== undefined) setOps.order = patch.order;
+        if (patch.title !== undefined) setOps.title = patch.title;
+        if (patch.instanceConfig !== undefined) setOps.instanceConfig = patch.instanceConfig;
+        if (patch.enabled !== undefined) setOps.enabled = patch.enabled;
+
+        const objectId = new ObjectId(id);
+        const result = await collection.updateOne({ _id: objectId }, { $set: setOps });
+        if (result.matchedCount === 0) return null;
+
+        const updated = await collection.findOne({ _id: objectId });
+        return updated ? toPublic(updated) : null;
+    }
+
+    async delete(id: string): Promise<boolean> {
+        if (!ObjectId.isValid(id)) return false;
+        const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
+        const result = await collection.deleteOne({ _id: new ObjectId(id) });
+        return (result.deletedCount ?? 0) > 0;
+    }
+
+    async findById(id: string): Promise<IWidgetPlacement | null> {
+        if (!ObjectId.isValid(id)) return null;
+        const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
+        const doc = await collection.findOne({ _id: new ObjectId(id) });
+        return doc ? toPublic(doc) : null;
+    }
+
+    async list(filter: IPlacementListFilter = {}): Promise<ReadonlyArray<IWidgetPlacement>> {
+        const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
+        const query: Record<string, unknown> = {};
+        if (filter.zoneId !== undefined) query.zoneId = filter.zoneId;
+        if (filter.pluginId !== undefined) query.pluginId = filter.pluginId;
+        if (filter.source !== undefined) query.source = filter.source;
+        if (filter.enabledOnly) query.enabled = true;
+
+        const docs = await collection
+            .find(query)
+            .sort({ zoneId: 1, order: 1 })
+            .toArray();
+        return docs.map(toPublic);
+    }
+}
+
+/**
+ * Convert a Mongo document to the public-facing `IWidgetPlacement`
+ * shape (string id, ISO dates).
+ */
+function toPublic(doc: IWidgetPlacementDocument): IWidgetPlacement {
+    return {
+        id: doc._id.toHexString(),
+        typeId: doc.typeId,
+        zoneId: doc.zoneId,
+        routes: doc.routes,
+        order: doc.order,
+        title: doc.title,
+        instanceConfig: doc.instanceConfig,
+        enabled: doc.enabled,
+        source: doc.source,
+        pluginId: doc.pluginId,
+        createdAt: doc.createdAt.toISOString(),
+        updatedAt: doc.updatedAt.toISOString()
+    };
+}

--- a/src/backend/modules/widgets/placements/route-matcher.ts
+++ b/src/backend/modules/widgets/placements/route-matcher.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Route-matcher for widget placement resolution.
+ *
+ * Pure function evaluating whether a placement's `routes` filter
+ * matches a request path. The legacy `WidgetService` used strict
+ * equality on the array; PR 2 preserves that semantic exactly — empty
+ * array matches every route, otherwise the route must appear by
+ * string equality. Glob and prefix matching are deferred until an
+ * operator UI surfaces the need.
+ *
+ * The matcher is extracted so the placement service's Mongo query
+ * and the resolver's in-memory filter share one source of truth, and
+ * so the matching rule can evolve in a single file when a more
+ * expressive grammar becomes necessary.
+ *
+ * @module backend/modules/widgets/placements/route-matcher
+ */
+
+/**
+ * Test whether a placement's route filter matches the given request
+ * path. Empty `routes` matches every path. Otherwise the path must
+ * appear in the array (exact match).
+ *
+ * @param routes - Placement's route filter.
+ * @param route - Request path resolved by the host.
+ * @returns True when the placement should render on the given route.
+ */
+export function routeMatches(routes: ReadonlyArray<string>, route: string): boolean {
+    if (routes.length === 0) return true;
+    return routes.indexOf(route) !== -1;
+}

--- a/src/backend/modules/widgets/widget-types/define-widget-type.ts
+++ b/src/backend/modules/widgets/widget-types/define-widget-type.ts
@@ -1,0 +1,115 @@
+/**
+ * @fileoverview defineWidgetType factory for producing typed widget-type
+ * descriptors.
+ *
+ * `defineWidgetType` is the only sanctioned way to construct an
+ * `IWidgetType`. Every descriptor it produces is tracked in a
+ * module-local set so the runtime registry can reject registration
+ * of any descriptor that was not minted here. Plugins do not import
+ * this function directly; they call
+ * `context.widgetTypes.register(options)` and the facade invokes
+ * `defineWidgetType` on their behalf.
+ *
+ * Mirrors the shape of `define-zone.ts` so the two registry pairs
+ * read consistently.
+ *
+ * @module backend/modules/widgets/widget-types/define-widget-type
+ */
+
+import type { IWidgetType, IDefineWidgetTypeOptions } from '@/types';
+
+/**
+ * Tracked set of every descriptor minted by `defineWidgetType` in
+ * this process.
+ */
+const KNOWN_WIDGET_TYPES: Map<string, IWidgetType> = new Map();
+
+/**
+ * Construct a frozen, runtime-tracked widget-type descriptor.
+ *
+ * Plugin code never invokes this function directly — the
+ * `PluginWidgetTypes` facade constructs descriptors on the plugin's
+ * behalf so the plugin id is tagged transparently and the lifecycle
+ * window is enforced.
+ *
+ * @param options - Descriptor configuration.
+ * @returns Frozen descriptor tracked in the known-type set.
+ * @throws Error if a descriptor with the same id was already defined.
+ */
+export function defineWidgetType(options: IDefineWidgetTypeOptions): IWidgetType {
+    if (KNOWN_WIDGET_TYPES.has(options.id)) {
+        throw new Error(
+            `Duplicate widget-type descriptor id: '${options.id}'. ` +
+            `Widget-type ids must be unique across the process.`
+        );
+    }
+
+    const descriptor: IWidgetType = Object.freeze({
+        id: options.id,
+        label: options.label,
+        description: options.description,
+        category: options.category,
+        defaultDataFetcher: options.defaultDataFetcher,
+        configSchema: options.configSchema
+    });
+
+    KNOWN_WIDGET_TYPES.set(options.id, descriptor);
+
+    return descriptor;
+}
+
+/**
+ * Test whether a descriptor was produced by `defineWidgetType` in
+ * this process. The runtime registry calls this to refuse forged
+ * descriptors that bypass the central constructor.
+ *
+ * @param descriptor - Candidate descriptor.
+ * @returns True if the descriptor is tracked.
+ */
+export function isKnownWidgetType(descriptor: IWidgetType): boolean {
+    const tracked = KNOWN_WIDGET_TYPES.get(descriptor.id);
+    const result = tracked === descriptor;
+
+    return result;
+}
+
+/**
+ * Snapshot every descriptor known to the process, in stable id order.
+ *
+ * @returns Array of descriptors, sorted by id.
+ */
+export function listKnownWidgetTypes(): ReadonlyArray<IWidgetType> {
+    const list = Array.from(KNOWN_WIDGET_TYPES.values()).sort((a, b) => a.id.localeCompare(b.id));
+
+    return list;
+}
+
+/**
+ * Forget a tracked descriptor.
+ *
+ * Called by the runtime registry when a type is disposed — either
+ * through a single registration's disposer or through bulk
+ * `disposeForPlugin` cleanup — so a future `defineWidgetType` call
+ * with the same id mints a fresh descriptor rather than returning a
+ * stale cached entry. Without this, a disable → re-enable cycle
+ * would trip the duplicate-id guard the next time the plugin
+ * declares its types. Same contract as `forgetZone` in the zone
+ * subsystem.
+ *
+ * @param id - Widget-type id to forget.
+ * @returns True if the descriptor was tracked and removed.
+ */
+export function forgetWidgetType(id: string): boolean {
+    return KNOWN_WIDGET_TYPES.delete(id);
+}
+
+/**
+ * Drop every tracked descriptor.
+ *
+ * Test-only utility. Production code never invokes this.
+ */
+export function __resetKnownWidgetTypesForTests(): void {
+    KNOWN_WIDGET_TYPES.clear();
+
+    return;
+}

--- a/src/backend/modules/widgets/widget-types/index.ts
+++ b/src/backend/modules/widgets/widget-types/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Widget-type subsystem barrel.
+ *
+ * Public exports for the widget-type subsystem — the
+ * `defineWidgetType` constructor, the runtime `WidgetTypeRegistry`,
+ * and the per-plugin `PluginWidgetTypes` facade. Consumed by
+ * `WidgetsModule`, the plugin loader, the placement resolver, and the
+ * compat-shim widget service.
+ *
+ * @module backend/modules/widgets/widget-types
+ */
+
+export {
+    defineWidgetType,
+    forgetWidgetType,
+    isKnownWidgetType,
+    listKnownWidgetTypes,
+    __resetKnownWidgetTypesForTests
+} from './define-widget-type.js';
+export { WidgetTypeRegistry, RESERVED_PLUGIN_ID } from './widget-type-registry.js';
+export { PluginWidgetTypes } from './plugin-widget-types.js';

--- a/src/backend/modules/widgets/widget-types/plugin-widget-types.ts
+++ b/src/backend/modules/widgets/widget-types/plugin-widget-types.ts
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Per-plugin widget-type facade.
+ *
+ * Each plugin receives an `IPluginWidgetTypes` instance wrapping the
+ * shared `WidgetTypeRegistry`. The facade constructs descriptors via
+ * `defineWidgetType` on the plugin's behalf, tags every registration
+ * with the plugin id, enforces the lifecycle window, and collects
+ * disposers so the plugin loader can drop every declared type on
+ * `disable()` without each plugin tracking them by hand.
+ *
+ * Mirrors `PluginZones` and `PluginHooks` so plugin authors learn one
+ * pattern for participating in extension surfaces.
+ *
+ * @module backend/modules/widgets/widget-types/plugin-widget-types
+ */
+
+import type {
+    IDefineWidgetTypeOptions,
+    IPluginWidgetTypes,
+    IWidgetTypeRegistry,
+    WidgetTypeRegisterDisposer,
+    ISystemLogService
+} from '@/types';
+import { defineWidgetType } from './define-widget-type.js';
+
+/**
+ * Concrete per-plugin facade. One instance per plugin per process.
+ */
+export class PluginWidgetTypes implements IPluginWidgetTypes {
+    private readonly disposers: Set<WidgetTypeRegisterDisposer> = new Set();
+    private open: boolean = true;
+
+    /**
+     * @param pluginId - Owning plugin id, used to tag every registration.
+     * @param registry - Shared process-wide widget-type registry.
+     * @param logger - Plugin-scoped logger.
+     */
+    constructor(
+        private readonly pluginId: string,
+        private readonly registry: IWidgetTypeRegistry,
+        private readonly logger: ISystemLogService
+    ) {}
+
+    /**
+     * Declare a widget type owned by this plugin.
+     */
+    register(options: IDefineWidgetTypeOptions): WidgetTypeRegisterDisposer {
+        if (!this.open) {
+            throw new Error(
+                `Plugin '${this.pluginId}' attempted to declare widget type '${options.id}' ` +
+                `after its lifecycle window closed. Widget-type registration is permitted only ` +
+                `during install/enable/init — declare types at startup, not inside request handlers.`
+            );
+        }
+
+        const descriptor = defineWidgetType(options);
+        const disposer = this.registry.register(this.pluginId, descriptor);
+        const wrapped: WidgetTypeRegisterDisposer = () => {
+            this.disposers.delete(wrapped);
+            disposer();
+        };
+        this.disposers.add(wrapped);
+
+        return wrapped;
+    }
+
+    /**
+     * Close the lifecycle window without disposing declared types.
+     * Idempotent.
+     */
+    seal(): void {
+        this.open = false;
+    }
+
+    /**
+     * Close the facade and drop every widget type it owns. Invoked
+     * by the plugin loader on `disable()` and `uninstall()`.
+     */
+    closeAndDisposeAll(): number {
+        this.open = false;
+        const snapshot = Array.from(this.disposers);
+        this.disposers.clear();
+        for (const dispose of snapshot) {
+            try {
+                dispose();
+            } catch (err) {
+                this.logger.warn(
+                    { err, pluginId: this.pluginId },
+                    'Widget-type disposer threw during plugin disable'
+                );
+            }
+        }
+
+        return snapshot.length;
+    }
+}

--- a/src/backend/modules/widgets/widget-types/widget-type-registry.ts
+++ b/src/backend/modules/widgets/widget-types/widget-type-registry.ts
@@ -148,6 +148,16 @@ export class WidgetTypeRegistry implements IWidgetTypeRegistry {
     }
 
     /**
+     * Return the plugin id that currently owns the given widget-type
+     * id, or `undefined` when unregistered. See `IWidgetTypeRegistry`
+     * JSDoc for the three-way decision the compat shim uses this for.
+     */
+    getOwnerPluginId(typeId: string): string | undefined {
+        const entry = this.types.get(typeId);
+        return entry?.pluginId;
+    }
+
+    /**
      * Produce the introspection snapshot consumed by the admin
      * endpoint. Groups every registered type by declaring plugin.
      */

--- a/src/backend/modules/widgets/widget-types/widget-type-registry.ts
+++ b/src/backend/modules/widgets/widget-types/widget-type-registry.ts
@@ -1,0 +1,202 @@
+/**
+ * @fileoverview Runtime widget-type registry implementation.
+ *
+ * Concrete `IWidgetTypeRegistry` backed by a Map of widget-type id →
+ * registered entry. Accepts plugin-declared types through `register`,
+ * validates the descriptor-identity check that proves a descriptor
+ * was minted via `defineWidgetType`, and produces the snapshot
+ * consumed by the `/api/admin/system/widget-types` endpoint.
+ *
+ * Mirrors `ZoneRegistry` in shape and semantics — see
+ * `src/backend/modules/widgets/zones/zone-registry.ts` for the
+ * pattern reference.
+ *
+ * @module backend/modules/widgets/widget-types/widget-type-registry
+ */
+
+import type {
+    IWidgetType,
+    IWidgetTypeRegistry,
+    IWidgetTypeSnapshot,
+    IWidgetTypeSnapshotRecord,
+    WidgetTypeRegisterDisposer,
+    ISystemLogService
+} from '@/types';
+import { forgetWidgetType, isKnownWidgetType } from './define-widget-type.js';
+
+const RESERVED_PLUGIN_ID = 'core';
+
+interface IRegisteredWidgetType {
+    readonly descriptor: IWidgetType;
+    readonly pluginId: string;
+    readonly registeredAt: number;
+    readonly source: string | null;
+}
+
+/**
+ * Map-backed widget-type registry. One instance per process,
+ * constructed during bootstrap and threaded into the plugin context
+ * via the per-plugin facade as well as into `WidgetsModule` so the
+ * placement resolver can look up types at SSR time.
+ */
+export class WidgetTypeRegistry implements IWidgetTypeRegistry {
+    private readonly types: Map<string, IRegisteredWidgetType> = new Map();
+
+    constructor(private readonly logger: ISystemLogService) {}
+
+    /**
+     * Register a declared widget type.
+     *
+     * Validates that the descriptor was minted by `defineWidgetType`
+     * and that no other plugin has already claimed the id.
+     *
+     * @param pluginId - Plugin id (or `'core'`) registering the type.
+     * @param descriptor - Descriptor minted by `defineWidgetType`.
+     * @returns Disposer that removes the registration.
+     */
+    register(pluginId: string, descriptor: IWidgetType): WidgetTypeRegisterDisposer {
+        if (!pluginId || typeof pluginId !== 'string') {
+            throw new Error('Widget-type registration requires a non-empty pluginId.');
+        }
+        if (!descriptor || typeof descriptor.id !== 'string') {
+            throw new Error('Widget-type registration requires a valid descriptor.');
+        }
+        if (!isKnownWidgetType(descriptor)) {
+            throw new Error(
+                `Widget-type descriptor '${descriptor.id}' was not produced by defineWidgetType. ` +
+                `Construct it through the central factory before registering.`
+            );
+        }
+
+        const existing = this.types.get(descriptor.id);
+        if (existing && existing.pluginId !== pluginId) {
+            throw new Error(
+                `Widget type '${descriptor.id}' is already declared by '${existing.pluginId}'. ` +
+                `Type ids are exclusive to their declaring component.`
+            );
+        }
+
+        const record: IRegisteredWidgetType = {
+            descriptor,
+            pluginId,
+            registeredAt: Date.now(),
+            source: captureRegistrationSource()
+        };
+
+        this.types.set(descriptor.id, record);
+
+        this.logger.debug(
+            { widgetTypeId: descriptor.id, pluginId },
+            'Widget type registered'
+        );
+
+        return () => {
+            const cur = this.types.get(descriptor.id);
+            if (!cur || cur !== record) return;
+            this.types.delete(descriptor.id);
+            forgetWidgetType(descriptor.id);
+            this.logger.debug(
+                { widgetTypeId: descriptor.id, pluginId },
+                'Widget type unregistered'
+            );
+        };
+    }
+
+    /**
+     * Remove every widget type declared by the given plugin.
+     *
+     * Core-owned types (`pluginId === 'core'`) are never affected.
+     *
+     * @param pluginId - Plugin whose types should be removed.
+     * @returns Count of types removed.
+     */
+    disposeForPlugin(pluginId: string): number {
+        if (pluginId === RESERVED_PLUGIN_ID) {
+            return 0;
+        }
+        let removed = 0;
+        for (const [id, entry] of this.types) {
+            if (entry.pluginId === pluginId) {
+                this.types.delete(id);
+                forgetWidgetType(id);
+                removed++;
+            }
+        }
+        if (removed > 0) {
+            this.logger.info({ pluginId, removed }, 'Widget types disposed for plugin');
+        }
+
+        return removed;
+    }
+
+    /**
+     * Check whether a widget-type id is registered.
+     */
+    has(typeId: string): boolean {
+        return this.types.has(typeId);
+    }
+
+    /**
+     * Retrieve the live descriptor for a widget type. Returns
+     * `undefined` when no type with that id is registered. Used by
+     * the placement resolver to look up the data fetcher at SSR
+     * time.
+     */
+    get(typeId: string): IWidgetType | undefined {
+        const entry = this.types.get(typeId);
+        return entry?.descriptor;
+    }
+
+    /**
+     * Produce the introspection snapshot consumed by the admin
+     * endpoint. Groups every registered type by declaring plugin.
+     */
+    snapshot(): IWidgetTypeSnapshot {
+        const byPlugin: Map<string, IWidgetTypeSnapshotRecord[]> = new Map();
+
+        for (const entry of this.types.values()) {
+            const bucket = byPlugin.get(entry.pluginId) ?? [];
+            bucket.push({
+                id: entry.descriptor.id,
+                label: entry.descriptor.label,
+                description: entry.descriptor.description,
+                category: entry.descriptor.category ?? null,
+                pluginId: entry.pluginId,
+                registeredAt: new Date(entry.registeredAt).toISOString(),
+                source: entry.source
+            });
+            byPlugin.set(entry.pluginId, bucket);
+        }
+
+        const groups = Array.from(byPlugin.entries())
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([pluginId, types]) => ({
+                pluginId,
+                types: types.sort((a, b) => a.id.localeCompare(b.id))
+            }));
+
+        return { groups };
+    }
+}
+
+/**
+ * Best-effort source-file capture, skipping frames inside the
+ * registry itself.
+ */
+function captureRegistrationSource(): string | null {
+    const stack = new Error().stack;
+    if (!stack) return null;
+    const lines = stack.split('\n');
+    for (let i = 2; i < lines.length; i++) {
+        const line = lines[i].trim();
+        if (line.includes('/widgets/widget-types/') || line.includes('node_modules')) continue;
+        const match = line.match(/\((.+:\d+:\d+)\)/) || line.match(/at (.+:\d+:\d+)$/);
+        if (match) {
+            return match[1];
+        }
+    }
+
+    return null;
+}
+
+export { RESERVED_PLUGIN_ID };

--- a/src/backend/services/plugin-manager.service.ts
+++ b/src/backend/services/plugin-manager.service.ts
@@ -1,14 +1,15 @@
 import { EventEmitter } from 'node:events';
-import type { IPlugin, IPluginContext, IPluginManifest, IHookRegistry, IZoneRegistry } from '@/types';
+import type { IPlugin, IPluginContext, IPluginManifest, IHookRegistry, IZoneRegistry, IWidgetTypeRegistry } from '@/types';
 import { PluginMetadataService } from './plugin-metadata.service.js';
 import { PluginDatabaseService } from '../modules/database/index.js';
 import { PluginApiService } from './plugin-api.service.js';
 import { BlockchainObserverService } from './blockchain-observer/index.js';
 import { BaseObserver } from '../modules/blockchain/observers/BaseObserver.js';
 import { WebSocketService } from './websocket.service.js';
+import { WidgetService } from './widget/widget.service.js';
 import { logger } from '../lib/logger.js';
 import { PluginHooks } from '../hooks/index.js';
-import { PluginZones } from '../modules/widgets/index.js';
+import { PluginZones, PluginWidgetTypes } from '../modules/widgets/index.js';
 
 /**
  * Lifecycle event payloads emitted by PluginManagerService.
@@ -39,6 +40,7 @@ interface ILoadedPlugin {
     manifest: IPluginManifest;
     hooks: PluginHooks;
     zones: PluginZones;
+    widgetTypes: PluginWidgetTypes;
 }
 
 /**
@@ -55,6 +57,7 @@ export class PluginManagerService {
     private events: EventEmitter = new EventEmitter();
     private hookRegistry: IHookRegistry | null = null;
     private zoneRegistry: IZoneRegistry | null = null;
+    private widgetTypeRegistry: IWidgetTypeRegistry | null = null;
 
     private constructor() {
         this.metadataService = PluginMetadataService.getInstance();
@@ -84,6 +87,19 @@ export class PluginManagerService {
      */
     public setZoneRegistry(registry: IZoneRegistry): void {
         this.zoneRegistry = registry;
+    }
+
+    /**
+     * Inject the process-wide widget-type registry.
+     *
+     * Called once during bootstrap from the plugin loader. Used to
+     * rebuild a plugin's widget-type facade after disable and to
+     * dispose widget-type declarations in bulk as a safety net.
+     *
+     * @param registry - Shared widget-type registry instance.
+     */
+    public setWidgetTypeRegistry(registry: IWidgetTypeRegistry): void {
+        this.widgetTypeRegistry = registry;
     }
 
     /**
@@ -162,19 +178,25 @@ export class PluginManagerService {
      *   every handler the plugin has registered.
      * @param zones - Per-plugin zone facade. Same lifecycle and bulk-
      *   disposal contract as the hooks facade.
+     * @param widgetTypes - Per-plugin widget-type facade. Same
+     *   lifecycle and bulk-disposal contract as the hooks and zones
+     *   facades; complementary to the placement soft-disable that
+     *   runs through the compat-shim `WidgetService` on `disposeWidgets`.
      */
     public registerPlugin(
         plugin: IPlugin,
         context: IPluginContext,
         hooks: PluginHooks,
-        zones: PluginZones
+        zones: PluginZones,
+        widgetTypes: PluginWidgetTypes
     ): void {
         this.loadedPlugins.set(plugin.manifest.id, {
             plugin,
             context,
             manifest: plugin.manifest,
             hooks,
-            zones
+            zones,
+            widgetTypes
         });
     }
 
@@ -281,6 +303,67 @@ export class PluginManagerService {
     }
 
     /**
+     * Rebuild a plugin's widget-type facade and rebind it to the live
+     * context. Called immediately before re-entering a plugin's
+     * install/enable/init path so the plugin sees an open lifecycle
+     * window for `context.widgetTypes.register(...)` calls.
+     *
+     * @param loaded - Loaded plugin record.
+     */
+    private rearmWidgetTypes(loaded: ILoadedPlugin): void {
+        if (!this.widgetTypeRegistry) {
+            return;
+        }
+        try {
+            loaded.widgetTypes.closeAndDisposeAll();
+        } catch (err) {
+            logger.warn({ err, pluginId: loaded.manifest.id }, 'Widget-type facade dispose threw during rearm');
+        }
+        this.widgetTypeRegistry.disposeForPlugin(loaded.manifest.id);
+        const fresh = new PluginWidgetTypes(loaded.manifest.id, this.widgetTypeRegistry, loaded.context.logger);
+        loaded.widgetTypes = fresh;
+        loaded.context.widgetTypes = fresh;
+    }
+
+    /**
+     * Close a plugin's widget-type facade, drop every registered type
+     * it owns, and chain into the compat-shim widget service to
+     * soft-disable the associated plugin-source placements and clear
+     * the legacy in-memory cache. The placement rows themselves
+     * survive (soft-disable) so operator customisations to ordering
+     * or routes are preserved across the plugin's disable/re-enable
+     * cycle.
+     *
+     * @param loaded - Loaded plugin record.
+     */
+    private async disposeWidgetTypes(loaded: ILoadedPlugin): Promise<void> {
+        try {
+            loaded.widgetTypes.closeAndDisposeAll();
+        } catch (err) {
+            logger.warn({ err, pluginId: loaded.manifest.id }, 'Widget-type facade dispose threw');
+        }
+        if (this.widgetTypeRegistry) {
+            this.widgetTypeRegistry.disposeForPlugin(loaded.manifest.id);
+        }
+        // Chain into the compat-shim widget service so its legacy
+        // in-memory cache is cleared and the matching plugin-source
+        // placements are soft-disabled. This closes the leak the
+        // PR 1 research flagged: `widgetService.unregisterAll` had no
+        // call site in the plugin manager before now, so plugin
+        // widgets persisted in the cache and (later) in the
+        // placement collection across disable/uninstall.
+        try {
+            const widgetService = WidgetService.getInstance();
+            await widgetService.unregisterAll(loaded.manifest.id);
+        } catch (err) {
+            logger.warn(
+                { err, pluginId: loaded.manifest.id },
+                'WidgetService compat-shim unregisterAll threw'
+            );
+        }
+    }
+
+    /**
      * Get all loaded plugin manifests.
      *
      * @returns Array of plugin manifests for all discovered plugins
@@ -314,10 +397,11 @@ export class PluginManagerService {
             }
 
             // Rebind fresh per-plugin facades so the plugin's install/
-            // enable/init path sees open lifecycle windows for hooks and
-            // zones.
+            // enable/init path sees open lifecycle windows for hooks,
+            // zones, and widget types.
             this.rearmHooks(loaded);
             this.rearmZones(loaded);
+            this.rearmWidgetTypes(loaded);
 
             // Run install hook if not already installed
             if (!metadata.installed && plugin.install) {
@@ -339,11 +423,12 @@ export class PluginManagerService {
             }
 
             // Seal the lifecycle windows. Subsequent register() attempts
-            // (e.g. inside request handlers) now throw — handlers and
-            // zone declarations registered during install/enable/init
-            // stay live.
+            // (e.g. inside request handlers) now throw — handlers,
+            // zones, and widget-type declarations registered during
+            // install/enable/init stay live.
             loaded.hooks.seal();
             loaded.zones.seal();
+            loaded.widgetTypes.seal();
 
             // Mark as enabled in database
             await this.metadataService.markEnabled(pluginId);
@@ -404,6 +489,7 @@ export class PluginManagerService {
             // disable hook remembered to call disposers itself.
             this.disposeHooks(loaded);
             this.disposeZones(loaded);
+            await this.disposeWidgetTypes(loaded);
 
             // Mark as disabled in database
             await this.metadataService.markDisabled(pluginId);
@@ -458,14 +544,17 @@ export class PluginManagerService {
             }
 
             // Rearm the per-plugin facades so the install hook may
-            // register handlers and declare zones. A previous disable/
-            // uninstall cycle leaves the facades closed, and the install
-            // lifecycle window is one of the three points where
-            // context.hooks.register(...) and context.zones.register(...)
-            // are allowed — reinstall and upgrade flows depend on these
-            // being fresh facades.
+            // register handlers, declare zones, and declare widget
+            // types. A previous disable/uninstall cycle leaves the
+            // facades closed, and the install lifecycle window is one
+            // of the three points where context.hooks.register(...),
+            // context.zones.register(...), and
+            // context.widgetTypes.register(...) are allowed —
+            // reinstall and upgrade flows depend on these being fresh
+            // facades.
             this.rearmHooks(loaded);
             this.rearmZones(loaded);
+            this.rearmWidgetTypes(loaded);
 
             // Run install hook if defined
             if (plugin.install) {
@@ -477,6 +566,7 @@ export class PluginManagerService {
             // will rearm the facades before plugin.enable/init runs.
             loaded.hooks.seal();
             loaded.zones.seal();
+            loaded.widgetTypes.seal();
 
             // Mark as installed in database
             await this.metadataService.markInstalled(pluginId);
@@ -599,9 +689,11 @@ export class PluginManagerService {
             }
 
             // Rebind fresh per-plugin facades so the plugin's enable/
-            // init path sees open lifecycle windows for hooks and zones.
+            // init path sees open lifecycle windows for hooks, zones,
+            // and widget types.
             this.rearmHooks(loaded);
             this.rearmZones(loaded);
+            this.rearmWidgetTypes(loaded);
 
             // Run enable hook if defined
             if (plugin.enable) {
@@ -618,6 +710,7 @@ export class PluginManagerService {
             // Seal the lifecycle windows now that enable+init have run.
             loaded.hooks.seal();
             loaded.zones.seal();
+            loaded.widgetTypes.seal();
 
             // Mark as enabled in database
             await this.metadataService.markEnabled(pluginId);
@@ -687,6 +780,7 @@ export class PluginManagerService {
             // disable hook remembered to call disposers itself.
             this.disposeHooks(loaded);
             this.disposeZones(loaded);
+            await this.disposeWidgetTypes(loaded);
 
             // Mark as disabled in database
             await this.metadataService.markDisabled(pluginId);

--- a/src/backend/services/widget/__tests__/widget.service.test.ts
+++ b/src/backend/services/widget/__tests__/widget.service.test.ts
@@ -200,7 +200,7 @@ describe('WidgetService', () => {
             await service.unregisterAll('no-widgets');
 
             expect(mockLogger.info).toHaveBeenCalledWith(
-                'All widgets unregistered for plugin',
+                'Legacy in-memory cache cleared for plugin',
                 { pluginId: 'no-widgets', count: 0 }
             );
         });

--- a/src/backend/services/widget/widget.service.ts
+++ b/src/backend/services/widget/widget.service.ts
@@ -3,18 +3,19 @@ import type {
     IWidgetConfig,
     IWidgetData,
     ISystemLogService,
-    IZoneRegistry
+    IZoneRegistry,
+    IWidgetTypeRegistry,
+    IPlacementService
 } from '@/types';
+import { defineWidgetType } from '../../modules/widgets/widget-types/define-widget-type.js';
+import type { PlacementResolver } from '../../modules/widgets/placements/placement-resolver.js';
 
 /**
  * Fallback set used for zone validation when no `IZoneRegistry` has
  * been injected yet — covers test paths that instantiate the service
  * without bootstrap wiring. Production always overrides this via
  * `setZoneRegistry(...)` immediately after bootstrap constructs the
- * registry, so this set's job is to mirror the registry's declared
- * core zones (see `modules/widgets/zones/descriptors.ts`) and nothing
- * more — divergence would have widgets warn-or-not depending on
- * whether the registry happened to be wired.
+ * registry, so this set mirrors the registry's declared core zones.
  */
 const FALLBACK_VALID_ZONES = new Set([
     'ticker-after',
@@ -24,90 +25,51 @@ const FALLBACK_VALID_ZONES = new Set([
     'plugin-content:after'
 ]);
 
+/** Default order applied when input omits one. */
+const DEFAULT_ORDER = 100;
+
 /**
- * Singleton service managing plugin widget registration and SSR data fetching.
+ * Compatibility-shim widget service.
  *
- * Maintains an in-memory registry of widgets registered by plugins. Provides methods
- * for filtering widgets by route and fetching their data during SSR. This service
- * enables plugins to extend existing pages by injecting components into designated
- * zones without modifying core page code.
+ * PR 2 reshapes the plugin-facing widget API: instead of an in-memory
+ * registry, plugin registrations are split into a widget-type
+ * declaration (against `IWidgetTypeRegistry`) plus a plugin-source
+ * placement (against `IPlacementService`). The shim translates the
+ * legacy `IWidgetService` calls into this new shape so the five
+ * existing plugins (and any third-party plugin shipping against the
+ * old API) keep working without code change.
  *
- * Key responsibilities:
- * - Widget registration and deregistration
- * - Route-based filtering of active widgets
- * - Parallel data fetching for SSR with timeout protection
- * - Widget ordering by zone and sort order
+ * Operational modes:
  *
- * @example
- * ```typescript
- * // Register a widget in plugin init() hook
- * await widgetService.register({
- *     id: 'reddit-feed',
- *     zone: 'main-after',
- *     routes: ['/'],
- *     order: 10,
- *     title: 'Community Buzz',
- *     fetchData: async () => ({ posts: [] })
- * }, 'reddit-sentiment');
+ * - **Wired** (production): every method delegates to the new
+ *   widget-type / placement services. `WidgetsModule.init()` calls
+ *   the `setWidgetTypeRegistry`/`setPlacementService`/`setPlacementResolver`
+ *   setters once during bootstrap.
+ * - **Unwired** (tests that don't construct `WidgetsModule`): the
+ *   legacy in-memory Map of widgets is consulted for the existing
+ *   sync admin reads and for `fetchWidgetsForRoute`. This preserves
+ *   the 27 unit tests in `widget.service.test.ts` without forcing
+ *   each to mock the new infrastructure.
  *
- * // Fetch widgets for SSR
- * const widgets = await widgetService.fetchWidgetsForRoute('/');
- * ```
+ * The dual mode is temporary — PR 3 removes the legacy code path and
+ * the `IWidgetService` interface alongside the rest of the legacy
+ * widget surface.
  */
 export class WidgetService implements IWidgetService {
     private static instance: WidgetService;
     private widgets: Map<string, IWidgetConfig> = new Map();
     private logger: ISystemLogService;
     private zoneRegistry: IZoneRegistry | null = null;
+    private widgetTypeRegistry: IWidgetTypeRegistry | null = null;
+    private placementService: IPlacementService | null = null;
+    private placementResolver: PlacementResolver | null = null;
 
-    /**
-     * Private constructor enforcing singleton pattern with dependency injection.
-     *
-     * @param logger - Structured logger for widget service telemetry
-     */
     private constructor(logger: ISystemLogService) {
         this.logger = logger;
     }
 
     /**
-     * Inject the process-wide zone registry.
-     *
-     * Called once during bootstrap after the registry is constructed so
-     * that subsequent widget registrations can validate `config.zone`
-     * against the live set of declared zones — including plugin-declared
-     * zones that the hardcoded fallback set could not anticipate.
-     *
-     * @param registry - Shared zone registry instance.
-     */
-    public setZoneRegistry(registry: IZoneRegistry): void {
-        this.zoneRegistry = registry;
-    }
-
-    /**
-     * Test whether a zone id is currently known.
-     *
-     * Prefers the injected `IZoneRegistry`; falls back to the hardcoded
-     * set when the registry has not been wired (e.g. unit tests
-     * instantiating the singleton directly).
-     *
-     * @param zone - Zone id to check.
-     * @returns True if the zone is known.
-     */
-    private isKnownZone(zone: string): boolean {
-        if (this.zoneRegistry) {
-            return this.zoneRegistry.has(zone);
-        }
-        return FALLBACK_VALID_ZONES.has(zone);
-    }
-
-    /**
      * Get or create the singleton instance.
-     *
-     * Must be called with logger on first access. Subsequent calls ignore the
-     * logger parameter and return the existing instance.
-     *
-     * @param logger - Structured logger (required on first call)
-     * @returns The singleton widget service instance
      */
     public static getInstance(logger?: ISystemLogService): WidgetService {
         if (!WidgetService.instance) {
@@ -120,21 +82,65 @@ export class WidgetService implements IWidgetService {
     }
 
     /**
+     * Test-only reset to clear the singleton between unit tests.
+     */
+    public static __resetForTests(): void {
+        // @ts-expect-error — clearing the private static for tests
+        WidgetService.instance = undefined;
+    }
+
+    /**
+     * Inject the process-wide zone registry. Called once during
+     * bootstrap from the plugin loader.
+     */
+    public setZoneRegistry(registry: IZoneRegistry): void {
+        this.zoneRegistry = registry;
+    }
+
+    /**
+     * Inject the process-wide widget-type registry. Called once
+     * during `WidgetsModule.init()`.
+     */
+    public setWidgetTypeRegistry(registry: IWidgetTypeRegistry): void {
+        this.widgetTypeRegistry = registry;
+    }
+
+    /**
+     * Inject the module-owned placement service. Called once during
+     * `WidgetsModule.init()`.
+     */
+    public setPlacementService(service: IPlacementService): void {
+        this.placementService = service;
+    }
+
+    /**
+     * Inject the module-owned placement resolver. Called once during
+     * `WidgetsModule.init()`. When set, `fetchWidgetsForRoute` routes
+     * through the resolver instead of the in-memory cache.
+     */
+    public setPlacementResolver(resolver: PlacementResolver): void {
+        this.placementResolver = resolver;
+    }
+
+    /**
+     * Test whether a zone id is currently known.
+     */
+    private isKnownZone(zone: string): boolean {
+        if (this.zoneRegistry) {
+            return this.zoneRegistry.has(zone);
+        }
+        return FALLBACK_VALID_ZONES.has(zone);
+    }
+
+    /**
      * Register a widget with the service.
      *
-     * Adds the widget to the in-memory registry. If a widget with the same ID
-     * already exists, it will be replaced. This allows plugins to re-register
-     * widgets on hot reload.
-     *
-     * @param config - Widget configuration including zone, routes, and data fetcher
-     * @param pluginId - ID of the plugin registering this widget
-     * @returns Promise that resolves when registration is complete
+     * In wired mode this splits into a widget-type declaration and a
+     * plugin-source placement upsert. In unwired mode it falls back
+     * to the legacy in-memory Map. Either way, the in-memory Map is
+     * updated for sync admin reads.
      */
     public async register(config: IWidgetConfig, pluginId: string): Promise<void> {
-        // Validate zone name against the live registry (preferred) or
-        // the hardcoded fallback set when the registry has not been
-        // wired. Unknown zones produce a warning but do not block
-        // registration — the warning is diagnostic, not authoritative.
         if (!this.isKnownZone(config.zone)) {
             this.logger.warn('Widget registered with unknown zone', {
                 widgetId: config.id,
@@ -143,35 +149,98 @@ export class WidgetService implements IWidgetService {
             });
         }
 
-        // Clone config to avoid mutations
+        // Maintain the legacy in-memory cache for sync admin reads
+        // (`getAllWidgets`, `getWidgetsByZone`). PR 3 will replace
+        // those endpoints with placement-backed lookups and remove
+        // this cache.
         const widgetConfig: IWidgetConfig = {
             ...config,
             pluginId,
-            order: config.order ?? 100 // Default order
+            order: config.order ?? DEFAULT_ORDER
         };
-
         this.widgets.set(config.id, widgetConfig);
 
-        this.logger.debug('Widget registered', {
-            widgetId: config.id,
-            pluginId,
-            zone: config.zone,
-            routes: config.routes
-        });
+        // If the new system isn't wired (tests), the in-memory cache
+        // is the entire behaviour — keep going.
+        if (!this.widgetTypeRegistry || !this.placementService) {
+            this.logger.debug(
+                { widgetId: config.id, pluginId },
+                'Widget registered (legacy in-memory mode — placement service not wired)'
+            );
+            return;
+        }
+
+        // Register the widget type if this plugin hasn't claimed the
+        // id yet. Re-registration during the same lifecycle window
+        // is a plugin bug; we tolerate it silently because the
+        // legacy API allowed silent replacement.
+        if (!this.widgetTypeRegistry.has(config.id)) {
+            try {
+                const descriptor = defineWidgetType({
+                    id: config.id,
+                    label: config.title ?? config.id,
+                    description: config.description ?? '',
+                    defaultDataFetcher: config.fetchData
+                });
+                this.widgetTypeRegistry.register(pluginId, descriptor);
+            } catch (err) {
+                this.logger.error(
+                    {
+                        err,
+                        widgetId: config.id,
+                        pluginId
+                    },
+                    'Failed to register widget type via compat shim'
+                );
+                return;
+            }
+        }
+
+        // Ensure the plugin-source placement exists and is enabled.
+        // Upsert semantics preserve operator customisations to
+        // `order`, `routes`, `title` across plugin disable/re-enable.
+        try {
+            await this.placementService.ensurePluginPlacement({
+                typeId: config.id,
+                zoneId: config.zone,
+                routes: config.routes,
+                order: config.order,
+                title: config.title,
+                pluginId
+            });
+        } catch (err) {
+            this.logger.error(
+                {
+                    err,
+                    widgetId: config.id,
+                    pluginId
+                },
+                'Failed to ensure plugin placement via compat shim'
+            );
+        }
+
+        this.logger.debug(
+            {
+                widgetId: config.id,
+                pluginId,
+                zone: config.zone,
+                routes: config.routes
+            },
+            'Widget registered via compat shim'
+        );
     }
 
     /**
-     * Unregister a widget from the service.
+     * Unregister a widget by id.
      *
-     * Removes the widget from the in-memory registry. The widget will no longer
-     * appear in calls to fetchWidgetsForRoute().
-     *
-     * @param widgetId - Unique ID of the widget to unregister
-     * @returns Promise that resolves when unregistration is complete
+     * Legacy semantic — used by tests; production plugin lifecycle
+     * uses `unregisterAll`. Clears the in-memory cache only; widget
+     * types are disposed via `PluginManagerService.disposeWidgetTypes`
+     * and placements are soft-disabled via
+     * `PlacementService.softDisableForPlugin`.
      */
     public async unregister(widgetId: string): Promise<void> {
         const deleted = this.widgets.delete(widgetId);
-
         if (deleted) {
             this.logger.debug('Widget unregistered', { widgetId });
         } else {
@@ -182,11 +251,10 @@ export class WidgetService implements IWidgetService {
     /**
      * Unregister all widgets for a plugin.
      *
-     * Removes all widgets registered by the specified plugin. Used during
-     * plugin disable/uninstall to clean up all widget registrations.
-     *
-     * @param pluginId - ID of the plugin whose widgets should be unregistered
-     * @returns Promise that resolves when all widgets are unregistered
+     * Closes the previous (PR 1) leak by chaining into the placement
+     * service's soft-disable path. Widget-type disposal goes through
+     * the dedicated plugin-manager lifecycle (see
+     * `PluginManagerService.disposeWidgetTypes`).
      */
     public async unregisterAll(pluginId: string): Promise<void> {
         const widgetsToRemove: string[] = [];
@@ -201,37 +269,53 @@ export class WidgetService implements IWidgetService {
             this.widgets.delete(widgetId);
         }
 
-        this.logger.info('All widgets unregistered for plugin', {
+        this.logger.info('Legacy in-memory cache cleared for plugin', {
             pluginId,
             count: widgetsToRemove.length
         });
+
+        if (this.placementService) {
+            try {
+                await this.placementService.softDisableForPlugin(pluginId);
+            } catch (err) {
+                this.logger.error(
+                    { err, pluginId },
+                    'Failed to soft-disable plugin placements via compat shim'
+                );
+            }
+        }
     }
 
     /**
-     * Fetch widget data for a specific route.
+     * Fetch widget data for a route.
      *
-     * Filters registered widgets by route match, executes their fetchData()
-     * functions in parallel with timeout protection, and returns the results
-     * sorted by zone and order.
-     *
-     * Widgets with failing fetchData() functions are excluded from results
-     * (errors are logged but not thrown).
-     *
-     * @param route - URL path to match against widget routes (e.g., '/', '/u/TXyz...')
-     * @param params - Route parameters extracted from the URL (e.g., { address: 'TXyz...' })
-     * @returns Promise resolving to array of widget data with pre-fetched content
+     * Routes through the placement resolver when wired; falls back to
+     * the legacy in-memory implementation for unwired test paths.
      */
     public async fetchWidgetsForRoute(
         route: string,
         params: Record<string, string> = {}
     ): Promise<IWidgetData[]> {
-        // Filter widgets by route
+        if (this.placementResolver) {
+            return this.placementResolver.resolveForRoute(route, params);
+        }
+
+        return this.legacyFetchWidgetsForRoute(route, params);
+    }
+
+    /**
+     * Legacy in-memory fetch retained as a fallback for tests that
+     * instantiate `WidgetService` without constructing `WidgetsModule`.
+     * Production paths always run through the placement resolver.
+     */
+    private async legacyFetchWidgetsForRoute(
+        route: string,
+        params: Record<string, string>
+    ): Promise<IWidgetData[]> {
         const matchingWidgets = Array.from(this.widgets.values()).filter(widget => {
-            // Empty routes array means show on all routes
             if (widget.routes.length === 0) {
                 return true;
             }
-            // Check for exact route match
             return widget.routes.includes(route);
         });
 
@@ -239,7 +323,7 @@ export class WidgetService implements IWidgetService {
             return [];
         }
 
-        this.logger.debug('Fetching widget data for route', {
+        this.logger.debug('Fetching widget data for route (legacy path)', {
             route,
             params,
             widgetCount: matchingWidgets.length
@@ -247,11 +331,9 @@ export class WidgetService implements IWidgetService {
 
         const TIMEOUT_MS = 5000;
 
-        // Fetch data for all matching widgets in parallel
         const widgetDataPromises = matchingWidgets.map(async (widget): Promise<IWidgetData | null> => {
             let timerId: NodeJS.Timeout | undefined;
             try {
-                // Use Promise.race for actual timeout enforcement, and clear timer when done
                 const timeoutPromise = new Promise<never>((_, reject) => {
                     timerId = setTimeout(() => reject(new Error('Widget fetch timeout')), TIMEOUT_MS);
                 });
@@ -261,7 +343,6 @@ export class WidgetService implements IWidgetService {
                 ]);
                 clearTimeout(timerId);
 
-                // Validate data is JSON-serializable
                 const data = this.validateSerializable(rawData, widget.id);
                 if (data === null) {
                     return null;
@@ -271,7 +352,7 @@ export class WidgetService implements IWidgetService {
                     id: widget.id,
                     zone: widget.zone,
                     pluginId: widget.pluginId!,
-                    order: widget.order ?? 100,
+                    order: widget.order ?? DEFAULT_ORDER,
                     title: widget.title,
                     data
                 };
@@ -288,19 +369,16 @@ export class WidgetService implements IWidgetService {
 
         const widgetDataResults = await Promise.all(widgetDataPromises);
 
-        // Filter out failed widgets and sort by zone then order
         const widgetData = widgetDataResults
             .filter((w): w is IWidgetData => w !== null)
             .sort((a, b) => {
-                // Sort by zone first (alphabetically)
                 if (a.zone !== b.zone) {
                     return a.zone.localeCompare(b.zone);
                 }
-                // Then by order
                 return a.order - b.order;
             });
 
-        this.logger.debug('Widget data fetched successfully', {
+        this.logger.debug('Widget data fetched successfully (legacy path)', {
             route,
             successCount: widgetData.length,
             failedCount: matchingWidgets.length - widgetData.length
@@ -309,16 +387,6 @@ export class WidgetService implements IWidgetService {
         return widgetData;
     }
 
-    /**
-     * Validate that data is JSON-serializable.
-     *
-     * Attempts a round-trip through JSON to catch non-serializable data
-     * (BigInt, circular references, functions) before SSR.
-     *
-     * @param data - Raw data from widget fetchData
-     * @param widgetId - Widget ID for error logging
-     * @returns Validated data or null if not serializable
-     */
     private validateSerializable(data: unknown, widgetId: string): unknown {
         try {
             return JSON.parse(JSON.stringify(data));
@@ -332,29 +400,22 @@ export class WidgetService implements IWidgetService {
     }
 
     /**
-     * Get all registered widgets (without fetching data).
+     * Get all registered widgets (sync legacy read).
      *
-     * Returns the raw widget configurations for all registered widgets.
-     * Useful for admin interfaces or debugging.
-     *
-     * @returns Array of widget configurations
+     * Returns the in-memory cache — plugin-source widgets only.
+     * Operator-source placements (introduced via the admin API in
+     * PR 3) are not visible through this method.
      */
     public getAllWidgets(): IWidgetConfig[] {
         return Array.from(this.widgets.values());
     }
 
     /**
-     * Get widgets for a specific zone (without fetching data).
-     *
-     * Returns widget configurations filtered by zone. Useful for debugging
-     * or admin interfaces that need to show which widgets are in each zone.
-     *
-     * @param zone - Zone name to filter by
-     * @returns Array of widget configurations in the specified zone
+     * Get widgets for a specific zone (sync legacy read).
      */
     public getWidgetsByZone(zone: string): IWidgetConfig[] {
         return Array.from(this.widgets.values())
             .filter(widget => widget.zone === zone)
-            .sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
+            .sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER));
     }
 }

--- a/src/backend/services/widget/widget.service.ts
+++ b/src/backend/services/widget/widget.service.ts
@@ -170,11 +170,47 @@ export class WidgetService implements IWidgetService {
             return;
         }
 
-        // Register the widget type if this plugin hasn't claimed the
-        // id yet. Re-registration during the same lifecycle window
-        // is a plugin bug; we tolerate it silently because the
-        // legacy API allowed silent replacement.
-        if (!this.widgetTypeRegistry.has(config.id)) {
+        // Resolve current ownership of the widget-type id before
+        // routing into the registry. Three cases:
+        //
+        // - owner === pluginId: same plugin re-registering (hot
+        //   reload during the same lifecycle window). Skip the
+        //   registry call because `defineWidgetType` would throw on
+        //   the cached id; the existing descriptor stays in place.
+        // - owner === undefined: id is unclaimed. Mint a descriptor
+        //   and register it.
+        // - owner is some other plugin: cross-plugin id collision.
+        //   Refuse to register the type AND refuse to create the
+        //   placement, otherwise the new plugin's placement would
+        //   silently render the first plugin's `defaultDataFetcher`.
+        const currentOwner = this.widgetTypeRegistry.getOwnerPluginId(config.id);
+        if (currentOwner !== undefined && currentOwner !== pluginId) {
+            this.logger.error(
+                {
+                    widgetId: config.id,
+                    pluginId,
+                    existingOwner: currentOwner
+                },
+                'Refusing widget registration: type id is already owned by another plugin'
+            );
+            return;
+        }
+
+        if (currentOwner === pluginId) {
+            // Same-plugin re-registration within an open lifecycle
+            // window. The legacy service silently replaced the
+            // in-memory config; the new system keeps the original
+            // descriptor (and its data fetcher) intact. Flag this as
+            // a likely plugin bug — re-enable through the admin UI
+            // is the supported path for applying changed data
+            // fetchers.
+            this.logger.warn(
+                { widgetId: config.id, pluginId },
+                'Widget re-registered within the same lifecycle window; the original widget-type descriptor is preserved. Re-enable the plugin to apply a changed data fetcher.'
+            );
+        }
+
+        if (currentOwner === undefined) {
             try {
                 const descriptor = defineWidgetType({
                     id: config.id,

--- a/src/backend/tests/vitest/mocks/database-service.ts
+++ b/src/backend/tests/vitest/mocks/database-service.ts
@@ -307,8 +307,12 @@ export function createMockDatabaseService(): IDatabaseService & {
                     if (options?.upsert) {
                         const id = new ObjectId();
                         const updateFields = (update as any).$set || {};
-                        // Merge filter fields with update fields (matches MongoDB behavior)
-                        const newDoc = { ...filter, ...updateFields, _id: id };
+                        const setOnInsertFields = (update as any).$setOnInsert || {};
+                        // Merge filter fields with $setOnInsert (insert-only) and $set fields.
+                        // MongoDB behavior: $set applies on insert AND update; $setOnInsert only
+                        // applies on insert. Spread order gives $set priority over $setOnInsert
+                        // on overlap, though by contract the two should not share keys.
+                        const newDoc = { ...filter, ...setOnInsertFields, ...updateFields, _id: id };
                         data.push(newDoc);
                         return { modifiedCount: 0, matchedCount: 0, acknowledged: true, upsertedCount: 1, upsertedId: id };
                     }

--- a/src/backend/tests/vitest/mocks/mongoose.ts
+++ b/src/backend/tests/vitest/mocks/mongoose.ts
@@ -130,6 +130,14 @@ export function matchesFilter(doc: any, filter: Filter<any>): boolean {
                 return exists ? docValue !== undefined : docValue === undefined;
             }
 
+            // Handle $size operator: { field: { $size: N } } — matches
+            // arrays of length N. Returns false for non-array values.
+            if ('$size' in value) {
+                const size = (value as any).$size;
+                const docValue = getNestedValue(doc, key);
+                return Array.isArray(docValue) && docValue.length === size;
+            }
+
             // Handle $gte operator: { field: { $gte: value } }
             if ('$gte' in value) {
                 const gteValue = (value as any).$gte;


### PR DESCRIPTION
## Summary

- PR 2 of three on the widget refactor. Splits the legacy widget concept into a *type* (the renderable capability, plugin-owned code) and a *placement* (where the type appears, operator-managed data). All five existing plugins keep working unchanged through a compat shim on `WidgetService`.
- New backend subsystems under `src/backend/modules/widgets/`: `widget-types/` (registry + per-plugin facade + `defineWidgetType` identity tracking) and `placements/` (`PlacementService` with `ensurePluginPlacement` / `softDisableForPlugin` / `findByRoute`, `PlacementResolver` for SSR with 5s timeout and JSON-serialisability guard, pure `routeMatches` predicate). Migration `001_create_widget_placements.ts` creates the collection with four indexes.
- Plugin lifecycle wired: bootstrap constructs `WidgetTypeRegistry` alongside `ZoneRegistry`; `loadPlugins` creates `PluginWidgetTypes` per plugin; `PluginManagerService` adds `rearmWidgetTypes` / `disposeWidgetTypes` at every activation path. `disposeWidgetTypes` chains into `WidgetService.unregisterAll(pluginId)` — closing the PR 1 leak where the legacy service's cleanup was never called.
- Compat shim semantics on `WidgetService`: `register` splits into type registration + placement upsert; `ensurePluginPlacement` uses find-then-(insert|update) so operator customisations to `order` / `routes` / `title` survive plugin disable/re-enable; `softDisableForPlugin` preserves placement rows for the same reason; `fetchWidgetsForRoute` delegates to the resolver in production and falls back to legacy in-memory mode for unit tests that don't construct `WidgetsModule`.

## Why now

The widget zone registry in PR 1 was scaffolding. This PR is the actual structural change the original brainstorm targeted: shift placement decisions (zone, routes, order, title) out of plugin code and into operator-managed data, so adding or moving a widget stops being a build-and-deploy event. With placements persisted, PR 3's drag-drop admin editor has a real model to edit.

## Notes

- No plugin-side code change required. Verified by the existing widget-service unit tests (27 passing).
- IPluginContext gains a `widgetTypes: IPluginWidgetTypes` field. Existing plugin code reads structurally; the new field does not break consumers.
- Legacy `IWidgetData` shape preserved end-to-end so the frontend `WidgetZone` component renders unchanged.
- 43 new tests (21 widget-type subsystem + 22 placement subsystem). Full backend suite at 901 passing / 1 skipped. Typecheck clean.
- PR 3 will migrate `trp-whale-alerts` to `context.widgetTypes` directly as a proof point and delete the legacy widget service + `WIDGET_ZONES` sidebar entries.