### PR TITLE
Add IFileService.getVariant and IStorageProvider exists/listByPrefix

### DIFF
--- a/packages/types/src/files/IFileService.ts
+++ b/packages/types/src/files/IFileService.ts
@@ -85,6 +85,38 @@ export interface IFileUploadOptions {
 }
 
 /**
+ * Caller-supplied options on `getVariant()`. At least one dimension is
+ * required. When only one is supplied the other is computed to preserve
+ * the source aspect ratio. Values outside the 1–4000 pixel range are
+ * rejected so a single request cannot pin a server CPU resizing a
+ * pathological image.
+ */
+export interface IVariantOptions {
+    /** Target width in pixels (1–4000). */
+    width?: number;
+    /** Target height in pixels (1–4000). */
+    height?: number;
+}
+
+/**
+ * Result returned by `getVariant()`. The URL points at the cached variant
+ * served by the storage provider's static middleware (or CDN); consumers
+ * embed it directly in `<img src>`.
+ */
+export interface IFileVariant {
+    /** Absolute public URL of the variant. */
+    url: string;
+    /** MIME type of the variant (matches the source). */
+    mimeType: string;
+    /** Variant size in bytes. */
+    sizeBytes: number;
+    /** Actual variant width in pixels. */
+    width: number;
+    /** Actual variant height in pixels. */
+    height: number;
+}
+
+/**
  * Filter shape for `list()`. All fields are optional and combine as AND
  * predicates.
  */
