### PR TITLE
Add operator UI for widget placements

### DIFF
--- a/docs/system/system-api-widgets.md
+++ b/docs/system/system-api-widgets.md
@@ -59,7 +59,7 @@ The placements controller refuses input on any of:
 - `zoneId` not registered in `IZoneRegistry`.
 - `routes` entry that doesn't start with `/`, contains whitespace, or carries a glob marker outside the trailing segment.
 - `order` outside `[0, 10000]`, non-integer, or non-finite.
-- `title` empty after trim, or longer than 80 characters.
+- `title` empty after trim, or longer than 80 characters. Pass `title: null` on PATCH to clear an existing override (`$unset`).
 - `instanceConfig` not a plain object.
 
 ## Route Pattern Grammar

--- a/docs/system/system-api-widgets.md
+++ b/docs/system/system-api-widgets.md
@@ -1,0 +1,96 @@
+# Widget Admin API
+
+Endpoints powering the `/system/widgets` operator UI. Three parallel namespaces under `/api/admin/system/` cover read-only zone and widget-type introspection plus full placement CRUD.
+
+## Why This Matters
+
+The type/placement split landed in PR 2 of the widget rewrite gave operators a data model they could edit; the endpoints documented here surface that model. Without them, placements can only change via plugin re-registration. With them, an operator can pin a widget to a route subtree, reorder zones, soft-disable a noisy plugin row, or revert customisations — all without redeploying.
+
+## How It Works
+
+All three routers chain `createAdminRateLimiter` before `requireAdmin` at mount time, so every endpoint is bounded per-IP and gated to the cookie or service-token auth path. Mutations on `/placements` broadcast `widgets:placements-update` over WebSocket to every connected socket; admin UIs refetch, public pages refetch widget data.
+
+The placements controller validates inputs against the live `IZoneRegistry` and `IWidgetTypeRegistry`. A request naming an unknown zone or type fails 400 before the placement service is touched. Route patterns flow through `normaliseRoutePattern` so the matcher's grammar (exact, `/u/*`, `/u/**`) is the single source of truth — see [Route Pattern Grammar](#route-pattern-grammar) below.
+
+## Endpoints
+
+### Zones — read-only introspection
+
+| Method | Path | Returns |
+|---|---|---|
+| GET | `/api/admin/system/zones` | `IZoneSnapshot` |
+
+Tracks-grouped catalogue of every registered zone with host (`site` / `core` / `plugin` / `admin`) and registration metadata.
+
+### Widget Types — read-only introspection
+
+| Method | Path | Returns |
+|---|---|---|
+| GET | `/api/admin/system/widget-types` | `IWidgetTypeSnapshot` |
+
+Plugin-grouped catalogue of every declared widget type.
+
+### Placements — full CRUD
+
+| Method | Path | Body | Returns | Status codes |
+|---|---|---|---|---|
+| GET | `/placements` | — | `{ success, placements: IWidgetPlacement[] }` | 200 |
+| GET | `/placements/:id` | — | `{ success, placement }` | 200 / 404 |
+| POST | `/placements` | `IPlacementInput` | `{ success, placement }` | 201 / 400 |
+| PATCH | `/placements/:id` | `IPlacementPatch` | `{ success, placement }` | 200 / 400 / 404 |
+| DELETE | `/placements/:id` | — | empty | 204 / 400 / 404 |
+| POST | `/placements/:id/restore-defaults` | — | `{ success, placement }` | 200 / 400 / 404 / 409 |
+
+Base path: `/api/admin/system/widgets`.
+
+`GET /placements` accepts query params `zoneId`, `pluginId`, `source` (`plugin`\|`operator`), and `enabledOnly` (`true`\|`1`).
+
+`POST /placements` always creates an operator-source row. Plugin-source rows are created exclusively by the legacy widget-service compatibility shim during plugin enable.
+
+`DELETE /placements/:id` refuses plugin-source rows with 400 — the supported reversals are disable (`PATCH { enabled: false }`) and restore-defaults. Operator rows delete cleanly.
+
+`POST /placements/:id/restore-defaults` is only valid on plugin-source rows. It looks up the plugin's cached registration args (captured the first time the plugin called `widgetService.register(...)` in this process) and applies them as a single update, re-enabling the row. Returns 409 when the cache lookup misses — re-enable the plugin to repopulate.
+
+## Validation Rules
+
+The placements controller refuses input on any of:
+
+- `typeId` not registered in `IWidgetTypeRegistry`.
+- `zoneId` not registered in `IZoneRegistry`.
+- `routes` entry that doesn't start with `/`, contains whitespace, or carries a glob marker outside the trailing segment.
+- `order` outside `[0, 10000]`, non-integer, or non-finite.
+- `title` empty after trim, or longer than 80 characters.
+- `instanceConfig` not a plain object.
+
+## Route Pattern Grammar
+
+Placement `routes` arrays accept three forms:
+
+| Form | Matches | Example |
+|---|---|---|
+| Exact | The literal path, nothing else | `/markets` |
+| Single-segment glob | One trailing segment, no deeper | `/u/*` matches `/u/TXyz`, not `/u/TXyz/holdings` |
+| Deep glob | Any depth below the prefix | `/admin/**` matches `/admin/users/edit` |
+
+Empty `routes: []` matches every route. The matcher is `routeMatches` in `src/backend/modules/widgets/placements/route-matcher.ts`.
+
+## WebSocket Event
+
+`widgets:placements-update` fires after every successful create / update / delete / restore. Payload:
+
+```typescript
+{
+    event: 'placement:created' | 'placement:updated' | 'placement:deleted' | 'placement:restored',
+    placementId: string,
+    zoneId?: string,
+    timestamp: string  // ISO-8601
+}
+```
+
+Audience: all connected sockets. Receivers refetch — admins re-pull the placement list, public pages re-pull their SSR widget data.
+
+## Further Reading
+
+- [Widgets Module README](../../src/backend/modules/widgets/README.md) — Complete contract and storage schema for the placement subsystem
+- [system-api.md](./system-api.md) — Admin auth conventions and response envelope
+- [plugins-widget-zones.md](../plugins/plugins-widget-zones.md) — Plugin-side widget registration patterns

--- a/docs/system/system-api.md
+++ b/docs/system/system-api.md
@@ -41,6 +41,7 @@ When both succeed, the cookie wins: `req.adminVia = 'user'`. Token-only is tagge
 | [system-api-scheduler.md](./system-api-scheduler.md) | `/scheduler/status`, `/scheduler/health`, `PATCH /scheduler/job/:jobName` |
 | [system-api-logs.md](./system-api-logs.md) | `/logs` query/stats/get/resolve/unresolve/delete |
 | [system-api-websockets.md](./system-api-websockets.md) | WebSocket monitoring endpoints + real-time event reference (`transaction:large`, `delegation:new`, `block:new`, `comments:new`, `chat:update`) |
+| [system-api-widgets.md](./system-api-widgets.md) | Widget placements admin CRUD + zone/widget-type introspection (`/api/admin/system/widgets/placements`, `/api/admin/system/zones`, `/api/admin/system/widget-types`) |
 
 ## Troubleshooting
 

--- a/packages/types/src/widget-placements/IPlacementService.ts
+++ b/packages/types/src/widget-placements/IPlacementService.ts
@@ -137,4 +137,28 @@ export interface IPlacementService {
      * @returns Placements in `(zoneId asc, order asc)` order.
      */
     list(filter?: IPlacementListFilter): Promise<ReadonlyArray<IWidgetPlacement>>;
+
+    /**
+     * Replace operator-editable fields on a plugin-source placement
+     * with the plugin's original registration args and re-enable the
+     * row. Used by the admin "restore plugin defaults" endpoint.
+     *
+     * Callers are responsible for verifying the placement is
+     * plugin-source and for resolving the plugin defaults — the
+     * service applies the patch atomically and broadcasts a
+     * `placement:restored` event.
+     *
+     * @param id - Placement id (stringified ObjectId).
+     * @param defaults - Plugin defaults to apply.
+     * @returns Updated placement, or null when no row matches.
+     */
+    restoreToPluginDefaults(
+        id: string,
+        defaults: {
+            zoneId: string;
+            routes: ReadonlyArray<string>;
+            order: number;
+            title?: string;
+        }
+    ): Promise<IWidgetPlacement | null>;
 }

