### PR TITLE
chore: bump types to 2.0.7 and snap --font-size-base to 15px

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12739,7 +12739,7 @@
     },
     "packages/types": {
       "name": "@delphian/tronrelic-types",
-      "version": "2.0.0",
+      "version": "2.0.7",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -12865,7 +12865,7 @@
     },
     "src/plugins/trp-x-poster/packages/types": {
       "name": "@delphian/trp-x-poster-types",
-      "version": "1.0.1",
+      "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delphian/tronrelic-types",
-    "version": "2.0.0",
+    "version": "2.0.7",
     "description": "Core type definitions for the TronRelic platform",
     "type": "module",
     "main": "dist/index.js",

--- a/src/frontend/app/primitives.scss
+++ b/src/frontend/app/primitives.scss
@@ -23,7 +23,7 @@
     --font-size-xxs: 0.5rem;     /* 8px - footnote-tier metadata (use sparingly) */
     --font-size-xs: 0.72rem;     /* 11.52px - table headers, tiny labels */
     --font-size-sm: 0.85rem;     /* 13.6px - most common small text */
-    --font-size-base: 0.95rem;   /* 15.2px - default body, buttons */
+    --font-size-base: 0.9375rem; /* 15px - default body, buttons */
     --font-size-md: 1rem;        /* 16px - standard paragraphs */
     --font-size-lg: 1.05rem;     /* 16.8px - large buttons */
     --font-size-xl: 1.6rem;      /* 25.6px - stat values */

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -45,7 +45,7 @@
     /* Typography — purpose-named font sizes */
     --font-size-caption:    var(--font-size-xs);    /* 0.72rem - labels, table headers, footnotes */
     --font-size-body-sm:    var(--font-size-sm);    /* 0.85rem - secondary body */
-    --font-size-body:       var(--font-size-base);  /* 0.95rem - default body, buttons */
+    --font-size-body:       var(--font-size-base);  /* 0.9375rem - default body, buttons */
     --font-size-body-lg:    var(--font-size-md);    /* 1rem    - emphasized body */
     --font-size-heading-sm: var(--font-size-lg);    /* 1.05rem - small headings */
     --font-size-heading-md: var(--font-size-xl);    /* 1.6rem  - default heading, stat values */
@@ -83,7 +83,7 @@
 
     --button-height-md: 42px;
     --button-padding-md: 0.55rem var(--spacing-9);           /* 0.55rem 1.25rem */
-    --button-font-size-md: var(--font-size-base);            /* 0.95rem */
+    --button-font-size-md: var(--font-size-base);            /* 0.9375rem */
 
     --button-height-lg: 50px;
     --button-padding-lg: var(--spacing-5) 1.75rem;           /* 0.75rem 1.75rem */


### PR DESCRIPTION
## Summary

- Bumps `@delphian/tronrelic-types` from 2.0.0 to 2.0.7 to align the package version with the published 2.0.x line.
- Snaps the `--font-size-base` primitive from 0.95rem (15.2px) to 0.9375rem (15px) for cleaner sub-pixel rounding across components that consume the default body size.