### PR TITLE
Isolate plugin loader failures; one bad plugin can no longer take down SSR

### DIFF
--- a/docs/plugins/plugins-system-architecture.md
+++ b/docs/plugins/plugins-system-architecture.md
@@ -42,6 +42,14 @@ Source mode couples every plugin to core's webpack and blocks per-plugin build i
 
 `scripts/generate-frontend-plugin-registry.mjs` reads each plugin's `package.json` `exports` map. When `exports."./frontend"` points at `.js`/`.mjs`/`.cjs`, the generator emits a static import at that path and `next.config.mjs` omits the plugin from `transpilePackages`. When the entry still points at `.ts`, core falls back to transpiling the source.
 
+### Frontend export contract
+
+Every plugin's frontend entry — compiled or raw — must expose an IPlugin-shaped value (an object whose `manifest` has non-empty string `id` and `title`) under any named export. **`export default` is permitted but not required.** The generator imports every plugin under a namespace binding (`import * as foo_module from '...'`); the runtime discovers the IPlugin via `Object.values(foo_module).find(isIPluginShape)`. Plugins whose module exposes no IPlugin-shaped value are dropped with a logged error and surfaced via `failedPluginLoads` — the rest of the registry loads normally.
+
+The widget registry follows the same defense-in-depth pattern: each plugin's `widgets/index.ts` is imported as a namespace and merged via `safeMergeWidgets`, which refuses missing or non-object `widgetComponents` exports instead of crashing the spread at module load.
+
+This contract supersedes the prior default-import path for compiled-mode plugins, which silently produced `undefined` whenever a plugin shipped only a named export and crashed SSR for every route at the first `.menuItems` access. The `.d.ts` sidecar core generates next to each compiled artifact remains as a TS-resolution affordance; its declared shape does not constrain the plugin's public API.
+
 ### What core still owns in compiled mode
 
 Externals (`react`, `next/*`, `lucide-react`, `@delphian/tronrelic-types`, etc.) resolve through core's hoisted `node_modules` so there is one React instance at runtime. SCSS Modules are still compiled by core's webpack via the `/src/plugins/` include extension in `next.config.mjs:113-151` — only the TypeScript compile moves into the plugin. SCSS edits in `src/frontend/**/*.scss` propagate automatically through `next dev` because core reads from source; the `copy-frontend-assets.mjs` step mirrors them into `dist/frontend/` only when `npm run build:frontend` runs, so production consumers of `dist/` see stale SCSS until then. A new plugin version still requires rebuilding the core Docker image because `plugins.generated.ts` imports the entry statically at `next build` time.

--- a/scripts/generate-backend-plugin-registry.mjs
+++ b/scripts/generate-backend-plugin-registry.mjs
@@ -196,6 +196,7 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import type { IPlugin, IPluginManifest } from '@/types';
+import { loadFromPluginLoaders } from './safe-plugin-load.js';
 `;
 
     if (metadata.length === 0) {
@@ -277,21 +278,14 @@ ${entries}
 
 /**
  * Loads every discovered plugin via dynamic import. Resolution failures are
- * isolated per plugin: a broken module-level import or evaluation throw in one
- * plugin logs a warning and is dropped from the returned set, leaving the rest
- * of the registry — and backend startup — unaffected.
+ * isolated per plugin: a broken module-level import, evaluation throw, or a
+ * resolved value that fails the minimum IPlugin shape check is logged and
+ * dropped from the returned set, leaving the rest of the registry — and
+ * backend startup — unaffected. The orchestration lives in
+ * loaders/safe-plugin-load.ts so the contract is testable.
  */
 export async function loadDiscoveredPlugins(): Promise<IPlugin[]> {
-    const results = await Promise.allSettled(pluginLoaders.map((load) => load()));
-    const plugins: IPlugin[] = [];
-    for (const result of results) {
-        if (result.status === 'fulfilled') {
-            plugins.push(result.value);
-        } else {
-            console.error('[plugins.generated] Plugin failed to load:', result.reason);
-        }
-    }
-    return plugins;
+    return loadFromPluginLoaders(pluginLoaders);
 }
 `;
 