@@ -153,6 +185,22 @@ export interface IFileService {
      * Fetch a single record without reading bytes.
      */
     getRecord(id: string): Promise<IFileRecord | null>;
+
+    /**
+     * Produce a resized variant of a stored image and return a URL
+     * pointing at the cached output. The variant is generated on first
+     * request and persisted alongside the source so subsequent calls
+     * — and direct browser hits to the returned URL — are served by
+     * the storage provider's static middleware without re-running the
+     * image processor.
+     *
+     * Returns null when the id does not resolve, when the source is
+     * not a supported raster image (jpeg/png/webp/gif), or when no
+     * dimension was provided. Dimensions outside 1–4000 are clamped.
+     * Variants never upscale: requesting a width larger than the
+     * source returns the source dimensions.
+     */
+    getVariant(id: string, options: IVariantOptions): Promise<IFileVariant | null>;
 
     /**
      * Enumerate records matching the filter, sorted by `uploadedAt` desc.

--- a/packages/types/src/files/IFileService.ts
+++ b/packages/types/src/files/IFileService.ts
@@ -85,18 +85,27 @@ export interface IFileUploadOptions {
 }
 
 /**
- * Caller-supplied options on `getVariant()`. At least one dimension is
- * required. When only one is supplied the other is computed to preserve
- * the source aspect ratio. Values outside the 1–4000 pixel range are
- * rejected so a single request cannot pin a server CPU resizing a
+ * Caller-supplied options on `getVariant()`. Modeled as a discriminated
+ * union so the type system enforces "at least one of width or height"
+ * — `{}` is unrepresentable. When only one is supplied the other is
+ * computed to preserve the source aspect ratio. Values outside the
+ * 1–4000 pixel range are clamped to the nearest endpoint; the 4000-pixel
+ * ceiling prevents a single request from pinning a server CPU resizing a
  * pathological image.
  */
-export interface IVariantOptions {
-    /** Target width in pixels (1–4000). */
-    width?: number;
-    /** Target height in pixels (1–4000). */
-    height?: number;
-}
+export type IVariantOptions =
+    | {
+        /** Target width in pixels (1–4000). */
+        width: number;
+        /** Target height in pixels (1–4000). */
+        height?: number;
+    }
+    | {
+        /** Target width in pixels (1–4000). */
+        width?: number;
+        /** Target height in pixels (1–4000). */
+        height: number;
+    };
 
 /**
  * Result returned by `getVariant()`. The URL points at the cached variant
@@ -194,11 +203,10 @@ export interface IFileService {
      * the storage provider's static middleware without re-running the
      * image processor.
      *
-     * Returns null when the id does not resolve, when the source is
-     * not a supported raster image (jpeg/png/webp/gif), or when no
-     * dimension was provided. Dimensions outside 1–4000 are clamped.
-     * Variants never upscale: requesting a width larger than the
-     * source returns the source dimensions.
+     * Returns null when the id does not resolve or when the source is
+     * not a supported raster image (jpeg/png/webp/gif). Dimensions
+     * outside 1–4000 are clamped. Variants never upscale: requesting a
+     * width larger than the source returns the source dimensions.
      */
     getVariant(id: string, options: IVariantOptions): Promise<IFileVariant | null>;
 

--- a/packages/types/src/files/IStorageProvider.ts
+++ b/packages/types/src/files/IStorageProvider.ts
@@ -1,4 +1,27 @@
 /**
+ * Lightweight metadata for a stored object, returned by
+ * `IStorageProvider.stat()`. Maps cleanly onto `fs.stat` on local
+ * filesystems and onto a `HEAD` response on S3-compatible backends.
+ * Sized as the union of what `IFileVariant` requires today plus the
+ * fields most likely to drive cache-control / conditional-GET work
+ * tomorrow, so the contract does not need to widen for the first
+ * follow-up consumer.
+ */
+export interface IStorageObjectStat {
+    /** Object size in bytes. */
+    sizeBytes: number;
+    /** Last modification time as reported by the backend. */
+    lastModified: Date;
+    /**
+     * MIME type as recorded by the backend, when available. S3 returns it
+     * in the `HEAD` response; local filesystem providers may have to read
+     * the inventory row or omit it. Optional so providers without cheap
+     * type metadata are not forced to fabricate one.
+     */
+    mimeType?: string;
+}
+
+/**
  * Abstract interface for file storage providers.
  *
  * Storage providers handle file upload, deletion, and URL generation.
@@ -41,18 +64,37 @@ export interface IStorageProvider {
     delete(handle: string): Promise<boolean>;
 
     /**
-     * Cheap existence check that avoids loading bytes. Used by
-     * `FileService.getVariant` to short-circuit cache hits without
-     * paying the I/O cost of reading the variant file. Implementations
-     * map this to `fs.access` (local), `HEAD` (S3), or equivalent.
+     * Cheapest possible existence check — no metadata, no bytes.
+     * Implementations map this to `fs.access` (local), `HEAD` with a
+     * discarded body (S3), or equivalent. Prefer `stat()` when the
+     * caller will also need size or modification time on a hit, since
+     * a single `stat` is always at least as cheap as `exists` + `stat`.
      */
     exists(handle: string): Promise<boolean>;
 
     /**
-     * Enumerate handles whose path starts with the supplied prefix.
-     * Used by `FileService.delete` to find and remove cached variants
-     * derived from the deleted source. Returns an empty array when no
-     * matches exist. Order is unspecified.
+     * Fetch object metadata without reading bytes. Returns null when
+     * the handle does not resolve, so callers can treat null/non-null
+     * as a combined existence + metadata check. Used by
+     * `FileService.getVariant` to short-circuit cache hits while still
+     * populating `IFileVariant.sizeBytes` from a single I/O call.
+     * Implementations map this to `fs.stat` (local), `HEAD` (S3), or
+     * equivalent.
+     */
+    stat(handle: string): Promise<IStorageObjectStat | null>;
+
+    /**
+     * Enumerate handles for stored objects whose storage-relative path
+     * starts with `prefix`. The prefix follows the same namespace and
+     * formatting rules as `upload()`'s `relativePath` argument — no
+     * leading slash, forward-slash separated — and providers translate
+     * it to whatever native enumeration their handle scheme uses (a
+     * directory walk for local filesystems, `ListObjectsV2` with
+     * `Prefix` for S3). The returned strings are handles suitable for
+     * passing back into `delete()` / `read()` / `getUrl()`, not raw
+     * paths. Used by `FileService.delete` to find and remove cached
+     * variants derived from the deleted source. Returns an empty array
+     * when no matches exist. Order is unspecified.
      */
     listByPrefix(prefix: string): Promise<string[]>;
 

--- a/packages/types/src/files/IStorageProvider.ts
+++ b/packages/types/src/files/IStorageProvider.ts
@@ -41,6 +41,22 @@ export interface IStorageProvider {
     delete(handle: string): Promise<boolean>;
 
     /**
+     * Cheap existence check that avoids loading bytes. Used by
+     * `FileService.getVariant` to short-circuit cache hits without
+     * paying the I/O cost of reading the variant file. Implementations
+     * map this to `fs.access` (local), `HEAD` (S3), or equivalent.
+     */
+    exists(handle: string): Promise<boolean>;
+
+    /**
+     * Enumerate handles whose path starts with the supplied prefix.
+     * Used by `FileService.delete` to find and remove cached variants
+     * derived from the deleted source. Returns an empty array when no
+     * matches exist. Order is unspecified.
+     */
+    listByPrefix(prefix: string): Promise<string[]>;
+
+    /**
      * Resolve the public, browser-safe URL for a previously stored file.
      */
     getUrl(handle: string): string;

--- a/packages/types/src/files/index.ts
+++ b/packages/types/src/files/index.ts
@@ -10,7 +10,9 @@ export type {
     IFileRecord,
     IFileSource,
     IFileUploadOptions,
-    IFileListFilter
+    IFileListFilter,
+    IVariantOptions,
+    IFileVariant
 } from './IFileService.js';
 export { FILE_SOURCE_KINDS, FileValidationError, FileSizeExceededError } from './IFileService.js';
 export type { IFilesSettings, IFilesSettingsService } from './IFilesSettings.js';

--- a/packages/types/src/files/index.ts
+++ b/packages/types/src/files/index.ts
@@ -4,7 +4,7 @@
  * Platform-wide file inventory contract published on the service registry
  * as `'files'` and the upload-policy settings the Files module owns.
  */
-export type { IStorageProvider } from './IStorageProvider.js';
+export type { IStorageProvider, IStorageObjectStat } from './IStorageProvider.js';
 export type {
     IFileService,
     IFileRecord,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -34,7 +34,7 @@ export type { IDatabaseService } from './database/IDatabaseService.js';
 export type { IMigration, IMigrationContext, MigrationTarget } from './database/IMigration.js';
 export type { IClickHouseService } from './clickhouse/index.js';
 export type { IPage, IPageSettings, IPageService, IMarkdownService, IFrontmatterData, IParsedMarkdown } from './pages/index.js';
-export type { IStorageProvider, IFileService, IFileRecord, IFileSource, IFileUploadOptions, IFileListFilter, IVariantOptions, IFileVariant, IFilesSettings, IFilesSettingsService } from './files/index.js';
+export type { IStorageProvider, IStorageObjectStat, IFileService, IFileRecord, IFileSource, IFileUploadOptions, IFileListFilter, IVariantOptions, IFileVariant, IFilesSettings, IFilesSettingsService } from './files/index.js';
 export { FILE_SOURCE_KINDS, FileValidationError, FileSizeExceededError } from './files/index.js';
 export type { IModule, IModuleMetadata } from './module/index.js';
 export { USER_FILTERS, USER_IDENTITY_STATES, UserIdentityState, SESSION_TTL_MS, isSessionFresh } from './user/index.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -34,7 +34,7 @@ export type { IDatabaseService } from './database/IDatabaseService.js';
 export type { IMigration, IMigrationContext, MigrationTarget } from './database/IMigration.js';
 export type { IClickHouseService } from './clickhouse/index.js';
 export type { IPage, IPageSettings, IPageService, IMarkdownService, IFrontmatterData, IParsedMarkdown } from './pages/index.js';
-export type { IStorageProvider, IFileService, IFileRecord, IFileSource, IFileUploadOptions, IFileListFilter, IFilesSettings, IFilesSettingsService } from './files/index.js';
+export type { IStorageProvider, IFileService, IFileRecord, IFileSource, IFileUploadOptions, IFileListFilter, IVariantOptions, IFileVariant, IFilesSettings, IFilesSettingsService } from './files/index.js';
 export { FILE_SOURCE_KINDS, FileValidationError, FileSizeExceededError } from './files/index.js';
 export type { IModule, IModuleMetadata } from './module/index.js';
 export { USER_FILTERS, USER_IDENTITY_STATES, UserIdentityState, SESSION_TTL_MS, isSessionFresh } from './user/index.js';


### PR DESCRIPTION
## Summary

Extend the file/storage type surface in `@delphian/tronrelic-types` to support cached image variants.

`IFileService` gains `getVariant(id, options)` returning `IFileVariant | null`. Callers pass `IVariantOptions` (`width` and/or `height`, 1–4000 px). Variants are generated on first request and persisted next to the source so subsequent calls and direct browser hits hit cache without re-running the image processor. Variants never upscale, and non-raster sources or unresolvable ids return `null`.

`IStorageProvider` gains `exists(handle)` for cheap cache-hit checks and `listByPrefix(prefix)` so `FileService.delete` can find and remove cached variants derived from a deleted source.

Types are re-exported through `packages/types/src/files/index.ts` and the package root `packages/types/src/index.ts`. No runtime code in core changes in this PR.