--- a/packages/types/src/widget-placements/IPlacementService.ts
+++ b/packages/types/src/widget-placements/IPlacementService.ts
@@ -35,12 +35,18 @@ export interface IPlacementListFilter {
 
 /**
  * Patch shape for `update`. Any subset of operator-editable fields.
+ *
+ * Title supports an explicit clear: `title: null` removes the field
+ * (`$unset`) so the placement falls back to the widget-type label.
+ * Omitting `title` from the patch leaves the existing value unchanged.
+ * `title: ''` is rejected at the controller boundary so blank cannot
+ * sneak in through clients that drop empty strings.
  */
 export interface IPlacementPatch {
     zoneId?: string;
     routes?: string[];
     order?: number;
-    title?: string;
+    title?: string | null;
     instanceConfig?: Record<string, unknown>;
     enabled?: boolean;
 }

--- a/src/backend/modules/widgets/README.md
+++ b/src/backend/modules/widgets/README.md
@@ -60,7 +60,7 @@ All endpoints require admin auth (cookie path: verified wallet + admin group; se
 | GET | `/api/admin/system/widgets/placements` | — | `{ success, placements: IWidgetPlacement[] }` | Query: `zoneId?`, `pluginId?`, `source?` (`plugin`\|`operator`), `enabledOnly?` |
 | GET | `/api/admin/system/widgets/placements/:id` | — | `{ success, placement }` or 404 | |
 | POST | `/api/admin/system/widgets/placements` | `IPlacementInput` | `{ success, placement }` 201 | Always `source: 'operator'`; rejects unknown `typeId`/`zoneId`/route patterns/order out of `[0,10000]`/title > 80 chars |
-| PATCH | `/api/admin/system/widgets/placements/:id` | `IPlacementPatch` | `{ success, placement }` or 404 | Operator-editable on every row, including plugin-source |
+| PATCH | `/api/admin/system/widgets/placements/:id` | `IPlacementPatch` | `{ success, placement }` or 404 | Operator-editable on every row, including plugin-source. `title: null` clears the override (`$unset`); omitting `title` leaves it unchanged |
 | DELETE | `/api/admin/system/widgets/placements/:id` | — | 204 / 400 / 404 | 400 on plugin-source rows (use disable or restore-defaults) |
 | POST | `/api/admin/system/widgets/placements/:id/restore-defaults` | — | `{ success, placement }` | 400 on operator rows; 409 when plugin has not registered in this process |
 

--- a/src/backend/modules/widgets/README.md
+++ b/src/backend/modules/widgets/README.md
@@ -1,0 +1,138 @@
+# Widgets Module
+
+Splits widget rendering into two persistent concerns: **types** (what a widget *is* — plugin-owned code) and **placements** (where a widget *appears* — operator-editable data). Plugin code keeps calling the legacy `widgetService.register(...)` API; the module's compat shim routes those calls into the type/placement infrastructure transparently. Operators edit placements at `/system/widgets`; changes broadcast over WebSocket so public pages live-refresh.
+
+## Quick Reference
+
+| | |
+|---|---|
+| Module id | `widgets` |
+| Admin UI | `/system/widgets` |
+| Backend API base | `/api/admin/system/widgets/placements`, `/api/admin/system/widget-types`, `/api/admin/system/zones` |
+| WebSocket event | `widgets:placements-update` |
+| Types package | `@delphian/tronrelic-types` — `IPlacementService`, `IWidgetPlacement`, `IPlacementInput`, `IPlacementPatch`, `IPluginPlacementInput`, `PlacementSource`, `IZoneRegistry`, `IZoneSnapshot`, `IWidgetTypeRegistry`, `IWidgetTypeSnapshot` |
+| Storage | `module_widgets_placements` (MongoDB) |
+| Migration | `module:widgets:001_create_placements_collection` (creates collection + 4 indexes) |
+| System menu node | "Widgets" under the System container — seeded by `WidgetsModule.run()` |
+| Legacy compat shim | `WidgetService` singleton at `src/backend/services/widget/widget.service.ts` |
+
+## Source Map
+
+| File | Purpose |
+|------|---------|
+| `WidgetsModule.ts` | `IModule` impl: wires registries, placement service, broadcast callback, mounts three admin routers, seeds menu entry |
+| `placements/placement.service.ts` | `IPlacementService` singleton: CRUD, `ensurePluginPlacement`, `softDisableForPlugin`, `findByRoute`, `restoreToPluginDefaults`, broadcast hook |
+| `placements/placement-resolver.ts` | SSR-time join of placements ↔ widget-type descriptors with 5s timeout and JSON serialisability check |
+| `placements/route-matcher.ts` | `routeMatches` predicate, `normaliseRoutePattern` validator, `partitionRoutePatterns` for the admin path |
+| `widget-types/widget-type-registry.ts` | Process-wide widget-type registry — bootstrap-instantiated, threaded into the plugin loader |
+| `widget-types/define-widget-type.ts` | Descriptor mint — runtime registry refuses unminted descriptors |
+| `widget-types/plugin-widget-types.ts` | Per-plugin facade (`context.widgetTypes`) tagging every registration with the plugin id |
+| `zones/zone-registry.ts` | Process-wide zone registry, auto-populated from core descriptors at module load |
+| `zones/define-zone.ts` | Zone descriptor mint |
+| `zones/descriptors.ts` | Core zone descriptors (`ZONES`) |
+| `api/zones.controller.ts` / `zones.routes.ts` | Read-only zone snapshot endpoint |
+| `api/widget-types.controller.ts` / `widget-types.routes.ts` | Read-only widget-type snapshot endpoint |
+| `api/placements.controller.ts` / `placements.routes.ts` | Placement CRUD + restore-defaults endpoints |
+| `database/IWidgetPlacementDocument.ts` | Mongo document shape + collection constant |
+| `migrations/001_create_placements_collection.ts` | Initial schema |
+| `../../services/widget/widget.service.ts` | Legacy `IWidgetService` compat shim — caches plugin defaults, splits `register()` into type + placement |
+
+## REST Contract
+
+All endpoints require admin auth (cookie path: verified wallet + admin group; service-token path: `ADMIN_API_TOKEN` via `x-admin-token` or `Authorization: Bearer`). All three routers chain `createAdminRateLimiter` before `requireAdmin`.
+
+### Zones — read-only
+
+| Method | Path | Returns |
+|---|---|---|
+| GET | `/api/admin/system/zones` | `IZoneSnapshot` — tracks (one per host) → zones |
+
+### Widget Types — read-only
+
+| Method | Path | Returns |
+|---|---|---|
+| GET | `/api/admin/system/widget-types` | `IWidgetTypeSnapshot` — groups (one per declaring plugin) → types |
+
+### Placements — full CRUD
+
+| Method | Path | Body | Returns | Notes |
+|---|---|---|---|---|
+| GET | `/api/admin/system/widgets/placements` | — | `{ success, placements: IWidgetPlacement[] }` | Query: `zoneId?`, `pluginId?`, `source?` (`plugin`\|`operator`), `enabledOnly?` |
+| GET | `/api/admin/system/widgets/placements/:id` | — | `{ success, placement }` or 404 | |
+| POST | `/api/admin/system/widgets/placements` | `IPlacementInput` | `{ success, placement }` 201 | Always `source: 'operator'`; rejects unknown `typeId`/`zoneId`/route patterns/order out of `[0,10000]`/title > 80 chars |
+| PATCH | `/api/admin/system/widgets/placements/:id` | `IPlacementPatch` | `{ success, placement }` or 404 | Operator-editable on every row, including plugin-source |
+| DELETE | `/api/admin/system/widgets/placements/:id` | — | 204 / 400 / 404 | 400 on plugin-source rows (use disable or restore-defaults) |
+| POST | `/api/admin/system/widgets/placements/:id/restore-defaults` | — | `{ success, placement }` | 400 on operator rows; 409 when plugin has not registered in this process |
+
+## Route Pattern Grammar
+
+`routes` arrays accept three forms, validated by `normaliseRoutePattern` and matched by `routeMatches`:
+
+| Form | Matches | Example |
+|---|---|---|
+| Exact | The literal path, nothing else | `/`, `/markets` |
+| Single-segment glob | One trailing segment, no deeper | `/u/*` matches `/u/TXyz`, not `/u/TXyz/holdings` |
+| Deep glob | Any depth below the prefix | `/admin/**` matches `/admin/users/edit` |
+
+Empty `routes: []` matches every route. Glob markers are only valid at the trailing position — `/*/markets` is rejected at write time.
+
+## WebSocket Contract
+
+| Event | Direction | Payload | Audience |
+|---|---|---|---|
+| `widgets:placements-update` | server → all | `{ event: 'placement:created' \| 'placement:updated' \| 'placement:deleted' \| 'placement:restored', placementId, zoneId?, timestamp }` | All connected sockets — public pages must refetch widget data to pick up operator changes |
+
+The placement service emits via a callback `WidgetsModule.init()` wires to `WebSocketService.getInstance().emit(...)`. Broadcast failures are logged but do not roll back the mutation.
+
+## Storage Schema
+
+`module_widgets_placements` collection (one row per placement):
+
+| Field | Type | Notes |
+|---|---|---|
+| `_id` | ObjectId | |
+| `typeId` | string | Widget-type id this placement renders |
+| `zoneId` | string | Zone id this placement targets |
+| `routes` | string[] | Route filter — empty matches every route |
+| `order` | number | Sort key within zone (lower renders first); plugin default `100` |
+| `title` | string? | Operator override of widget heading |
+| `instanceConfig` | object? | Per-instance config; the type's data fetcher consumes it |
+| `enabled` | boolean | `false` hides the row at SSR resolve |
+| `source` | `'plugin'` \| `'operator'` | Discriminator; controls disable vs. delete semantics |
+| `pluginId` | string? | Set only when `source === 'plugin'` |
+| `createdAt` / `updatedAt` | Date | |
+
+Indexes (migration 001): `(typeId, pluginId)` sparse unique for plugin-row atomicity; `(enabled, zoneId, order)` for SSR queries; `routes` multikey; `source`.
+
+## Lifecycle Semantics
+
+**Plugin register/enable** — `widgetService.register(config, pluginId)` calls land in the compat shim which (a) caches the original args under `${pluginId}::${typeId}` for restore-defaults, (b) mints a type descriptor via `defineWidgetType` and stores it in the registry, (c) calls `placementService.ensurePluginPlacement(...)` which upserts the row with `enabled: true` while preserving any operator customisations on existing rows.
+
+**Plugin disable** — `widgetService.unregisterAll(pluginId)` calls `placementService.softDisableForPlugin(pluginId)` which flips `enabled: false` on every plugin-source row. Rows stay in the DB so operator customisations survive re-enable. The plugin-default cache is *not* cleared so restore-defaults still works on soft-disabled rows.
+
+**Operator create/edit/delete** — flows through the admin REST endpoints. Operator-source rows go in with `source: 'operator'` and no `pluginId`. Plugin-source rows can be patched (order, routes, title, enabled) but not deleted via the API — the supported reversals are disable and restore-defaults.
+
+**Restore-defaults** — only valid on plugin-source rows. Resolves the cached registration args from the widget service and applies them as a single `$set` (re-enabling, resetting order/routes/title); the row's id and `createdAt` survive. Cache misses (plugin never registered this process) return 409 — re-enable the plugin to repopulate.
+
+## SSR Resolution
+
+`PlacementResolver.resolveForRoute(route, params)` runs at every page render:
+
+1. `placementService.findByRoute(route)` pulls `enabled: true` rows whose `routes` either is empty, matches exactly, or contains a glob suffix (post-filtered by `routeMatches` in-memory for grammar correctness).
+2. Each placement joins to its `IWidgetType` descriptor via the registry. Unregistered types (plugin disabled) silently skip.
+3. The type's `defaultDataFetcher(route, params)` runs in parallel with a 5s `Promise.race` timeout and a JSON round-trip serialisability check. Failed fetches drop with an error log; one bad widget cannot drag down the page.
+4. Results sort by `(zoneId asc, order asc)` and return as `IWidgetData[]` matching the legacy frontend `<WidgetZone>` contract.
+
+## Lifecycle Obligations
+
+- Modules and plugins do not call `defineWidgetType` or `defineZone` directly — use the per-plugin facade (`context.widgetTypes`, `context.zones`) so registrations carry the owning plugin id and clean up on disable.
+- Type ids are exclusive — the registry refuses cross-plugin id conflicts and the compat shim refuses to upsert a placement under those conditions.
+- The placement service is a singleton (`PlacementService.getInstance()`); always inject via the module rather than re-instantiate. `setDependencies` is idempotent — first call wins.
+- Broadcast callback is wired exactly once during `WidgetsModule.init()`. Tests that touch `PlacementService` directly should call `__resetForTests()` between cases.
+
+## Related
+
+- [system-database.md](../../../docs/system/system-database.md) — `IDatabaseService` rules the placement service follows
+- [system-hooks.md](../../../docs/system/system-hooks.md) — Adjacent system for *core inviting plugins in*; widgets is the inverse direction (plugins publishing types core renders)
+- [plugins-widget-zones.md](../../../docs/plugins/plugins-widget-zones.md) — Plugin-side widget-zone integration patterns
+- [plugins-frontend-context-styling.md](../../../docs/plugins/plugins-frontend-context-styling.md) — How widgets render on the frontend

--- a/src/backend/modules/widgets/WidgetsModule.ts
+++ b/src/backend/modules/widgets/WidgetsModule.ts
@@ -1,22 +1,25 @@
 /**
  * @fileoverview Widget module — IModule implementation.
  *
- * Owns three subsystems in PR 2: the widget-zone registry (PR 1
- * scaffolding, still bootstrap-instantiated), the widget-type
- * registry (also bootstrap-instantiated, plugin-declared types), and
- * the new placement-persistence layer that records every operator-
- * or plugin-source placement in MongoDB and resolves them at SSR
- * time. The legacy `WidgetService` becomes a compatibility shim that
- * delegates type registration and placement upsert/disable/fetch to
- * this module's services, keeping every existing plugin working
- * with no plugin-side code change.
+ * Owns three subsystems: the widget-zone registry (bootstrap-
+ * instantiated), the widget-type registry (also bootstrap-instantiated,
+ * plugin-declared types), and the placement-persistence layer that
+ * records every operator- or plugin-source placement in MongoDB and
+ * resolves them at SSR time. The legacy `WidgetService` is a
+ * compatibility shim that delegates type registration and placement
+ * upsert/disable/fetch to this module's services, keeping every
+ * existing plugin working without code change.
  *
- * The registries (zones, widget types) are constructed in
- * `bootstrapInit` and threaded through `sharedDeps` so the plugin
- * loader's per-plugin facades and this module both receive the same
- * instances. The placement service is module-owned because it needs
- * the `IDatabaseService` injected via module DI and has no plugin-
- * facing surface.
+ * The module also mounts the admin REST surface: a read-only
+ * zone-introspection endpoint, a read-only widget-type introspection
+ * endpoint, and a full CRUD endpoint set for placements. Together
+ * these power the `/system/widgets` operator UI.
+ *
+ * Mutations to placements broadcast a `widgets:placements-update`
+ * refetch signal over WebSocket so connected clients — including
+ * public pages rendering widgets — pick up changes without a hard
+ * reload. The broadcast callback is wired here so the placement
+ * service has no direct dependency on `WebSocketService`.
  *
  * @module backend/modules/widgets/WidgetsModule
  */
@@ -28,6 +31,7 @@ import type {
     IDatabaseService,
     IZoneRegistry,
     IWidgetTypeRegistry,
+    IMenuService,
     ISystemLogService
 } from '@/types';
 import { logger } from '../../lib/logger.js';
@@ -35,9 +39,15 @@ import { requireAdmin } from '../../api/middleware/admin-auth.js';
 import { createAdminRateLimiter } from '../../api/middleware/rate-limit.js';
 import { ZonesController } from './api/zones.controller.js';
 import { createZonesAdminRouter } from './api/zones.routes.js';
+import { PlacementsController } from './api/placements.controller.js';
+import { createPlacementsAdminRouter } from './api/placements.routes.js';
+import { WidgetTypesController } from './api/widget-types.controller.js';
+import { createWidgetTypesAdminRouter } from './api/widget-types.routes.js';
 import { PlacementService } from './placements/placement.service.js';
 import { PlacementResolver } from './placements/placement-resolver.js';
 import { WidgetService } from '../../services/widget/widget.service.js';
+import { WebSocketService } from '../../services/websocket.service.js';
+import { MAIN_SYSTEM_CONTAINER_ID } from '../menu/index.js';
 
 /**
  * Dependencies required by the widgets module.
@@ -46,7 +56,9 @@ import { WidgetService } from '../../services/widget/widget.service.js';
  * `bootstrapInit` and threaded through `sharedDeps` so both this
  * module and the plugin loader receive the same instances. `database`
  * is the platform-shared `IDatabaseService` the placement service
- * uses for the `module_widgets_placements` collection.
+ * uses for the `module_widgets_placements` collection. `menuService`
+ * is the navigation singleton — the module seeds the `/system/widgets`
+ * admin menu entry during `run()`.
  */
 export interface IWidgetsModuleDependencies {
     /** Shared process-wide zone registry. */
@@ -55,6 +67,8 @@ export interface IWidgetsModuleDependencies {
     widgetTypeRegistry: IWidgetTypeRegistry;
     /** Database service for placement persistence. */
     database: IDatabaseService;
+    /** Menu service for seeding the admin menu entry. */
+    menuService: IMenuService;
     /** Express app for admin route mounting. */
     app: Express;
 }
@@ -63,38 +77,42 @@ export interface IWidgetsModuleDependencies {
  * Widgets module class.
  *
  * Lifecycle:
- * - `init()` — store deps, configure the `PlacementService`
- *   singleton, construct the `PlacementResolver`, and wire the
- *   legacy `WidgetService` compatibility shim so plugin registrations
- *   route into the new infrastructure.
- * - `run()` — mount the admin zone introspection router (PR 1).
- *   Future PRs add placement-CRUD admin routes here.
+ * - `init()` — store deps, configure the `PlacementService` singleton,
+ *   construct the `PlacementResolver`, wire the legacy `WidgetService`
+ *   compat shim, and bind the placement broadcast callback to
+ *   `WebSocketService`.
+ * - `run()` — mount the admin routers and seed the System menu entry.
  */
 export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
     readonly metadata: IModuleMetadata = {
         id: 'widgets',
         name: 'Widgets',
-        version: '2.0.0',
-        description: 'Widget zone registry, widget type catalog, and placement persistence.'
+        version: '2.1.0',
+        description: 'Widget zone registry, widget type catalog, placement persistence, and admin REST.'
     };
 
     private zoneRegistry!: IZoneRegistry;
     private widgetTypeRegistry!: IWidgetTypeRegistry;
     private database!: IDatabaseService;
+    private menuService!: IMenuService;
     private app!: Express;
     private zonesController!: ZonesController;
+    private placementsController!: PlacementsController;
+    private widgetTypesController!: WidgetTypesController;
     private placementService!: PlacementService;
     private placementResolver!: PlacementResolver;
+    private widgetService!: WidgetService;
 
     private readonly logger: ISystemLogService = logger.child({ module: 'widgets' });
 
     /**
      * Initialise the module.
      *
-     * Wires the placement subsystem and the legacy `WidgetService`
-     * compatibility shim so that, by the time `loadPlugins(...)` runs,
-     * every plugin call to `context.widgetService.register(...)` is
-     * already routed into the new type/placement infrastructure.
+     * Wires the placement subsystem, the legacy `WidgetService`
+     * compatibility shim, and the placement-broadcast callback so
+     * that by the time `loadPlugins(...)` runs every plugin
+     * registration routes into the new infrastructure with WebSocket
+     * notifications already in place.
      *
      * @param dependencies - Injected dependencies.
      * @throws Error if any dependency is missing.
@@ -111,6 +129,9 @@ export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
         if (!dependencies.database) {
             throw new Error('WidgetsModule requires database dependency');
         }
+        if (!dependencies.menuService) {
+            throw new Error('WidgetsModule requires menuService dependency');
+        }
         if (!dependencies.app) {
             throw new Error('WidgetsModule requires app dependency');
         }
@@ -118,6 +139,7 @@ export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
         this.zoneRegistry = dependencies.zoneRegistry;
         this.widgetTypeRegistry = dependencies.widgetTypeRegistry;
         this.database = dependencies.database;
+        this.menuService = dependencies.menuService;
         this.app = dependencies.app;
 
         this.zonesController = new ZonesController(this.zoneRegistry, this.logger);
@@ -130,37 +152,112 @@ export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
             this.logger
         );
 
+        // Wire the broadcast callback that fires after every
+        // placement mutation. The `WebSocketService` singleton is
+        // initialised earlier in `bootstrapInit()` (gated by
+        // `ENABLE_WEBSOCKETS`); when WebSockets are disabled the
+        // service is a no-op so the placement service still
+        // executes mutations cleanly.
+        this.placementService.setBroadcast((event, payload) => {
+            const wsService = WebSocketService.getInstance();
+            wsService.emit({
+                event: 'widgets:placements-update',
+                payload: {
+                    event,
+                    placementId: payload.id,
+                    zoneId: payload.zoneId,
+                    timestamp: new Date().toISOString()
+                }
+            });
+        });
+
         // Wire the legacy `WidgetService` compatibility shim. The
-        // singleton was already constructed during the plugin loader
+        // singleton was constructed earlier during the plugin loader
         // setup, but its widget-type and placement back-ends only
         // become populated here. Plugin registrations during
-        // `loadPlugins(...)` (which runs after every module's `run()`)
-        // therefore see the fully-wired shim.
-        const widgetService = WidgetService.getInstance(this.logger);
-        widgetService.setZoneRegistry(this.zoneRegistry);
-        widgetService.setWidgetTypeRegistry(this.widgetTypeRegistry);
-        widgetService.setPlacementService(this.placementService);
-        widgetService.setPlacementResolver(this.placementResolver);
+        // `loadPlugins(...)` (which runs after every module's
+        // `run()`) therefore see the fully-wired shim with the
+        // broadcast callback already firing.
+        this.widgetService = WidgetService.getInstance(this.logger);
+        this.widgetService.setZoneRegistry(this.zoneRegistry);
+        this.widgetService.setWidgetTypeRegistry(this.widgetTypeRegistry);
+        this.widgetService.setPlacementService(this.placementService);
+        this.widgetService.setPlacementResolver(this.placementResolver);
+
+        // Admin REST controllers. The placements controller pulls
+        // plugin defaults through `widgetService.getPluginDefault`
+        // so it does not import the legacy service directly.
+        this.placementsController = new PlacementsController({
+            placements: this.placementService,
+            zones: this.zoneRegistry,
+            widgetTypes: this.widgetTypeRegistry,
+            getPluginDefault: (pluginId, typeId) =>
+                this.widgetService.getPluginDefault(pluginId, typeId),
+            logger: this.logger
+        });
+        this.widgetTypesController = new WidgetTypesController(
+            this.widgetTypeRegistry,
+            this.logger
+        );
 
         this.logger.info('Widgets module initialized');
     }
 
     /**
-     * Activate the module — mount the admin zone introspection router.
+     * Activate the module — mount admin routers and seed the System
+     * menu entry.
      *
-     * The platform-default admin rate limiter runs before
-     * `requireAdmin` so the brute-force cost against the auth gate is
-     * bounded per IP (60 req / 60s). Matches the MenuModule `/manage`
-     * precedent and satisfies CodeQL's `js/missing-rate-limiting`
-     * rule.
+     * Three admin routers mount in parallel namespaces under
+     * `/api/admin/system/`: `zones` (introspection), `widget-types`
+     * (introspection), and `widgets/placements` (CRUD). Each gets the
+     * platform-default admin rate limiter applied before
+     * `requireAdmin` so the brute-force cost against the auth gate
+     * stays bounded per IP.
      */
     async run(): Promise<void> {
         this.logger.info('Running widgets module...');
 
-        const adminRouter: Router = createZonesAdminRouter(this.zonesController);
-        const rateLimiter = createAdminRateLimiter('system-zones');
-        this.app.use('/api/admin/system/zones', rateLimiter, requireAdmin, adminRouter);
+        const zonesRouter: Router = createZonesAdminRouter(this.zonesController);
+        this.app.use(
+            '/api/admin/system/zones',
+            createAdminRateLimiter('system-zones'),
+            requireAdmin,
+            zonesRouter
+        );
         this.logger.info('Zone introspection router mounted at /api/admin/system/zones');
+
+        const widgetTypesRouter: Router = createWidgetTypesAdminRouter(this.widgetTypesController);
+        this.app.use(
+            '/api/admin/system/widget-types',
+            createAdminRateLimiter('system-widget-types'),
+            requireAdmin,
+            widgetTypesRouter
+        );
+        this.logger.info('Widget-type introspection router mounted at /api/admin/system/widget-types');
+
+        const placementsRouter: Router = createPlacementsAdminRouter(this.placementsController);
+        this.app.use(
+            '/api/admin/system/widgets/placements',
+            createAdminRateLimiter('system-widget-placements'),
+            requireAdmin,
+            placementsRouter
+        );
+        this.logger.info('Placements admin router mounted at /api/admin/system/widgets/placements');
+
+        // Seed the System menu entry. `MAIN_SYSTEM_CONTAINER_ID`
+        // forces `requiresAdmin: true` via the parent-chain check in
+        // `MenuService.create` — see [menu README → System Container].
+        await this.menuService.create({
+            namespace: 'main',
+            label: 'Widgets',
+            description: 'Place plugin widgets in zones and manage operator overrides.',
+            url: '/system/widgets',
+            icon: 'LayoutGrid',
+            order: 35,
+            parent: MAIN_SYSTEM_CONTAINER_ID,
+            enabled: true
+        });
+        this.logger.info('Widgets admin menu entry seeded under the System container');
 
         this.logger.info('Widgets module running');
     }

--- a/src/backend/modules/widgets/__tests__/placements.controller.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.controller.test.ts
@@ -169,6 +169,45 @@ describe('PlacementsController.listPlacements', () => {
 
         expect(placements.list).toHaveBeenCalledWith({});
     });
+
+    it('strips malformed zoneId values that fail the format regex', async () => {
+        const { controller, placements } = buildController();
+        (placements.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+        await controller.listPlacements(
+            { query: { zoneId: '../etc/passwd' } } as unknown as Request,
+            buildResponse()
+        );
+
+        expect(placements.list).toHaveBeenCalledWith({});
+    });
+
+    it('strips zoneId values that arrive as a parsed Mongo-operator object', async () => {
+        const { controller, placements } = buildController();
+        (placements.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+        // Express's `qs` parser turns `?zoneId[$ne]=foo` into this
+        // object form. The safe-string gate must reject it before it
+        // can reach the Mongo filter.
+        await controller.listPlacements(
+            { query: { zoneId: { $ne: 'main-after' } } } as unknown as Request,
+            buildResponse()
+        );
+
+        expect(placements.list).toHaveBeenCalledWith({});
+    });
+
+    it('strips malformed pluginId values', async () => {
+        const { controller, placements } = buildController();
+        (placements.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+        await controller.listPlacements(
+            { query: { pluginId: 'plugin id with spaces' } } as unknown as Request,
+            buildResponse()
+        );
+
+        expect(placements.list).toHaveBeenCalledWith({});
+    });
 });
 
 describe('PlacementsController.getPlacement', () => {

--- a/src/backend/modules/widgets/__tests__/placements.controller.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.controller.test.ts
@@ -1,0 +1,431 @@
+/// <reference types="vitest" />
+
+/**
+ * @fileoverview Unit tests for the placements admin controller.
+ *
+ * Drives `PlacementsController` against a mocked `IPlacementService`,
+ * registry stubs, and Express request/response doubles. Verifies
+ * input validation, status codes, registry lookups, and the
+ * special-cases for plugin-source rows (delete refusal,
+ * restore-defaults).
+ *
+ * @module backend/modules/widgets/__tests__/placements.controller
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type {
+    ISystemLogService,
+    IPlacementService,
+    IWidgetPlacement,
+    IZoneRegistry,
+    IWidgetTypeRegistry
+} from '@/types';
+import type { Request, Response } from 'express';
+import { PlacementsController } from '../api/placements.controller.js';
+import type { IPluginRegistrationDefaults } from '../../../services/widget/widget.service.js';
+
+class MockLogger implements ISystemLogService {
+    public level = 'info';
+    public fatal = vi.fn();
+    public error = vi.fn();
+    public warn = vi.fn();
+    public info = vi.fn();
+    public debug = vi.fn();
+    public trace = vi.fn();
+    public child = vi.fn((_b: Record<string, unknown>): ISystemLogService => this);
+    public async initialize() {}
+    public async saveLog() {}
+    public async getLogs() {
+        return { logs: [], total: 0, page: 1, limit: 50, totalPages: 0, hasNextPage: false, hasPrevPage: false };
+    }
+    public async markAsResolved() {}
+    public async cleanup() { return 0; }
+    public async getStatistics() { return { total: 0, byLevel: {} as any, byService: {}, unresolved: 0 }; }
+    public async getLogById() { return null; }
+    public async markAsUnresolved() { return null; }
+    public async deleteAllLogs() { return 0; }
+    public async getStats() { return { total: 0, byLevel: {} as any, resolved: 0, unresolved: 0 }; }
+    public async waitUntilInitialized() {}
+}
+
+function buildPlacement(overrides: Partial<IWidgetPlacement> = {}): IWidgetPlacement {
+    return {
+        id: overrides.id ?? 'abc',
+        typeId: overrides.typeId ?? 'widget:type',
+        zoneId: overrides.zoneId ?? 'main-after',
+        routes: overrides.routes ?? ['/'],
+        order: overrides.order ?? 100,
+        title: overrides.title,
+        instanceConfig: overrides.instanceConfig,
+        enabled: overrides.enabled ?? true,
+        source: overrides.source ?? 'operator',
+        pluginId: overrides.pluginId,
+        createdAt: overrides.createdAt ?? '2026-01-01T00:00:00.000Z',
+        updatedAt: overrides.updatedAt ?? '2026-01-01T00:00:00.000Z'
+    };
+}
+
+function buildResponse(): Response {
+    const res: Partial<Response> = {};
+    res.status = vi.fn(() => res as Response) as any;
+    res.json = vi.fn(() => res as Response) as any;
+    res.end = vi.fn(() => res as Response) as any;
+    return res as Response;
+}
+
+function buildController(overrides: {
+    placements?: Partial<IPlacementService>;
+    zones?: Partial<IZoneRegistry>;
+    widgetTypes?: Partial<IWidgetTypeRegistry>;
+    getPluginDefault?: (pluginId: string, typeId: string) => IPluginRegistrationDefaults | null;
+} = {}) {
+    const placements = {
+        list: vi.fn(),
+        findById: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        restoreToPluginDefaults: vi.fn(),
+        ensurePluginPlacement: vi.fn(),
+        softDisableForPlugin: vi.fn(),
+        findByRoute: vi.fn(),
+        ...overrides.placements
+    } as unknown as IPlacementService;
+
+    const zones = {
+        has: vi.fn(),
+        snapshot: vi.fn(),
+        register: vi.fn(),
+        disposeForPlugin: vi.fn(),
+        get: vi.fn(),
+        ...overrides.zones
+    } as unknown as IZoneRegistry;
+
+    const widgetTypes = {
+        has: vi.fn(),
+        snapshot: vi.fn(),
+        register: vi.fn(),
+        disposeForPlugin: vi.fn(),
+        get: vi.fn(),
+        getOwnerPluginId: vi.fn(),
+        ...overrides.widgetTypes
+    } as unknown as IWidgetTypeRegistry;
+
+    const controller = new PlacementsController({
+        placements,
+        zones,
+        widgetTypes,
+        getPluginDefault: overrides.getPluginDefault ?? (() => null),
+        logger: new MockLogger()
+    });
+
+    return { controller, placements, zones, widgetTypes };
+}
+
+describe('PlacementsController.listPlacements', () => {
+    it('returns placements with no filter', async () => {
+        const { controller, placements } = buildController();
+        (placements.list as ReturnType<typeof vi.fn>).mockResolvedValue([buildPlacement()]);
+
+        const res = buildResponse();
+        await controller.listPlacements({ query: {} } as Request, res);
+
+        expect(placements.list).toHaveBeenCalledWith({});
+        expect(res.json).toHaveBeenCalledWith({ success: true, placements: [expect.any(Object)] });
+    });
+
+    it('forwards every supported filter from the query string', async () => {
+        const { controller, placements } = buildController();
+        (placements.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+        await controller.listPlacements(
+            {
+                query: {
+                    zoneId: 'main-after',
+                    pluginId: 'whale-alerts',
+                    source: 'plugin',
+                    enabledOnly: 'true'
+                }
+            } as unknown as Request,
+            buildResponse()
+        );
+
+        expect(placements.list).toHaveBeenCalledWith({
+            zoneId: 'main-after',
+            pluginId: 'whale-alerts',
+            source: 'plugin',
+            enabledOnly: true
+        });
+    });
+
+    it('ignores unrecognised source values', async () => {
+        const { controller, placements } = buildController();
+        (placements.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+        await controller.listPlacements(
+            { query: { source: 'bogus' } } as unknown as Request,
+            buildResponse()
+        );
+
+        expect(placements.list).toHaveBeenCalledWith({});
+    });
+});
+
+describe('PlacementsController.getPlacement', () => {
+    it('returns 404 when the placement does not exist', async () => {
+        const { controller, placements } = buildController();
+        (placements.findById as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const res = buildResponse();
+        await controller.getPlacement({ params: { id: 'x' } } as unknown as Request, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('returns the placement when found', async () => {
+        const { controller, placements } = buildController();
+        const placement = buildPlacement({ id: 'abc' });
+        (placements.findById as ReturnType<typeof vi.fn>).mockResolvedValue(placement);
+
+        const res = buildResponse();
+        await controller.getPlacement({ params: { id: 'abc' } } as unknown as Request, res);
+
+        expect(res.json).toHaveBeenCalledWith({ success: true, placement });
+    });
+});
+
+describe('PlacementsController.createPlacement', () => {
+    it('rejects unknown widget-type ids with 400', async () => {
+        const { controller, widgetTypes, zones } = buildController();
+        (widgetTypes.has as ReturnType<typeof vi.fn>).mockReturnValue(false);
+        (zones.has as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+        const res = buildResponse();
+        await controller.createPlacement(
+            { body: { typeId: 'mystery', zoneId: 'main-after', routes: ['/'] } } as Request,
+            res
+        );
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            error: expect.stringContaining('Unknown widget type id')
+        }));
+    });
+
+    it('rejects unknown zone ids with 400', async () => {
+        const { controller, widgetTypes, zones } = buildController();
+        (widgetTypes.has as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (zones.has as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+        const res = buildResponse();
+        await controller.createPlacement(
+            { body: { typeId: 't', zoneId: 'ghost-zone', routes: ['/'] } } as Request,
+            res
+        );
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            error: expect.stringContaining('Unknown zone id')
+        }));
+    });
+
+    it('rejects malformed route patterns', async () => {
+        const { controller, widgetTypes, zones } = buildController();
+        (widgetTypes.has as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (zones.has as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+        const res = buildResponse();
+        await controller.createPlacement(
+            { body: { typeId: 't', zoneId: 'main-after', routes: ['no-slash'] } } as Request,
+            res
+        );
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            error: expect.stringContaining('Invalid route pattern')
+        }));
+    });
+
+    it('rejects orders outside the allowed range', async () => {
+        const { controller, widgetTypes, zones } = buildController();
+        (widgetTypes.has as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (zones.has as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+        const res = buildResponse();
+        await controller.createPlacement(
+            { body: { typeId: 't', zoneId: 'main-after', routes: [], order: -1 } } as Request,
+            res
+        );
+
+        expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('creates an operator-source placement on valid input', async () => {
+        const { controller, placements, widgetTypes, zones } = buildController();
+        (widgetTypes.has as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (zones.has as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (placements.create as ReturnType<typeof vi.fn>).mockResolvedValue(buildPlacement({ id: 'new-id' }));
+
+        const res = buildResponse();
+        await controller.createPlacement(
+            {
+                body: {
+                    typeId: 't',
+                    zoneId: 'main-after',
+                    routes: ['/'],
+                    order: 10,
+                    title: 'Hello',
+                    enabled: true
+                }
+            } as Request,
+            res
+        );
+
+        expect(placements.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                typeId: 't',
+                zoneId: 'main-after',
+                routes: ['/'],
+                order: 10,
+                title: 'Hello',
+                enabled: true
+            }),
+            { source: 'operator' }
+        );
+        expect(res.status).toHaveBeenCalledWith(201);
+    });
+});
+
+describe('PlacementsController.updatePlacement', () => {
+    it('rejects unknown zone ids in the patch', async () => {
+        const { controller, zones } = buildController();
+        (zones.has as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+        const res = buildResponse();
+        await controller.updatePlacement(
+            { params: { id: 'abc' }, body: { zoneId: 'phantom' } } as unknown as Request,
+            res
+        );
+
+        expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 404 when the placement disappears', async () => {
+        const { controller, placements } = buildController();
+        (placements.update as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const res = buildResponse();
+        await controller.updatePlacement(
+            { params: { id: 'abc' }, body: { order: 5 } } as unknown as Request,
+            res
+        );
+
+        expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('passes the patch to the service on valid input', async () => {
+        const { controller, placements } = buildController();
+        (placements.update as ReturnType<typeof vi.fn>).mockResolvedValue(buildPlacement());
+
+        await controller.updatePlacement(
+            { params: { id: 'abc' }, body: { order: 5, enabled: false } } as unknown as Request,
+            buildResponse()
+        );
+
+        expect(placements.update).toHaveBeenCalledWith('abc', { order: 5, enabled: false });
+    });
+});
+
+describe('PlacementsController.deletePlacement', () => {
+    it('refuses to delete plugin-source rows', async () => {
+        const { controller, placements } = buildController();
+        (placements.findById as ReturnType<typeof vi.fn>).mockResolvedValue(buildPlacement({ source: 'plugin', pluginId: 'p' }));
+
+        const res = buildResponse();
+        await controller.deletePlacement({ params: { id: 'abc' } } as unknown as Request, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(placements.delete).not.toHaveBeenCalled();
+    });
+
+    it('deletes operator-source rows', async () => {
+        const { controller, placements } = buildController();
+        (placements.findById as ReturnType<typeof vi.fn>).mockResolvedValue(buildPlacement({ source: 'operator' }));
+        (placements.delete as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+        const res = buildResponse();
+        await controller.deletePlacement({ params: { id: 'abc' } } as unknown as Request, res);
+
+        expect(placements.delete).toHaveBeenCalledWith('abc');
+        expect(res.status).toHaveBeenCalledWith(204);
+    });
+
+    it('returns 404 when the placement is missing', async () => {
+        const { controller, placements } = buildController();
+        (placements.findById as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const res = buildResponse();
+        await controller.deletePlacement({ params: { id: 'abc' } } as unknown as Request, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+    });
+});
+
+describe('PlacementsController.restorePluginDefaults', () => {
+    it('rejects operator-source rows', async () => {
+        const { controller, placements } = buildController();
+        (placements.findById as ReturnType<typeof vi.fn>).mockResolvedValue(buildPlacement({ source: 'operator' }));
+
+        const res = buildResponse();
+        await controller.restorePluginDefaults({ params: { id: 'abc' } } as unknown as Request, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 409 when defaults are not cached', async () => {
+        const { controller, placements } = buildController({
+            getPluginDefault: () => null
+        });
+        (placements.findById as ReturnType<typeof vi.fn>).mockResolvedValue(buildPlacement({
+            source: 'plugin',
+            pluginId: 'p',
+            typeId: 't'
+        }));
+
+        const res = buildResponse();
+        await controller.restorePluginDefaults({ params: { id: 'abc' } } as unknown as Request, res);
+
+        expect(res.status).toHaveBeenCalledWith(409);
+    });
+
+    it('restores via the service when defaults exist', async () => {
+        const { controller, placements } = buildController({
+            getPluginDefault: () => ({
+                pluginId: 'p',
+                typeId: 't',
+                zone: 'main-after',
+                routes: ['/'],
+                order: 25,
+                title: 'Default'
+            })
+        });
+        (placements.findById as ReturnType<typeof vi.fn>).mockResolvedValue(buildPlacement({
+            id: 'abc',
+            source: 'plugin',
+            pluginId: 'p',
+            typeId: 't'
+        }));
+        (placements.restoreToPluginDefaults as ReturnType<typeof vi.fn>).mockResolvedValue(buildPlacement({ id: 'abc' }));
+
+        const res = buildResponse();
+        await controller.restorePluginDefaults({ params: { id: 'abc' } } as unknown as Request, res);
+
+        expect(placements.restoreToPluginDefaults).toHaveBeenCalledWith('abc', {
+            zoneId: 'main-after',
+            routes: ['/'],
+            order: 25,
+            title: 'Default'
+        });
+        expect(res.json).toHaveBeenCalledWith({ success: true, placement: expect.any(Object) });
+    });
+});

--- a/src/backend/modules/widgets/__tests__/placements.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.test.ts
@@ -348,6 +348,19 @@ describe('PlacementService CRUD', () => {
         ).rejects.toThrow(/requires options\.pluginId/);
     });
 
+    it('update accepts title: null as an explicit unset signal', async () => {
+        const placement = await service.create({
+            typeId: 't',
+            zoneId: 'main-after',
+            routes: ['/'],
+            title: 'Operator Title'
+        });
+        expect(placement.title).toBe('Operator Title');
+
+        const cleared = await service.update(placement.id, { title: null });
+        expect(cleared?.title).toBeUndefined();
+    });
+
     it('update preserves untouched fields', async () => {
         const placement = await service.create({
             typeId: 't',

--- a/src/backend/modules/widgets/__tests__/placements.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.test.ts
@@ -20,7 +20,11 @@ import type {
 import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
 import { PlacementService } from '../placements/placement.service.js';
 import { PlacementResolver } from '../placements/placement-resolver.js';
-import { routeMatches } from '../placements/route-matcher.js';
+import {
+    routeMatches,
+    normaliseRoutePattern,
+    partitionRoutePatterns
+} from '../placements/route-matcher.js';
 
 class MockLogger implements ISystemLogService {
     public level = 'info';
@@ -57,6 +61,92 @@ describe('routeMatches', () => {
         expect(routeMatches(['/', '/markets'], '/markets')).toBe(true);
         expect(routeMatches(['/'], '/markets')).toBe(false);
         expect(routeMatches(['/'], '/u/TXyz')).toBe(false);
+    });
+
+    it('handles single-segment globs', () => {
+        expect(routeMatches(['/u/*'], '/u/TXyz')).toBe(true);
+        expect(routeMatches(['/u/*'], '/u/')).toBe(false);
+        expect(routeMatches(['/u/*'], '/u')).toBe(false);
+        expect(routeMatches(['/u/*'], '/u/TXyz/holdings')).toBe(false);
+        expect(routeMatches(['/u/*'], '/users/TXyz')).toBe(false);
+    });
+
+    it('handles deep globs', () => {
+        expect(routeMatches(['/u/**'], '/u/TXyz')).toBe(true);
+        expect(routeMatches(['/u/**'], '/u/TXyz/holdings')).toBe(true);
+        expect(routeMatches(['/u/**'], '/u/TXyz/holdings/2024')).toBe(true);
+        expect(routeMatches(['/u/**'], '/u')).toBe(false);
+        expect(routeMatches(['/u/**'], '/users/TXyz')).toBe(false);
+    });
+
+    it('a deep glob at the root matches any path', () => {
+        expect(routeMatches(['/**'], '/')).toBe(true);
+        expect(routeMatches(['/**'], '/markets')).toBe(true);
+        expect(routeMatches(['/**'], '/a/b/c')).toBe(true);
+    });
+
+    it('mixes patterns in a single filter', () => {
+        const filter = ['/', '/markets', '/u/*'];
+        expect(routeMatches(filter, '/')).toBe(true);
+        expect(routeMatches(filter, '/markets')).toBe(true);
+        expect(routeMatches(filter, '/u/TXyz')).toBe(true);
+        expect(routeMatches(filter, '/u/TXyz/h')).toBe(false);
+        expect(routeMatches(filter, '/admin')).toBe(false);
+    });
+});
+
+describe('normaliseRoutePattern', () => {
+    it('accepts exact paths', () => {
+        expect(normaliseRoutePattern('/')).toBe('/');
+        expect(normaliseRoutePattern('/markets')).toBe('/markets');
+    });
+
+    it('accepts trailing single and deep globs', () => {
+        expect(normaliseRoutePattern('/u/*')).toBe('/u/*');
+        expect(normaliseRoutePattern('/u/**')).toBe('/u/**');
+    });
+
+    it('trims whitespace surrounding a pattern', () => {
+        expect(normaliseRoutePattern('  /markets  ')).toBe('/markets');
+    });
+
+    it('rejects empty and whitespace-only input', () => {
+        expect(normaliseRoutePattern('')).toBeNull();
+        expect(normaliseRoutePattern('   ')).toBeNull();
+    });
+
+    it('rejects patterns without a leading slash', () => {
+        expect(normaliseRoutePattern('markets')).toBeNull();
+        expect(normaliseRoutePattern('u/*')).toBeNull();
+    });
+
+    it('rejects internal whitespace', () => {
+        expect(normaliseRoutePattern('/with space')).toBeNull();
+    });
+
+    it('rejects glob markers anywhere except the trailing segment', () => {
+        expect(normaliseRoutePattern('/*/markets')).toBeNull();
+        expect(normaliseRoutePattern('/u/*/extra')).toBeNull();
+        expect(normaliseRoutePattern('/u*')).toBeNull();
+    });
+});
+
+describe('partitionRoutePatterns', () => {
+    it('separates exact entries from glob entries', () => {
+        const { exact, patterns } = partitionRoutePatterns([
+            '/',
+            '/markets',
+            '/u/*',
+            '/admin/**'
+        ]);
+        expect(exact).toEqual(['/', '/markets']);
+        expect(patterns).toEqual(['/u/*', '/admin/**']);
+    });
+
+    it('returns empty buckets for an empty input', () => {
+        const { exact, patterns } = partitionRoutePatterns([]);
+        expect(exact).toEqual([]);
+        expect(patterns).toEqual([]);
     });
 });
 
@@ -353,7 +443,8 @@ describe('PlacementResolver', () => {
             update: vi.fn(),
             delete: vi.fn(),
             findById: vi.fn(),
-            list: vi.fn()
+            list: vi.fn(),
+            restoreToPluginDefaults: vi.fn()
         };
         resolver = new PlacementResolver(placementService, typeRegistry, logger);
     });
@@ -442,5 +533,228 @@ describe('PlacementResolver', () => {
         expect(result.map(r => r.id)).toEqual(['t2', 't3', 't1']);
         expect(result.map(r => r.zone)).toEqual(['main-after', 'main-after', 'main-before']);
         expect(result.map(r => r.order)).toEqual([5, 100, 50]);
+    });
+});
+
+describe('PlacementService.findByRoute (globs)', () => {
+    let logger: MockLogger;
+    let db: ReturnType<typeof createMockDatabaseService>;
+    let service: PlacementService;
+
+    beforeEach(() => {
+        logger = new MockLogger();
+        db = createMockDatabaseService();
+        PlacementService.__resetForTests();
+        PlacementService.setDependencies(db, logger);
+        service = PlacementService.getInstance();
+    });
+
+    it('returns placements with single-glob patterns when the route matches one segment', async () => {
+        await service.create({ typeId: 'profile:summary', zoneId: 'main-after', routes: ['/u/*'] });
+        await service.create({ typeId: 'home:hero', zoneId: 'main-after', routes: ['/'] });
+
+        const results = await service.findByRoute('/u/TXyz');
+        const ids = results.map(p => p.typeId).sort();
+        expect(ids).toEqual(['profile:summary']);
+    });
+
+    it('returns placements with deep-glob patterns at any depth', async () => {
+        await service.create({ typeId: 'admin:nav', zoneId: 'main-after', routes: ['/admin/**'] });
+        await service.create({ typeId: 'home:hero', zoneId: 'main-after', routes: ['/'] });
+
+        const results = await service.findByRoute('/admin/users/edit');
+        const ids = results.map(p => p.typeId).sort();
+        expect(ids).toEqual(['admin:nav']);
+    });
+
+    it('excludes single-glob rows when the route has extra depth', async () => {
+        await service.create({ typeId: 'profile:summary', zoneId: 'main-after', routes: ['/u/*'] });
+
+        const results = await service.findByRoute('/u/TXyz/holdings');
+        expect(results).toEqual([]);
+    });
+});
+
+describe('PlacementService broadcast wiring', () => {
+    let logger: MockLogger;
+    let db: ReturnType<typeof createMockDatabaseService>;
+    let service: PlacementService;
+    let broadcast: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        logger = new MockLogger();
+        db = createMockDatabaseService();
+        broadcast = vi.fn();
+        PlacementService.__resetForTests();
+        PlacementService.setDependencies(db, logger);
+        service = PlacementService.getInstance();
+        service.setBroadcast(broadcast);
+    });
+
+    it('fires placement:created on create', async () => {
+        const placement = await service.create({ typeId: 't', zoneId: 'main-after', routes: [] });
+
+        expect(broadcast).toHaveBeenCalledTimes(1);
+        expect(broadcast).toHaveBeenCalledWith('placement:created', {
+            id: placement.id,
+            zoneId: 'main-after'
+        });
+    });
+
+    it('fires placement:updated on update', async () => {
+        const placement = await service.create({ typeId: 't', zoneId: 'main-after', routes: [] });
+        broadcast.mockClear();
+
+        await service.update(placement.id, { order: 50 });
+
+        expect(broadcast).toHaveBeenCalledTimes(1);
+        expect(broadcast).toHaveBeenCalledWith('placement:updated', {
+            id: placement.id,
+            zoneId: 'main-after'
+        });
+    });
+
+    it('fires placement:deleted on delete', async () => {
+        const placement = await service.create({ typeId: 't', zoneId: 'main-after', routes: [] });
+        broadcast.mockClear();
+
+        await service.delete(placement.id);
+
+        expect(broadcast).toHaveBeenCalledTimes(1);
+        expect(broadcast).toHaveBeenCalledWith('placement:deleted', { id: placement.id });
+    });
+
+    it('fires placement:restored on restoreToPluginDefaults', async () => {
+        const placement = await service.ensurePluginPlacement({
+            typeId: 't',
+            zoneId: 'main-after',
+            routes: [],
+            order: 25,
+            pluginId: 'p'
+        });
+        broadcast.mockClear();
+
+        await service.restoreToPluginDefaults(placement.id, {
+            zoneId: 'main-after',
+            routes: ['/'],
+            order: 25
+        });
+
+        expect(broadcast).toHaveBeenCalledTimes(1);
+        expect(broadcast).toHaveBeenCalledWith('placement:restored', {
+            id: placement.id,
+            zoneId: 'main-after'
+        });
+    });
+
+    it('does not fire on update of an unknown id', async () => {
+        await service.update('507f1f77bcf86cd799439011', { order: 5 });
+        expect(broadcast).not.toHaveBeenCalled();
+    });
+
+    it('does not fire on delete of an unknown id', async () => {
+        await service.delete('507f1f77bcf86cd799439011');
+        expect(broadcast).not.toHaveBeenCalled();
+    });
+
+    it('swallows broadcast errors so the mutation still succeeds', async () => {
+        broadcast.mockImplementation(() => { throw new Error('boom'); });
+        const placement = await service.create({ typeId: 't', zoneId: 'main-after', routes: [] });
+
+        expect(placement.id).toBeTruthy();
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.objectContaining({ event: 'placement:created' }),
+            expect.stringContaining('Placement broadcast callback threw')
+        );
+    });
+
+    it('ignores broadcast after setBroadcast(null)', async () => {
+        service.setBroadcast(null);
+        await service.create({ typeId: 't', zoneId: 'main-after', routes: [] });
+        expect(broadcast).not.toHaveBeenCalled();
+    });
+});
+
+describe('PlacementService.restoreToPluginDefaults', () => {
+    let logger: MockLogger;
+    let db: ReturnType<typeof createMockDatabaseService>;
+    let service: PlacementService;
+
+    beforeEach(() => {
+        logger = new MockLogger();
+        db = createMockDatabaseService();
+        PlacementService.__resetForTests();
+        PlacementService.setDependencies(db, logger);
+        service = PlacementService.getInstance();
+    });
+
+    it('restores zone, routes, order, title, and re-enables the row', async () => {
+        const placement = await service.ensurePluginPlacement({
+            typeId: 't',
+            zoneId: 'main-after',
+            routes: ['/'],
+            order: 25,
+            title: 'Default',
+            pluginId: 'p'
+        });
+
+        // Operator customisation, then disable.
+        await service.update(placement.id, {
+            zoneId: 'main-before',
+            routes: ['/dashboard'],
+            order: 1,
+            title: 'Operator Title',
+            enabled: false
+        });
+
+        const restored = await service.restoreToPluginDefaults(placement.id, {
+            zoneId: 'main-after',
+            routes: ['/'],
+            order: 25,
+            title: 'Default'
+        });
+
+        expect(restored).not.toBeNull();
+        expect(restored?.zoneId).toBe('main-after');
+        expect(restored?.routes).toEqual(['/']);
+        expect(restored?.order).toBe(25);
+        expect(restored?.title).toBe('Default');
+        expect(restored?.enabled).toBe(true);
+    });
+
+    it('unsets title when defaults have no title', async () => {
+        const placement = await service.ensurePluginPlacement({
+            typeId: 't',
+            zoneId: 'main-after',
+            routes: ['/'],
+            title: 'Operator Title',
+            pluginId: 'p'
+        });
+
+        const restored = await service.restoreToPluginDefaults(placement.id, {
+            zoneId: 'main-after',
+            routes: ['/'],
+            order: 100
+        });
+
+        expect(restored?.title).toBeUndefined();
+    });
+
+    it('returns null for unknown ids', async () => {
+        const result = await service.restoreToPluginDefaults('507f1f77bcf86cd799439011', {
+            zoneId: 'main-after',
+            routes: [],
+            order: 100
+        });
+        expect(result).toBeNull();
+    });
+
+    it('returns null for malformed ids', async () => {
+        const result = await service.restoreToPluginDefaults('not-an-objectid', {
+            zoneId: 'main-after',
+            routes: [],
+            order: 100
+        });
+        expect(result).toBeNull();
     });
 });