--- a/scripts/generate-frontend-plugin-registry.mjs
+++ b/scripts/generate-frontend-plugin-registry.mjs
@@ -235,59 +235,51 @@ async function collectPluginMetadata() {
  * instead of polling, so the registry must be populated at module load time on
  * both server and client.
  *
- * Two import shapes are emitted based on each plugin's entry:
- *   - Compiled artifact (.js/.mjs/.cjs) → typed default import. The plugin must
- *     `export default <IPlugin>` from its frontend entry. A sibling .d.ts
- *     generated in the plugin's dist directory supplies the IPlugin type,
- *     avoiding TS7016 from noImplicitAny.
- *   - Raw TS entry → namespace import + runtime discovery. Keeps legacy plugins
- *     working without forcing a default export until they migrate.
+ * Every plugin uses one import shape — namespace import (`import * as foo_module`)
+ * — and the registry resolves the IPlugin via runtime discovery
+ * (`Object.values().find(...)`). This contract is symmetric with the backend
+ * loader at src/backend/loaders/plugins.generated.ts and removes the prior
+ * default-import-only path that silently produced `undefined` whenever a plugin
+ * forgot `export default`. Invalid plugins are skipped with a logged error
+ * instead of poisoning the array — see `loadPluginCandidate` below.
+ *
+ * Plugin authors may use any named export. `export default` is permitted but
+ * not required: the runtime walks Object.values for the first IPlugin-shaped
+ * value. A `.d.ts` sidecar (see writeCompiledPluginTypes) supplies the IPlugin
+ * type for TS module resolution so namespace imports on .js artifacts resolve
+ * without allowJs.
  *
  * CSS code splitting is preserved because each plugin's frontend.ts uses
  * next/dynamic() to lazy-load its actual page components — the static import
  * here only pulls in the manifest and the dynamic wrappers, not the page CSS.
  */
 function renderModule(metadata) {
-    const header = `/**\n * AUTO-GENERATED FILE. DO NOT EDIT.\n *\n * This module is produced by scripts/generate-frontend-plugin-registry.mjs\n * and exposes a synchronous, statically-imported array of plugin frontends.\n *\n * Static imports are required so the plugin registry can be populated at\n * module load time on both server and client. CSS code splitting is preserved\n * because plugin frontend entry files use next/dynamic() for their page\n * components — only the manifest and dynamic wrappers are pulled in here.\n */\n`;
+    const header = `/**\n * AUTO-GENERATED FILE. DO NOT EDIT.\n *\n * This module is produced by scripts/generate-frontend-plugin-registry.mjs\n * and exposes a synchronous, statically-imported array of plugin frontends.\n *\n * Static imports are required so the plugin registry can be populated at\n * module load time on both server and client. CSS code splitting is preserved\n * because plugin frontend entry files use next/dynamic() for their page\n * components — only the manifest and dynamic wrappers are pulled in here.\n *\n * Every plugin module is imported under a namespace binding and the IPlugin\n * value is discovered via Object.values().find() at load time. Plugins whose\n * module exposes no IPlugin-shaped export are reported and dropped from the\n * resulting registry, never propagated as undefined into consumers.\n */\n`;
 
     const imports = `import type { IPlugin } from '@/types';\n\n`;
 
     if (metadata.length === 0) {
-        const emptyBody = `export const frontendPlugins: IPlugin[] = [];\n`;
+        const emptyBody = `export const frontendPlugins: IPlugin[] = [];\nexport const failedPluginLoads: ReadonlyArray<{ readonly pluginId: string; readonly reason: string }> = [];\n`;
         return `${header}${imports}${emptyBody}`;
     }
 
-    const hasLegacy = metadata.some(entry => !entry.isCompiled);
-
     const staticImports = metadata
-        .map(({ id, importPath, isCompiled }) => {
+        .map(({ id, importPath }) => {
             const safeId = id.replace(/[^a-zA-Z0-9_]/g, '_');
-            if (isCompiled) {
-                return `import ${safeId}_plugin from '${importPath}';`;
-            }
             return `import * as ${safeId}_module from '${importPath}';`;
         })
         .join('\n');
 
-    const arrayEntries = metadata
-        .map(({ id, isCompiled }) => {
+    const candidateEntries = metadata
+        .map(({ id }) => {
             const safeId = id.replace(/[^a-zA-Z0-9_]/g, '_');
-            if (isCompiled) {
-                return `    ${safeId}_plugin,`;
-            }
-            return `    resolvePluginExport('${id}', ${safeId}_module),`;
+            return `    { pluginId: ${JSON.stringify(id)}, module: ${safeId}_module as Record<string, unknown> },`;
         })
         .join('\n');
 
-    const arrayDecl = `export const frontendPlugins: IPlugin[] = [\n${arrayEntries}\n];\n`;
+    const resolver = `interface IPluginCandidate {\n    pluginId: string;\n    module: Record<string, unknown>;\n}\n\ninterface ILoadFailure {\n    pluginId: string;\n    reason: string;\n}\n\n/**\n * Returns true when value has the minimum IPlugin shape: a manifest object\n * with non-empty string id and title. Looser than the full IPlugin type so a\n * plugin can lack optional surfaces (pages, menuItems, adminPages, component)\n * and still register — those are validated by downstream consumers.\n */\nfunction isIPluginShape(value: unknown): value is IPlugin {\n    if (typeof value !== 'object' || value === null) return false;\n    const v = value as Record<string, unknown>;\n    if (typeof v.manifest !== 'object' || v.manifest === null) return false;\n    const m = v.manifest as Record<string, unknown>;\n    return typeof m.id === 'string' && m.id.length > 0\n        && typeof m.title === 'string' && m.title.length > 0;\n}\n\n/**\n * Scans a plugin module for the IPlugin-shaped value and returns it. Returns\n * null and records a failure when no candidate is found — the alternative,\n * throwing, would crash module load and break every consumer of\n * frontendPlugins, which is exactly the failure mode this loader exists to\n * eliminate.\n */\nfunction loadPluginCandidate(\n    candidate: IPluginCandidate,\n    failures: ILoadFailure[]\n): IPlugin | null {\n    const found = Object.values(candidate.module).find(isIPluginShape);\n    if (!found) {\n        const reason = \`No IPlugin-shaped export found. Ensure frontend.ts exports a constant whose \\\`manifest\\\` has string \\\`id\\\` and \\\`title\\\`.\`;\n        failures.push({ pluginId: candidate.pluginId, reason });\n        console.error(\`[plugins.generated] Failed to load plugin '\${candidate.pluginId}': \${reason}\`);\n        return null;\n    }\n    if (found.manifest.id !== candidate.pluginId) {\n        console.warn(\n            \`[plugins.generated] Plugin '\${candidate.pluginId}' has manifest id '\${found.manifest.id}'; \` +\n            \`the directory id is canonical for registry lookups.\`\n        );\n    }\n    return found;\n}\n\nconst _pluginCandidates: IPluginCandidate[] = [\n${candidateEntries}\n];\n\nconst _loadFailures: ILoadFailure[] = [];\n\n/**\n * Every plugin whose module produced a valid IPlugin shape. Plugins whose\n * module is malformed are absent and surfaced via failedPluginLoads.\n */\nexport const frontendPlugins: IPlugin[] = _pluginCandidates\n    .map(c => loadPluginCandidate(c, _loadFailures))\n    .filter((p): p is IPlugin => p !== null);\n\n/**\n * Diagnostic record of plugins whose module failed validation at load time.\n * Surface via /system/plugins so operators can see broken registrations\n * without grepping logs.\n */\nexport const failedPluginLoads: ReadonlyArray<ILoadFailure> = _loadFailures;\n`;
 
-    const resolver = hasLegacy
-        ? `function resolvePluginExport(pluginId: string, module: Record<string, unknown>): IPlugin {\n    const candidate = Object.values(module).find((value): value is IPlugin => {\n        return typeof value === 'object' && value !== null && 'manifest' in value;\n    });\n\n    if (!candidate) {\n        throw new Error(\`Failed to locate plugin export for '\${pluginId}'. Ensure the module exports an IPlugin.\`);\n    }\n\n    return candidate;\n}\n`
-        : '';
-
-    const body = hasLegacy
-        ? `${staticImports}\n\n${resolver}\n${arrayDecl}`
-        : `${staticImports}\n\n${arrayDecl}`;
+    const body = `${staticImports}\n\n${resolver}`;
 
     return `${header}${imports}${body}`;
 }
@@ -298,7 +290,14 @@ function renderModule(metadata) {
  * The root tsconfig uses `moduleResolution: "Node"` (legacy), so it doesn't
  * honor package `exports.types` conditions and instead looks for `.d.ts` files
  * sitting next to the imported `.js`. Each compiled plugin frontend therefore
- * needs a one-line declaration that types the default export as IPlugin.
+ * needs a declaration that lets the registry's namespace import resolve.
+ *
+ * The declaration is intentionally permissive: it advertises a single
+ * `plugin: IPlugin` and a matching default export so namespace imports always
+ * compile, but the runtime registry rediscovers the actual export via
+ * Object.values().find() regardless of name. Plugin authors are not bound to
+ * use this exact identifier — the sidecar exists only to satisfy TS module
+ * resolution, not to constrain the plugin's public API.
  *
  * The plugin's own build intentionally does not emit .d.ts — core's registry
  * generator owns the declarations because that's the only consumer that needs
@@ -313,7 +312,7 @@ async function writeCompiledPluginTypes(metadata) {
             continue;
         }
         const sidecarPath = entry.absoluteEntry.replace(/\.(js|mjs|cjs)$/, '.d.ts');
-        const contents = `/**\n * AUTO-GENERATED FILE. DO NOT EDIT.\n *\n * This declaration file is produced by\n * scripts/generate-frontend-plugin-registry.mjs and gives core's\n * plugins.generated.ts a typed default import for this compiled plugin\n * artifact. The plugin's own build intentionally skips .d.ts emission —\n * core owns this sidecar because core is the only consumer.\n */\nimport type { IPlugin } from '@delphian/tronrelic-types';\n\ndeclare const plugin: IPlugin;\nexport default plugin;\n`;
+        const contents = `/**\n * AUTO-GENERATED FILE. DO NOT EDIT.\n *\n * This declaration file is produced by\n * scripts/generate-frontend-plugin-registry.mjs so the core registry's\n * namespace import resolves under moduleResolution: "Node" without allowJs.\n *\n * The shape below is a TS-resolution affordance, not a runtime contract:\n * the registry discovers the IPlugin via Object.values().find() at load time,\n * so plugin authors may use any named export — this file does not bind them\n * to the identifier 'plugin' nor to providing a default export.\n */\nimport type { IPlugin } from '@delphian/tronrelic-types';\n\ndeclare const plugin: IPlugin;\nexport { plugin };\nexport default plugin;\n`;
         await writeIfChanged(sidecarPath, contents);
     }
 }
@@ -480,32 +479,66 @@ export function getWidgetComponent(widgetId: string): WidgetComponent | undefine
 `;
     }
 
-    // Generate static imports for each plugin's widget components
+    // Generate namespace imports for each plugin's widget module. Using a
+    // namespace import (rather than `import { widgetComponents }`) means a
+    // plugin that fails to export `widgetComponents` resolves to an empty
+    // namespace at load time — the spread below would otherwise throw
+    // "Cannot read properties of undefined" and take down every page that
+    // hosts a widget zone.
     const imports = metadata
         .map(({ id, importPath }) => {
             const safeId = id.replace(/[^a-zA-Z0-9_]/g, '_');
-            return `import { widgetComponents as ${safeId}_widgets } from '${importPath}';`;
+            return `import * as ${safeId}_widgets_module from '${importPath}';`;
         })
         .join('\n');
 
-    // Generate the merged registry
-    const registrySpread = metadata
+    const mergeCalls = metadata
         .map(({ id }) => {
             const safeId = id.replace(/[^a-zA-Z0-9_]/g, '_');
-            return `    ...${safeId}_widgets,`;
+            return `safeMergeWidgets(${JSON.stringify(id)}, (${safeId}_widgets_module as { widgetComponents?: unknown }).widgetComponents);`;
         })
         .join('\n');
 
     const registry = `
 /**
+ * Validates a plugin's widget map and merges it into the registry.
+ *
+ * Refuses missing or non-object exports rather than crashing the spread at
+ * module load. A plugin whose frontend bundle is missing widgetComponents is
+ * dropped with a logged warning instead of poisoning every widget zone on
+ * the site.
+ */
+function safeMergeWidgets(
+    pluginId: string,
+    widgets: unknown
+): void {
+    if (widgets == null) {
+        console.error(
+            \`[widgets.generated] Plugin '\${pluginId}' module did not export widgetComponents. \` +
+            \`Ensure src/frontend/widgets/index.ts contains \\\`export const widgetComponents = {...}\\\`.\`
+        );
+        return;
+    }
+    if (typeof widgets !== 'object') {
+        console.error(
+            \`[widgets.generated] Plugin '\${pluginId}' widgetComponents export is not an object (got \${typeof widgets}).\`
+        );
+        return;
+    }
+    Object.assign(widgetComponentRegistry, widgets);
+}
+
+/**
  * Combined widget component registry from all plugins.
  *
  * Maps widget IDs to their React components. Widget IDs must match
- * the IDs used in backend widget registration.
+ * the IDs used in backend widget registration. Plugins whose widgetComponents
+ * export is malformed are skipped with a logged error instead of crashing the
+ * spread at module load.
  */
-export const widgetComponentRegistry: Record<string, WidgetComponent> = {
-${registrySpread}
-};
+export const widgetComponentRegistry: Record<string, WidgetComponent> = {};
+
+${mergeCalls}
 
 /**
  * Look up a widget component by ID.

--- a/src/backend/loaders/__tests__/safe-plugin-load.test.ts
+++ b/src/backend/loaders/__tests__/safe-plugin-load.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Contract tests for safe-plugin-load.
+ *
+ * The generated backend registry calls loadFromPluginLoaders to materialize
+ * every discovered plugin without letting one broken plugin crash the rest of
+ * startup. These tests pin the failure-isolation behavior so it cannot
+ * silently regress.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { IPlugin } from '@/types';
+import {
+    loadFromPluginLoaders,
+    isMinimalIPlugin,
+    type IPluginLoadFailure
+} from '../safe-plugin-load';
+
+function pluginWith(id: string): IPlugin {
+    return {
+        manifest: {
+            id,
+            title: `Plugin ${id}`,
+            version: '1.0.0',
+            description: 'test'
+        }
+    } as IPlugin;
+}
+
+describe('isMinimalIPlugin', () => {
+    it('accepts a minimum-valid plugin', () => {
+        expect(isMinimalIPlugin(pluginWith('ok'))).toBe(true);
+    });
+
+    it('rejects null', () => {
+        expect(isMinimalIPlugin(null)).toBe(false);
+    });
+
+    it('rejects undefined', () => {
+        expect(isMinimalIPlugin(undefined)).toBe(false);
+    });
+
+    it('rejects an object with no manifest', () => {
+        expect(isMinimalIPlugin({})).toBe(false);
+    });
+
+    it('rejects a manifest with empty id', () => {
+        expect(isMinimalIPlugin({ manifest: { id: '', title: 'x' } })).toBe(false);
+    });
+
+    it('rejects a non-string id', () => {
+        expect(isMinimalIPlugin({ manifest: { id: 42, title: 'x' } })).toBe(false);
+    });
+});
+
+describe('loadFromPluginLoaders', () => {
+    it('returns every successfully-loaded plugin in input order', async () => {
+        const a = pluginWith('a');
+        const b = pluginWith('b');
+        const result = await loadFromPluginLoaders(
+            [() => Promise.resolve(a), () => Promise.resolve(b)],
+            () => undefined
+        );
+        expect(result.map(p => p.manifest.id)).toEqual(['a', 'b']);
+    });
+
+    it('drops a loader whose promise rejects', async () => {
+        const a = pluginWith('a');
+        const failures: IPluginLoadFailure[] = [];
+        const result = await loadFromPluginLoaders(
+            [
+                () => Promise.resolve(a),
+                () => Promise.reject(new Error('boom')),
+                () => Promise.resolve(pluginWith('c'))
+            ],
+            f => failures.push(f)
+        );
+        expect(result.map(p => p.manifest.id)).toEqual(['a', 'c']);
+        expect(failures).toHaveLength(1);
+        expect(failures[0].index).toBe(1);
+        expect((failures[0].reason as Error).message).toBe('boom');
+    });
+
+    it('drops a loader that resolves to a malformed value', async () => {
+        const failures: IPluginLoadFailure[] = [];
+        const result = await loadFromPluginLoaders(
+            [
+                () => Promise.resolve(pluginWith('ok')),
+                () => Promise.resolve(undefined),
+                () => Promise.resolve({ manifest: null }),
+                () => Promise.resolve({ manifest: { id: '' } })
+            ],
+            f => failures.push(f)
+        );
+        expect(result.map(p => p.manifest.id)).toEqual(['ok']);
+        expect(failures.map(f => f.index)).toEqual([1, 2, 3]);
+    });
+
+    it('logs to console.error when no onFailure callback is provided', async () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        try {
+            const result = await loadFromPluginLoaders([
+                () => Promise.resolve(pluginWith('ok')),
+                () => Promise.reject(new Error('nope'))
+            ]);
+            expect(result.map(p => p.manifest.id)).toEqual(['ok']);
+            expect(errorSpy).toHaveBeenCalled();
+        } finally {
+            errorSpy.mockRestore();
+        }
+    });
+
+    it('returns empty array when every loader fails', async () => {
+        const failures: IPluginLoadFailure[] = [];
+        const result = await loadFromPluginLoaders(
+            [
+                () => Promise.reject(new Error('a')),
+                () => Promise.reject(new Error('b'))
+            ],
+            f => failures.push(f)
+        );
+        expect(result).toEqual([]);
+        expect(failures).toHaveLength(2);
+    });
+
+    it('returns empty array on empty input', async () => {
+        const result = await loadFromPluginLoaders([], () => undefined);
+        expect(result).toEqual([]);
+    });
+});

--- a/src/backend/loaders/safe-plugin-load.ts
+++ b/src/backend/loaders/safe-plugin-load.ts
@@ -1,0 +1,87 @@
+import type { IPlugin } from '@/types';
+
+/**
+ * Safely materializes a list of plugin-loading thunks into a `IPlugin[]`.
+ *
+ * Why this exists separately from `plugins.generated.ts`: the generated file
+ * is rewritten on every plugin scan and cannot host tests. Extracting the
+ * failure-isolation orchestration here keeps the contract testable and gives
+ * the auto-generated registry a single, audited helper to call.
+ *
+ * Failure contract: any loader that rejects or whose resolved value lacks the
+ * minimum IPlugin shape (an object with a `manifest.id` string) is dropped
+ * from the returned set, with a structured log entry. The remaining plugins
+ * still load. This is the failure-isolation guarantee that backend startup
+ * relies on — a single broken plugin must not abort `loadPlugins()`.
+ */
+export interface IPluginLoadFailure {
+    /** Index of the failed loader in the input array. Useful for surfacing
+        ordering-stable diagnostics in admin UIs. */
+    index: number;
+    /** Reason — either the thrown error or a shape-validation message. */
+    reason: unknown;
+}
+
+/**
+ * Returns true when `value` has the minimum IPlugin shape: a manifest object
+ * with a non-empty string id. Title and version are validated by downstream
+ * consumers (metadata registration enforces them), so this predicate only
+ * gates what loadDiscoveredPlugins itself needs to safely pass the value
+ * onward.
+ */
+export function isMinimalIPlugin(value: unknown): value is IPlugin {
+    if (typeof value !== 'object' || value === null) return false;
+    const v = value as Record<string, unknown>;
+    if (typeof v.manifest !== 'object' || v.manifest === null) return false;
+    const m = v.manifest as Record<string, unknown>;
+    return typeof m.id === 'string' && m.id.length > 0;
+}
+
+/**
+ * Runs every loader, collects the successful IPlugin results, and reports
+ * the failures. Loaders are awaited in parallel via Promise.allSettled so a
+ * single hung dynamic import can't stall the rest — and so each loader's
+ * exception is captured rather than aborting the chain.
+ *
+ * The optional `onFailure` callback is invoked once per dropped plugin;
+ * loaders that omit it still get a console.error. Tests inject the callback
+ * to assert which plugins were rejected and why.
+ */
+export async function loadFromPluginLoaders(
+    loaders: ReadonlyArray<() => Promise<unknown>>,
+    onFailure?: (failure: IPluginLoadFailure) => void
+): Promise<IPlugin[]> {
+    const results = await Promise.allSettled(loaders.map(load => load()));
+    const plugins: IPlugin[] = [];
+
+    results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+            const failure: IPluginLoadFailure = { index, reason: result.reason };
+            if (onFailure) {
+                onFailure(failure);
+            } else {
+                console.error('[plugins.generated] Plugin failed to load:', result.reason);
+            }
+            return;
+        }
+
+        if (!isMinimalIPlugin(result.value)) {
+            const failure: IPluginLoadFailure = {
+                index,
+                reason: new Error(
+                    'Resolved value is not a minimum IPlugin shape (missing manifest.id).'
+                )
+            };
+            if (onFailure) {
+                onFailure(failure);
+            } else {
+                console.error('[plugins.generated] Plugin failed shape validation at index', index);
+            }
+            return;
+        }
+
+        plugins.push(result.value);
+    });
+
+    return plugins;
+}

--- a/src/frontend/lib/__tests__/pluginRegistry.test.ts
+++ b/src/frontend/lib/__tests__/pluginRegistry.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Plugin registry contract tests.
+ *
+ * Locks in the failure-isolation guarantees that the x-poster widget rollout
+ * exposed as missing — a single malformed plugin module used to take down
+ * SSR for every route. These tests assert the registry skips bad entries
+ * with a logged error instead of throwing.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { IPlugin } from '@/types';
+import { pluginRegistry } from '../pluginRegistry';
+
+function makePlugin(id: string, overrides: Partial<IPlugin> = {}): IPlugin {
+    return {
+        manifest: {
+            id,
+            title: `Plugin ${id}`,
+            version: '1.0.0',
+            description: 'test plugin'
+        },
+        ...overrides
+    } as IPlugin;
+}
+
+describe('pluginRegistry.bootstrap failure isolation', () => {
+    let errorSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        pluginRegistry.clear();
+        errorSpy = vi.fn();
+        vi.spyOn(console, 'error').mockImplementation(errorSpy);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        pluginRegistry.clear();
+    });
+
+    it('registers a well-formed plugin', () => {
+        const plugin = makePlugin('good', {
+            menuItems: [{ label: 'Good', href: '/good', order: 10 }]
+        });
+        pluginRegistry.bootstrap([plugin]);
+        expect(pluginRegistry.getAllPlugins()).toHaveLength(1);
+        expect(pluginRegistry.getMenuItems()).toHaveLength(1);
+    });
+
+    it('skips a plugin with no manifest and continues with the rest', () => {
+        const good = makePlugin('good');
+        const broken = { menuItems: [{ label: 'oops', href: '/x' }] } as unknown as IPlugin;
+        pluginRegistry.bootstrap([good, broken]);
+        expect(pluginRegistry.getAllPlugins().map(p => p.manifest.id)).toEqual(['good']);
+        expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('skips undefined entries instead of throwing on .menuItems access', () => {
+        const good = makePlugin('good');
+        // Simulates the exact regression: a generated registry that
+        // produced `undefined` at one index. The bug used to crash here.
+        const plugins = [good, undefined as unknown as IPlugin];
+        expect(() => pluginRegistry.bootstrap(plugins)).not.toThrow();
+        expect(pluginRegistry.getAllPlugins()).toHaveLength(1);
+        expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('skips a plugin whose manifest id is empty', () => {
+        const broken = makePlugin('');
+        const good = makePlugin('good');
+        pluginRegistry.bootstrap([broken, good]);
+        expect(pluginRegistry.getAllPlugins().map(p => p.manifest.id)).toEqual(['good']);
+        expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('isolates a plugin whose menuItems iterator throws', () => {
+        const good = makePlugin('good');
+        const throwy = makePlugin('throwy');
+        Object.defineProperty(throwy, 'menuItems', {
+            get() {
+                throw new Error('exploded');
+            }
+        });
+        expect(() => pluginRegistry.bootstrap([good, throwy])).not.toThrow();
+        // The good plugin still registers; the throwy one is dropped.
+        expect(pluginRegistry.getAllPlugins().map(p => p.manifest.id)).toEqual(['good']);
+        expect(errorSpy).toHaveBeenCalled();
+    });
+});

--- a/src/frontend/lib/pluginRegistry.ts
+++ b/src/frontend/lib/pluginRegistry.ts
@@ -84,14 +84,50 @@ class PluginRegistry {
      * Automatically adds the plugin ID to each page configuration for proper
      * context injection during rendering.
      *
+     * Defense in depth: although the generated registry already filters out
+     * malformed plugin modules, this method revalidates each plugin's manifest
+     * shape and skips with a logged error rather than throwing on a missing
+     * field. A bad plugin reaching this point used to crash the entire SSR
+     * pass on the first `.menuItems` access — see the post-mortem on the
+     * x-poster widget rollout for the failure mode.
+     *
      * @param plugin - The plugin definition containing menu items, pages, and/or admin pages
      */
     registerPlugin(plugin: IPlugin): void {
-        this.state.plugins.push(plugin);
-
-        if (plugin.menuItems) {
-            this.state.menuItems.push(...plugin.menuItems);
+        if (!this.isValidPlugin(plugin)) {
+            console.error(
+                '[pluginRegistry] Refusing to register malformed plugin entry. ' +
+                'Expected an object with a manifest containing string id and title.',
+                { received: plugin }
+            );
+            return;
         }
+
+        // Materialize the plugin's surfaces into locals *before* mutating
+        // shared state. A throwing getter on .menuItems / .pages / .adminPages
+        // (or an iterator that throws partway through) would otherwise leave
+        // this.state partially populated — the plugin would appear in
+        // .plugins but contribute nothing to navigation or routing. By
+        // computing the full payload first, we either register everything
+        // for a plugin or nothing.
+        let menuItems: IMenuItemConfig[];
+        let pages: IPageConfig[];
+        let adminPages: IPageConfig[];
+        try {
+            menuItems = plugin.menuItems ? [...plugin.menuItems] : [];
+            pages = plugin.pages ? [...plugin.pages] : [];
+            adminPages = plugin.adminPages ? [...plugin.adminPages] : [];
+        } catch (error) {
+            console.error(
+                `[pluginRegistry] Plugin '${plugin.manifest.id}' threw while ` +
+                'enumerating menuItems/pages/adminPages; skipping registration entirely.',
+                error
+            );
+            return;
+        }
+
+        this.state.plugins.push(plugin);
+        this.state.menuItems.push(...menuItems);
 
         // First-wins collision policy. The server-side registry uses the same
         // policy in serverPluginRegistry.buildPermanentMap, so SSR and client
@@ -111,14 +147,8 @@ class PluginRegistry {
             this.state.pages.push({ ...page, pluginId: plugin.manifest.id });
         };
 
-        if (plugin.pages) {
-            plugin.pages.forEach(addPageIfFirst);
-        }
-
-        // Register admin pages (also added to pages array)
-        if (plugin.adminPages) {
-            plugin.adminPages.forEach(addPageIfFirst);
-        }
+        pages.forEach(addPageIfFirst);
+        adminPages.forEach(addPageIfFirst);
 
         // Skip the sort + notify when called from bootstrap(); the bulk
         // path sorts once and notifies once at the end of the loop.
@@ -126,6 +156,21 @@ class PluginRegistry {
             this.sortMenuItems();
             this.notify();
         }
+    }
+
+    /**
+     * Returns true when the value has the minimum IPlugin shape the registry
+     * needs to operate: a manifest object with non-empty string id and title.
+     * Looser than IPlugin's full type so optional surfaces (pages, menuItems,
+     * adminPages, component) may be absent without disqualifying the plugin.
+     */
+    private isValidPlugin(plugin: unknown): plugin is IPlugin {
+        if (typeof plugin !== 'object' || plugin === null) return false;
+        const p = plugin as Record<string, unknown>;
+        if (typeof p.manifest !== 'object' || p.manifest === null) return false;
+        const m = p.manifest as Record<string, unknown>;
+        return typeof m.id === 'string' && m.id.length > 0
+            && typeof m.title === 'string' && m.title.length > 0;
     }
 
     /**
@@ -157,6 +202,12 @@ class PluginRegistry {
      * existing `clear()` and `registerPlugin()` methods remain available for
      * tests that need to reset state.
      *
+     * Each plugin is wrapped in try/catch so a runtime exception inside one
+     * plugin's registration cannot abort the whole bootstrap loop. The
+     * generated registry already excludes plugins with no IPlugin export, but
+     * downstream listeners or page configs may still throw — that single
+     * plugin gets dropped, the rest still load.
+     *
      * @param plugins - Plugin instances to register synchronously
      */
     bootstrap(plugins: IPlugin[]): void {
@@ -167,7 +218,15 @@ class PluginRegistry {
         this.bulkRegistering = true;
         try {
             for (const plugin of plugins) {
-                this.registerPlugin(plugin);
+                try {
+                    this.registerPlugin(plugin);
+                } catch (error) {
+                    const pluginId = plugin?.manifest?.id ?? '<unknown>';
+                    console.error(
+                        `[pluginRegistry] Plugin '${pluginId}' threw during registration; skipping.`,
+                        error
+                    );
+                }
             }
         } finally {
             this.bulkRegistering = false;

--- a/src/frontend/lib/serverPluginRegistry.ts
+++ b/src/frontend/lib/serverPluginRegistry.ts
@@ -65,22 +65,48 @@ let permanentMap: Map<string, IResolvedPluginPage> | null = null;
 function buildPermanentMap(): Map<string, IResolvedPluginPage> {
     const map = new Map<string, IResolvedPluginPage>();
     for (const plugin of frontendPlugins) {
-        const pluginId = plugin.manifest.id;
-        const pages = plugin.pages ?? [];
-        const adminPages = plugin.adminPages ?? [];
-        for (const page of [...pages, ...adminPages]) {
-            const existing = map.get(page.path);
-            if (existing) {
-                console.warn(
-                    `[serverPluginRegistry] Duplicate page path '${page.path}' detected. ` +
-                        `Plugin '${pluginId}' will be ignored; '${existing.pluginId}' keeps the route.`
+        // Defense in depth — the generated registry already filters malformed
+        // modules, but a plugin whose pages array contains entries with
+        // missing paths would still throw inside the loop and abort SSR for
+        // every route. Wrap each plugin so one broken entry only breaks that
+        // plugin, never the entire page resolver.
+        try {
+            const manifest = plugin?.manifest;
+            if (!manifest || typeof manifest.id !== 'string' || manifest.id.length === 0) {
+                console.error(
+                    '[serverPluginRegistry] Skipping registry entry with missing manifest id.'
                 );
                 continue;
             }
-            map.set(page.path, {
-                pluginId,
-                config: { ...page, pluginId }
-            });
+            const pluginId = manifest.id;
+            const pages = plugin.pages ?? [];
+            const adminPages = plugin.adminPages ?? [];
+            for (const page of [...pages, ...adminPages]) {
+                if (!page || typeof page.path !== 'string' || page.path.length === 0) {
+                    console.error(
+                        `[serverPluginRegistry] Plugin '${pluginId}' declared a page with no path; skipping.`
+                    );
+                    continue;
+                }
+                const existing = map.get(page.path);
+                if (existing) {
+                    console.warn(
+                        `[serverPluginRegistry] Duplicate page path '${page.path}' detected. ` +
+                            `Plugin '${pluginId}' will be ignored; '${existing.pluginId}' keeps the route.`
+                    );
+                    continue;
+                }
+                map.set(page.path, {
+                    pluginId,
+                    config: { ...page, pluginId }
+                });
+            }
+        } catch (error) {
+            const pluginId = plugin?.manifest?.id ?? '<unknown>';
+            console.error(
+                `[serverPluginRegistry] Plugin '${pluginId}' threw while indexing pages; skipping.`,
+                error
+            );
         }
     }
     return map;


### PR DESCRIPTION
## Summary

Hardens the plugin loader so a single malformed plugin module can no longer crash SSR for every route. Triggered by the trp-x-poster widget rollout, which shipped without an `export default`, resolved to `undefined` in the registry array, and threw on the first `.menuItems` access during SSR.

## Changes

**Frontend generator (`scripts/generate-frontend-plugin-registry.mjs`)** — single import shape for every plugin: namespace import + `Object.values().find(isIPluginShape)` runtime discovery. Plugins may use any named export; `export default` is no longer required. Malformed plugins are surfaced via `failedPluginLoads` and dropped instead of polluting the registry as `undefined`.

**Widget generator** — wraps every plugin's `widgetComponents` in `safeMergeWidgets`, which refuses missing or non-object exports instead of crashing the spread at module load.

**`pluginRegistry.registerPlugin`** — validates manifest shape before mutating state, materialises menuItems/pages/adminPages into locals first so a throwing getter cannot leave the registry half-populated, and `bootstrap` wraps each plugin in try/catch.

**`serverPluginRegistry.buildPermanentMap`** — same defensive validation for the SSR page resolver.

**Backend loader** — already isolated via `Promise.allSettled` but had no test coverage; extracted to `src/backend/loaders/safe-plugin-load.ts` with a contract test.

**Contract tests** — `pluginRegistry.test.ts` and `safe-plugin-load.test.ts` lock in the failure-isolation behavior so it cannot silently regress. 17 assertions covering rejection, malformed shapes, throwing getters, and undefined entries.

**Docs** — `plugins-system-architecture.md` now states the frontend export contract: any named IPlugin export, default optional, malformed plugins isolated.