### PR TITLE
Plumb placement instanceConfig to data fetchers and validate via JSON Schema (#261)

### DIFF
--- a/docs/plugins/plugins-widget-zones-registration.md
+++ b/docs/plugins/plugins-widget-zones-registration.md
@@ -125,7 +125,54 @@ When two plugins target the same zone, set explicit `defaultOrder` to win determ
 
 ## Data Fetchers
 
-`defaultDataFetcher(route, params)` receives the resolved route and any params the host extracted (e.g. `{ address }` on `/u/[address]`). It must return JSON-serialisable data quickly — heavy work belongs in a scheduled job that writes to a plugin-owned MongoDB collection that the fetcher then reads. A 5-second per-fetcher timeout is enforced by the SSR resolver via `Promise.race`. Failures should resolve to empty data, never throw — a throw is converted to an empty payload but logged as a fetcher error.
+`defaultDataFetcher(route, params, placement?)` receives the resolved route, any params the host extracted (e.g. `{ address }` on `/u/[address]`), and a per-placement `IWidgetPlacementContext` — `{ id, instanceConfig }` — that lets one widget type produce per-placement variation without shipping a type per permutation. The third argument is optional, so existing fetchers that ignore placement-scoped config remain valid. The resolver substitutes an empty object for `instanceConfig` when a placement carries no overrides, so fetchers can read keys unconditionally.
+
+Fetchers must return JSON-serialisable data quickly — heavy work belongs in a scheduled job that writes to a plugin-owned MongoDB collection that the fetcher then reads. A 5-second per-fetcher timeout is enforced by the SSR resolver via `Promise.race`. Failures should resolve to empty data, never throw — a throw is converted to an empty payload but logged as a fetcher error.
+
+```typescript
+defaultDataFetcher: async (_route, _params, placement) => {
+    const cap = Number(placement?.instanceConfig?.maxPosts);
+    const maxPosts = Number.isFinite(cap) ? Math.min(20, Math.max(1, Math.floor(cap))) : 5;
+    return { posts: await service.recent(maxPosts) };
+}
+```
+
+## Per-Placement Configuration Schemas
+
+A widget type may declare `configSchema` — a JSON Schema Draft 7 object — to constrain the `instanceConfig` operators attach to its placements. When a schema is declared, the placement admin API validates `instanceConfig` against it on every create and patch using AJV, rejecting invalid bodies with a structured 400 listing per-field errors:
+
+```json
+{
+    "success": false,
+    "error": "instanceConfig failed widget-type schema validation",
+    "errors": [
+        { "path": "/maxPosts", "message": "must be <= 20" }
+    ]
+}
+```
+
+The schema flows through `IRegisterWidgetTypeInput.configSchema` (and the convenience `IRegisterWidgetInput.configSchema`) into the widget type descriptor; the validation path retrieves it via `IWidgetsService.getTypeConfigSchema(typeId)`. Validators compile once per schema reference and cache for the descriptor's lifetime — re-enabling a plugin invalidates the cache by minting a fresh descriptor.
+
+Widget types that declare no schema accept any plain JSON object as `instanceConfig` (the shape-only "must be a plain object" guard still applies). For the smoothest operator-UX path keep top-level schema properties as primitives (`string`, `number`, `boolean`, `enum`) — the `/system/widgets` JSON-textarea editor surfaces the structured field errors inline regardless of nesting.
+
+```typescript
+widgets.registerWidget({
+    id: 'my-plugin:feed',
+    label: 'Feed',
+    description: 'Recent posts',
+    defaultZoneId: 'main-after',
+    defaultRoutes: [],
+    defaultInstanceConfig: { maxPosts: 5 },
+    configSchema: {
+        type: 'object',
+        properties: {
+            maxPosts: { type: 'integer', minimum: 1, maximum: 20 }
+        },
+        additionalProperties: false
+    },
+    defaultDataFetcher: async (_route, _params, placement) => { /* ... */ }
+}, ownerId);
+```
 
 ## Admin Introspection
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "@scure/bip32": "^1.4.0",
         "@scure/bip39": "^1.3.0",
         "@types/multer": "^2.0.0",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "axios": "^1.7.5",
         "bullmq": "^5.8.2",
         "compression": "^1.7.4",
@@ -874,6 +876,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/debug": {
       "version": "4.4.3",
       "dev": true,
@@ -889,6 +908,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/ms": {
       "version": "2.1.3",
@@ -2312,7 +2338,6 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -2958,18 +2983,36 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "dev": true,
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -4871,6 +4914,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/debug": {
       "version": "4.4.3",
       "dev": true,
@@ -4886,6 +4946,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/ms": {
       "version": "2.1.3",
@@ -5144,7 +5211,6 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5179,6 +5245,8 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5190,6 +5258,22 @@
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -6820,8 +6904,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -9127,6 +9212,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11488,6 +11582,8 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -12739,8 +12835,11 @@
     },
     "packages/types": {
       "name": "@delphian/tronrelic-types",
-      "version": "2.0.7",
+      "version": "2.1.0",
       "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
       "devDependencies": {
         "@types/node": "^20.11.0",
         "@types/react": "^18.2.46",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "@scure/bip32": "^1.4.0",
     "@scure/bip39": "^1.3.0",
     "@types/multer": "^2.0.0",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "axios": "^1.7.5",
     "bullmq": "^5.8.2",
     "compression": "^1.7.4",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delphian/tronrelic-types",
-    "version": "2.0.7",
+    "version": "2.1.0",
     "description": "Core type definitions for the TronRelic platform",
     "type": "module",
     "main": "dist/index.js",
@@ -30,6 +30,9 @@
         "directory": "packages/types"
     },
     "license": "AGPL-3.0-or-later",
+    "dependencies": {
+        "@types/json-schema": "^7.0.15"
+    },
     "peerDependencies": {
         "axios": "^1.0.0",
         "mongodb": "^6.0.0",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -81,6 +81,7 @@ export type {
 } from './widget-zones/index.js';
 export type {
     IWidgetType,
+    IWidgetPlacementContext,
     WidgetDataFetcher,
     IWidgetTypeSnapshot,
     IWidgetTypeSnapshotRecord,

--- a/packages/types/src/widget-types/IWidgetType.ts
+++ b/packages/types/src/widget-types/IWidgetType.ts
@@ -17,11 +17,43 @@
  * @module types/widget-types/IWidgetType
  */
 
+import type { JSONSchema7 } from 'json-schema';
+
+/**
+ * Per-placement context forwarded to a widget's data fetcher at SSR
+ * time. Lets a single widget type produce per-placement variation
+ * (post count, threshold, filter, title length) without shipping one
+ * widget type per configuration permutation.
+ *
+ * The context surface is intentionally narrow — placement id plus the
+ * operator-editable `instanceConfig` blob — so future placement fields
+ * (zoneId, routes, title) can be added without re-breaking the fetcher
+ * signature. `instanceConfig` is always an object; the resolver
+ * substitutes `{}` when the placement record carries no config so
+ * fetchers can read keys unconditionally.
+ */
+export interface IWidgetPlacementContext {
+    /** Placement id this fetch is rendering. */
+    readonly id: string;
+    /**
+     * Operator-editable instance configuration. Empty object when the
+     * placement carries no overrides. Validated against the widget
+     * type's `configSchema` at write time (if a schema is declared) so
+     * fetchers can trust the shape on read.
+     */
+    readonly instanceConfig: Record<string, unknown>;
+}
+
 /**
  * SSR data fetcher signature shared between widget types and the
- * legacy widget service. Receives the resolved route and any params
- * extracted by the host (e.g. `{ address }` on `/u/[address]`) and
- * returns the JSON-serialisable data the frontend component renders.
+ * legacy widget service. Receives the resolved route, any params
+ * extracted by the host (e.g. `{ address }` on `/u/[address]`), and
+ * the per-placement context (placement id and instanceConfig).
+ *
+ * The third arg is optional so existing fetchers that ignore
+ * placement-scoped config remain valid without code changes. New
+ * fetchers wanting per-placement variation declare the third
+ * parameter and read `placement?.instanceConfig`.
  *
  * Implementations must return quickly (under 5 s; the resolver enforces
  * a Promise.race timeout) and should not throw — return an empty
@@ -30,7 +62,8 @@
  */
 export type WidgetDataFetcher = (
     route: string,
-    params: Record<string, string>
+    params: Record<string, string>,
+    placement?: IWidgetPlacementContext
 ) => Promise<unknown>;
 
 /**
@@ -62,13 +95,18 @@ export interface IWidgetType {
      */
     readonly defaultDataFetcher: WidgetDataFetcher;
     /**
-     * Optional schema describing the operator-editable instance
-     * configuration this widget type accepts. Reserved for the
-     * admin placement editor in a future PR; today the resolver
-     * does not forward instanceConfig anywhere, so this field is
-     * informational only.
+     * Optional JSON Schema Draft 7 describing the operator-editable
+     * instance configuration this widget type accepts. When present,
+     * `instanceConfig` is validated against this schema at write time
+     * by the placement admin API; invalid bodies are rejected with a
+     * structured 400 listing per-field errors. The runtime resolver
+     * forwards the (validated) `instanceConfig` into the fetcher via
+     * the third `placement` argument of {@link WidgetDataFetcher}.
+     *
+     * Widget types that declare no schema accept any plain object as
+     * `instanceConfig` (the existing shape-only check still applies).
      */
-    readonly configSchema?: unknown;
+    readonly configSchema?: JSONSchema7;
 }
 
 /**
@@ -89,8 +127,8 @@ export interface IDefineWidgetTypeOptions {
     category?: string;
     /** SSR data fetcher. See {@link WidgetDataFetcher}. */
     defaultDataFetcher: WidgetDataFetcher;
-    /** Optional instance-config schema. Informational in this PR. */
-    configSchema?: unknown;
+    /** Optional JSON Schema Draft 7 for `instanceConfig` validation. */
+    configSchema?: JSONSchema7;
 }
 
 /**

--- a/packages/types/src/widget-types/index.ts
+++ b/packages/types/src/widget-types/index.ts
@@ -12,6 +12,7 @@
 
 export type {
     IWidgetType,
+    IWidgetPlacementContext,
     IDefineWidgetTypeOptions,
     WidgetDataFetcher,
     WidgetTypeRegisterDisposer

--- a/packages/types/src/widget/IWidgetsService.ts
+++ b/packages/types/src/widget/IWidgetsService.ts
@@ -16,6 +16,7 @@
  * @module types/widget/IWidgetsService
  */
 
+import type { JSONSchema7 } from 'json-schema';
 import type { WidgetDataFetcher } from '../widget-types/IWidgetType.js';
 import type { IZoneSnapshot } from '../widget-zones/IZoneRegistry.js';
 import type { IWidgetTypeSnapshot } from '../widget-types/IWidgetTypeRegistry.js';
@@ -63,8 +64,16 @@ export interface IRegisterWidgetTypeInput {
      * placeholder.
      */
     defaultDataFetcher: WidgetDataFetcher;
-    /** Optional informational schema for the per-placement instanceConfig. */
-    configSchema?: unknown;
+    /**
+     * Optional JSON Schema Draft 7 describing the operator-editable
+     * `instanceConfig` this widget type accepts. When present, the
+     * placement admin API validates `instanceConfig` on create/patch
+     * and rejects invalid bodies with a structured 400 listing per-
+     * field errors. Plugin authors may declare a flat schema (string,
+     * number, boolean, or enum top-level properties) for the cleanest
+     * admin-UX path.
+     */
+    configSchema?: JSONSchema7;
 }
 
 /**
@@ -124,6 +133,22 @@ export interface IWidgetsService {
 
     /** True when a widget type with the given id is registered. */
     hasType(typeId: string): boolean;
+
+    /**
+     * Retrieve the JSON Schema declared by a widget type for its
+     * per-placement `instanceConfig`, or `undefined` when the type is
+     * unregistered or declares no schema.
+     *
+     * Used by the placement admin API to validate operator-supplied
+     * `instanceConfig` against the type's contract on every write
+     * (create / patch). Returning a clone is *not* required because
+     * the descriptor is frozen at mint time and `JSONSchema7` values
+     * are read-only by convention.
+     *
+     * @param typeId - Widget-type id to look up.
+     * @returns Declared schema, or `undefined`.
+     */
+    getTypeConfigSchema(typeId: string): JSONSchema7 | undefined;
 
     /**
      * Resolve the widgets to render for a given route. Queries the

--- a/src/backend/modules/widgets/README.md
+++ b/src/backend/modules/widgets/README.md
@@ -11,7 +11,7 @@ Owns every concern of the widget subsystem behind a single public surface: `IWid
 | Public service | `'widgets'` on the service registry (`IWidgetsService`) |
 | Backend API base | `/api/admin/system/widgets/placements`, `/api/admin/system/widget-types`, `/api/admin/system/zones`, plus SSR fetch at `/api/widgets` |
 | WebSocket event | `widgets:placements-update` |
-| Types package | `@delphian/tronrelic-types` — `IWidgetsService`, `IRegisterWidgetTypeInput`, `IRegisterZoneInput`, `IRegisterWidgetInput`, `IWidgetPlacement`, `IPlacementInput`, `IPlacementPatch`, `IPlacementListFilter`, `IWidgetType`, `IZoneDescriptor`, `IZoneSnapshot`, `IWidgetTypeSnapshot` |
+| Types package | `@delphian/tronrelic-types` — `IWidgetsService`, `IRegisterWidgetTypeInput`, `IRegisterZoneInput`, `IRegisterWidgetInput`, `IWidgetPlacement`, `IPlacementInput`, `IPlacementPatch`, `IPlacementListFilter`, `IWidgetType`, `IWidgetPlacementContext`, `IZoneDescriptor`, `IZoneSnapshot`, `IWidgetTypeSnapshot` |
 | Storage | `module_widgets_placements` (MongoDB) |
 | Migration | `module:widgets:001_create_placements_collection` (creates collection + 4 indexes) |
 | System menu node | "Widgets" under the System container — seeded by `WidgetsModule.run()` |
@@ -135,6 +135,12 @@ Indexes (migration 001): `(typeId, pluginId)` sparse unique for plugin-row atomi
 
 ## SSR Resolution
 
-`PlacementResolver.resolveForRoute(route, params)` (called via `widgets.fetchWidgetsForRoute(route, params)`) runs at every page render: queries enabled placements matching the route via `placementService.findByRoute`, looks up each type's `defaultDataFetcher` in the widget-type registry, runs them in parallel under a 5-second per-fetcher timeout, validates JSON-serialisability via round-trip, sorts by `(zoneId, order)`, and returns the `IWidgetData[]` bundle the frontend embeds.
+`PlacementResolver.resolveForRoute(route, params)` (called via `widgets.fetchWidgetsForRoute(route, params)`) runs at every page render: queries enabled placements matching the route via `placementService.findByRoute`, looks up each type's `defaultDataFetcher` in the widget-type registry, invokes each fetcher with `(route, params, { id, instanceConfig })` where the third arg carries the placement's id and operator-editable instance config, runs them in parallel under a 5-second per-fetcher timeout, validates JSON-serialisability via round-trip, sorts by `(zoneId, order)`, and returns the `IWidgetData[]` bundle the frontend embeds. The resolver substitutes `{}` for `instanceConfig` when a placement carries no overrides, so fetchers can read keys without null-guarding every access.
 
 Failures within a fetcher are logged and the widget is omitted — they never propagate out. Placements whose `typeId` is unregistered (e.g. plugin disabled) are silently skipped, leaving the rest of the route's widgets unaffected.
+
+## Instance-Config Schema Validation
+
+Widget types may declare `configSchema` (JSON Schema Draft 7) on registration. The placement admin API compiles each declared schema once via AJV and validates `instanceConfig` against it on every create and patch. Schema-invalid bodies return 400 with `{ error, errors: [{ path, message }] }`; widget types without a schema fall through to the existing shape-only "plain object" guard. The validator cache is keyed on the schema reference (WeakMap), so re-enabling a plugin mints a fresh descriptor and a fresh compiled validator without explicit invalidation.
+
+Consumers retrieve the schema for an arbitrary `typeId` via `IWidgetsService.getTypeConfigSchema(typeId)` — the controller's single touchpoint into the type-side contract. Adminship still flows through `IWidgetsService`; the registry stays internal to the module.

--- a/src/backend/modules/widgets/__tests__/placements.controller.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.controller.test.ts
@@ -87,7 +87,7 @@ function buildResponseStub() {
     const json = vi.fn();
     const end = vi.fn();
     const res = {
-        status: vi.fn(function (this: typeof res) { return this; }),
+        status: vi.fn().mockReturnThis(),
         json,
         end
     };

--- a/src/backend/modules/widgets/__tests__/placements.controller.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.controller.test.ts
@@ -1,0 +1,274 @@
+/// <reference types="vitest" />
+
+/**
+ * @fileoverview Unit tests for the placement admin controller's
+ * instanceConfig schema validation path.
+ *
+ * Phase 2 of the per-placement instanceConfig work introduced AJV
+ * validation against the widget type's declared `configSchema`. These
+ * tests cover the structured 400 path on schema failure, the
+ * pass-through when no schema is declared, and the patch-side lookup
+ * via the existing placement's typeId.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import type { JSONSchema7 } from 'json-schema';
+import type { ISystemLogService, IWidgetsService, IWidgetPlacement } from '@/types';
+import { PlacementsController } from '../api/placements.controller.js';
+
+/**
+ * Build a minimal `IWidgetsService` stub. Each test overrides the
+ * methods it actually exercises so failures from unrelated calls are
+ * easy to spot (the default `vi.fn()` returns undefined / throws on
+ * await).
+ */
+function buildWidgetsServiceStub(overrides: Partial<IWidgetsService> = {}): IWidgetsService {
+    const stub: Partial<IWidgetsService> = {
+        listZones: vi.fn(() => ({ tracks: [] })),
+        listTypes: vi.fn(() => ({ groups: [] })),
+        hasZone: vi.fn(() => true),
+        hasType: vi.fn(() => true),
+        getTypeConfigSchema: vi.fn(() => undefined),
+        fetchWidgetsForRoute: vi.fn(async () => []),
+        registerType: vi.fn(),
+        registerZone: vi.fn(),
+        registerWidget: vi.fn(),
+        unregisterAllForOwner: vi.fn(),
+        listPlacements: vi.fn(async () => []),
+        findPlacementById: vi.fn(async () => null),
+        createPlacement: vi.fn(),
+        updatePlacement: vi.fn(),
+        deletePlacement: vi.fn(),
+        restorePluginDefaults: vi.fn(),
+        ...overrides
+    };
+    return stub as IWidgetsService;
+}
+
+/**
+ * Build a minimal `ISystemLogService` stub — only `error` / `warn`
+ * are exercised by the controller paths these tests touch.
+ */
+function buildLoggerStub(): ISystemLogService {
+    return {
+        level: 'info',
+        fatal: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+        child: vi.fn(function (this: ISystemLogService) { return this; }),
+        initialize: vi.fn(async () => {}),
+        saveLog: vi.fn(async () => {}),
+        getLogs: vi.fn(async () => ({
+            logs: [], total: 0, page: 1, limit: 50, totalPages: 0,
+            hasNextPage: false, hasPrevPage: false
+        })),
+        markAsResolved: vi.fn(async () => {}),
+        cleanup: vi.fn(async () => 0),
+        getStatistics: vi.fn(async () => ({
+            total: 0, byLevel: {} as any, byService: {}, unresolved: 0
+        })),
+        getLogById: vi.fn(async () => null),
+        markAsUnresolved: vi.fn(async () => null),
+        deleteAllLogs: vi.fn(async () => 0),
+        getStats: vi.fn(async () => ({ total: 0, byLevel: {} as any, resolved: 0, unresolved: 0 })),
+        waitUntilInitialized: vi.fn(async () => {})
+    } as unknown as ISystemLogService;
+}
+
+/**
+ * Construct a minimal Express response stub recording `status()` and
+ * `json()` calls so assertions can inspect the wire shape.
+ */
+function buildResponseStub() {
+    const json = vi.fn();
+    const end = vi.fn();
+    const res = {
+        status: vi.fn(function (this: typeof res) { return this; }),
+        json,
+        end
+    };
+    return res as unknown as Response & {
+        status: ReturnType<typeof vi.fn>;
+        json: typeof json;
+        end: typeof end;
+    };
+}
+
+const validCreateBody = {
+    typeId: 'plugin:type',
+    zoneId: 'main-after',
+    routes: [],
+    enabled: true
+};
+
+describe('PlacementsController instanceConfig schema validation', () => {
+    let widgets: IWidgetsService;
+    let logger: ISystemLogService;
+    let controller: PlacementsController;
+    let res: ReturnType<typeof buildResponseStub>;
+
+    beforeEach(() => {
+        logger = buildLoggerStub();
+        res = buildResponseStub();
+    });
+
+    describe('createPlacement', () => {
+        it('rejects schema-invalid instanceConfig with 400 and per-field errors', async () => {
+            const schema: JSONSchema7 = {
+                type: 'object',
+                properties: {
+                    maxPosts: { type: 'integer', minimum: 1, maximum: 20 }
+                },
+                required: ['maxPosts'],
+                additionalProperties: false
+            };
+            widgets = buildWidgetsServiceStub({
+                getTypeConfigSchema: vi.fn(() => schema),
+                createPlacement: vi.fn(async () => { throw new Error('should not reach service'); })
+            });
+            controller = new PlacementsController(widgets, logger);
+
+            const req = {
+                body: {
+                    ...validCreateBody,
+                    instanceConfig: { maxPosts: 99 } // exceeds maximum
+                }
+            } as Request;
+
+            await controller.createPlacement(req, res);
+
+            expect(res.status).toHaveBeenCalledWith(400);
+            const payload = res.json.mock.calls[0][0];
+            expect(payload.success).toBe(false);
+            expect(payload.error).toMatch(/instanceConfig/);
+            expect(Array.isArray(payload.errors)).toBe(true);
+            expect(payload.errors.length).toBeGreaterThan(0);
+            expect(payload.errors[0]).toEqual(
+                expect.objectContaining({
+                    path: expect.stringContaining('maxPosts'),
+                    message: expect.any(String)
+                })
+            );
+            expect(widgets.createPlacement).not.toHaveBeenCalled();
+        });
+
+        it('accepts instanceConfig when no schema is declared and proceeds to the service', async () => {
+            widgets = buildWidgetsServiceStub({
+                getTypeConfigSchema: vi.fn(() => undefined),
+                createPlacement: vi.fn(async () => ({ id: 'new-id' } as IWidgetPlacement))
+            });
+            controller = new PlacementsController(widgets, logger);
+
+            const req = {
+                body: {
+                    ...validCreateBody,
+                    instanceConfig: { anything: 'goes', count: 7 }
+                }
+            } as Request;
+
+            await controller.createPlacement(req, res);
+
+            expect(res.status).toHaveBeenCalledWith(201);
+            expect(widgets.createPlacement).toHaveBeenCalledTimes(1);
+            expect(widgets.createPlacement).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    instanceConfig: { anything: 'goes', count: 7 }
+                })
+            );
+        });
+
+        it('accepts schema-valid instanceConfig and forwards to the service', async () => {
+            const schema: JSONSchema7 = {
+                type: 'object',
+                properties: {
+                    maxPosts: { type: 'integer', minimum: 1, maximum: 20 }
+                },
+                additionalProperties: false
+            };
+            widgets = buildWidgetsServiceStub({
+                getTypeConfigSchema: vi.fn(() => schema),
+                createPlacement: vi.fn(async () => ({ id: 'new-id' } as IWidgetPlacement))
+            });
+            controller = new PlacementsController(widgets, logger);
+
+            const req = {
+                body: {
+                    ...validCreateBody,
+                    instanceConfig: { maxPosts: 5 }
+                }
+            } as Request;
+
+            await controller.createPlacement(req, res);
+
+            expect(res.status).toHaveBeenCalledWith(201);
+            expect(widgets.createPlacement).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('updatePlacement', () => {
+        it('rejects schema-invalid instanceConfig on patch with 400 and per-field errors', async () => {
+            const schema: JSONSchema7 = {
+                type: 'object',
+                properties: { theme: { enum: ['light', 'dark'] } },
+                additionalProperties: false
+            };
+            const existing = {
+                id: 'p-1',
+                typeId: 'plugin:type',
+                zoneId: 'main-after',
+                routes: [],
+                order: 100,
+                enabled: true,
+                source: 'operator',
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString()
+            } as IWidgetPlacement;
+
+            widgets = buildWidgetsServiceStub({
+                getTypeConfigSchema: vi.fn(() => schema),
+                findPlacementById: vi.fn(async () => existing),
+                updatePlacement: vi.fn(async () => { throw new Error('should not reach service'); })
+            });
+            controller = new PlacementsController(widgets, logger);
+
+            const req = {
+                params: { id: 'p-1' },
+                body: { instanceConfig: { theme: 'neon' } } // not in enum
+            } as unknown as Request;
+
+            await controller.updatePlacement(req, res);
+
+            expect(res.status).toHaveBeenCalledWith(400);
+            const payload = res.json.mock.calls[0][0];
+            expect(payload.success).toBe(false);
+            expect(Array.isArray(payload.errors)).toBe(true);
+            expect(payload.errors[0]).toEqual(
+                expect.objectContaining({ path: expect.stringContaining('theme') })
+            );
+            expect(widgets.updatePlacement).not.toHaveBeenCalled();
+        });
+
+        it('returns 404 when the patch targets a placement that no longer exists', async () => {
+            widgets = buildWidgetsServiceStub({
+                getTypeConfigSchema: vi.fn(() => ({ type: 'object' } as JSONSchema7)),
+                findPlacementById: vi.fn(async () => null),
+                updatePlacement: vi.fn()
+            });
+            controller = new PlacementsController(widgets, logger);
+
+            const req = {
+                params: { id: 'p-missing' },
+                body: { instanceConfig: { foo: 1 } }
+            } as unknown as Request;
+
+            await controller.updatePlacement(req, res);
+
+            expect(res.status).toHaveBeenCalledWith(404);
+            expect(widgets.updatePlacement).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/backend/modules/widgets/__tests__/placements.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.test.ts
@@ -528,6 +528,43 @@ describe('PlacementResolver', () => {
         );
     });
 
+    it('forwards { id, instanceConfig } to the data fetcher', async () => {
+        const fetcher = vi.fn(async () => ({ ok: true }));
+        (typeRegistry as any).__types.set('plugin:type', buildType('plugin:type', fetcher));
+        (placementService.findByRoute as ReturnType<typeof vi.fn>).mockResolvedValue([
+            buildPlacement({
+                id: 'p-cfg',
+                typeId: 'plugin:type',
+                instanceConfig: { maxPosts: 3, theme: 'compact' }
+            })
+        ]);
+
+        await resolver.resolveForRoute('/markets', { foo: 'bar' });
+
+        expect(fetcher).toHaveBeenCalledTimes(1);
+        expect(fetcher).toHaveBeenCalledWith(
+            '/markets',
+            { foo: 'bar' },
+            { id: 'p-cfg', instanceConfig: { maxPosts: 3, theme: 'compact' } }
+        );
+    });
+
+    it('substitutes an empty instanceConfig object when the placement carries none', async () => {
+        const fetcher = vi.fn(async () => ({ ok: true }));
+        (typeRegistry as any).__types.set('plugin:type', buildType('plugin:type', fetcher));
+        (placementService.findByRoute as ReturnType<typeof vi.fn>).mockResolvedValue([
+            buildPlacement({ id: 'p-empty', typeId: 'plugin:type', instanceConfig: undefined })
+        ]);
+
+        await resolver.resolveForRoute('/', {});
+
+        expect(fetcher).toHaveBeenCalledWith(
+            '/',
+            {},
+            { id: 'p-empty', instanceConfig: {} }
+        );
+    });
+
     it('sorts results by zone (alphabetical), then order', async () => {
         // 'main-after' sorts before 'main-before' alphabetically, so
         // the expected ordering joins zone-asc then order-asc within

--- a/src/backend/modules/widgets/api/placements.controller.ts
+++ b/src/backend/modules/widgets/api/placements.controller.ts
@@ -143,8 +143,26 @@ export class PlacementsController {
 
         let validator = this.validatorCache.get(schema);
         if (!validator) {
-            validator = this.ajv.compile(schema);
-            this.validatorCache.set(schema, validator);
+            // Plugin-supplied schemas can be malformed (unsupported
+            // keyword, bad $ref, draft mismatch). Surface that as a
+            // structured 400 so a schema-author bug never lands as a
+            // 500 for the operator submitting a placement edit.
+            try {
+                validator = this.ajv.compile(schema);
+                this.validatorCache.set(schema, validator);
+            } catch (compileErr) {
+                this.logger.error(
+                    {
+                        err: compileErr,
+                        typeId
+                    },
+                    'Failed to compile widget configSchema'
+                );
+                return [{
+                    path: '',
+                    message: `Widget type schema compilation failed: ${compileErr instanceof Error ? compileErr.message : String(compileErr)}`
+                }];
+            }
         }
 
         if (validator(instanceConfig)) return null;

--- a/src/backend/modules/widgets/api/placements.controller.ts
+++ b/src/backend/modules/widgets/api/placements.controller.ts
@@ -16,6 +16,9 @@
  */
 
 import type { Request, Response } from 'express';
+import Ajv, { type ValidateFunction } from 'ajv';
+import addFormats from 'ajv-formats';
+import type { JSONSchema7 } from 'json-schema';
 import type {
     ISystemLogService,
     IWidgetsService,
@@ -30,6 +33,18 @@ import {
     UnknownWidgetTypeError,
     UnknownZoneError
 } from '../widgets.errors.js';
+
+/**
+ * Per-field validation error reported back to the client in the
+ * structured 400 body when `instanceConfig` fails a widget type's
+ * declared schema. `path` is the JSON Pointer to the offending field
+ * (empty string for root-level errors); `message` is AJV's human-
+ * readable summary.
+ */
+interface IInstanceConfigFieldError {
+    readonly path: string;
+    readonly message: string;
+}
 
 /**
  * Upper bound on a placement's `order` field. Lower numbers render
@@ -78,10 +93,68 @@ function safeStringParam(value: unknown, pattern: RegExp): string | undefined {
  * Admin controller for placement CRUD plus restore-defaults.
  */
 export class PlacementsController {
+    /**
+     * Shared AJV instance. `allErrors` so a single bad submission
+     * surfaces every offending field at once rather than feeding the
+     * operator one error per round-trip. `strict: false` lets plugin
+     * authors declare schemas with unrecognised keywords (e.g. UI
+     * hints) without AJV refusing to compile.
+     */
+    private readonly ajv: Ajv;
+
+    /**
+     * Compile cache keyed on the schema *object identity*. Because
+     * widget-type descriptors are frozen at mint time and re-minted on
+     * every plugin re-enable, the schema reference changes whenever
+     * the underlying contract changes — so a WeakMap keyed on the
+     * schema is correct without an explicit invalidation hook, and the
+     * entry is GC'd when the descriptor goes away.
+     */
+    private readonly validatorCache: WeakMap<JSONSchema7, ValidateFunction>;
+
     constructor(
         private readonly widgets: IWidgetsService,
         private readonly logger: ISystemLogService
-    ) {}
+    ) {
+        this.ajv = new Ajv({ allErrors: true, strict: false });
+        addFormats(this.ajv);
+        this.validatorCache = new WeakMap();
+    }
+
+    /**
+     * Validate `instanceConfig` against the widget type's declared
+     * JSON Schema, when one is declared. Returns the structured
+     * per-field errors on failure, or `null` when validation passes
+     * (or no schema was declared — in which case the caller has
+     * already enforced the shape-only "plain object" guard via
+     * `parseInstanceConfig`). Compiled validators are cached on the
+     * schema reference so the per-write cost is a single AJV invoke.
+     *
+     * @param typeId - Widget-type id whose schema gates this body.
+     * @param instanceConfig - The operator-supplied config object.
+     * @returns Array of per-field errors, or `null` when valid.
+     */
+    private validateInstanceConfigAgainstSchema(
+        typeId: string,
+        instanceConfig: Record<string, unknown>
+    ): ReadonlyArray<IInstanceConfigFieldError> | null {
+        const schema = this.widgets.getTypeConfigSchema(typeId);
+        if (!schema) return null;
+
+        let validator = this.validatorCache.get(schema);
+        if (!validator) {
+            validator = this.ajv.compile(schema);
+            this.validatorCache.set(schema, validator);
+        }
+
+        if (validator(instanceConfig)) return null;
+
+        const errors = validator.errors ?? [];
+        return errors.map(err => ({
+            path: err.instancePath,
+            message: err.message ?? 'invalid value'
+        }));
+    }
 
     /**
      * GET /api/admin/system/widgets/placements
@@ -141,6 +214,21 @@ export class PlacementsController {
                 return;
             }
 
+            if (parsed.input.instanceConfig !== undefined) {
+                const fieldErrors = this.validateInstanceConfigAgainstSchema(
+                    parsed.input.typeId,
+                    parsed.input.instanceConfig
+                );
+                if (fieldErrors) {
+                    res.status(400).json({
+                        success: false,
+                        error: 'instanceConfig failed widget-type schema validation',
+                        errors: fieldErrors
+                    });
+                    return;
+                }
+            }
+
             const placement = await this.widgets.createPlacement(parsed.input);
             res.status(201).json({ success: true, placement });
         } catch (err) {
@@ -162,6 +250,32 @@ export class PlacementsController {
             if ('error' in parsed) {
                 res.status(400).json({ success: false, error: parsed.error });
                 return;
+            }
+
+            if (parsed.patch.instanceConfig !== undefined) {
+                // PATCH bodies don't carry typeId — the schema gate is
+                // determined by the existing row's typeId, so we have
+                // to read first. 404 here matches the post-update 404
+                // below; an operator patching a vanished placement
+                // gets a consistent error regardless of which body
+                // field was set.
+                const existing = await this.widgets.findPlacementById(req.params.id);
+                if (!existing) {
+                    res.status(404).json({ success: false, error: 'Placement not found' });
+                    return;
+                }
+                const fieldErrors = this.validateInstanceConfigAgainstSchema(
+                    existing.typeId,
+                    parsed.patch.instanceConfig
+                );
+                if (fieldErrors) {
+                    res.status(400).json({
+                        success: false,
+                        error: 'instanceConfig failed widget-type schema validation',
+                        errors: fieldErrors
+                    });
+                    return;
+                }
             }
 
             const placement = await this.widgets.updatePlacement(req.params.id, parsed.patch);

--- a/src/backend/modules/widgets/placements/placement-resolver.ts
+++ b/src/backend/modules/widgets/placements/placement-resolver.ts
@@ -116,8 +116,15 @@ export class PlacementResolver {
             const timeoutPromise = new Promise<never>((_, reject) => {
                 timerId = setTimeout(() => reject(new Error('Widget fetch timeout')), TIMEOUT_MS);
             });
+            // Substitute an empty object when the placement carries no
+            // overrides so fetchers can read keys unconditionally
+            // without null-guards on every access.
+            const placementContext = {
+                id: placement.id,
+                instanceConfig: placement.instanceConfig ?? {}
+            };
             const raw = await Promise.race([
-                type.defaultDataFetcher(route, params),
+                type.defaultDataFetcher(route, params, placementContext),
                 timeoutPromise
             ]);
             clearTimeout(timerId);

--- a/src/backend/modules/widgets/widgets.service.ts
+++ b/src/backend/modules/widgets/widgets.service.ts
@@ -26,6 +26,7 @@
  * @module backend/modules/widgets/widgets.service
  */
 
+import type { JSONSchema7 } from 'json-schema';
 import type {
     ISystemLogService,
     IWidgetsService,
@@ -165,6 +166,10 @@ export class WidgetsService implements IWidgetsService {
 
     hasType(typeId: string): boolean {
         return this.widgetTypes.has(typeId);
+    }
+
+    getTypeConfigSchema(typeId: string): JSONSchema7 | undefined {
+        return this.widgetTypes.get(typeId)?.configSchema;
     }
 
     async fetchWidgetsForRoute(

--- a/src/frontend/app/(core)/system/widgets/page.module.scss
+++ b/src/frontend/app/(core)/system/widgets/page.module.scss
@@ -271,6 +271,25 @@
     box-shadow: var(--input-shadow-focus);
 }
 
+.textarea {
+    background: var(--input-background);
+    border: var(--input-border);
+    border-radius: var(--input-border-radius);
+    padding: var(--input-padding);
+    color: var(--color-text);
+    font-size: var(--font-size-body-sm);
+    font-family: var(--font-mono);
+    line-height: var(--line-height-normal);
+    resize: vertical;
+    transition: var(--input-transition);
+}
+
+.textarea:focus-visible {
+    outline: none;
+    border-color: var(--input-border-focus);
+    box-shadow: var(--input-shadow-focus);
+}
+
 .routes_chips {
     display: flex;
     flex-wrap: wrap;

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -79,6 +79,7 @@ interface IPlacement {
     routes: string[];
     order: number;
     title?: string;
+    instanceConfig?: Record<string, unknown>;
     enabled: boolean;
     source: 'plugin' | 'operator';
     pluginId?: string;
@@ -95,6 +96,7 @@ interface IPlacementPatch {
     routes?: string[];
     order?: number;
     title?: string | null | undefined;
+    instanceConfig?: Record<string, unknown>;
     enabled?: boolean;
 }
 
@@ -108,6 +110,7 @@ interface IPlacementCreate {
     routes: string[];
     order?: number;
     title?: string;
+    instanceConfig?: Record<string, unknown>;
     enabled?: boolean;
 }
 
@@ -125,6 +128,27 @@ function authHeader(token: string | null): HeadersInit {
  */
 function sourceTone(source: IPlacement['source']): 'info' | 'success' {
     return source === 'plugin' ? 'info' : 'success';
+}
+
+/**
+ * Flatten the structured 400 body the placement API returns into a
+ * single human-readable message for the toast. Server-side schema
+ * validation surfaces a top-level `error` plus an `errors: [{path,
+ * message}]` array; we render `path: message` lines beneath the
+ * summary so an operator typing JSON sees which field failed without
+ * having to inspect the network tab.
+ */
+function formatApiError(
+    body: { error?: string; errors?: ReadonlyArray<{ path?: string; message?: string }> },
+    status: number,
+    verb: string
+): string {
+    const summary = body.error || `${verb} failed (${status})`;
+    if (!Array.isArray(body.errors) || body.errors.length === 0) return summary;
+    const fields = body.errors
+        .map(e => `${e.path?.length ? e.path : '/'}: ${e.message ?? 'invalid'}`)
+        .join('; ');
+    return `${summary} — ${fields}`;
 }
 
 /**
@@ -255,7 +279,7 @@ export default function WidgetsAdminPage() {
             });
             if (!res.ok) {
                 const body = await res.json().catch(() => ({}));
-                throw new Error(body.error || `Update failed (${res.status})`);
+                throw new Error(formatApiError(body, res.status, 'Update'));
             }
         },
         [headers]
@@ -294,7 +318,7 @@ export default function WidgetsAdminPage() {
             });
             if (!res.ok) {
                 const body = await res.json().catch(() => ({}));
-                throw new Error(body.error || `Create failed (${res.status})`);
+                throw new Error(formatApiError(body, res.status, 'Create'));
             }
         },
         [headers]
@@ -836,6 +860,16 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
     const [enabled, setEnabled] = useState<boolean>(initial?.enabled ?? true);
     const [saving, setSaving] = useState<boolean>(false);
     const [routeError, setRouteError] = useState<string | null>(null);
+    // Per-placement instanceConfig surface. Pre-populate edit-mode rows
+    // with the existing config (pretty-printed); leave create-mode blank
+    // so an operator who doesn't need overrides just submits empty —
+    // the parser treats blank as "no instanceConfig in payload".
+    const [instanceConfigText, setInstanceConfigText] = useState<string>(
+        initial?.instanceConfig
+            ? JSON.stringify(initial.instanceConfig, null, 2)
+            : ''
+    );
+    const [instanceConfigError, setInstanceConfigError] = useState<string | null>(null);
 
     const handleAddRoute = useCallback(() => {
         const trimmed = routeDraft.trim();
@@ -874,6 +908,33 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
     const handleSubmit = useCallback(
         async (e: FormEvent) => {
             e.preventDefault();
+
+            // Parse instanceConfig out of the textarea. Empty input
+            // collapses to `undefined` so the payload omits the field
+            // entirely (no change on patch, no overrides on create);
+            // any other input must parse to a plain JSON object. Array
+            // and primitive parses are rejected client-side rather
+            // than relying on the server's shape-only guard so the
+            // operator sees the failure inline.
+            const rawConfig = instanceConfigText.trim();
+            let parsedInstanceConfig: Record<string, unknown> | undefined;
+            if (rawConfig.length > 0) {
+                try {
+                    const candidate = JSON.parse(rawConfig);
+                    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+                        setInstanceConfigError('Instance config must be a JSON object');
+                        return;
+                    }
+                    parsedInstanceConfig = candidate as Record<string, unknown>;
+                } catch (err) {
+                    setInstanceConfigError(
+                        err instanceof Error ? `Invalid JSON: ${err.message}` : 'Invalid JSON'
+                    );
+                    return;
+                }
+            }
+            setInstanceConfigError(null);
+
             setSaving(true);
             try {
                 if (mode === 'create') {
@@ -883,6 +944,7 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
                         routes,
                         order,
                         title: title.trim().length > 0 ? title.trim() : undefined,
+                        instanceConfig: parsedInstanceConfig,
                         enabled
                     };
                     await onSubmit(payload);
@@ -906,6 +968,7 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
                         routes,
                         order,
                         title: titlePatch,
+                        instanceConfig: parsedInstanceConfig,
                         enabled
                     };
                     await onSubmit(payload);
@@ -914,7 +977,7 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
                 setSaving(false);
             }
         },
-        [enabled, mode, onSubmit, order, routes, title, typeId, zoneId]
+        [enabled, initial?.title, instanceConfigText, mode, onSubmit, order, routes, title, typeId, zoneId]
     );
 
     const canSubmit = typeId.length > 0 && zoneId.length > 0;
@@ -1039,6 +1102,26 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
                         disabled={saving}
                     />
                 </div>
+            </div>
+
+            <div className={styles.field}>
+                <label htmlFor="wp-instance-config">Instance config</label>
+                <textarea
+                    id="wp-instance-config"
+                    className={styles.textarea}
+                    rows={6}
+                    value={instanceConfigText}
+                    onChange={(e) => { setInstanceConfigText(e.target.value); setInstanceConfigError(null); }}
+                    placeholder='{"maxPosts": 5}'
+                    disabled={saving}
+                    spellCheck={false}
+                    aria-describedby="wp-instance-config-hint"
+                />
+                {instanceConfigError && <span className={styles.field_error}>{instanceConfigError}</span>}
+                <span id="wp-instance-config-hint" className={styles.field_hint}>
+                    Optional per-placement JSON object validated against the widget type&apos;s schema
+                    on save. Leave empty for no overrides.
+                </span>
             </div>
 
             <label className={styles.inline_toggle}>

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -909,13 +909,19 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
         async (e: FormEvent) => {
             e.preventDefault();
 
-            // Parse instanceConfig out of the textarea. Empty input
-            // collapses to `undefined` so the payload omits the field
-            // entirely (no change on patch, no overrides on create);
-            // any other input must parse to a plain JSON object. Array
-            // and primitive parses are rejected client-side rather
-            // than relying on the server's shape-only guard so the
-            // operator sees the failure inline.
+            // Parse instanceConfig out of the textarea. Any non-empty
+            // input must parse to a plain JSON object — array and
+            // primitive parses are rejected client-side rather than
+            // relying on the server's shape-only guard so the operator
+            // sees the failure inline.
+            //
+            // Empty textarea has different semantics by mode:
+            //   - create → omit (no overrides; defaults apply)
+            //   - edit   → send `{}` to explicitly clear overrides on
+            //              the existing row. Omitting the field on
+            //              patch would leave the prior value intact,
+            //              contradicting the "Leave empty for no
+            //              overrides" hint shown beneath the field.
             const rawConfig = instanceConfigText.trim();
             let parsedInstanceConfig: Record<string, unknown> | undefined;
             if (rawConfig.length > 0) {
@@ -932,6 +938,8 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
                     );
                     return;
                 }
+            } else if (mode === 'edit') {
+                parsedInstanceConfig = {};
             }
             setInstanceConfigError(null);
 


### PR DESCRIPTION
Closes #261.

## Summary

Wires the operator-editable `instanceConfig` field on widget placements all the way through to the data fetcher, tightens `configSchema` to JSON Schema Draft 7 with AJV validation at the admin write path, and adds a JSON textarea editor to `/system/widgets` so operators can set per-placement config without hand-editing the database.

## Phase 1 — Runtime plumbing

- `WidgetDataFetcher` gains an optional third arg `placement?: IWidgetPlacementContext` (`{ id, instanceConfig }`). Optional so every existing fetcher still type-checks unchanged.
- `PlacementResolver.fetchOne` forwards `{ id: placement.id, instanceConfig: placement.instanceConfig ?? {} }` to each fetcher — substituting `{}` when the placement carries no overrides so fetchers can read keys unconditionally.
- `@delphian/tronrelic-types` bumped to `2.1.0` and exports `IWidgetPlacementContext`.

## Phase 2 — Schema declaration and validation

- `IWidgetType.configSchema` and `IRegisterWidgetTypeInput.configSchema` tightened from `unknown` to `JSONSchema7`.
- New `IWidgetsService.getTypeConfigSchema(typeId)` lookup so the placement controller stays funneled through the unified service (the widgets-module rule that controllers never reach into registries directly).
- `PlacementsController` compiles AJV validators on demand (cache keyed on the schema reference via WeakMap), rejects schema-invalid `instanceConfig` on both create and patch with a structured 400: `{ error, errors: [{ path, message }] }`.
- Widget types that declare no schema retain the existing shape-only "plain object" guard.

## Phase 3 — Admin editor

- `PlacementForm` in `/system/widgets` gets a monospace JSON textarea pre-populated from `initial?.instanceConfig`.
- Client parses on submit; rejects non-JSON or non-object input inline.
- New `formatApiError` helper flattens the structured 400 body into the toast message so per-field validation errors surface inline.

## Tests

- 2 new resolver tests confirm the context shape and the empty-object fallback.
- 5 new controller tests cover schema-invalid 400, no-schema pass-through, valid-config pass-through, patch-side rejection by `existing.typeId`, and 404 on patch against a vanished row.
- Full widgets suite: 84 passing.

## Docs

- `docs/plugins/plugins-widget-zones-registration.md` documents the new fetcher arg and the schema-validation contract.
- `src/backend/modules/widgets/README.md` updates the SSR resolution section and adds an "Instance-Config Schema Validation" section.