--- a/src/backend/modules/widgets/__tests__/widget-types.controller.test.ts
+++ b/src/backend/modules/widgets/__tests__/widget-types.controller.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="vitest" />
+
+/**
+ * @fileoverview Unit tests for the widget-types introspection
+ * controller.
+ *
+ * The controller is read-only — its only job is to forward the
+ * registry snapshot to the client. The tests verify the snapshot is
+ * passed through untouched, and that errors thrown by the registry
+ * surface as a 500 instead of leaking.
+ *
+ * @module backend/modules/widgets/__tests__/widget-types.controller
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type {
+    ISystemLogService,
+    IWidgetTypeRegistry,
+    IWidgetTypeSnapshot
+} from '@/types';
+import type { Request, Response } from 'express';
+import { WidgetTypesController } from '../api/widget-types.controller.js';
+
+class MockLogger implements ISystemLogService {
+    public level = 'info';
+    public fatal = vi.fn();
+    public error = vi.fn();
+    public warn = vi.fn();
+    public info = vi.fn();
+    public debug = vi.fn();
+    public trace = vi.fn();
+    public child = vi.fn((_b: Record<string, unknown>): ISystemLogService => this);
+    public async initialize() {}
+    public async saveLog() {}
+    public async getLogs() {
+        return { logs: [], total: 0, page: 1, limit: 50, totalPages: 0, hasNextPage: false, hasPrevPage: false };
+    }
+    public async markAsResolved() {}
+    public async cleanup() { return 0; }
+    public async getStatistics() { return { total: 0, byLevel: {} as any, byService: {}, unresolved: 0 }; }
+    public async getLogById() { return null; }
+    public async markAsUnresolved() { return null; }
+    public async deleteAllLogs() { return 0; }
+    public async getStats() { return { total: 0, byLevel: {} as any, resolved: 0, unresolved: 0 }; }
+    public async waitUntilInitialized() {}
+}
+
+function buildResponse(): Response {
+    const res: Partial<Response> = {};
+    res.status = vi.fn(() => res as Response) as any;
+    res.json = vi.fn(() => res as Response) as any;
+    return res as Response;
+}
+
+describe('WidgetTypesController.getSnapshot', () => {
+    it('forwards the registry snapshot verbatim', () => {
+        const snapshot: IWidgetTypeSnapshot = {
+            groups: [
+                {
+                    pluginId: 'whale-alerts',
+                    types: [
+                        {
+                            id: 'whale:recent',
+                            label: 'Recent Whales',
+                            description: 'Recent whale transactions',
+                            category: null,
+                            pluginId: 'whale-alerts',
+                            registeredAt: '2026-01-01T00:00:00.000Z',
+                            source: null
+                        }
+                    ]
+                }
+            ]
+        };
+
+        const registry = {
+            snapshot: vi.fn(() => snapshot),
+            register: vi.fn(),
+            disposeForPlugin: vi.fn(),
+            has: vi.fn(),
+            get: vi.fn(),
+            getOwnerPluginId: vi.fn()
+        } as unknown as IWidgetTypeRegistry;
+
+        const controller = new WidgetTypesController(registry, new MockLogger());
+        const res = buildResponse();
+        controller.getSnapshot({} as Request, res);
+
+        expect(registry.snapshot).toHaveBeenCalled();
+        expect(res.json).toHaveBeenCalledWith(snapshot);
+    });
+
+    it('responds with 500 when the registry throws', () => {
+        const registry = {
+            snapshot: vi.fn(() => { throw new Error('boom'); }),
+            register: vi.fn(),
+            disposeForPlugin: vi.fn(),
+            has: vi.fn(),
+            get: vi.fn(),
+            getOwnerPluginId: vi.fn()
+        } as unknown as IWidgetTypeRegistry;
+
+        const logger = new MockLogger();
+        const controller = new WidgetTypesController(registry, logger);
+        const res = buildResponse();
+        controller.getSnapshot({} as Request, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(logger.error).toHaveBeenCalled();
+    });
+});

--- a/src/backend/modules/widgets/api/placements.controller.ts
+++ b/src/backend/modules/widgets/api/placements.controller.ts
@@ -322,16 +322,18 @@ export class PlacementsController {
 
     /**
      * Parse and validate a patch-placement request body. Every field
-     * is optional, but those provided must validate.
+     * is optional, but those provided must validate. `title: null`
+     * is the explicit unset signal and is preserved through to the
+     * service so it can `$unset` the field.
      */
     private parsePatchBody(body: unknown):
-        | { patch: { zoneId?: string; routes?: string[]; order?: number; title?: string; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
+        | { patch: { zoneId?: string; routes?: string[]; order?: number; title?: string | null; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
         | { error: string } {
         if (!body || typeof body !== 'object') {
             return { error: 'Request body must be an object' };
         }
         const b = body as Record<string, unknown>;
-        const patch: { zoneId?: string; routes?: string[]; order?: number; title?: string; instanceConfig?: Record<string, unknown>; enabled?: boolean } = {};
+        const patch: { zoneId?: string; routes?: string[]; order?: number; title?: string | null; instanceConfig?: Record<string, unknown>; enabled?: boolean } = {};
 
         if (b.zoneId !== undefined) {
             if (typeof b.zoneId !== 'string' || b.zoneId.length === 0) {
@@ -356,9 +358,17 @@ export class PlacementsController {
         }
 
         if (b.title !== undefined) {
-            const result = this.parseTitle(b.title);
-            if ('error' in result) return result;
-            patch.title = result.title;
+            // `null` is the explicit unset signal — preserve it
+            // through to the service, which translates it to
+            // `$unset: { title: '' }`. Anything else goes through
+            // `parseTitle` for the standard string-shape checks.
+            if (b.title === null) {
+                patch.title = null;
+            } else {
+                const result = this.parseTitle(b.title);
+                if ('error' in result) return result;
+                patch.title = result.title;
+            }
         }
 
         if (b.instanceConfig !== undefined) {
@@ -418,9 +428,10 @@ export class PlacementsController {
     }
 
     /**
-     * Validate the optional `title` field. Trimmed; empty after trim
-     * is rejected because an empty title is meaningless — clear the
-     * field by omitting it from the patch.
+     * Validate the optional `title` field for the create path.
+     * Trimmed; empty after trim is rejected (an empty title carries
+     * no meaning — pass `null` to the patch endpoint to clear an
+     * existing override, or simply omit the field on create).
      */
     private parseTitle(value: unknown): { title?: string } | { error: string } {
         if (value === undefined) return { title: undefined };

--- a/src/backend/modules/widgets/api/placements.controller.ts
+++ b/src/backend/modules/widgets/api/placements.controller.ts
@@ -62,6 +62,46 @@ const MAX_ORDER = 10_000;
 const MAX_TITLE_LENGTH = 80;
 
 /**
+ * Format gate for zone ids. Zone ids are lowercase-dotted (letters,
+ * digits, hyphens, underscores, colons for namespaced cases), start
+ * with a letter, and never exceed 64 characters. Anything else is a
+ * malformed input and must not reach the Mongo query.
+ */
+const ZONE_ID_PATTERN = /^[a-z][a-z0-9_:-]{0,63}$/;
+
+/**
+ * Format gate for plugin ids. Same shape as a zone id minus the
+ * colon — plugin ids never carry namespaced segments.
+ */
+const PLUGIN_ID_PATTERN = /^[a-z][a-z0-9-]{0,63}$/;
+
+/**
+ * Read a query-string value, coerce it to a string, validate it
+ * against the supplied regex, and return the sanitised result.
+ *
+ * Two-step defence:
+ *
+ * 1. Explicit `String(...)` coercion neutralises Express's parsed-
+ *    object form (`?zoneId[$ne]=foo` becomes a `[object Object]`
+ *    literal that fails the regex). CodeQL's taint analysis
+ *    recognises `String(taint)` as a coercion sanitiser.
+ * 2. The regex enforces a known-safe shape, so even if a coerced
+ *    value somehow carried Mongo operators they could not survive
+ *    the test.
+ *
+ * Returns `undefined` when the value is missing or fails validation.
+ * Callers omit the filter key in that case, preserving the existing
+ * "no filter" semantic.
+ */
+function safeStringParam(value: unknown, pattern: RegExp): string | undefined {
+    if (value === undefined || value === null) return undefined;
+    if (typeof value !== 'string') return undefined;
+    const coerced = String(value);
+    if (coerced.length === 0) return undefined;
+    return pattern.test(coerced) ? coerced : undefined;
+}
+
+/**
  * Admin controller for placement CRUD plus restore-defaults.
  */
 export class PlacementsController {
@@ -72,7 +112,9 @@ export class PlacementsController {
      *
      * Query params (all optional): `zoneId`, `pluginId`, `source`
      * (`plugin` | `operator`), `enabledOnly` (truthy → only enabled
-     * rows).
+     * rows). Each string param is coerced through `String(...)` and
+     * gated against a format regex before reaching the placement
+     * service — see `safeStringParam` for the NoSQL-injection defence.
      */
     listPlacements = async (req: Request, res: Response): Promise<void> => {
         try {
@@ -83,12 +125,16 @@ export class PlacementsController {
                 enabledOnly?: boolean;
             } = {};
 
-            if (typeof req.query.zoneId === 'string' && req.query.zoneId.length > 0) {
-                filter.zoneId = req.query.zoneId;
-            }
-            if (typeof req.query.pluginId === 'string' && req.query.pluginId.length > 0) {
-                filter.pluginId = req.query.pluginId;
-            }
+            const zoneId = safeStringParam(req.query.zoneId, ZONE_ID_PATTERN);
+            if (zoneId !== undefined) filter.zoneId = zoneId;
+
+            const pluginId = safeStringParam(req.query.pluginId, PLUGIN_ID_PATTERN);
+            if (pluginId !== undefined) filter.pluginId = pluginId;
+
+            // `source` and `enabledOnly` ride on equality allowlists
+            // already — a non-matching value (object, number, anything
+            // other than the listed strings) simply fails the
+            // comparison and the filter key is omitted.
             if (req.query.source === 'plugin' || req.query.source === 'operator') {
                 filter.source = req.query.source;
             }

--- a/src/backend/modules/widgets/api/placements.controller.ts
+++ b/src/backend/modules/widgets/api/placements.controller.ts
@@ -131,12 +131,15 @@ export class PlacementsController {
             const pluginId = safeStringParam(req.query.pluginId, PLUGIN_ID_PATTERN);
             if (pluginId !== undefined) filter.pluginId = pluginId;
 
-            // `source` and `enabledOnly` ride on equality allowlists
-            // already — a non-matching value (object, number, anything
-            // other than the listed strings) simply fails the
-            // comparison and the filter key is omitted.
-            if (req.query.source === 'plugin' || req.query.source === 'operator') {
-                filter.source = req.query.source;
+            // `source` and `enabledOnly` ride on equality allowlists.
+            // Assign the literal we just compared against rather than
+            // the request value so CodeQL's taint tracking sees a
+            // constant flowing into the filter, not a sanitised-but-
+            // still-tainted user input.
+            if (req.query.source === 'plugin') {
+                filter.source = 'plugin';
+            } else if (req.query.source === 'operator') {
+                filter.source = 'operator';
             }
             if (req.query.enabledOnly === 'true' || req.query.enabledOnly === '1') {
                 filter.enabledOnly = true;

--- a/src/backend/modules/widgets/api/placements.controller.ts
+++ b/src/backend/modules/widgets/api/placements.controller.ts
@@ -1,0 +1,454 @@
+/**
+ * @fileoverview Admin controller for widget-placement CRUD.
+ *
+ * Powers the `/system/widgets` placement editor. All endpoints are
+ * mounted behind `requireAdmin` and the platform's admin rate
+ * limiter — see `WidgetsModule.run()` for the bind.
+ *
+ * The controller validates input against the live zone and widget-
+ * type registries before touching the placement service. A request
+ * naming an unknown zone or type is refused before any state change.
+ * Pattern validation for `routes` flows through
+ * `normaliseRoutePattern` so the matcher's accepted grammar (exact,
+ * `/seg/*`, `/seg/**`) is the single source of truth.
+ *
+ * @module backend/modules/widgets/api/placements.controller
+ */
+
+import type { Request, Response } from 'express';
+import type {
+    ISystemLogService,
+    IPlacementService,
+    IZoneRegistry,
+    IWidgetTypeRegistry,
+    PlacementSource
+} from '@/types';
+import { normaliseRoutePattern } from '../placements/route-matcher.js';
+import type { IPluginRegistrationDefaults } from '../../../services/widget/widget.service.js';
+
+/**
+ * Resolver for plugin defaults. Provided by `WidgetsModule.init()` so
+ * the controller does not import the legacy widget service directly.
+ */
+export type PluginDefaultsResolver = (
+    pluginId: string,
+    typeId: string
+) => IPluginRegistrationDefaults | null;
+
+/**
+ * Constructor dependencies for the placements controller.
+ */
+export interface IPlacementsControllerDeps {
+    placements: IPlacementService;
+    zones: IZoneRegistry;
+    widgetTypes: IWidgetTypeRegistry;
+    getPluginDefault: PluginDefaultsResolver;
+    logger: ISystemLogService;
+}
+
+/**
+ * Upper bound on a placement's `order` field. Lower numbers render
+ * first within a zone. The bound is generous (10,000) so operators can
+ * use coarse-grained values like 100/200/300 without colliding with
+ * plugin defaults that cluster around 100.
+ */
+const MAX_ORDER = 10_000;
+
+/**
+ * Upper bound on a placement `title` override length. Matches the
+ * existing legacy widget-config `title` constraint and the column
+ * budget of the rendered card heading.
+ */
+const MAX_TITLE_LENGTH = 80;
+
+/**
+ * Admin controller for placement CRUD plus restore-defaults.
+ */
+export class PlacementsController {
+    constructor(private readonly deps: IPlacementsControllerDeps) {}
+
+    /**
+     * GET /api/admin/system/widgets/placements
+     *
+     * Query params (all optional): `zoneId`, `pluginId`, `source`
+     * (`plugin` | `operator`), `enabledOnly` (truthy → only enabled
+     * rows).
+     */
+    listPlacements = async (req: Request, res: Response): Promise<void> => {
+        try {
+            const filter: {
+                zoneId?: string;
+                pluginId?: string;
+                source?: PlacementSource;
+                enabledOnly?: boolean;
+            } = {};
+
+            if (typeof req.query.zoneId === 'string' && req.query.zoneId.length > 0) {
+                filter.zoneId = req.query.zoneId;
+            }
+            if (typeof req.query.pluginId === 'string' && req.query.pluginId.length > 0) {
+                filter.pluginId = req.query.pluginId;
+            }
+            if (req.query.source === 'plugin' || req.query.source === 'operator') {
+                filter.source = req.query.source;
+            }
+            if (req.query.enabledOnly === 'true' || req.query.enabledOnly === '1') {
+                filter.enabledOnly = true;
+            }
+
+            const placements = await this.deps.placements.list(filter);
+            res.json({ success: true, placements });
+        } catch (err) {
+            this.deps.logger.error({ err }, 'Failed to list placements');
+            res.status(500).json({ success: false, error: 'Failed to list placements' });
+        }
+    };
+
+    /**
+     * GET /api/admin/system/widgets/placements/:id
+     */
+    getPlacement = async (req: Request, res: Response): Promise<void> => {
+        try {
+            const placement = await this.deps.placements.findById(req.params.id);
+            if (!placement) {
+                res.status(404).json({ success: false, error: 'Placement not found' });
+                return;
+            }
+            res.json({ success: true, placement });
+        } catch (err) {
+            this.deps.logger.error({ err, id: req.params.id }, 'Failed to read placement');
+            res.status(500).json({ success: false, error: 'Failed to read placement' });
+        }
+    };
+
+    /**
+     * POST /api/admin/system/widgets/placements
+     *
+     * Body: `{ typeId, zoneId, routes, order?, title?, instanceConfig?, enabled? }`.
+     * Always creates an operator-source row; plugin-source rows are
+     * only writable by the legacy widget-service compatibility shim.
+     */
+    createPlacement = async (req: Request, res: Response): Promise<void> => {
+        try {
+            const parsed = this.parseCreateBody(req.body);
+            if ('error' in parsed) {
+                res.status(400).json({ success: false, error: parsed.error });
+                return;
+            }
+
+            const placement = await this.deps.placements.create(parsed.input, { source: 'operator' });
+            res.status(201).json({ success: true, placement });
+        } catch (err) {
+            this.deps.logger.error({ err }, 'Failed to create placement');
+            res.status(500).json({ success: false, error: 'Failed to create placement' });
+        }
+    };
+
+    /**
+     * PATCH /api/admin/system/widgets/placements/:id
+     *
+     * Body: any subset of `{ zoneId, routes, order, title, instanceConfig, enabled }`.
+     * Operator-editable on every row regardless of source — the whole
+     * point of the type+placement split is that operators own the
+     * placement record.
+     */
+    updatePlacement = async (req: Request, res: Response): Promise<void> => {
+        try {
+            const parsed = this.parsePatchBody(req.body);
+            if ('error' in parsed) {
+                res.status(400).json({ success: false, error: parsed.error });
+                return;
+            }
+
+            const placement = await this.deps.placements.update(req.params.id, parsed.patch);
+            if (!placement) {
+                res.status(404).json({ success: false, error: 'Placement not found' });
+                return;
+            }
+            res.json({ success: true, placement });
+        } catch (err) {
+            this.deps.logger.error({ err, id: req.params.id }, 'Failed to update placement');
+            res.status(500).json({ success: false, error: 'Failed to update placement' });
+        }
+    };
+
+    /**
+     * DELETE /api/admin/system/widgets/placements/:id
+     *
+     * Operator-source rows delete cleanly. Plugin-source rows are
+     * refused with 400 — the supported paths are disable (via PATCH
+     * `enabled: false`) and restore-defaults (which re-enables and
+     * reverts operator changes). Plugin row deletion would only
+     * re-appear on the next plugin re-register, leaving operator
+     * customisations destroyed and the row identical to its plugin
+     * default.
+     */
+    deletePlacement = async (req: Request, res: Response): Promise<void> => {
+        try {
+            const existing = await this.deps.placements.findById(req.params.id);
+            if (!existing) {
+                res.status(404).json({ success: false, error: 'Placement not found' });
+                return;
+            }
+            if (existing.source === 'plugin') {
+                res.status(400).json({
+                    success: false,
+                    error: 'Plugin-source placements cannot be deleted. Disable the row or restore plugin defaults instead.'
+                });
+                return;
+            }
+
+            const removed = await this.deps.placements.delete(req.params.id);
+            if (!removed) {
+                res.status(404).json({ success: false, error: 'Placement not found' });
+                return;
+            }
+            res.status(204).end();
+        } catch (err) {
+            this.deps.logger.error({ err, id: req.params.id }, 'Failed to delete placement');
+            res.status(500).json({ success: false, error: 'Failed to delete placement' });
+        }
+    };
+
+    /**
+     * POST /api/admin/system/widgets/placements/:id/restore-defaults
+     *
+     * Reverts a plugin-source placement to the args the plugin
+     * originally passed to `widgetService.register(...)`. Requires
+     * the plugin to have registered in this process — defaults are
+     * cached in memory and disappear on restart of a disabled plugin.
+     */
+    restorePluginDefaults = async (req: Request, res: Response): Promise<void> => {
+        try {
+            const existing = await this.deps.placements.findById(req.params.id);
+            if (!existing) {
+                res.status(404).json({ success: false, error: 'Placement not found' });
+                return;
+            }
+            if (existing.source !== 'plugin') {
+                res.status(400).json({
+                    success: false,
+                    error: 'Restore defaults is only valid for plugin-source placements. Operator-created rows have no plugin defaults to restore.'
+                });
+                return;
+            }
+            if (!existing.pluginId) {
+                res.status(400).json({
+                    success: false,
+                    error: 'Placement is missing its owning plugin id. Cannot resolve defaults.'
+                });
+                return;
+            }
+
+            const defaults = this.deps.getPluginDefault(existing.pluginId, existing.typeId);
+            if (!defaults) {
+                res.status(409).json({
+                    success: false,
+                    error: 'Plugin has not registered in this process. Re-enable the plugin to repopulate defaults, then retry.'
+                });
+                return;
+            }
+
+            const placement = await this.deps.placements.restoreToPluginDefaults(req.params.id, {
+                zoneId: defaults.zone,
+                routes: defaults.routes,
+                order: defaults.order,
+                title: defaults.title
+            });
+            if (!placement) {
+                res.status(404).json({ success: false, error: 'Placement not found' });
+                return;
+            }
+            res.json({ success: true, placement });
+        } catch (err) {
+            this.deps.logger.error({ err, id: req.params.id }, 'Failed to restore plugin defaults');
+            res.status(500).json({ success: false, error: 'Failed to restore plugin defaults' });
+        }
+    };
+
+    /**
+     * Parse and validate a create-placement request body. Returns the
+     * normalised input shape on success or a 400-eligible error
+     * message describing the first validation failure.
+     */
+    private parseCreateBody(body: unknown):
+        | { input: { typeId: string; zoneId: string; routes: string[]; order?: number; title?: string; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
+        | { error: string } {
+        if (!body || typeof body !== 'object') {
+            return { error: 'Request body must be an object' };
+        }
+        const b = body as Record<string, unknown>;
+
+        if (typeof b.typeId !== 'string' || b.typeId.length === 0) {
+            return { error: 'typeId is required' };
+        }
+        if (!this.deps.widgetTypes.has(b.typeId)) {
+            return { error: `Unknown widget type id: '${b.typeId}'` };
+        }
+
+        if (typeof b.zoneId !== 'string' || b.zoneId.length === 0) {
+            return { error: 'zoneId is required' };
+        }
+        if (!this.deps.zones.has(b.zoneId)) {
+            return { error: `Unknown zone id: '${b.zoneId}'` };
+        }
+
+        const routesResult = this.parseRoutes(b.routes);
+        if ('error' in routesResult) return routesResult;
+
+        const orderResult = this.parseOrder(b.order);
+        if ('error' in orderResult) return orderResult;
+
+        const titleResult = this.parseTitle(b.title);
+        if ('error' in titleResult) return titleResult;
+
+        const instanceConfigResult = this.parseInstanceConfig(b.instanceConfig);
+        if ('error' in instanceConfigResult) return instanceConfigResult;
+
+        const enabled = typeof b.enabled === 'boolean' ? b.enabled : true;
+
+        return {
+            input: {
+                typeId: b.typeId,
+                zoneId: b.zoneId,
+                routes: routesResult.routes,
+                order: orderResult.order,
+                title: titleResult.title,
+                instanceConfig: instanceConfigResult.instanceConfig,
+                enabled
+            }
+        };
+    }
+
+    /**
+     * Parse and validate a patch-placement request body. Every field
+     * is optional, but those provided must validate.
+     */
+    private parsePatchBody(body: unknown):
+        | { patch: { zoneId?: string; routes?: string[]; order?: number; title?: string; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
+        | { error: string } {
+        if (!body || typeof body !== 'object') {
+            return { error: 'Request body must be an object' };
+        }
+        const b = body as Record<string, unknown>;
+        const patch: { zoneId?: string; routes?: string[]; order?: number; title?: string; instanceConfig?: Record<string, unknown>; enabled?: boolean } = {};
+
+        if (b.zoneId !== undefined) {
+            if (typeof b.zoneId !== 'string' || b.zoneId.length === 0) {
+                return { error: 'zoneId must be a non-empty string' };
+            }
+            if (!this.deps.zones.has(b.zoneId)) {
+                return { error: `Unknown zone id: '${b.zoneId}'` };
+            }
+            patch.zoneId = b.zoneId;
+        }
+
+        if (b.routes !== undefined) {
+            const result = this.parseRoutes(b.routes);
+            if ('error' in result) return result;
+            patch.routes = result.routes;
+        }
+
+        if (b.order !== undefined) {
+            const result = this.parseOrder(b.order);
+            if ('error' in result) return result;
+            if (result.order !== undefined) patch.order = result.order;
+        }
+
+        if (b.title !== undefined) {
+            const result = this.parseTitle(b.title);
+            if ('error' in result) return result;
+            patch.title = result.title;
+        }
+
+        if (b.instanceConfig !== undefined) {
+            const result = this.parseInstanceConfig(b.instanceConfig);
+            if ('error' in result) return result;
+            patch.instanceConfig = result.instanceConfig;
+        }
+
+        if (b.enabled !== undefined) {
+            if (typeof b.enabled !== 'boolean') {
+                return { error: 'enabled must be a boolean' };
+            }
+            patch.enabled = b.enabled;
+        }
+
+        return { patch };
+    }
+
+    /**
+     * Validate and normalise the `routes` field. Accepts an array of
+     * pattern strings; each must pass `normaliseRoutePattern`.
+     */
+    private parseRoutes(value: unknown): { routes: string[] } | { error: string } {
+        if (!Array.isArray(value)) {
+            return { error: 'routes must be an array of strings' };
+        }
+        const out: string[] = [];
+        for (const entry of value) {
+            if (typeof entry !== 'string') {
+                return { error: 'Each routes entry must be a string' };
+            }
+            const normalised = normaliseRoutePattern(entry);
+            if (normalised === null) {
+                return { error: `Invalid route pattern: '${entry}'. Patterns must start with '/' and may end in '/*' or '/**'.` };
+            }
+            out.push(normalised);
+        }
+        return { routes: out };
+    }
+
+    /**
+     * Validate the `order` field. Optional, must be a non-negative
+     * integer at or below `MAX_ORDER`.
+     */
+    private parseOrder(value: unknown): { order?: number } | { error: string } {
+        if (value === undefined) return { order: undefined };
+        if (typeof value !== 'number' || !Number.isFinite(value)) {
+            return { error: 'order must be a finite number' };
+        }
+        if (!Number.isInteger(value)) {
+            return { error: 'order must be an integer' };
+        }
+        if (value < 0 || value > MAX_ORDER) {
+            return { error: `order must be between 0 and ${MAX_ORDER}` };
+        }
+        return { order: value };
+    }
+
+    /**
+     * Validate the optional `title` field. Trimmed; empty after trim
+     * is rejected because an empty title is meaningless — clear the
+     * field by omitting it from the patch.
+     */
+    private parseTitle(value: unknown): { title?: string } | { error: string } {
+        if (value === undefined) return { title: undefined };
+        if (typeof value !== 'string') {
+            return { error: 'title must be a string' };
+        }
+        const trimmed = value.trim();
+        if (trimmed.length === 0) {
+            return { error: 'title must be non-empty when provided' };
+        }
+        if (trimmed.length > MAX_TITLE_LENGTH) {
+            return { error: `title must be at most ${MAX_TITLE_LENGTH} characters` };
+        }
+        return { title: trimmed };
+    }
+
+    /**
+     * Validate the optional `instanceConfig` field. Must be a plain
+     * object; the placement service is the schema-aware consumer —
+     * the controller only enforces shape.
+     */
+    private parseInstanceConfig(value: unknown):
+        | { instanceConfig?: Record<string, unknown> }
+        | { error: string } {
+        if (value === undefined) return { instanceConfig: undefined };
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            return { error: 'instanceConfig must be a plain object' };
+        }
+        return { instanceConfig: value as Record<string, unknown> };
+    }
+}

--- a/src/backend/modules/widgets/api/placements.routes.ts
+++ b/src/backend/modules/widgets/api/placements.routes.ts
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Router factory for the placements admin endpoint set.
+ *
+ * Mounted by `WidgetsModule.run()` under
+ * `/api/admin/system/widgets/placements`. Authentication and the
+ * platform-default admin rate limiter are applied at mount time, so
+ * the router itself does not re-apply either.
+ *
+ * @module backend/modules/widgets/api/placements.routes
+ */
+
+import { Router } from 'express';
+import type { PlacementsController } from './placements.controller.js';
+
+/**
+ * Build the placements admin router with all CRUD endpoints plus the
+ * restore-defaults action.
+ *
+ * @param controller - Controller with the request handlers bound.
+ * @returns Express router ready to mount.
+ */
+export function createPlacementsAdminRouter(controller: PlacementsController): Router {
+    const router = Router();
+
+    router.get('/', controller.listPlacements);
+    router.get('/:id', controller.getPlacement);
+    router.post('/', controller.createPlacement);
+    router.patch('/:id', controller.updatePlacement);
+    router.delete('/:id', controller.deletePlacement);
+    router.post('/:id/restore-defaults', controller.restorePluginDefaults);
+
+    return router;
+}

--- a/src/backend/modules/widgets/api/widget-types.controller.ts
+++ b/src/backend/modules/widgets/api/widget-types.controller.ts
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Admin controller for widget-type introspection.
+ *
+ * Serves the registry's snapshot to the `/system/widgets` admin
+ * placement editor. The snapshot lists every declared widget type
+ * grouped by owning plugin — the placement editor renders this as
+ * the type palette an operator picks from when creating a new
+ * placement.
+ *
+ * Read-only — widget types are declared in plugin code, not by
+ * operators. The placement *records* are the operator-editable
+ * surface; see `placements.controller.ts`.
+ *
+ * @module backend/modules/widgets/api/widget-types.controller
+ */
+
+import type { Request, Response } from 'express';
+import type { IWidgetTypeRegistry, ISystemLogService } from '@/types';
+
+/**
+ * Admin endpoint controller for widget-type introspection.
+ */
+export class WidgetTypesController {
+    /**
+     * Construct the controller.
+     *
+     * @param registry - Shared process-wide widget-type registry.
+     * @param logger - Scoped logger.
+     */
+    constructor(
+        private readonly registry: IWidgetTypeRegistry,
+        private readonly logger: ISystemLogService
+    ) {}
+
+    /**
+     * Return the current widget-type snapshot.
+     *
+     * Always succeeds — empty registries return an empty `groups`
+     * array so the admin UI can render its palette scaffold
+     * unconditionally.
+     */
+    getSnapshot = (_req: Request, res: Response): void => {
+        try {
+            const snapshot = this.registry.snapshot();
+            res.json(snapshot);
+        } catch (err) {
+            this.logger.error({ err }, 'Failed to read widget-type snapshot');
+            res.status(500).json({ success: false, error: 'Failed to read widget-type snapshot' });
+        }
+    };
+}

--- a/src/backend/modules/widgets/api/widget-types.routes.ts
+++ b/src/backend/modules/widgets/api/widget-types.routes.ts
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Router factory for the widget-types introspection
+ * admin endpoint.
+ *
+ * Single read-only `GET /` route returning the registry snapshot.
+ * Mounted under `/api/admin/system/widget-types` by
+ * `WidgetsModule.run()` with `requireAdmin` and the admin rate
+ * limiter applied at mount time.
+ *
+ * @module backend/modules/widgets/api/widget-types.routes
+ */
+
+import { Router } from 'express';
+import type { WidgetTypesController } from './widget-types.controller.js';
+
+/**
+ * Build the widget-types admin router.
+ *
+ * @param controller - Controller with the snapshot handler bound.
+ * @returns Express router with the snapshot route attached.
+ */
+export function createWidgetTypesAdminRouter(controller: WidgetTypesController): Router {
+    const router = Router();
+    router.get('/', controller.getSnapshot);
+    return router;
+}

--- a/src/backend/modules/widgets/index.ts
+++ b/src/backend/modules/widgets/index.ts
@@ -35,10 +35,30 @@ export {
     PluginWidgetTypes
 } from './widget-types/index.js';
 
-export { PlacementService, PlacementResolver, routeMatches } from './placements/index.js';
+export {
+    PlacementService,
+    PlacementResolver,
+    routeMatches,
+    normaliseRoutePattern,
+    partitionRoutePatterns
+} from './placements/index.js';
+export type {
+    PlacementBroadcastCallback,
+    PlacementBroadcastEvent
+} from './placements/placement.service.js';
 
 export type { IWidgetPlacementDocument } from './database/index.js';
 export { WIDGET_PLACEMENT_COLLECTION } from './database/index.js';
 
 export { ZonesController } from './api/zones.controller.js';
 export { createZonesAdminRouter } from './api/zones.routes.js';
+
+export { PlacementsController } from './api/placements.controller.js';
+export type {
+    IPlacementsControllerDeps,
+    PluginDefaultsResolver
+} from './api/placements.controller.js';
+export { createPlacementsAdminRouter } from './api/placements.routes.js';
+
+export { WidgetTypesController } from './api/widget-types.controller.js';
+export { createWidgetTypesAdminRouter } from './api/widget-types.routes.js';

--- a/src/backend/modules/widgets/placements/index.ts
+++ b/src/backend/modules/widgets/placements/index.ts
@@ -8,4 +8,4 @@
 
 export { PlacementService } from './placement.service.js';
 export { PlacementResolver } from './placement-resolver.js';
-export { routeMatches } from './route-matcher.js';
+export { routeMatches, normaliseRoutePattern, partitionRoutePatterns } from './route-matcher.js';

--- a/src/backend/modules/widgets/placements/placement.service.ts
+++ b/src/backend/modules/widgets/placements/placement.service.ts
@@ -44,10 +44,36 @@ const DEFAULT_ORDER = 100;
  * compat-shim widget service, the placement resolver, and the admin
  * API surface.
  */
+/**
+ * Discriminator for the placement broadcast callback. Mirrors the
+ * subset of events on `WidgetsPlacementsUpdatePayload` shipped over
+ * the wire; `WidgetsModule` is responsible for translating these into
+ * the socket payload via `WebSocketService`.
+ */
+export type PlacementBroadcastEvent =
+    | 'placement:created'
+    | 'placement:updated'
+    | 'placement:deleted'
+    | 'placement:restored';
+
+/**
+ * Callback invoked by the placement service after every successful
+ * mutation. `WidgetsModule.init()` wires this to broadcast a refetch
+ * signal over WebSocket so connected clients re-pull widget data.
+ *
+ * Errors thrown by the callback are caught inside the service so
+ * placement writes never roll back on a broadcast failure.
+ */
+export type PlacementBroadcastCallback = (
+    event: PlacementBroadcastEvent,
+    placement: { id: string; zoneId?: string }
+) => void;
+
 export class PlacementService implements IPlacementService {
     private static instance: PlacementService;
     private readonly database: IDatabaseService;
     private readonly logger: ISystemLogService;
+    private broadcast: PlacementBroadcastCallback | null = null;
 
     private constructor(database: IDatabaseService, logger: ISystemLogService) {
         this.database = database;
@@ -62,6 +88,44 @@ export class PlacementService implements IPlacementService {
     public static setDependencies(database: IDatabaseService, logger: ISystemLogService): void {
         if (!PlacementService.instance) {
             PlacementService.instance = new PlacementService(database, logger);
+        }
+    }
+
+    /**
+     * Wire a broadcast callback the service invokes after every
+     * successful create/update/delete/restore. `WidgetsModule.init()`
+     * passes a closure that emits a `widgets:placements-update`
+     * envelope through `WebSocketService`. Optional — when unset, the
+     * service operates silently (useful for tests and for the legacy
+     * unwired code path that predates the broadcast hook).
+     *
+     * @param callback - Function the service invokes post-write.
+     */
+    public setBroadcast(callback: PlacementBroadcastCallback | null): void {
+        this.broadcast = callback;
+    }
+
+    /**
+     * Internal helper that invokes the broadcast callback if one is
+     * wired and swallows any thrown error. Broadcast failure must not
+     * roll back the placement mutation that already succeeded.
+     *
+     * @param event - Mutation kind.
+     * @param payload - Placement identifiers carried in the envelope.
+     */
+    private fireBroadcast(event: PlacementBroadcastEvent, payload: { id: string; zoneId?: string }): void {
+        if (!this.broadcast) return;
+        try {
+            this.broadcast(event, payload);
+        } catch (err) {
+            this.logger.warn(
+                {
+                    err: err instanceof Error ? err.message : String(err),
+                    event,
+                    placementId: payload.id
+                },
+                'Placement broadcast callback threw — placement write succeeded but the notification was not delivered'
+            );
         }
     }
 
@@ -168,27 +232,37 @@ export class PlacementService implements IPlacementService {
 
     async findByRoute(route: string): Promise<ReadonlyArray<IWidgetPlacement>> {
         const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
-        // Push the route filter into Mongo. Empty `routes` matches
-        // every path; otherwise the exact path must appear in the
-        // array. The multikey index on `routes` (built implicitly on
-        // every array field) plus the compound
-        // `enabled_zone_order` index from migration 001 keeps the
-        // common SSR query cheap as placement counts grow. The
-        // pure `routeMatches` predicate in `route-matcher.ts`
-        // remains the canonical statement of the matching rule for
-        // any non-Mongo caller and for future grammar extension.
+        // Push the cheap filter into Mongo: empty `routes` matches
+        // every path; an exact match of `route` matches that path;
+        // a row whose `routes` contains any entry ending in `/*` or
+        // `/**` is a candidate that must be re-checked in memory by
+        // the matcher.
+        //
+        // The multikey index on `routes` keeps the equality and regex
+        // arms cheap; the regex arm narrows on the suffix marker
+        // before the in-memory filter runs. As placement counts grow
+        // the worst-case pull is roughly "rows with empty routes" +
+        // "rows containing a glob" + "rows containing the exact
+        // route" — bounded by the count of routes-using rows and
+        // never the full collection.
         const documents = await collection
             .find({
                 enabled: true,
                 $or: [
                     { routes: { $size: 0 } },
-                    { routes: route }
+                    { routes: route },
+                    { routes: { $regex: '\\*$' } }
                 ]
             })
             .sort({ zoneId: 1, order: 1 })
             .toArray();
 
-        return documents.map(toPublic);
+        // Pull-side filter: ensures glob patterns honour the matcher
+        // rules (single-segment vs deep prefix, leading-slash, exact
+        // form) instead of the broader Mongo `$regex` arm.
+        const filtered = documents.filter(doc => routeMatches(doc.routes, route));
+
+        return filtered.map(toPublic);
     }
 
     async create(
@@ -230,7 +304,9 @@ export class PlacementService implements IPlacementService {
             throw new Error('Placement create succeeded but document could not be re-read');
         }
 
-        return toPublic(created);
+        const publicShape = toPublic(created);
+        this.fireBroadcast('placement:created', { id: publicShape.id, zoneId: publicShape.zoneId });
+        return publicShape;
     }
 
     async update(id: string, patch: IPlacementPatch): Promise<IWidgetPlacement | null> {
@@ -250,14 +326,90 @@ export class PlacementService implements IPlacementService {
         if (result.matchedCount === 0) return null;
 
         const updated = await collection.findOne({ _id: objectId });
-        return updated ? toPublic(updated) : null;
+        if (!updated) return null;
+
+        const publicShape = toPublic(updated);
+        this.fireBroadcast('placement:updated', { id: publicShape.id, zoneId: publicShape.zoneId });
+        return publicShape;
     }
 
     async delete(id: string): Promise<boolean> {
         if (!ObjectId.isValid(id)) return false;
         const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
         const result = await collection.deleteOne({ _id: new ObjectId(id) });
-        return (result.deletedCount ?? 0) > 0;
+        const removed = (result.deletedCount ?? 0) > 0;
+        if (removed) {
+            this.fireBroadcast('placement:deleted', { id });
+        }
+        return removed;
+    }
+
+    /**
+     * Replace operator-editable fields on a plugin-source placement
+     * with the plugin's original registration args, then re-enable
+     * the row. Used by the admin "restore plugin defaults" endpoint.
+     *
+     * The controller is responsible for verifying the placement is
+     * plugin-source and resolving the defaults from the legacy widget
+     * service's cache before calling this method. The service only
+     * applies the patch atomically and broadcasts the dedicated
+     * `placement:restored` event so receivers can distinguish a
+     * restore from a plain update.
+     *
+     * @param id - Placement id (stringified ObjectId).
+     * @param defaults - Plugin defaults to apply. `instanceConfig` is
+     *   not part of plugin registration args — it is operator state —
+     *   so it is intentionally absent from the input. The row's
+     *   existing `instanceConfig` survives restore.
+     * @returns Updated placement, or null when no row matches.
+     */
+    async restoreToPluginDefaults(
+        id: string,
+        defaults: {
+            zoneId: string;
+            routes: ReadonlyArray<string>;
+            order: number;
+            title?: string;
+        }
+    ): Promise<IWidgetPlacement | null> {
+        if (!ObjectId.isValid(id)) return null;
+
+        const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
+        const objectId = new ObjectId(id);
+        const now = new Date();
+
+        const setOps: Partial<IWidgetPlacementDocument> = {
+            zoneId: defaults.zoneId,
+            routes: [...defaults.routes],
+            order: defaults.order,
+            enabled: true,
+            updatedAt: now
+        };
+
+        // `$unset` the optional title field when the plugin never set
+        // one so the restored row matches a fresh plugin registration
+        // exactly, not "plugin defaults plus operator title".
+        const unsetOps: Record<string, ''> = {};
+        if (defaults.title !== undefined) {
+            setOps.title = defaults.title;
+        } else {
+            unsetOps.title = '';
+        }
+
+        const updateDoc: Record<string, unknown> = { $set: setOps };
+        if (Object.keys(unsetOps).length > 0) {
+            updateDoc.$unset = unsetOps;
+        }
+
+        const result = await collection.updateOne({ _id: objectId }, updateDoc);
+        if (result.matchedCount === 0) return null;
+
+        const updated = await collection.findOne({ _id: objectId });
+        if (!updated) return null;
+
+        const publicShape = toPublic(updated);
+        this.fireBroadcast('placement:restored', { id: publicShape.id, zoneId: publicShape.zoneId });
+        return publicShape;
     }
 
     async findById(id: string): Promise<IWidgetPlacement | null> {

--- a/src/backend/modules/widgets/placements/placement.service.ts
+++ b/src/backend/modules/widgets/placements/placement.service.ts
@@ -314,15 +314,26 @@ export class PlacementService implements IPlacementService {
 
         const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
         const setOps: Partial<IWidgetPlacementDocument> = { updatedAt: new Date() };
+        const unsetOps: Record<string, ''> = {};
         if (patch.zoneId !== undefined) setOps.zoneId = patch.zoneId;
         if (patch.routes !== undefined) setOps.routes = [...patch.routes];
         if (patch.order !== undefined) setOps.order = patch.order;
-        if (patch.title !== undefined) setOps.title = patch.title;
+        if (patch.title === null) {
+            // Explicit unset signal — drop the title field so the
+            // placement falls back to the widget-type label.
+            unsetOps.title = '';
+        } else if (patch.title !== undefined) {
+            setOps.title = patch.title;
+        }
         if (patch.instanceConfig !== undefined) setOps.instanceConfig = patch.instanceConfig;
         if (patch.enabled !== undefined) setOps.enabled = patch.enabled;
 
         const objectId = new ObjectId(id);
-        const result = await collection.updateOne({ _id: objectId }, { $set: setOps });
+        const updateDoc: Record<string, unknown> = { $set: setOps };
+        if (Object.keys(unsetOps).length > 0) {
+            updateDoc.$unset = unsetOps;
+        }
+        const result = await collection.updateOne({ _id: objectId }, updateDoc);
         if (result.matchedCount === 0) return null;
 
         const updated = await collection.findOne({ _id: objectId });

--- a/src/backend/modules/widgets/placements/route-matcher.ts
+++ b/src/backend/modules/widgets/placements/route-matcher.ts
@@ -2,24 +2,79 @@
  * @fileoverview Route-matcher for widget placement resolution.
  *
  * Pure function evaluating whether a placement's `routes` filter
- * matches a request path. The legacy `WidgetService` used strict
- * equality on the array; PR 2 preserves that semantic exactly — empty
- * array matches every route, otherwise the route must appear by
- * string equality. Glob and prefix matching are deferred until an
- * operator UI surfaces the need.
+ * matches a request path. Three pattern grammars share one matcher:
  *
- * The matcher is extracted so the placement service's Mongo query
- * and the resolver's in-memory filter share one source of truth, and
- * so the matching rule can evolve in a single file when a more
- * expressive grammar becomes necessary.
+ * - **Exact** — `'/markets'` matches the path `/markets` and nothing
+ *   else.
+ * - **Prefix** — `'/u/*'` matches anything under `/u/` with one
+ *   additional segment (`/u/TXyz` matches, `/u/TXyz/holdings` does
+ *   not).
+ * - **Deep prefix** — `'/u/**'` matches anything under `/u/` at any
+ *   depth, including `/u/TXyz/holdings/2024`.
+ *
+ * Empty `routes` array still matches every path, preserving the
+ * original "no filter" semantic.
+ *
+ * The matcher is extracted so the placement service's Mongo query and
+ * the resolver's in-memory filter share one source of truth, and so
+ * the matching rule can evolve in a single file when a more expressive
+ * grammar becomes necessary.
  *
  * @module backend/modules/widgets/placements/route-matcher
  */
 
 /**
+ * Marker suffix for a single-segment glob.
+ */
+const SINGLE_GLOB_SUFFIX = '/*';
+
+/**
+ * Marker suffix for a deep glob — matches one or more trailing
+ * segments.
+ */
+const DEEP_GLOB_SUFFIX = '/**';
+
+/**
+ * Test whether a single pattern matches the given request path.
+ *
+ * @param pattern - One entry from a placement's `routes` array.
+ * @param route - Request path the host resolved.
+ * @returns True when the pattern accepts the path.
+ */
+function patternMatches(pattern: string, route: string): boolean {
+    if (pattern === route) {
+        return true;
+    }
+
+    if (pattern.endsWith(DEEP_GLOB_SUFFIX)) {
+        const prefix = pattern.slice(0, -DEEP_GLOB_SUFFIX.length);
+        if (prefix.length === 0) {
+            return route.startsWith('/');
+        }
+        // Match `/<prefix>/<anything>` but not the bare prefix —
+        // a deep glob is "anything under here", not the parent page.
+        return route.startsWith(`${prefix}/`);
+    }
+
+    if (pattern.endsWith(SINGLE_GLOB_SUFFIX)) {
+        const prefix = pattern.slice(0, -SINGLE_GLOB_SUFFIX.length);
+        if (!route.startsWith(`${prefix}/`)) {
+            return false;
+        }
+        // Single-segment glob — the remainder after the prefix must be
+        // exactly one path segment with no further slashes.
+        const remainder = route.slice(prefix.length + 1);
+        return remainder.length > 0 && remainder.indexOf('/') === -1;
+    }
+
+    return false;
+}
+
+/**
  * Test whether a placement's route filter matches the given request
- * path. Empty `routes` matches every path. Otherwise the path must
- * appear in the array (exact match).
+ * path. Empty `routes` matches every path. Otherwise, any matching
+ * entry — exact, single-glob (`/u/*`), or deep-glob (`/u/**`) —
+ * accepts the path.
  *
  * @param routes - Placement's route filter.
  * @param route - Request path resolved by the host.
@@ -27,5 +82,84 @@
  */
 export function routeMatches(routes: ReadonlyArray<string>, route: string): boolean {
     if (routes.length === 0) return true;
-    return routes.indexOf(route) !== -1;
+    for (const pattern of routes) {
+        if (patternMatches(pattern, route)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Validate and normalise a route pattern.
+ *
+ * Used by the admin API to reject malformed entries before they reach
+ * the database. Valid forms:
+ *
+ * - `'/'` — root only.
+ * - `'/seg1/seg2/...'` — exact path, must start with `/`.
+ * - `'/seg/*'` — single-segment glob.
+ * - `'/seg/**'` — deep glob.
+ *
+ * Empty strings, patterns without a leading slash, patterns
+ * containing whitespace, and glob markers in non-trailing positions
+ * are all rejected.
+ *
+ * @param pattern - Candidate pattern.
+ * @returns Normalised pattern, or null when invalid.
+ */
+export function normaliseRoutePattern(pattern: string): string | null {
+    if (typeof pattern !== 'string') {
+        return null;
+    }
+    const trimmed = pattern.trim();
+    if (trimmed.length === 0) {
+        return null;
+    }
+    if (!trimmed.startsWith('/')) {
+        return null;
+    }
+    if (/\s/.test(trimmed)) {
+        return null;
+    }
+
+    const withoutTrailingGlob = trimmed.endsWith(DEEP_GLOB_SUFFIX)
+        ? trimmed.slice(0, -DEEP_GLOB_SUFFIX.length)
+        : trimmed.endsWith(SINGLE_GLOB_SUFFIX)
+            ? trimmed.slice(0, -SINGLE_GLOB_SUFFIX.length)
+            : trimmed;
+    if (withoutTrailingGlob.includes('*')) {
+        return null;
+    }
+
+    return trimmed;
+}
+
+/**
+ * Split a placement's route filter into the components needed for the
+ * Mongo query: exact paths (cheap equality) and pattern entries that
+ * must be filtered in memory after the query returns.
+ *
+ * The placement service uses this to push exact-match filtering down
+ * into Mongo and apply the glob predicate as a second pass on the
+ * smaller result set. Empty input means "match all routes" — no
+ * predicate work needed.
+ *
+ * @param routes - Placement's route filter.
+ * @returns Buckets keyed by `exact` and `patterns`.
+ */
+export function partitionRoutePatterns(routes: ReadonlyArray<string>): {
+    exact: string[];
+    patterns: string[];
+} {
+    const exact: string[] = [];
+    const patterns: string[] = [];
+    for (const entry of routes) {
+        if (entry.endsWith(SINGLE_GLOB_SUFFIX) || entry.endsWith(DEEP_GLOB_SUFFIX)) {
+            patterns.push(entry);
+        } else {
+            exact.push(entry);
+        }
+    }
+    return { exact, patterns };
 }

--- a/src/backend/services/websocket.service.ts
+++ b/src/backend/services/websocket.service.ts
@@ -399,6 +399,10 @@ export class WebSocketService implements IWebSocketService {
         break;
       case 'menu:update':
       case 'menu:namespace-config:update':
+      case 'widgets:placements-update':
+        // Broadcast to every connected socket. Widget placements
+        // affect public render order, so non-admin clients must
+        // refetch their widget data to see operator changes.
         this.io.emit(event.event, event.payload);
         break;
       default:

--- a/src/backend/services/widget/__tests__/widget.service.test.ts
+++ b/src/backend/services/widget/__tests__/widget.service.test.ts
@@ -440,4 +440,76 @@ describe('WidgetService', () => {
             expect(widgets).toEqual([]);
         });
     });
+
+    describe('getPluginDefault', () => {
+        it('returns null when never registered', () => {
+            expect(service.getPluginDefault('p', 'w')).toBeNull();
+        });
+
+        it('returns the plugin defaults captured at first registration', async () => {
+            await service.register(
+                createWidget({
+                    id: 'whale:recent',
+                    zone: 'main-after',
+                    routes: ['/'],
+                    order: 25,
+                    title: 'Recent Whales'
+                }),
+                'whale-alerts'
+            );
+
+            const defaults = service.getPluginDefault('whale-alerts', 'whale:recent');
+            expect(defaults).not.toBeNull();
+            expect(defaults?.zone).toBe('main-after');
+            expect(defaults?.routes).toEqual(['/']);
+            expect(defaults?.order).toBe(25);
+            expect(defaults?.title).toBe('Recent Whales');
+            expect(defaults?.pluginId).toBe('whale-alerts');
+            expect(defaults?.typeId).toBe('whale:recent');
+        });
+
+        it('does not overwrite cached defaults on same-plugin re-registration', async () => {
+            await service.register(
+                createWidget({ id: 'w', order: 10, title: 'First' }),
+                'p'
+            );
+            await service.register(
+                createWidget({ id: 'w', order: 99, title: 'Second' }),
+                'p'
+            );
+
+            const defaults = service.getPluginDefault('p', 'w');
+            expect(defaults?.order).toBe(10);
+            expect(defaults?.title).toBe('First');
+        });
+
+        it('isolates defaults between plugins for the same typeId', async () => {
+            // Two plugins claiming the same id is normally rejected by
+            // the registry, but the legacy in-memory cache still tracks
+            // each pluginId::typeId tuple independently. The compat-shim
+            // bails out before the placement upsert in that case, so
+            // the cache reflects the first plugin's args only — the
+            // second plugin's entry never lands. This test pins that
+            // behaviour: same id under a different plugin id does not
+            // collide.
+            await service.register(
+                createWidget({ id: 'shared', order: 5 }),
+                'plugin-a'
+            );
+
+            const a = service.getPluginDefault('plugin-a', 'shared');
+            const b = service.getPluginDefault('plugin-b', 'shared');
+            expect(a?.order).toBe(5);
+            expect(b).toBeNull();
+        });
+
+        it('clones the routes array so callers cannot mutate cached state', async () => {
+            const config = createWidget({ id: 'w', routes: ['/markets'] });
+            await service.register(config, 'p');
+            config.routes.push('/leaked');
+
+            const defaults = service.getPluginDefault('p', 'w');
+            expect(defaults?.routes).toEqual(['/markets']);
+        });
+    });
 });

--- a/src/backend/services/widget/widget.service.ts
+++ b/src/backend/services/widget/widget.service.ts
@@ -11,6 +11,27 @@ import { defineWidgetType } from '../../modules/widgets/widget-types/define-widg
 import type { PlacementResolver } from '../../modules/widgets/placements/placement-resolver.js';
 
 /**
+ * Snapshot of a plugin's original `widgetService.register(...)` call.
+ *
+ * Captured the first time a plugin registers a given type id in a
+ * process and retained for the lifetime of that process so the admin
+ * "restore plugin defaults" endpoint can revert operator changes to a
+ * plugin-owned placement without consulting the plugin code itself.
+ *
+ * Only the operator-editable fields (`zone`, `routes`, `order`,
+ * `title`) are kept — the data fetcher lives on the widget-type
+ * descriptor and is not part of placement state.
+ */
+export interface IPluginRegistrationDefaults {
+    pluginId: string;
+    typeId: string;
+    zone: string;
+    routes: string[];
+    order: number;
+    title?: string;
+}
+
+/**
  * Fallback set used for zone validation when no `IZoneRegistry` has
  * been injected yet — covers test paths that instantiate the service
  * without bootstrap wiring. Production always overrides this via
@@ -63,6 +84,14 @@ export class WidgetService implements IWidgetService {
     private widgetTypeRegistry: IWidgetTypeRegistry | null = null;
     private placementService: IPlacementService | null = null;
     private placementResolver: PlacementResolver | null = null;
+
+    /**
+     * Cache of every plugin's first `register(...)` call in this
+     * process, keyed by `${pluginId}::${typeId}`. Restore-defaults
+     * reads from this map; the singleton resets it via
+     * `__resetForTests` between unit tests.
+     */
+    private pluginDefaults: Map<string, IPluginRegistrationDefaults> = new Map();
 
     private constructor(logger: ISystemLogService) {
         this.logger = logger;
@@ -123,6 +152,25 @@ export class WidgetService implements IWidgetService {
     }
 
     /**
+     * Retrieve the cached plugin defaults for a given plugin id and
+     * widget-type id. Returns `null` when the combination was never
+     * registered in this process (e.g. plugin disabled before this
+     * process started, or a typo). Consumed by the placements admin
+     * controller to power the restore-defaults endpoint.
+     *
+     * @param pluginId - Plugin id that originally registered the type.
+     * @param typeId - Widget-type id.
+     * @returns Snapshot of the plugin's first registration args, or
+     *   null when missing.
+     */
+    public getPluginDefault(
+        pluginId: string,
+        typeId: string
+    ): IPluginRegistrationDefaults | null {
+        return this.pluginDefaults.get(`${pluginId}::${typeId}`) ?? null;
+    }
+
+    /**
      * Test whether a zone id is currently known.
      */
     private isKnownZone(zone: string): boolean {
@@ -160,8 +208,29 @@ export class WidgetService implements IWidgetService {
         };
         this.widgets.set(config.id, widgetConfig);
 
-        // If the new system isn't wired (tests), the in-memory cache
-        // is the entire behaviour — keep going.
+        // Capture the plugin's original registration args. The cache
+        // is wired-mode-independent so unit tests that exercise
+        // `register()` without constructing `WidgetsModule` still see
+        // `getPluginDefault` return the canonical defaults. Only the
+        // first call within the process populates the entry —
+        // same-plugin re-registration during a single lifecycle
+        // preserves the original descriptor (see the same-plugin
+        // owner branch below) and the cached defaults follow that
+        // semantic.
+        const cacheKey = `${pluginId}::${config.id}`;
+        if (!this.pluginDefaults.has(cacheKey)) {
+            this.pluginDefaults.set(cacheKey, {
+                pluginId,
+                typeId: config.id,
+                zone: config.zone,
+                routes: [...config.routes],
+                order: config.order ?? DEFAULT_ORDER,
+                title: config.title
+            });
+        }
+
+        // If the new system isn't wired (tests), the in-memory caches
+        // above are the entire behaviour — keep going.
         if (!this.widgetTypeRegistry || !this.placementService) {
             this.logger.debug(
                 { widgetId: config.id, pluginId },

--- a/src/backend/services/widget/widget.service.ts
+++ b/src/backend/services/widget/widget.service.ts
@@ -158,6 +158,9 @@ export class WidgetService implements IWidgetService {
      * process started, or a typo). Consumed by the placements admin
      * controller to power the restore-defaults endpoint.
      *
+     * The returned object is a shallow copy with a fresh `routes`
+     * array so callers cannot mutate the cached entry.
+     *
      * @param pluginId - Plugin id that originally registered the type.
      * @param typeId - Widget-type id.
      * @returns Snapshot of the plugin's first registration args, or
@@ -167,7 +170,16 @@ export class WidgetService implements IWidgetService {
         pluginId: string,
         typeId: string
     ): IPluginRegistrationDefaults | null {
-        return this.pluginDefaults.get(`${pluginId}::${typeId}`) ?? null;
+        const entry = this.pluginDefaults.get(`${pluginId}::${typeId}`);
+        if (!entry) return null;
+        return {
+            pluginId: entry.pluginId,
+            typeId: entry.typeId,
+            zone: entry.zone,
+            routes: [...entry.routes],
+            order: entry.order,
+            title: entry.title
+        };
     }
 
     /**

--- a/src/backend/tests/vitest/mocks/database-service.ts
+++ b/src/backend/tests/vitest/mocks/database-service.ts
@@ -269,11 +269,19 @@ export function createMockDatabaseService(): IDatabaseService & {
 
                     if (docIndex !== -1) {
                         const updateFields = (update as any).$set || {};
+                        const unsetFields = (update as any).$unset || {};
                         const incFields = (update as any).$inc || {};
                         const pushFields = (update as any).$push || {};
 
                         // Apply $set
                         data[docIndex] = { ...data[docIndex], ...updateFields };
+
+                        // Apply $unset - remove fields. MongoDB ignores the
+                        // value of $unset entries (typically empty string);
+                        // mirror that by deleting each key regardless.
+                        for (const key of Object.keys(unsetFields)) {
+                            delete (data[docIndex] as any)[key];
+                        }
 
                         // Apply $inc - increment numeric fields
                         for (const [key, amount] of Object.entries(incFields)) {

--- a/src/backend/tests/vitest/mocks/mongoose.ts
+++ b/src/backend/tests/vitest/mocks/mongoose.ts
@@ -646,16 +646,21 @@ export function createMockCollection(name: string) {
             const docIndex = data.findIndex((d: any) => matchesFilter(d, filter));
 
             if (docIndex !== -1) {
-                const updateFields = (update as any).$set || {};
-                data[docIndex] = { ...data[docIndex], ...updateFields };
+                const setFields = (update as any).$set || {};
+                const unsetFields = (update as any).$unset || {};
+                data[docIndex] = { ...data[docIndex], ...setFields };
+                for (const key of Object.keys(unsetFields)) {
+                    delete (data[docIndex] as any)[key];
+                }
                 return { modifiedCount: 1, matchedCount: 1, acknowledged: true, upsertedCount: 0 };
             }
 
             // Handle upsert
             if (options?.upsert) {
                 const id = new ObjectId();
-                const updateFields = (update as any).$set || {};
-                const newDoc = { ...updateFields, _id: id };
+                const setFields = (update as any).$set || {};
+                const setOnInsertFields = (update as any).$setOnInsert || {};
+                const newDoc = { ...setOnInsertFields, ...setFields, _id: id };
                 data.push(newDoc);
                 return { modifiedCount: 0, matchedCount: 0, acknowledged: true, upsertedCount: 1, upsertedId: id };
             }
@@ -671,8 +676,12 @@ export function createMockCollection(name: string) {
 
             data.forEach((doc, index) => {
                 if (matchesFilter(doc, filter)) {
-                    const updateFields = (update as any).$set || {};
-                    data[index] = { ...data[index], ...updateFields };
+                    const setFields = (update as any).$set || {};
+                    const unsetFields = (update as any).$unset || {};
+                    data[index] = { ...data[index], ...setFields };
+                    for (const key of Object.keys(unsetFields)) {
+                        delete (data[index] as any)[key];
+                    }
                     modifiedCount++;
                 }
             });

--- a/src/frontend/app/(core)/system/widgets/page.module.scss
+++ b/src/frontend/app/(core)/system/widgets/page.module.scss
@@ -1,0 +1,278 @@
+/**
+ * Scoped styles for the widget placement admin page.
+ *
+ * Page structure flows through layout primitives (Page, PageHeader,
+ * Stack); this module contributes the per-track section, the zone
+ * header strip, the placement table cells with their inline route
+ * chips, and the create/edit form layout. Every value comes from
+ * design tokens so themes propagate.
+ */
+
+@use '../../../../app/breakpoints' as *;
+
+.container {
+    container-type: inline-size;
+    container-name: widgets-admin;
+}
+
+.toolbar {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--gap-md);
+    flex-wrap: wrap;
+}
+
+.toolbar p {
+    max-width: var(--max-width-prose);
+    margin: 0;
+}
+
+.track {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+}
+
+.track_title {
+    margin: 0;
+    font-size: var(--font-size-heading-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text);
+    text-transform: capitalize;
+}
+
+.zone_list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+}
+
+.zone {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+    padding: var(--card-padding-sm);
+    background: var(--color-surface);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+}
+
+.zone_header {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    flex-wrap: wrap;
+}
+
+.zone_label {
+    margin: 0;
+    font-size: var(--font-size-body-lg);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text);
+    display: inline-flex;
+    align-items: baseline;
+    gap: var(--gap-xs);
+}
+
+.zone_id {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+    font-weight: var(--font-weight-normal);
+}
+
+.zone_count {
+    margin-left: auto;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-caption);
+}
+
+.zone_empty {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-body-sm);
+    font-style: italic;
+}
+
+.widget_cell {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+}
+
+.widget_label {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text);
+}
+
+.widget_meta {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+}
+
+.route_chip {
+    display: inline-block;
+    margin-right: var(--gap-2xs);
+    padding: var(--padding-2xs) var(--padding-xs);
+    background: var(--color-surface-muted);
+    border-radius: var(--radius-xs);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-caption);
+    color: var(--color-text);
+}
+
+.route_chip:last-child {
+    margin-right: 0;
+}
+
+.row_actions {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-xs);
+}
+
+/* ------------------------------------------------------------------ */
+/* Placement form                                                      */
+/* ------------------------------------------------------------------ */
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+}
+
+.field label,
+.field_label {
+    font-size: var(--font-size-body-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text);
+}
+
+.field_hint {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+}
+
+.field_error {
+    font-size: var(--font-size-caption);
+    color: var(--color-danger-text);
+}
+
+.field_row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+    gap: var(--gap-md);
+}
+
+.select {
+    background: var(--input-background);
+    border: var(--input-border);
+    border-radius: var(--input-border-radius);
+    padding: var(--input-padding);
+    color: var(--color-text);
+    font-size: var(--input-font-size);
+    transition: var(--input-transition);
+}
+
+.select:focus-visible {
+    outline: none;
+    border-color: var(--input-border-focus);
+    box-shadow: var(--input-shadow-focus);
+}
+
+.routes_chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-xs);
+    min-height: var(--button-height-sm);
+    align-items: center;
+}
+
+.route_chip_editable {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-2xs);
+    padding: var(--padding-2xs) var(--padding-xs);
+    background: var(--color-primary-alpha-15);
+    border: var(--border-width-thin) solid var(--color-primary-alpha-38);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-caption);
+    color: var(--color-text);
+}
+
+.route_chip_remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-full);
+    cursor: pointer;
+    transition: background-color var(--transition-base), color var(--transition-base);
+}
+
+.route_chip_remove:hover {
+    background: var(--color-danger-alpha-18);
+    color: var(--color-danger-text);
+}
+
+.route_chip_remove:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 var(--border-width-medium) var(--color-focus-alpha-25);
+}
+
+.routes_input_row {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+}
+
+.routes_input_row > :first-child {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.inline_toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    color: var(--color-text);
+    font-size: var(--font-size-body-sm);
+}
+
+.form_footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--gap-sm);
+    margin-top: var(--gap-sm);
+}
+
+/* ------------------------------------------------------------------ */
+/* Responsive                                                          */
+/* ------------------------------------------------------------------ */
+
+@container widgets-admin (max-width: #{$breakpoint-mobile-md}) {
+    .toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .field_row {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    .zone_count {
+        margin-left: 0;
+        width: 100%;
+    }
+}

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -1,0 +1,861 @@
+'use client';
+
+/**
+ * @fileoverview Operator UI for widget placements.
+ *
+ * Renders a per-zone view of every placement that resolves to that
+ * zone, grouped by zone host (site / core / plugin / admin). Each row
+ * surfaces source (plugin vs operator), route filter, render order,
+ * and an enabled switch, plus inline edit / delete / restore-defaults
+ * actions. Create-placement opens a modal with a type picker, a zone
+ * picker, and a route chip input that accepts exact paths or globs
+ * (`/u/*`, `/admin/**`).
+ *
+ * Lives behind the System container, which is admin-gated. Like
+ * `/system/menu` and `/system/hooks` this is a client component
+ * because the admin token lives in `localStorage` and the page can
+ * only read it post-mount. WebSocket subscription to
+ * `widgets:placements-update` triggers a list refetch so admin
+ * changes propagate live to every open admin tab.
+ *
+ * @module app/(core)/system/widgets/page
+ */
+
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    type FormEvent,
+    type KeyboardEvent
+} from 'react';
+import { Pencil, Plus, RefreshCw, Trash2, X } from 'lucide-react';
+import type { IZoneSnapshot, IWidgetTypeSnapshot } from '@/types';
+
+import { Page, PageHeader, Stack } from '../../../../components/layout';
+import { Badge } from '../../../../components/ui/Badge';
+import { Button } from '../../../../components/ui/Button';
+import { IconButton } from '../../../../components/ui/IconButton';
+import { Input } from '../../../../components/ui/Input';
+import { Switch } from '../../../../components/ui/Switch';
+import { Tbody, Td, Th, Thead, Tr, Table } from '../../../../components/ui/Table';
+import { ClientTime } from '../../../../components/ui/ClientTime';
+import { useModal } from '../../../../components/ui/ModalProvider';
+import { useToast } from '../../../../components/ui/ToastProvider';
+import { ConfirmDialog } from '../../../../components/ui/ConfirmDialog';
+import { useSystemAuth } from '../../../../features/system';
+import { getSocket } from '../../../../lib/socketClient';
+
+import styles from './page.module.scss';
+
+/**
+ * Public-facing placement record returned by the admin list endpoint.
+ * Mirrors `IWidgetPlacement` from the backend types package but
+ * declared inline here so the frontend module is self-contained.
+ */
+interface IPlacement {
+    id: string;
+    typeId: string;
+    zoneId: string;
+    routes: string[];
+    order: number;
+    title?: string;
+    enabled: boolean;
+    source: 'plugin' | 'operator';
+    pluginId?: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+/**
+ * Patch shape sent to PATCH /placements/:id.
+ */
+interface IPlacementPatch {
+    zoneId?: string;
+    routes?: string[];
+    order?: number;
+    title?: string | undefined;
+    enabled?: boolean;
+}
+
+/**
+ * Create-placement input. Matches the backend controller's
+ * normalised body.
+ */
+interface IPlacementCreate {
+    typeId: string;
+    zoneId: string;
+    routes: string[];
+    order?: number;
+    title?: string;
+    enabled?: boolean;
+}
+
+/**
+ * Build the standard `X-Admin-Token` header. Centralised so the
+ * empty-token edge case (token cleared mid-session) yields a clean
+ * 401 from the backend rather than a bare `undefined` cast.
+ */
+function authHeader(token: string | null): HeadersInit {
+    return { 'X-Admin-Token': token ?? '' };
+}
+
+/**
+ * Translate a placement source into a Badge tone.
+ */
+function sourceTone(source: IPlacement['source']): 'info' | 'success' {
+    return source === 'plugin' ? 'info' : 'success';
+}
+
+/**
+ * Type-snapshot lookup utility — returns the type's label and
+ * declaring plugin id for rendering inside the table.
+ */
+function lookupType(snapshot: IWidgetTypeSnapshot | null, typeId: string): { label: string; pluginId: string } | null {
+    if (!snapshot) return null;
+    for (const group of snapshot.groups) {
+        for (const type of group.types) {
+            if (type.id === typeId) return { label: type.label, pluginId: group.pluginId };
+        }
+    }
+    return null;
+}
+
+/**
+ * Zone-snapshot lookup — returns the zone label so the table can
+ * render human-readable zone names without dropping back to id.
+ */
+function lookupZone(snapshot: IZoneSnapshot | null, zoneId: string): { label: string; host: string } | null {
+    if (!snapshot) return null;
+    for (const track of snapshot.tracks) {
+        for (const zone of track.zones) {
+            if (zone.id === zoneId) return { label: zone.label, host: zone.host };
+        }
+    }
+    return null;
+}
+
+/**
+ * Top-level admin page rendering the placement editor.
+ */
+export default function WidgetsAdminPage() {
+    const { token } = useSystemAuth();
+    const { open: openModal, close: closeModal } = useModal();
+    const { push: pushToast } = useToast();
+
+    const [zones, setZones] = useState<IZoneSnapshot | null>(null);
+    const [types, setTypes] = useState<IWidgetTypeSnapshot | null>(null);
+    const [placements, setPlacements] = useState<IPlacement[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+    const [busyId, setBusyId] = useState<string | null>(null);
+
+    const headers = useMemo<HeadersInit>(() => authHeader(token), [token]);
+
+    const notifyError = useCallback(
+        (title: string, err: unknown) => {
+            pushToast({
+                tone: 'danger',
+                title,
+                description: err instanceof Error ? err.message : String(err)
+            });
+        },
+        [pushToast]
+    );
+
+    const notifySuccess = useCallback(
+        (title: string) => pushToast({ tone: 'success', title }),
+        [pushToast]
+    );
+
+    /**
+     * Fetch the three snapshots needed to render the page. The
+     * loading flag is only set on first-load; refetches triggered by
+     * WebSocket events do not flash a loading state.
+     */
+    const fetchAll = useCallback(
+        async (firstLoad: boolean): Promise<void> => {
+            if (firstLoad) setLoading(true);
+            setError(null);
+            try {
+                const [zonesRes, typesRes, placementsRes] = await Promise.all([
+                    fetch('/api/admin/system/zones', { headers }),
+                    fetch('/api/admin/system/widget-types', { headers }),
+                    fetch('/api/admin/system/widgets/placements', { headers })
+                ]);
+                if (!zonesRes.ok) throw new Error(`Failed to load zones (${zonesRes.status})`);
+                if (!typesRes.ok) throw new Error(`Failed to load widget types (${typesRes.status})`);
+                if (!placementsRes.ok) throw new Error(`Failed to load placements (${placementsRes.status})`);
+                const [zonesData, typesData, placementsData] = await Promise.all([
+                    zonesRes.json(),
+                    typesRes.json(),
+                    placementsRes.json()
+                ]);
+                setZones(zonesData as IZoneSnapshot);
+                setTypes(typesData as IWidgetTypeSnapshot);
+                setPlacements((placementsData.placements ?? []) as IPlacement[]);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : String(err));
+            } finally {
+                if (firstLoad) setLoading(false);
+            }
+        },
+        [headers]
+    );
+
+    /* Initial load. */
+    useEffect(() => {
+        void fetchAll(true);
+    }, [fetchAll]);
+
+    /* WebSocket refetch trigger. */
+    useEffect(() => {
+        const socket = getSocket();
+        const handler = () => { void fetchAll(false); };
+        socket.on('widgets:placements-update', handler);
+        return () => {
+            socket.off('widgets:placements-update', handler);
+        };
+    }, [fetchAll]);
+
+    /**
+     * PATCH a single placement and notify the user on outcome.
+     */
+    const patchPlacement = useCallback(
+        async (id: string, patch: IPlacementPatch): Promise<void> => {
+            setBusyId(id);
+            try {
+                const res = await fetch(`/api/admin/system/widgets/placements/${id}`, {
+                    method: 'PATCH',
+                    headers: { ...headers, 'Content-Type': 'application/json' },
+                    body: JSON.stringify(patch)
+                });
+                if (!res.ok) {
+                    const body = await res.json().catch(() => ({}));
+                    throw new Error(body.error || `Update failed (${res.status})`);
+                }
+                notifySuccess('Placement updated');
+            } catch (err) {
+                notifyError('Could not update placement', err);
+            } finally {
+                setBusyId(null);
+            }
+        },
+        [headers, notifyError, notifySuccess]
+    );
+
+    /**
+     * Create a new operator-source placement.
+     */
+    const createPlacement = useCallback(
+        async (input: IPlacementCreate): Promise<void> => {
+            const res = await fetch('/api/admin/system/widgets/placements', {
+                method: 'POST',
+                headers: { ...headers, 'Content-Type': 'application/json' },
+                body: JSON.stringify(input)
+            });
+            if (!res.ok) {
+                const body = await res.json().catch(() => ({}));
+                throw new Error(body.error || `Create failed (${res.status})`);
+            }
+        },
+        [headers]
+    );
+
+    /**
+     * Delete an operator-source placement.
+     */
+    const deletePlacement = useCallback(
+        async (id: string): Promise<void> => {
+            const res = await fetch(`/api/admin/system/widgets/placements/${id}`, {
+                method: 'DELETE',
+                headers
+            });
+            if (!res.ok && res.status !== 204) {
+                const body = await res.json().catch(() => ({}));
+                throw new Error(body.error || `Delete failed (${res.status})`);
+            }
+        },
+        [headers]
+    );
+
+    /**
+     * Restore plugin defaults on a plugin-source placement.
+     */
+    const restoreDefaults = useCallback(
+        async (id: string): Promise<void> => {
+            setBusyId(id);
+            try {
+                const res = await fetch(`/api/admin/system/widgets/placements/${id}/restore-defaults`, {
+                    method: 'POST',
+                    headers
+                });
+                if (!res.ok) {
+                    const body = await res.json().catch(() => ({}));
+                    throw new Error(body.error || `Restore failed (${res.status})`);
+                }
+                notifySuccess('Plugin defaults restored');
+            } catch (err) {
+                notifyError('Could not restore defaults', err);
+            } finally {
+                setBusyId(null);
+            }
+        },
+        [headers, notifyError, notifySuccess]
+    );
+
+    /**
+     * Group placements by zone for rendering. Zones with no
+     * placements still render so operators can see they exist.
+     */
+    const grouped = useMemo(() => {
+        if (!zones) return [] as Array<{ trackId: string; trackLabel: string; rows: Array<{ zoneId: string; zoneLabel: string; placements: IPlacement[] }> }>;
+        const byZone = new Map<string, IPlacement[]>();
+        for (const placement of placements) {
+            const bucket = byZone.get(placement.zoneId) ?? [];
+            bucket.push(placement);
+            byZone.set(placement.zoneId, bucket);
+        }
+        for (const bucket of byZone.values()) {
+            bucket.sort((a, b) => a.order - b.order);
+        }
+        return zones.tracks.map(track => ({
+            trackId: track.id,
+            trackLabel: track.label,
+            rows: track.zones.map(zone => ({
+                zoneId: zone.id,
+                zoneLabel: zone.label,
+                placements: byZone.get(zone.id) ?? []
+            }))
+        }));
+    }, [zones, placements]);
+
+    /**
+     * Open the create/edit form modal.
+     */
+    const openPlacementModal = useCallback(
+        (mode: 'create' | 'edit', initial?: IPlacement) => {
+            const id = openModal({
+                title: mode === 'create' ? 'Create placement' : `Edit placement`,
+                size: 'md',
+                content: (
+                    <PlacementForm
+                        mode={mode}
+                        initial={initial}
+                        types={types}
+                        zones={zones}
+                        onCancel={() => closeModal(id)}
+                        onSubmit={async (data) => {
+                            try {
+                                if (mode === 'create') {
+                                    await createPlacement(data as IPlacementCreate);
+                                    notifySuccess('Placement created');
+                                } else if (initial) {
+                                    await patchPlacement(initial.id, data as IPlacementPatch);
+                                }
+                                closeModal(id);
+                            } catch (err) {
+                                notifyError(
+                                    mode === 'create' ? 'Could not create placement' : 'Could not update placement',
+                                    err
+                                );
+                            }
+                        }}
+                    />
+                )
+            });
+        },
+        [
+            closeModal,
+            createPlacement,
+            notifyError,
+            notifySuccess,
+            openModal,
+            patchPlacement,
+            types,
+            zones
+        ]
+    );
+
+    /**
+     * Open the delete-confirm modal. Plugin-source rows are not
+     * deletable — the delete button is hidden for those, but if
+     * somehow invoked the dialog explains the constraint.
+     */
+    const openDeleteModal = useCallback(
+        (placement: IPlacement) => {
+            const isPluginSource = placement.source === 'plugin';
+            const id = openModal({
+                title: 'Delete placement',
+                size: 'sm',
+                content: (
+                    <ConfirmDialog
+                        label={placement.title ?? placement.typeId}
+                        message={
+                            isPluginSource
+                                ? 'Plugin-source rows cannot be deleted. Disable the row or restore plugin defaults instead.'
+                                : undefined
+                        }
+                        confirmLabel="Delete"
+                        onCancel={() => closeModal(id)}
+                        onConfirm={async () => {
+                            if (isPluginSource) {
+                                closeModal(id);
+                                return;
+                            }
+                            try {
+                                await deletePlacement(placement.id);
+                                notifySuccess('Placement deleted');
+                                closeModal(id);
+                            } catch (err) {
+                                notifyError('Could not delete placement', err);
+                            }
+                        }}
+                    />
+                )
+            });
+        },
+        [closeModal, deletePlacement, notifyError, notifySuccess, openModal]
+    );
+
+    return (
+        <Page>
+            <div className={styles.container}>
+                <PageHeader
+                    title="Widget Placements"
+                    subtitle="Where plugin widgets appear, in what order, and on which routes."
+                />
+
+                <Stack gap="lg">
+                    <div className={styles.toolbar}>
+                        <p className="text-muted">
+                            Each placement points a registered widget type at a zone. Plugin rows are seeded
+                            automatically and survive disable/re-enable; operator rows are yours to create
+                            and remove.
+                        </p>
+                        <Button
+                            variant="primary"
+                            icon={<Plus size={16} />}
+                            onClick={() => openPlacementModal('create')}
+                            disabled={!zones || !types}
+                        >
+                            Create placement
+                        </Button>
+                    </div>
+
+                    {error && <div className="alert" role="alert">{error}</div>}
+
+                    {loading && (
+                        <p className="text-muted">Loading placement editor&hellip;</p>
+                    )}
+
+                    {!loading && grouped.length === 0 && (
+                        <p className="text-muted">No zones declared.</p>
+                    )}
+
+                    {!loading && grouped.map(track => (
+                        <section key={track.trackId} className={styles.track}>
+                            <h2 className={styles.track_title}>{track.trackLabel}</h2>
+                            <div className={styles.zone_list}>
+                                {track.rows.map(zone => (
+                                    <ZoneSection
+                                        key={zone.zoneId}
+                                        zoneId={zone.zoneId}
+                                        zoneLabel={zone.zoneLabel}
+                                        placements={zone.placements}
+                                        types={types}
+                                        zones={zones}
+                                        busyId={busyId}
+                                        onToggleEnabled={(p, next) => patchPlacement(p.id, { enabled: next })}
+                                        onEdit={(p) => openPlacementModal('edit', p)}
+                                        onDelete={openDeleteModal}
+                                        onRestore={(p) => restoreDefaults(p.id)}
+                                    />
+                                ))}
+                            </div>
+                        </section>
+                    ))}
+                </Stack>
+            </div>
+        </Page>
+    );
+}
+
+/* ------------------------------------------------------------------ */
+/* Zone section                                                        */
+/* ------------------------------------------------------------------ */
+
+interface ZoneSectionProps {
+    zoneId: string;
+    zoneLabel: string;
+    placements: IPlacement[];
+    types: IWidgetTypeSnapshot | null;
+    zones: IZoneSnapshot | null;
+    busyId: string | null;
+    onToggleEnabled: (placement: IPlacement, next: boolean) => void;
+    onEdit: (placement: IPlacement) => void;
+    onDelete: (placement: IPlacement) => void;
+    onRestore: (placement: IPlacement) => void;
+}
+
+function ZoneSection({
+    zoneId,
+    zoneLabel,
+    placements,
+    types,
+    zones,
+    busyId,
+    onToggleEnabled,
+    onEdit,
+    onDelete,
+    onRestore
+}: ZoneSectionProps) {
+    const zoneInfo = lookupZone(zones, zoneId);
+
+    return (
+        <section className={styles.zone}>
+            <header className={styles.zone_header}>
+                <h3 className={styles.zone_label}>
+                    {zoneLabel}
+                    <span className={styles.zone_id}>{zoneId}</span>
+                </h3>
+                {zoneInfo && <Badge tone="neutral">{zoneInfo.host}</Badge>}
+                <span className={styles.zone_count}>
+                    {placements.length} {placements.length === 1 ? 'placement' : 'placements'}
+                </span>
+            </header>
+
+            {placements.length === 0 ? (
+                <p className={styles.zone_empty}>No placements in this zone.</p>
+            ) : (
+                <Table variant="compact">
+                    <Thead>
+                        <Tr>
+                            <Th>Widget</Th>
+                            <Th width="shrink">Source</Th>
+                            <Th>Routes</Th>
+                            <Th width="shrink">Order</Th>
+                            <Th width="shrink">Updated</Th>
+                            <Th width="shrink">Enabled</Th>
+                            <Th width="shrink">Actions</Th>
+                        </Tr>
+                    </Thead>
+                    <Tbody>
+                        {placements.map(placement => {
+                            const typeInfo = lookupType(types, placement.typeId);
+                            return (
+                                <Tr key={placement.id}>
+                                    <Td>
+                                        <div className={styles.widget_cell}>
+                                            <span className={styles.widget_label}>
+                                                {placement.title ?? typeInfo?.label ?? placement.typeId}
+                                            </span>
+                                            <span className={styles.widget_meta}>
+                                                {placement.typeId}
+                                                {typeInfo && ` · ${typeInfo.pluginId}`}
+                                            </span>
+                                        </div>
+                                    </Td>
+                                    <Td>
+                                        <Badge tone={sourceTone(placement.source)}>
+                                            {placement.source === 'plugin'
+                                                ? `plugin: ${placement.pluginId ?? '?'}`
+                                                : 'operator'}
+                                        </Badge>
+                                    </Td>
+                                    <Td muted>
+                                        {placement.routes.length === 0
+                                            ? <em>every route</em>
+                                            : placement.routes.map(r => (
+                                                <code key={r} className={styles.route_chip}>{r}</code>
+                                            ))}
+                                    </Td>
+                                    <Td>{placement.order}</Td>
+                                    <Td muted>
+                                        <ClientTime date={placement.updatedAt} format="relative" />
+                                    </Td>
+                                    <Td>
+                                        <Switch
+                                            size="sm"
+                                            on={placement.enabled}
+                                            onChange={(next) => onToggleEnabled(placement, next)}
+                                            disabled={busyId === placement.id}
+                                            aria-label={`${placement.enabled ? 'Disable' : 'Enable'} placement ${placement.title ?? placement.typeId}`}
+                                        />
+                                    </Td>
+                                    <Td>
+                                        <div className={styles.row_actions}>
+                                            <IconButton
+                                                size="sm"
+                                                variant="primary"
+                                                aria-label={`Edit ${placement.title ?? placement.typeId}`}
+                                                onClick={() => onEdit(placement)}
+                                            >
+                                                <Pencil size={14} />
+                                            </IconButton>
+                                            {placement.source === 'plugin' ? (
+                                                <IconButton
+                                                    size="sm"
+                                                    variant="ghost"
+                                                    aria-label={`Restore plugin defaults for ${placement.title ?? placement.typeId}`}
+                                                    onClick={() => onRestore(placement)}
+                                                    disabled={busyId === placement.id}
+                                                >
+                                                    <RefreshCw size={14} />
+                                                </IconButton>
+                                            ) : (
+                                                <IconButton
+                                                    size="sm"
+                                                    variant="danger"
+                                                    aria-label={`Delete ${placement.title ?? placement.typeId}`}
+                                                    onClick={() => onDelete(placement)}
+                                                >
+                                                    <Trash2 size={14} />
+                                                </IconButton>
+                                            )}
+                                        </div>
+                                    </Td>
+                                </Tr>
+                            );
+                        })}
+                    </Tbody>
+                </Table>
+            )}
+        </section>
+    );
+}
+
+/* ------------------------------------------------------------------ */
+/* Placement form (create + edit)                                      */
+/* ------------------------------------------------------------------ */
+
+interface PlacementFormProps {
+    mode: 'create' | 'edit';
+    initial?: IPlacement;
+    types: IWidgetTypeSnapshot | null;
+    zones: IZoneSnapshot | null;
+    onSubmit: (data: IPlacementCreate | IPlacementPatch) => Promise<void>;
+    onCancel: () => void;
+}
+
+function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: PlacementFormProps) {
+    const [typeId, setTypeId] = useState<string>(initial?.typeId ?? '');
+    const [zoneId, setZoneId] = useState<string>(initial?.zoneId ?? '');
+    const [routes, setRoutes] = useState<string[]>(initial?.routes ?? []);
+    const [routeDraft, setRouteDraft] = useState<string>('');
+    const [order, setOrder] = useState<number>(initial?.order ?? 100);
+    const [title, setTitle] = useState<string>(initial?.title ?? '');
+    const [enabled, setEnabled] = useState<boolean>(initial?.enabled ?? true);
+    const [saving, setSaving] = useState<boolean>(false);
+    const [routeError, setRouteError] = useState<string | null>(null);
+
+    const handleAddRoute = useCallback(() => {
+        const trimmed = routeDraft.trim();
+        if (trimmed.length === 0) return;
+        if (!trimmed.startsWith('/')) {
+            setRouteError('Patterns must start with /');
+            return;
+        }
+        if (/\s/.test(trimmed)) {
+            setRouteError('Patterns cannot contain whitespace');
+            return;
+        }
+        if (routes.includes(trimmed)) {
+            setRouteError('Pattern already added');
+            return;
+        }
+        setRoutes(prev => [...prev, trimmed]);
+        setRouteDraft('');
+        setRouteError(null);
+    }, [routeDraft, routes]);
+
+    const handleRouteKey = useCallback(
+        (e: KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === 'Enter' || e.key === ',') {
+                e.preventDefault();
+                handleAddRoute();
+            }
+        },
+        [handleAddRoute]
+    );
+
+    const handleRemoveRoute = useCallback((entry: string) => {
+        setRoutes(prev => prev.filter(r => r !== entry));
+    }, []);
+
+    const handleSubmit = useCallback(
+        async (e: FormEvent) => {
+            e.preventDefault();
+            setSaving(true);
+            try {
+                if (mode === 'create') {
+                    const payload: IPlacementCreate = {
+                        typeId,
+                        zoneId,
+                        routes,
+                        order,
+                        title: title.trim().length > 0 ? title.trim() : undefined,
+                        enabled
+                    };
+                    await onSubmit(payload);
+                } else {
+                    const payload: IPlacementPatch = {
+                        zoneId,
+                        routes,
+                        order,
+                        title: title.trim().length > 0 ? title.trim() : undefined,
+                        enabled
+                    };
+                    await onSubmit(payload);
+                }
+            } finally {
+                setSaving(false);
+            }
+        },
+        [enabled, mode, onSubmit, order, routes, title, typeId, zoneId]
+    );
+
+    const canSubmit = typeId.length > 0 && zoneId.length > 0;
+
+    return (
+        <form className={styles.form} onSubmit={handleSubmit}>
+            <div className={styles.field}>
+                <label htmlFor="wp-type">Widget type</label>
+                <select
+                    id="wp-type"
+                    className={styles.select}
+                    value={typeId}
+                    onChange={(e) => setTypeId(e.target.value)}
+                    disabled={mode === 'edit' || saving}
+                    required
+                >
+                    <option value="">Select a type&hellip;</option>
+                    {types?.groups.map(group => (
+                        <optgroup key={group.pluginId} label={group.pluginId}>
+                            {group.types.map(t => (
+                                <option key={t.id} value={t.id}>{t.label} ({t.id})</option>
+                            ))}
+                        </optgroup>
+                    ))}
+                </select>
+                {mode === 'edit' && (
+                    <span className={styles.field_hint}>
+                        Type is fixed for existing placements — create a new placement to use a different type.
+                    </span>
+                )}
+            </div>
+
+            <div className={styles.field}>
+                <label htmlFor="wp-zone">Zone</label>
+                <select
+                    id="wp-zone"
+                    className={styles.select}
+                    value={zoneId}
+                    onChange={(e) => setZoneId(e.target.value)}
+                    disabled={saving}
+                    required
+                >
+                    <option value="">Select a zone&hellip;</option>
+                    {zones?.tracks.map(track => (
+                        <optgroup key={track.id} label={track.label}>
+                            {track.zones.map(z => (
+                                <option key={z.id} value={z.id}>{z.label} ({z.id})</option>
+                            ))}
+                        </optgroup>
+                    ))}
+                </select>
+            </div>
+
+            <div className={styles.field}>
+                <label htmlFor="wp-routes">Routes</label>
+                <div className={styles.routes_chips}>
+                    {routes.length === 0 && (
+                        <span className={styles.field_hint}>Leave empty to render on every route.</span>
+                    )}
+                    {routes.map(entry => (
+                        <span key={entry} className={styles.route_chip_editable}>
+                            <code>{entry}</code>
+                            <button
+                                type="button"
+                                aria-label={`Remove ${entry}`}
+                                onClick={() => handleRemoveRoute(entry)}
+                                disabled={saving}
+                                className={styles.route_chip_remove}
+                            >
+                                <X size={12} aria-hidden />
+                            </button>
+                        </span>
+                    ))}
+                </div>
+                <div className={styles.routes_input_row}>
+                    <Input
+                        id="wp-routes"
+                        value={routeDraft}
+                        onChange={(e) => { setRouteDraft(e.target.value); setRouteError(null); }}
+                        onKeyDown={handleRouteKey}
+                        placeholder="/u/* or /markets or /admin/**"
+                        disabled={saving}
+                    />
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={handleAddRoute}
+                        disabled={saving || routeDraft.trim().length === 0}
+                    >
+                        Add
+                    </Button>
+                </div>
+                {routeError && <span className={styles.field_error}>{routeError}</span>}
+                <span className={styles.field_hint}>
+                    Press Enter or comma to add. Use <code>/u/*</code> for a single segment,
+                    {' '}<code>/u/**</code> for any depth.
+                </span>
+            </div>
+
+            <div className={styles.field_row}>
+                <div className={styles.field}>
+                    <label htmlFor="wp-order">Order</label>
+                    <Input
+                        id="wp-order"
+                        type="number"
+                        min={0}
+                        max={10000}
+                        value={order}
+                        onChange={(e) => setOrder(parseInt(e.target.value, 10) || 0)}
+                        disabled={saving}
+                    />
+                </div>
+                <div className={styles.field}>
+                    <label htmlFor="wp-title">Title override</label>
+                    <Input
+                        id="wp-title"
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                        placeholder="Optional"
+                        maxLength={80}
+                        disabled={saving}
+                    />
+                </div>
+            </div>
+
+            <label className={styles.inline_toggle}>
+                <Switch
+                    size="sm"
+                    on={enabled}
+                    onChange={setEnabled}
+                    disabled={saving}
+                    aria-label="Enabled"
+                />
+                <span>Enabled</span>
+            </label>
+
+            <div className={styles.form_footer}>
+                <Button type="button" variant="ghost" onClick={onCancel} disabled={saving}>Cancel</Button>
+                <Button type="submit" variant="primary" loading={saving} disabled={!canSubmit}>
+                    {mode === 'create' ? 'Create placement' : 'Save changes'}
+                </Button>
+            </div>
+        </form>
+    );
+}

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -13,9 +13,12 @@
  *
  * Lives behind the System container, which is admin-gated. Like
  * `/system/menu` and `/system/hooks` this is a client component
- * because the admin token lives in `localStorage` and the page can
- * only read it post-mount. WebSocket subscription to
- * `widgets:placements-update` triggers a list refetch so admin
+ * because the page needs hooks (`useModal`, `useToast`, WebSocket
+ * subscription, redux). Admin auth runs on the cookie path —
+ * same-origin fetches carry the signed `tronrelic_uid` cookie, which
+ * `requireAdmin` consults; `useSystemAuth().token` stays as an empty
+ * string for transitional API compatibility. WebSocket subscription
+ * to `widgets:placements-update` triggers a list refetch so admin
  * changes propagate live to every open admin tab.
  *
  * @module app/(core)/system/widgets/page
@@ -68,13 +71,14 @@ interface IPlacement {
 }
 
 /**
- * Patch shape sent to PATCH /placements/:id.
+ * Patch shape sent to PATCH /placements/:id. `title: null` is the
+ * explicit unset signal honored server-side as `$unset: { title }`.
  */
 interface IPlacementPatch {
     zoneId?: string;
     routes?: string[];
     order?: number;
-    title?: string | undefined;
+    title?: string | null | undefined;
     enabled?: boolean;
 }
 
@@ -219,21 +223,39 @@ export default function WidgetsAdminPage() {
     }, [fetchAll]);
 
     /**
-     * PATCH a single placement and notify the user on outcome.
+     * PATCH a single placement, throwing on failure.
+     *
+     * The modal-edit path awaits this directly and lets the outer
+     * try/catch handle the failure UX (toast + keep modal open). The
+     * row-level enable switch goes through `togglePlacement` instead,
+     * which adds the standalone toast UX.
      */
     const patchPlacement = useCallback(
         async (id: string, patch: IPlacementPatch): Promise<void> => {
+            const res = await fetch(`/api/admin/system/widgets/placements/${id}`, {
+                method: 'PATCH',
+                headers: { ...headers, 'Content-Type': 'application/json' },
+                body: JSON.stringify(patch)
+            });
+            if (!res.ok) {
+                const body = await res.json().catch(() => ({}));
+                throw new Error(body.error || `Update failed (${res.status})`);
+            }
+        },
+        [headers]
+    );
+
+    /**
+     * Toast-wrapping wrapper for the inline enable switch and any
+     * other standalone-row mutation. Toasts success or failure and
+     * never throws, since the callers (Switch's `onChange`) have
+     * nowhere to surface the error.
+     */
+    const togglePlacement = useCallback(
+        async (id: string, patch: IPlacementPatch): Promise<void> => {
             setBusyId(id);
             try {
-                const res = await fetch(`/api/admin/system/widgets/placements/${id}`, {
-                    method: 'PATCH',
-                    headers: { ...headers, 'Content-Type': 'application/json' },
-                    body: JSON.stringify(patch)
-                });
-                if (!res.ok) {
-                    const body = await res.json().catch(() => ({}));
-                    throw new Error(body.error || `Update failed (${res.status})`);
-                }
+                await patchPlacement(id, patch);
                 notifySuccess('Placement updated');
             } catch (err) {
                 notifyError('Could not update placement', err);
@@ -241,7 +263,7 @@ export default function WidgetsAdminPage() {
                 setBusyId(null);
             }
         },
-        [headers, notifyError, notifySuccess]
+        [patchPlacement, notifyError, notifySuccess]
     );
 
     /**
@@ -352,6 +374,7 @@ export default function WidgetsAdminPage() {
                                     notifySuccess('Placement created');
                                 } else if (initial) {
                                     await patchPlacement(initial.id, data as IPlacementPatch);
+                                    notifySuccess('Placement updated');
                                 }
                                 closeModal(id);
                             } catch (err) {
@@ -466,7 +489,7 @@ export default function WidgetsAdminPage() {
                                         types={types}
                                         zones={zones}
                                         busyId={busyId}
-                                        onToggleEnabled={(p, next) => patchPlacement(p.id, { enabled: next })}
+                                        onToggleEnabled={(p, next) => togglePlacement(p.id, { enabled: next })}
                                         onEdit={(p) => openPlacementModal('edit', p)}
                                         onDelete={openDeleteModal}
                                         onRestore={(p) => restoreDefaults(p.id)}
@@ -699,11 +722,25 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
                     };
                     await onSubmit(payload);
                 } else {
+                    const trimmedTitle = title.trim();
+                    const hadInitialTitle = typeof initial?.title === 'string' && initial.title.length > 0;
+                    // Edit-mode title semantics:
+                    //   - non-empty input → set the new value
+                    //   - blank input when the row HAD a title → null
+                    //     (explicit clear signal honored as $unset)
+                    //   - blank input when the row had no title →
+                    //     omit so the patch is a no-op for that field
+                    const titlePatch: string | null | undefined =
+                        trimmedTitle.length > 0
+                            ? trimmedTitle
+                            : hadInitialTitle
+                                ? null
+                                : undefined;
                     const payload: IPlacementPatch = {
                         zoneId,
                         routes,
                         order,
-                        title: title.trim().length > 0 ? title.trim() : undefined,
+                        title: titlePatch,
                         enabled
                     };
                     await onSubmit(payload);

--- a/src/shared/types/socket.ts
+++ b/src/shared/types/socket.ts
@@ -165,6 +165,31 @@ export interface MenuNamespaceConfigUpdatePayload {
   };
 }
 
+/**
+ * Refetch signal emitted whenever a widget placement is created,
+ * updated, soft-disabled, deleted, or restored to plugin defaults via
+ * the admin API.
+ *
+ * Broadcast to every connected socket — placements drive what renders
+ * on public pages, so non-admin visitors must refetch their widget
+ * data to pick up operator changes without a hard reload. The payload
+ * carries only identifiers; clients re-request whatever they need
+ * (placement list for admin UIs, widget data for public pages) with
+ * their own credentials.
+ */
+export interface WidgetsPlacementsUpdatePayload {
+  event: 'widgets:placements-update';
+  payload: {
+    /** Event discriminator: created, updated, deleted, defaults-restored. */
+    event: 'placement:created' | 'placement:updated' | 'placement:deleted' | 'placement:restored';
+    /** Placement id affected by the event. */
+    placementId: string;
+    /** Zone the placement belongs to, when the row still exists. */
+    zoneId?: string;
+    timestamp: string;
+  };
+}
+
 export type TronRelicSocketEvent =
   | TransactionAlertPayload
   | BlockNotificationPayload
@@ -173,4 +198,5 @@ export type TronRelicSocketEvent =
   | MemoUpdatePayload
   | UserUpdatePayload
   | MenuUpdatePayload
-  | MenuNamespaceConfigUpdatePayload;
+  | MenuNamespaceConfigUpdatePayload
+  | WidgetsPlacementsUpdatePayload;


### PR DESCRIPTION
## Summary

PR 3 of the widget rewrite. Delivers the operator-facing placement editor the type/placement split was built for: full CRUD REST endpoints, a `/system/widgets` admin page subscribing to a new `widgets:placements-update` WebSocket event, glob-aware route patterns, and a `restore-to-plugin-defaults` action backed by an in-memory cache of plugin registration args.

## What landed

**Backend**

- `PlacementsController` + `WidgetTypesController` under `/api/admin/system/widgets/placements` and `/api/admin/system/widget-types`. Each mount chains the platform admin rate limiter before `requireAdmin`.
- `PlacementService.restoreToPluginDefaults(id, defaults)` reverts a plugin row to its original registration args via `$set` + `$unset`, broadcasting a dedicated `placement:restored` event. `setBroadcast(...)` wires the callback `WidgetsModule.init()` routes to `WebSocketService`.
- Route matcher extended to accept exact paths, single-segment globs (`/u/*`), and deep globs (`/u/**`). `normaliseRoutePattern` is the single source of validation truth; `findByRoute` narrows with a Mongo `$regex` arm and finalises with the matcher in memory.
- `WidgetService` caches each plugin's first `register(...)` args under `${pluginId}::${typeId}`. The cache write is wired-mode-independent so unwired test paths still populate it; `getPluginDefault(pluginId, typeId)` is the new accessor.
- `WidgetsModule` mounts the three admin routers, wires the broadcast callback, and seeds the System menu entry. New dep `menuService` is already in `sharedDeps` so bootstrap is unchanged.
- `widgets:placements-update` added to shared socket types and the emit switch; broadcast to every connected socket (public pages refetch widget data on operator changes).

**Frontend**

- `/system/widgets` renders zones grouped by host with a compact table per zone (widget, source badge, routes, order, updated, enabled switch, edit/restore/delete actions). Live-refreshes on `widgets:placements-update`.
- Modal form for create + edit with type picker (grouped by plugin), zone picker (grouped by host), chip input for routes accepting globs, order, optional title override, enabled switch.
- Plugin rows show restore-defaults in place of delete; operator rows show delete.

**Tests, mocks, docs**

- 50 new + extended test cases across placement service, controllers, route matcher, broadcast wiring, plugin-default cache. Full backend suite: 956 passing, 1 skipped. Type check clean.
- Mongoose + database-service mocks gained `$unset` support; mongoose mock now honors `$setOnInsert` on upsert.
- New `src/backend/modules/widgets/README.md` (contract-first AI-agent reference) and `docs/system/system-api-widgets.md` linked from the `system-api.md` detail table.