### PR TITLE
feat(auth): Phase 1 — stand up Better Auth alongside legacy user system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,35 @@ GITHUB_USERNAME=
 
 # Note: PR testing environments are automatically provisioned via GitHub Actions
 # No manual configuration needed for PR environments
+
+# ==============================================
+# Authentication (Better Auth)
+# ==============================================
+# Required in production - HMAC secret for signing Better Auth session tokens
+# Generate with: openssl rand -hex 32
+BETTER_AUTH_SECRET=
+
+# Optional - canonical base URL for OAuth redirect URIs and magic-link URLs
+# Defaults to SITE_URL when unset
+BETTER_AUTH_URL=
+
+# Optional - comma-separated emails auto-promoted to the `admin` group on signup
+# Empty means no auto-promotion; first admin bootstrapped via service-token path
+ADMIN_EMAILS=
+
+# ==============================================
+# Email Delivery (Resend)
+# ==============================================
+# Used for Better Auth magic-link emails
+# Get an API key at https://resend.com
+RESEND_API_KEY=
+RESEND_FROM_ADDRESS=
+
+# ==============================================
+# OAuth Providers (Better Auth)
+# ==============================================
+# Both ID and SECRET must be set for a provider to load; otherwise omitted
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @delphian:registry=https://npm.pkg.github.com
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "src/plugins/*/packages/*"
       ],
       "dependencies": {
+        "@better-auth/passkey": "1.6.11",
         "@clickhouse/client": "^1.8.1",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -24,6 +25,7 @@
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "axios": "^1.7.5",
+        "better-auth": "1.6.11",
         "bullmq": "^5.8.2",
         "compression": "^1.7.4",
         "cookie-parser": "^1.4.7",
@@ -65,6 +67,7 @@
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
         "remark-html": "^16.0.1",
+        "resend": "6.12.4",
         "socket.io": "^4.7.5",
         "socket.io-client": "^4.7.5",
         "tronweb": "^5.3.1",
@@ -189,13 +192,186 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@bufbuild/protobuf": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.10.2.tgz",
-      "integrity": "sha512-uFsRXwIGyu+r6AMdz+XijIIZJYpoWeYzILt5yZ2d3mCjQrWUTVpVD9WL/jZAbvp+Ed04rOhrsk7FiTcEDseB5A==",
-      "dev": true,
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+    "node_modules/@better-auth/core": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.11.tgz",
+      "integrity": "sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@standard-schema/spec": "^1.1.0",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21",
+        "@cloudflare/workers-types": ">=4",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.5",
+        "jose": "^6.1.0",
+        "kysely": "^0.28.5",
+        "nanostores": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/core/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@better-auth/drizzle-adapter": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.11.tgz",
+      "integrity": "sha512-4jpkETIGZOHCf7BK4jnu22fdN6jjomH0/HhEzkaWy3+Eppi5PYlHTF/460jrTmA3Xc+Vqwp9t282ymHiEPypGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "drizzle-orm": "^0.45.2"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/kysely-adapter": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.11.tgz",
+      "integrity": "sha512-/g8M9RfIjdcZDnbstSUvQiINkvdNlCeZr248zwqx2/PVksQI1MhQofbzUn3RnQnbPKp0EPwpX/dR3oudRFenUg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "kysely": "^0.28.17"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/memory-adapter": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.11.tgz",
+      "integrity": "sha512-hpdfw0BBf8MuzLkIdmbcUZICbY9r/bhLO2RxSnkzT5+/O+0I0u2I8+m0YUP7vNllP/ZCKASHOYgXPLO75Z0f9Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0"
+      }
+    },
+    "node_modules/@better-auth/mongo-adapter": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.11.tgz",
+      "integrity": "sha512-3Tor8rSv8vSEIMEaV2PFpPEuVhqc1gNoZ6eGvoh3LwExXXuj8madew6ob+H1pH7Aphn3Ar5PQ08AguT8TbwFAA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/passkey": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/passkey/-/passkey-1.6.11.tgz",
+      "integrity": "sha512-QjL+OyiKRSHFRhSp2CSe7u5jnRL5G+Eh4bW9eV4WFZQ+2a/S+113kHQxPqxhy3Onb5cQhkT5Bhyz7cxKNDJTPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simplewebauthn/browser": "^13.2.2",
+        "@simplewebauthn/server": "^13.2.3",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21",
+        "better-auth": "^1.6.11",
+        "better-call": "1.3.5",
+        "nanostores": "^1.0.1"
+      }
+    },
+    "node_modules/@better-auth/passkey/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@better-auth/prisma-adapter": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.11.tgz",
+      "integrity": "sha512-Pw+7q7zTp+VSci1V+CYMvuxIbAeVMZLe4lRo46LJoAKMHfjFl5T/ycsyFvWs/DkWC7n9gZZzRDEbHp0I5FiKKw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/telemetry": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.11.tgz",
+      "integrity": "sha512-hsjDHc8MZbm6/AHeNdtywrWedXevnBjmdvnHTcZub+rTVjOv+Td0roI8USKuC6uUibmrl//2rJfVCsGbopihNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21"
+      }
+    },
+    "node_modules/@better-auth/utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
+    },
+    "node_modules/@better-auth/utils/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@better-fetch/fetch": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
     },
     "node_modules/@clickhouse/client": {
       "version": "1.14.0",
@@ -1308,6 +1484,12 @@
         "@ethersproject/strings": "^5.8.0"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "dev": true,
@@ -1451,6 +1633,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
       "license": "MIT"
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -1615,6 +1803,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.4.2",
       "license": "MIT",
@@ -1694,6 +1894,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -2020,6 +2229,174 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.7.0.tgz",
+      "integrity": "sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "license": "MIT"
@@ -2035,7 +2412,7 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.56.1",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.56.1"
@@ -2163,12 +2540,45 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.0.tgz",
+      "integrity": "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "license": "MIT"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -2389,7 +2799,7 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -2402,7 +2812,7 @@
     },
     "node_modules/@types/react": {
       "version": "18.3.26",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3203,6 +3613,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "dev": true,
@@ -3336,6 +3760,152 @@
       "version": "5.1.2",
       "license": "MIT"
     },
+    "node_modules/better-auth": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.11.tgz",
+      "integrity": "sha512-Wwt6+q07dwIhsp6XiM7L1qSXVUWBEtNl+eZvwM778CguFqDZFBN9Pt6LtFaHl55t8Z+Zc//5kxcbgDY8/79vFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/core": "1.6.11",
+        "@better-auth/drizzle-adapter": "1.6.11",
+        "@better-auth/kysely-adapter": "1.6.11",
+        "@better-auth/memory-adapter": "1.6.11",
+        "@better-auth/mongo-adapter": "1.6.11",
+        "@better-auth/prisma-adapter": "1.6.11",
+        "@better-auth/telemetry": "1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
+        "better-call": "1.3.5",
+        "defu": "^6.1.4",
+        "jose": "^6.1.3",
+        "kysely": "^0.28.17",
+        "nanostores": "^1.1.1",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@lynx-js/react": "*",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "@sveltejs/kit": "^2.0.0",
+        "@tanstack/react-start": "^1.0.0",
+        "@tanstack/solid-start": "^1.0.0",
+        "better-sqlite3": "^12.0.0",
+        "drizzle-kit": ">=0.31.4",
+        "drizzle-orm": "^0.45.2",
+        "mongodb": "^6.0.0 || ^7.0.0",
+        "mysql2": "^3.0.0",
+        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "pg": "^8.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "solid-js": "^1.0.0",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@lynx-js/react": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "@tanstack/react-start": {
+          "optional": true
+        },
+        "@tanstack/solid-start": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "drizzle-kit": {
+          "optional": true
+        },
+        "drizzle-orm": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/better-auth/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/better-call": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
+      "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/utils": "^0.4.0",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "license": "MIT",
@@ -3402,14 +3972,6 @@
       "engines": {
         "node": ">=16.20.1"
       }
-    },
-    "node_modules/buffer-builder": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
-      "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
-      "dev": true,
-      "license": "MIT/X11",
-      "peer": true
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
@@ -3596,7 +4158,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -3714,14 +4276,6 @@
     "node_modules/colorette": {
       "version": "2.0.20",
       "license": "MIT"
-    },
-    "node_modules/colorjs.io": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
-      "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3925,7 +4479,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4068,6 +4622,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -5259,6 +5819,12 @@
       "version": "2.1.1",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -5524,144 +6090,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/gcp-metadata/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/gcp-metadata/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/gcp-metadata/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/generator-function": {
@@ -6288,7 +6716,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -6706,20 +7134,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "dev": true,
@@ -6854,6 +7268,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "license": "MIT",
@@ -6980,6 +7403,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kysely": {
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
+      "integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -8159,6 +8591,21 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nanostores": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.3.0.tgz",
+      "integrity": "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "dev": true,
@@ -8746,6 +9193,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -8862,6 +9315,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/qrcode.react": {
@@ -8998,7 +9469,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -9042,6 +9513,12 @@
       "peerDependencies": {
         "redux": "^5.0.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -9230,6 +9707,27 @@
       "version": "5.1.1",
       "license": "MIT"
     },
+    "node_modules/resend": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
+      "integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "dev": true,
@@ -9327,6 +9825,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.52.5",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rou3": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
+      "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -9449,7 +9953,7 @@
       "version": "1.97.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.1.tgz",
       "integrity": "sha512-uf6HoO8fy6ClsrShvMgaKUn14f2EHQLQRtpsZZLeU/Mv0Q1K5P0+x2uvH6Cub39TVVbWNSrraUhDAoFph6vh0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -9464,391 +9968,6 @@
       },
       "optionalDependencies": {
         "@parcel/watcher": "^2.4.1"
-      }
-    },
-    "node_modules/sass-embedded": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.97.1.tgz",
-      "integrity": "sha512-wH3CbOThHYGX0bUyqFf7laLKyhVWIFc2lHynitkqMIUCtX2ixH9mQh0bN7+hkUu5BFt/SXvEMjFbkEbBMpQiSQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@bufbuild/protobuf": "^2.5.0",
-        "buffer-builder": "^0.2.0",
-        "colorjs.io": "^0.5.0",
-        "immutable": "^5.0.2",
-        "rxjs": "^7.4.0",
-        "supports-color": "^8.1.1",
-        "sync-child-process": "^1.0.2",
-        "varint": "^6.0.0"
-      },
-      "bin": {
-        "sass": "dist/bin/sass.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "optionalDependencies": {
-        "sass-embedded-all-unknown": "1.97.1",
-        "sass-embedded-android-arm": "1.97.1",
-        "sass-embedded-android-arm64": "1.97.1",
-        "sass-embedded-android-riscv64": "1.97.1",
-        "sass-embedded-android-x64": "1.97.1",
-        "sass-embedded-darwin-arm64": "1.97.1",
-        "sass-embedded-darwin-x64": "1.97.1",
-        "sass-embedded-linux-arm": "1.97.1",
-        "sass-embedded-linux-arm64": "1.97.1",
-        "sass-embedded-linux-musl-arm": "1.97.1",
-        "sass-embedded-linux-musl-arm64": "1.97.1",
-        "sass-embedded-linux-musl-riscv64": "1.97.1",
-        "sass-embedded-linux-musl-x64": "1.97.1",
-        "sass-embedded-linux-riscv64": "1.97.1",
-        "sass-embedded-linux-x64": "1.97.1",
-        "sass-embedded-unknown-all": "1.97.1",
-        "sass-embedded-win32-arm64": "1.97.1",
-        "sass-embedded-win32-x64": "1.97.1"
-      }
-    },
-    "node_modules/sass-embedded-all-unknown": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.97.1.tgz",
-      "integrity": "sha512-0au5gUNibfob7W/g+ycBx74O22CL8vwHiZdEDY6J0uzMkHPiSJk//h0iRf5AUnMArFHJjFd3urIiQIaoRKYa1Q==",
-      "cpu": [
-        "!arm",
-        "!arm64",
-        "!riscv64",
-        "!x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "sass": "1.97.1"
-      }
-    },
-    "node_modules/sass-embedded-android-arm": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.97.1.tgz",
-      "integrity": "sha512-B5dlv4utJ+yC8ZpBeWTHwSZPVKRlqA8pcaD0FAzeNm/DelIFgQUQtt0UwgYoAI6wDIiie5uSVpMK9l2DaCbiBQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-android-arm64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.97.1.tgz",
-      "integrity": "sha512-h62DmOiS2Jn87s8+8GhJcMerJnTKa1IsIa9iIKjLiqbAvBDKCGUs027RugZkM+Zx7I+vhPq86PUXBYZ9EkRxdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-android-riscv64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.97.1.tgz",
-      "integrity": "sha512-tGup88vgaXPnUHEgDMujrt5rfYadvkiVjRb/45FJTx2hQFoGVbmUXz5XqUFjIIbEjQ3kAJqp86A2jy11s43UiQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-android-x64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.97.1.tgz",
-      "integrity": "sha512-CAzKjjzu90LZduye2O9+UGX1oScMyF5/RVOa5CxACKALeIS+3XL3LVdV47kwKPoBv5B1aFUvGLscY0CR7jBAbg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.97.1.tgz",
-      "integrity": "sha512-tyDzspzh5PbqdAFGtVKUXuf0up6Lff3c1U8J7+4Y7jW6AWRBnq95vTzIIxfnNifGCTI2fW5e7GAZpYygKpNwcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.97.1.tgz",
-      "integrity": "sha512-FMrRuSPI2ICt2M2SYaLbiG4yxn86D6ae+XtrRdrrBMhWprAcB7Iyu67bgRzZkipMZNIKKeTR7EUvJHgZzi5ixQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-arm": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.97.1.tgz",
-      "integrity": "sha512-48VxaTUApLyx1NXFdZhKqI/7FYLmz8Ju3Ki2V/p+mhn5raHgAiYeFgn8O1WGxTOh+hBb9y3FdSR5a8MNTbmKMQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.97.1.tgz",
-      "integrity": "sha512-im80gfDWRivw9Su3r3YaZmJaCATcJgu3CsCSLodPk1b1R2+X/E12zEQayvrl05EGT9PDwTtuiqKgS4ND4xjwVg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.97.1.tgz",
-      "integrity": "sha512-FUFs466t3PVViVOKY/60JgLLtl61Pf7OW+g5BeEfuqVcSvYUECVHeiYHtX1fT78PEVa0h9tHpM6XpWti+7WYFA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.97.1.tgz",
-      "integrity": "sha512-kD35WSD9o0279Ptwid3Jnbovo1FYnuG2mayYk9z4ZI4mweXEK6vTu+tlvCE/MdF/zFKSj11qaxaH+uzXe2cO5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-musl-riscv64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.97.1.tgz",
-      "integrity": "sha512-ZgpYps5YHuhA2+KiLkPukRbS5298QObgUhPll/gm5i0LOZleKCwrFELpVPcbhsSBuxqji2uaag5OL+n3JRBVVg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.97.1.tgz",
-      "integrity": "sha512-wcAigOyyvZ6o1zVypWV7QLZqpOEVnlBqJr9MbpnRIm74qFTSbAEmShoh8yMXBymzuVSmEbThxAwW01/TLf62tA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-riscv64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.97.1.tgz",
-      "integrity": "sha512-9j1qE1ZrLMuGb+LUmBzw93Z4TNfqlRkkxjPVZy6u5vIggeSfvGbte7eRoYBNWX6SFew/yBCL90KXIirWFSGrlQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-x64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.97.1.tgz",
-      "integrity": "sha512-7nrLFYMH/UgvEgXR5JxQJ6y9N4IJmnFnYoDxN0nw0jUp+CQWQL4EJ4RqAKTGelneueRbccvt2sEyPK+X0KJ9Jg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-unknown-all": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.97.1.tgz",
-      "integrity": "sha512-oPSeKc7vS2dx3ZJHiUhHKcyqNq0GWzAiR8zMVpPd/kVMl5ZfVyw+5HTCxxWDBGkX02lNpou27JkeBPCaneYGAQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "!android",
-        "!darwin",
-        "!linux",
-        "!win32"
-      ],
-      "peer": true,
-      "dependencies": {
-        "sass": "1.97.1"
-      }
-    },
-    "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.97.1.tgz",
-      "integrity": "sha512-L5j7J6CbZgHGwcfVedMVpM3z5MYeighcyZE8GF2DVmjWzZI3JtPKNY11wNTD/P9o1Uql10YPOKhGH0iWIXOT7Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-win32-x64": {
-      "version": "1.97.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.97.1.tgz",
-      "integrity": "sha512-rfaZAKXU8cW3E7gvdafyD6YtgbEcsDeT99OEiHXRT0UGFuXT8qCOjpAwIKaOA3XXr2d8S42xx6cXcaZ1a+1fgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/scheduler": {
@@ -9938,6 +10057,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -10327,6 +10452,16 @@
       "version": "2.1.0",
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "license": "MIT",
@@ -10631,31 +10766,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/sync-child-process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
-      "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "sync-message-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/sync-message-port": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.1.3.tgz",
-      "integrity": "sha512-GTt8rSKje5FilG+wEdfCkOcLL7LWqpMlr2c3LRuKt/YXxcJ52aGSbGBAdI4L3aaqfrBt6y711El53ItyH1NWzg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/tdigest": {
@@ -11336,6 +11446,24 @@
         "@esbuild/win32-x64": "0.25.11"
       }
     },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -11631,14 +11759,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/varint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "setup": "./scripts/setup.sh"
   },
   "dependencies": {
+    "@better-auth/passkey": "1.6.11",
     "@clickhouse/client": "^1.8.1",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
@@ -63,6 +64,7 @@
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "axios": "^1.7.5",
+    "better-auth": "1.6.11",
     "bullmq": "^5.8.2",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.7",
@@ -104,6 +106,7 @@
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
     "remark-html": "^16.0.1",
+    "resend": "6.12.4",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5",
     "tronweb": "^5.3.1",

--- a/src/backend/config/env.ts
+++ b/src/backend/config/env.ts
@@ -29,6 +29,48 @@ const envSchema = z.object({
    * placeholder must not be used in any non-development deployment.
    */
   SESSION_SECRET: z.string().optional(),
+  /**
+   * Better Auth HMAC secret used to sign session tokens and the session cookie.
+   * Required in production for the same reason as SESSION_SECRET — the absence
+   * of a secret would let any caller mint a forged session token.
+   * Generate with `openssl rand -hex 32`.
+   */
+  BETTER_AUTH_SECRET: z.string().optional(),
+  /**
+   * Canonical base URL Better Auth uses to construct OAuth redirect URIs and
+   * email magic-link URLs. Optional — falls back to SITE_URL when unset.
+   */
+  BETTER_AUTH_URL: z.string().optional(),
+  /**
+   * Comma-separated list of email addresses auto-promoted to the `admin`
+   * group when they complete signup. Empty/unset means no auto-promotion;
+   * the operator bootstraps the first admin via the service-token path.
+   */
+  ADMIN_EMAILS: z.string().optional(),
+  /**
+   * Resend API key used to send magic-link emails. When unset, the magic-link
+   * plugin still mints links but the send callback logs them to console for
+   * development. Set in any environment where real users sign in.
+   */
+  RESEND_API_KEY: z.string().optional(),
+  /**
+   * Verified `From` address Resend uses for outbound mail. Must be on a
+   * domain whose DKIM/SPF records are configured in Resend.
+   */
+  RESEND_FROM_ADDRESS: z.string().optional(),
+  /**
+   * Google OAuth client ID and secret. Both must be set for the Google
+   * social provider to load; otherwise it is omitted from Better Auth's
+   * provider list.
+   */
+  GOOGLE_CLIENT_ID: z.string().optional(),
+  GOOGLE_CLIENT_SECRET: z.string().optional(),
+  /**
+   * GitHub OAuth client ID and secret. Both must be set for the GitHub
+   * social provider to load; otherwise it is omitted.
+   */
+  GITHUB_CLIENT_ID: z.string().optional(),
+  GITHUB_CLIENT_SECRET: z.string().optional(),
   ENABLE_TELEMETRY: z
     .union([
       z.boolean(),
@@ -87,6 +129,23 @@ if (!parsed.data.SESSION_SECRET) {
     '[env] SESSION_SECRET unset — using a fixed development placeholder. Identity cookies will be signed with a known secret. Set SESSION_SECRET before deploying anywhere non-local.'
   );
   parsed.data.SESSION_SECRET = DEV_SESSION_SECRET_FALLBACK;
+}
+
+// Mirror the SESSION_SECRET policy for BETTER_AUTH_SECRET. A missing secret
+// in dev/test is acceptable with a warning and a fixed placeholder so local
+// signup flows work without per-developer config; production must supply a
+// real secret or boot fails.
+const DEV_BETTER_AUTH_SECRET_FALLBACK = 'tronrelic-dev-better-auth-secret-do-not-use-in-prod';
+if (!parsed.data.BETTER_AUTH_SECRET) {
+  if (parsed.data.NODE_ENV === 'production' || parsed.data.ENV === 'production') {
+    throw new Error(
+      'BETTER_AUTH_SECRET is required in production. Generate one with `openssl rand -hex 32` and set it in your environment.'
+    );
+  }
+  console.warn(
+    '[env] BETTER_AUTH_SECRET unset — using a fixed development placeholder. Better Auth session tokens will be signed with a known secret. Set BETTER_AUTH_SECRET before deploying anywhere non-local.'
+  );
+  parsed.data.BETTER_AUTH_SECRET = DEV_BETTER_AUTH_SECRET_FALLBACK;
 }
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/src/backend/loaders/express.ts
+++ b/src/backend/loaders/express.ts
@@ -29,8 +29,14 @@ export function createExpressApp(): Express {
   // window in `userContextMiddleware` — but `requireAdmin` reads only from
   // `req.signedCookies` to close the cookie-forgery vector.
   app.use(cookieParser(env.SESSION_SECRET));
-  app.use(express.json({ limit: '5mb' }));
-  app.use(express.urlencoded({ extended: true }));
+  // Body parsers consume the raw request stream, but Better Auth's
+  // Node integration needs the original body to validate magic-link
+  // tokens, OAuth callbacks, and passkey assertions. Skip them on
+  // `/api/auth/*` so `toNodeHandler` (mounted by UserModule.run()) can
+  // read the body itself. Cookie-parser above is safe to leave global
+  // because it only reads headers.
+  app.use(skipForAuthRoutes(express.json({ limit: '5mb' })));
+  app.use(skipForAuthRoutes(express.urlencoded({ extended: true })));
   app.use(morgan(env.NODE_ENV === 'production' ? 'combined' : 'dev'));
 
   // Serve uploaded files from /public/uploads directory
@@ -65,4 +71,26 @@ export function createExpressApp(): Express {
 
   app.use(errorHandler);
   return app;
+}
+
+/**
+ * Wrap an Express middleware so it skips itself on `/api/auth/*` paths.
+ *
+ * Used to keep the global body parsers from consuming the request
+ * stream that Better Auth's Node handler needs to read. The wrapper
+ * preserves the original middleware's signature so it composes
+ * transparently with `app.use(...)`.
+ *
+ * @param middleware - Middleware to bypass on auth routes.
+ * @returns A new middleware that calls through on `/api/auth/*` and
+ *          delegates to the original elsewhere.
+ */
+function skipForAuthRoutes(middleware: express.RequestHandler): express.RequestHandler {
+  return function authBypass(req, res, next): void {
+    if (req.path.startsWith('/api/auth/') || req.path === '/api/auth') {
+      next();
+      return;
+    }
+    middleware(req, res, next);
+  };
 }

--- a/src/backend/modules/user/UserModule.ts
+++ b/src/backend/modules/user/UserModule.ts
@@ -23,6 +23,8 @@
  */
 
 import type { Express, Router } from 'express';
+import mongoose from 'mongoose';
+import { toNodeHandler } from 'better-auth/node';
 import type { ICacheService, IClickHouseService, IDatabaseService, IMenuService, IModule, IModuleMetadata, ISchedulerService, IServiceRegistry, ISystemConfigService } from '@/types';
 import { logger } from '../../lib/logger.js';
 import { MAIN_SYSTEM_CONTAINER_ID } from '../menu/index.js';
@@ -31,6 +33,8 @@ import { UserService } from './services/user.service.js';
 import { GscService } from './services/gsc.service.js';
 import { TrafficService } from './services/traffic.service.js';
 import { UserGroupService } from './services/user-group.service.js';
+import { GroupService } from './services/group.service.js';
+import { setAuthInstance } from './services/auth-facade.js';
 import { initGeoIP } from './services/geo.service.js';
 import { UserController } from './api/user.controller.js';
 import { UserGroupController } from './api/user-group.controller.js';
@@ -39,6 +43,7 @@ import { createUserRouter, createAdminUserRouter, createProfileRouter } from './
 import { createAdminUserGroupRouter } from './api/user-group.routes.js';
 import { createAdminTrafficRouter } from './api/traffic.routes.js';
 import { requireAdmin } from '../../api/middleware/admin-auth.js';
+import { createAuth, type Auth } from './auth.js';
 
 /**
  * User module dependencies for initialization.
@@ -175,6 +180,19 @@ export class UserModule implements IModule<IUserModuleDependencies> {
     private trafficController!: TrafficController;
 
     /**
+     * Better Auth instance and its group-membership companion service.
+     *
+     * Phase 1 wiring: the auth instance is configured against the
+     * `module_user_auth_*` collections and reads/writes the `groups`
+     * additional field through {@link GroupService}. The legacy
+     * UUID-based user system continues to run alongside it until the
+     * Phase 6 cutover migration. See `auth.ts` for the configuration
+     * surface and the file header for the Db-injection exception.
+     */
+    private auth!: Auth;
+    private groupService!: GroupService;
+
+    /**
      * Logger instance for this module.
      */
     private readonly logger = logger.child({ module: 'user' });
@@ -272,6 +290,30 @@ export class UserModule implements IModule<IUserModuleDependencies> {
         // Reads ClickHouse `traffic_events` aggregates and per-user history.
         this.trafficController = new TrafficController(this.trafficService, this.logger);
 
+        // Better Auth wiring (Phase 1 of the auth refactor).
+        //
+        // GroupService is configured first because the BA after-create
+        // hook needs to call addMember() during signup. The auth
+        // factory takes a raw MongoDB Db handle — see auth.ts for the
+        // documented exception to the IDatabaseService rule. The
+        // facade is configured last so it cannot be queried before
+        // the auth instance exists.
+        GroupService.setDependencies(this.database, this.logger);
+        this.groupService = GroupService.getInstance();
+        const authDb = mongoose.connection.db;
+        if (!authDb) {
+            throw new Error(
+                'mongoose.connection.db is undefined — UserModule.init() ran before connectDatabase() completed.'
+            );
+        }
+        this.auth = createAuth({
+            db: authDb,
+            groupService: this.groupService,
+            logger: this.logger
+        });
+        setAuthInstance(this.auth);
+        this.logger.info('Better Auth instance configured and facade wired');
+
         this.logger.info('User module initialized');
     }
 
@@ -320,6 +362,16 @@ export class UserModule implements IModule<IUserModuleDependencies> {
         // discover it via context.services.get<IUserGroupService>('user-groups').
         this.serviceRegistry.register('user-groups', this.userGroupService);
         this.logger.info('UserGroupService registered on service registry as "user-groups"');
+
+        // Mount Better Auth's HTTP handler at /api/auth/* (Phase 1).
+        //
+        // `toNodeHandler` adapts BA's fetch-style handler to the Express
+        // (req, res) signature. Mounting here, before the legacy user
+        // routes, keeps `/api/auth/*` cleanly isolated from the
+        // UUID-based identity surface that the cutover migration will
+        // remove in Phase 6.
+        this.app.all('/api/auth/*', toNodeHandler(this.auth));
+        this.logger.info('Better Auth handler mounted at /api/auth/*');
 
         // Create and mount public router (IoC - module attaches itself to app)
         const publicRouter = this.createPublicRouter();

--- a/src/backend/modules/user/__tests__/auth-facade.test.ts
+++ b/src/backend/modules/user/__tests__/auth-facade.test.ts
@@ -1,0 +1,176 @@
+/// <reference types="vitest" />
+
+/**
+ * @fileoverview Phase 1 sanity tests for the auth facade.
+ *
+ * Covers the configuration contract (must call setAuthInstance before
+ * any predicate) and the four predicate functions against a stubbed
+ * auth instance. The facade routes group checks through the live
+ * {@link GroupService} singleton, so tests configure both in
+ * lockstep — same wiring as `UserModule.init()`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Request } from 'express';
+import type { ISystemLogService } from '@/types';
+import {
+    isLoggedIn,
+    isAnonymous,
+    isInGroup,
+    isAdmin,
+    setAuthInstance,
+    resetAuthInstanceForTests
+} from '../services/auth-facade.js';
+import { GroupService, ADMIN_GROUP_ID } from '../services/group.service.js';
+import { AUTH_USERS_COLLECTION } from '../services/auth-constants.js';
+import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+
+class StubLogger implements ISystemLogService {
+    public level: string = 'info';
+    info(): void {}
+    warn(): void {}
+    error(): void {}
+    debug(): void {}
+    trace(): void {}
+    fatal(): void {}
+    child(): ISystemLogService { return this; }
+    async initialize(): Promise<void> {}
+    async saveLog(): Promise<void> {}
+    async getLogs(): Promise<any> {
+        return { logs: [], total: 0, page: 1, limit: 50, totalPages: 0, hasNextPage: false, hasPrevPage: false };
+    }
+    async markAsResolved(): Promise<void> {}
+    async cleanup(): Promise<number> { return 0; }
+    async getStatistics(): Promise<any> { return { total: 0, byLevel: {}, byService: {}, unresolved: 0 }; }
+    async getLogById(): Promise<any> { return null; }
+    async markAsUnresolved(): Promise<any> { return null; }
+    async deleteAllLogs(): Promise<number> { return 0; }
+    async getStats(): Promise<any> { return { total: 0, byLevel: {}, resolved: 0, unresolved: 0 }; }
+}
+
+/**
+ * Construct an Express-like request stub with headers populated.
+ *
+ * The facade only reads `req.headers` (via {@link fromNodeHeaders} from
+ * better-auth/node), so the rest of the Express request surface is
+ * unused and can be omitted from the stub.
+ */
+function makeRequest(headers: Record<string, string> = {}): Request {
+    return { headers } as unknown as Request;
+}
+
+/**
+ * Build a stubbed Better Auth instance that returns a fixed session
+ * (or null) regardless of the headers passed in.
+ *
+ * Sufficient for facade contract tests; full session validation lives
+ * in Better Auth's own test suite.
+ */
+function makeStubAuth(session: { user: { id: string; email: string } } | null) {
+    return {
+        api: {
+            getSession: vi.fn(async () => session)
+        }
+    } as any;
+}
+
+describe('auth facade', () => {
+    let mockDatabase: ReturnType<typeof createMockDatabaseService>;
+
+    beforeEach(() => {
+        mockDatabase = createMockDatabaseService();
+        GroupService.resetForTests();
+        GroupService.setDependencies(mockDatabase, new StubLogger());
+    });
+
+    afterEach(() => {
+        resetAuthInstanceForTests();
+        GroupService.resetForTests();
+    });
+
+    describe('configuration contract', () => {
+        it('throws when a predicate runs before setAuthInstance', async () => {
+            await expect(isLoggedIn(makeRequest())).rejects.toThrow(/not configured/i);
+        });
+
+        it('accepts a fresh auth instance via setAuthInstance', () => {
+            const auth = makeStubAuth(null);
+            expect(() => setAuthInstance(auth)).not.toThrow();
+        });
+    });
+
+    describe('isLoggedIn / isAnonymous', () => {
+        it('returns false / true respectively when no session resolves', async () => {
+            setAuthInstance(makeStubAuth(null));
+            const req = makeRequest();
+            expect(await isLoggedIn(req)).toBe(false);
+            expect(await isAnonymous(req)).toBe(true);
+        });
+
+        it('returns true / false respectively when a session resolves', async () => {
+            setAuthInstance(makeStubAuth({ user: { id: 'user_abc', email: 'a@b.com' } }));
+            const req = makeRequest();
+            expect(await isLoggedIn(req)).toBe(true);
+            expect(await isAnonymous(req)).toBe(false);
+        });
+
+        it('caches the resolved session on the request object', async () => {
+            const auth = makeStubAuth({ user: { id: 'user_abc', email: 'a@b.com' } });
+            setAuthInstance(auth);
+            const req = makeRequest();
+            await isLoggedIn(req);
+            await isAnonymous(req);
+            await isAdmin(req);
+            expect(auth.api.getSession).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('isInGroup / isAdmin', () => {
+        it('returns false for anonymous callers regardless of group', async () => {
+            setAuthInstance(makeStubAuth(null));
+            const req = makeRequest();
+            expect(await isInGroup(req, 'admin')).toBe(false);
+            expect(await isInGroup(req, 'vip')).toBe(false);
+            expect(await isAdmin(req)).toBe(false);
+        });
+
+        it('returns true for a logged-in user with the requested group', async () => {
+            setAuthInstance(makeStubAuth({ user: { id: 'user_abc', email: 'a@b.com' } }));
+            mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({
+                _id: 'user_abc',
+                email: 'a@b.com',
+                emailVerified: true,
+                groups: ['admin', 'vip']
+            });
+            const req = makeRequest();
+            expect(await isInGroup(req, 'admin')).toBe(true);
+            expect(await isInGroup(req, 'vip')).toBe(true);
+            expect(await isAdmin(req)).toBe(true);
+        });
+
+        it('routes isAdmin through the ADMIN_GROUP_ID constant', async () => {
+            setAuthInstance(makeStubAuth({ user: { id: 'user_abc', email: 'a@b.com' } }));
+            mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({
+                _id: 'user_abc',
+                email: 'a@b.com',
+                emailVerified: true,
+                groups: [ADMIN_GROUP_ID]
+            });
+            const req = makeRequest();
+            expect(await isAdmin(req)).toBe(true);
+        });
+
+        it('returns false for a logged-in user not in the group', async () => {
+            setAuthInstance(makeStubAuth({ user: { id: 'user_plain', email: 'p@b.com' } }));
+            mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({
+                _id: 'user_plain',
+                email: 'p@b.com',
+                emailVerified: true,
+                groups: ['vip']
+            });
+            const req = makeRequest();
+            expect(await isAdmin(req)).toBe(false);
+            expect(await isInGroup(req, 'admin')).toBe(false);
+        });
+    });
+});

--- a/src/backend/modules/user/__tests__/group.service.test.ts
+++ b/src/backend/modules/user/__tests__/group.service.test.ts
@@ -1,0 +1,185 @@
+/// <reference types="vitest" />
+
+/**
+ * @fileoverview Phase 1 sanity tests for {@link GroupService}.
+ *
+ * Covers the singleton contract and the read methods (which the
+ * in-memory mock supports). Mutation tests are deferred to integration
+ * coverage because the shared `createMockDatabaseService` mock does not
+ * implement `$addToSet` / `$pull` semantics; spying on the underlying
+ * collection handle here is sufficient to verify that the right MongoDB
+ * operator is issued.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { ISystemLogService } from '@/types';
+import { GroupService, ADMIN_GROUP_ID } from '../services/group.service.js';
+import { AUTH_USERS_COLLECTION } from '../services/auth-constants.js';
+import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+
+/**
+ * Minimal stub logger — GroupService only emits debug-level breadcrumbs.
+ */
+class StubLogger implements ISystemLogService {
+    public level: string = 'info';
+    info(): void {}
+    warn(): void {}
+    error(): void {}
+    debug(): void {}
+    trace(): void {}
+    fatal(): void {}
+    child(): ISystemLogService { return this; }
+    async initialize(): Promise<void> {}
+    async saveLog(): Promise<void> {}
+    async getLogs(): Promise<any> {
+        return { logs: [], total: 0, page: 1, limit: 50, totalPages: 0, hasNextPage: false, hasPrevPage: false };
+    }
+    async markAsResolved(): Promise<void> {}
+    async cleanup(): Promise<number> { return 0; }
+    async getStatistics(): Promise<any> { return { total: 0, byLevel: {}, byService: {}, unresolved: 0 }; }
+    async getLogById(): Promise<any> { return null; }
+    async markAsUnresolved(): Promise<any> { return null; }
+    async deleteAllLogs(): Promise<number> { return 0; }
+    async getStats(): Promise<any> { return { total: 0, byLevel: {}, resolved: 0, unresolved: 0 }; }
+}
+
+/**
+ * Seed a BA-shaped user row directly into the mock's users collection.
+ *
+ * Bypasses {@link GroupService.addMember} because the mock doesn't
+ * implement `$addToSet`; reads can still exercise the documents.
+ */
+function seedAuthUser(
+    db: ReturnType<typeof createMockDatabaseService>,
+    id: string,
+    groups: string[] = []
+): void {
+    db.getCollectionData(AUTH_USERS_COLLECTION).push({
+        _id: id,
+        email: `${id}@example.com`,
+        emailVerified: true,
+        groups
+    });
+}
+
+describe('GroupService', () => {
+    let mockDatabase: ReturnType<typeof createMockDatabaseService>;
+    let service: GroupService;
+
+    beforeEach(() => {
+        mockDatabase = createMockDatabaseService();
+        GroupService.resetForTests();
+        GroupService.setDependencies(mockDatabase, new StubLogger());
+        service = GroupService.getInstance();
+    });
+
+    afterEach(() => {
+        GroupService.resetForTests();
+    });
+
+    describe('singleton contract', () => {
+        it('throws when getInstance() runs before setDependencies()', () => {
+            GroupService.resetForTests();
+            expect(() => GroupService.getInstance()).toThrow(/setDependencies/i);
+        });
+
+        it('returns the same instance across calls', () => {
+            const a = GroupService.getInstance();
+            const b = GroupService.getInstance();
+            expect(a).toBe(b);
+        });
+
+        it('keeps the first dependencies on a second setDependencies() call', () => {
+            const firstInstance = GroupService.getInstance();
+            GroupService.setDependencies(createMockDatabaseService(), new StubLogger());
+            const secondInstance = GroupService.getInstance();
+            expect(secondInstance).toBe(firstInstance);
+        });
+    });
+
+    describe('getUserGroups', () => {
+        it('returns the stored groups array for a known user', async () => {
+            seedAuthUser(mockDatabase, 'user_abc', ['admin', 'vip']);
+            const groups = await service.getUserGroups('user_abc');
+            expect(groups).toEqual(expect.arrayContaining(['admin', 'vip']));
+        });
+
+        it('returns an empty array for an unknown user', async () => {
+            const groups = await service.getUserGroups('user_missing');
+            expect(groups).toEqual([]);
+        });
+
+        it('returns an empty array when the user has no groups field', async () => {
+            mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({
+                _id: 'user_no_groups',
+                email: 'x@example.com'
+            });
+            const groups = await service.getUserGroups('user_no_groups');
+            expect(groups).toEqual([]);
+        });
+    });
+
+    describe('isMember', () => {
+        it('returns true when the user is in the requested group', async () => {
+            seedAuthUser(mockDatabase, 'user_admin', ['admin', 'vip']);
+            const result = await service.isMember('user_admin', 'admin');
+            expect(result).toBe(true);
+        });
+
+        it('returns false when the user is not in the requested group', async () => {
+            seedAuthUser(mockDatabase, 'user_plain', ['vip']);
+            const result = await service.isMember('user_plain', 'admin');
+            expect(result).toBe(false);
+        });
+
+        it('returns false for a missing user', async () => {
+            const result = await service.isMember('user_missing', 'admin');
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('isAdmin', () => {
+        it('delegates to isMember with the reserved admin group id', async () => {
+            seedAuthUser(mockDatabase, 'user_admin', ['admin']);
+            const spy = vi.spyOn(service, 'isMember');
+            await service.isAdmin('user_admin');
+            expect(spy).toHaveBeenCalledWith('user_admin', ADMIN_GROUP_ID);
+        });
+    });
+
+    describe('addMember', () => {
+        it('issues an $addToSet update against the users collection', async () => {
+            const collection = mockDatabase.getCollection(AUTH_USERS_COLLECTION);
+            const spy = vi.spyOn(collection, 'updateOne');
+            await service.addMember('user_abc', 'admin');
+            expect(spy).toHaveBeenCalledWith(
+                { _id: 'user_abc' },
+                { $addToSet: { groups: 'admin' } }
+            );
+        });
+    });
+
+    describe('removeMember', () => {
+        it('issues a $pull update against the users collection', async () => {
+            const collection = mockDatabase.getCollection(AUTH_USERS_COLLECTION);
+            const spy = vi.spyOn(collection, 'updateOne');
+            await service.removeMember('user_abc', 'admin');
+            expect(spy).toHaveBeenCalledWith(
+                { _id: 'user_abc' },
+                { $pull: { groups: 'admin' } }
+            );
+        });
+    });
+
+    describe('setUserGroups', () => {
+        it('replaces the groups array with $set and deduplicates input', async () => {
+            const collection = mockDatabase.getCollection(AUTH_USERS_COLLECTION);
+            const spy = vi.spyOn(collection, 'updateOne');
+            await service.setUserGroups('user_abc', ['admin', 'vip', 'admin']);
+            expect(spy).toHaveBeenCalledWith(
+                { _id: 'user_abc' },
+                { $set: { groups: ['admin', 'vip'] } }
+            );
+        });
+    });
+});

--- a/src/backend/modules/user/auth.ts
+++ b/src/backend/modules/user/auth.ts
@@ -212,11 +212,22 @@ function buildSocialProviders(): {
  * @returns Ordered list of Better Auth plugins for the instance.
  */
 function buildPlugins(log: ISystemLogService): Array<ReturnType<typeof passkey | typeof magicLink>> {
-    const plugins: Array<ReturnType<typeof passkey | typeof magicLink>> = [passkey()];
+    const plugins: Array<ReturnType<typeof passkey | typeof magicLink>> = [
+        passkey({
+            // Remap the plugin's owned `passkey` table to the project's
+            // `module_user_auth_*` convention so it sits alongside the
+            // other BA-managed collections.
+            schema: { passkey: { modelName: AUTH_COLLECTIONS.passkeys } }
+        })
+    ];
     const isProduction = env.NODE_ENV === 'production' || env.ENV === 'production';
     const hasResend = Boolean(env.RESEND_API_KEY && env.RESEND_FROM_ADDRESS);
     if (hasResend || !isProduction) {
         plugins.push(magicLink({ sendMagicLink: buildMagicLinkSender(log) }));
+    } else {
+        log.warn(
+            'Magic-link plugin DISABLED in production: RESEND_API_KEY and/or RESEND_FROM_ADDRESS unset. Sign-in via magic-link is not available until these are configured.'
+        );
     }
     return plugins;
 }
@@ -242,12 +253,20 @@ function buildMagicLinkSender(
         const from = env.RESEND_FROM_ADDRESS;
         sender = async ({ email, url }): Promise<void> => {
             try {
-                await resend.emails.send({
+                // The Resend SDK does not throw on API-level failures
+                // (invalid key, unverified domain, quota exceeded). It
+                // resolves with `{ data, error }`, so failures are
+                // silent unless we explicitly inspect the `error` field
+                // and throw.
+                const { error: resendError } = await resend.emails.send({
                     from,
                     to: email,
                     subject: 'Sign in to TronRelic',
                     html: renderMagicLinkEmail(url)
                 });
+                if (resendError) {
+                    throw new Error(resendError.message || 'Unknown Resend error');
+                }
             } catch (error) {
                 log.error({ error, email }, 'Resend magic-link send failed');
                 throw error;

--- a/src/backend/modules/user/auth.ts
+++ b/src/backend/modules/user/auth.ts
@@ -1,0 +1,326 @@
+/**
+ * @fileoverview Better Auth instance factory for the user module.
+ *
+ * Constructs the single Better Auth instance the application exposes at
+ * `/api/auth/*`. The factory accepts injected dependencies (a native
+ * MongoDB `Db` handle and the {@link GroupService} used for ADMIN_EMAILS
+ * auto-promotion) so the instance can be built without reaching for
+ * module-level singletons, and so tests can supply mocks for both.
+ *
+ * **Collection naming.** Better Auth's model names are remapped to the
+ * `module_user_auth_*` convention so the BA-owned tables sit alongside the
+ * user module's other collections in the database. The legacy unprefixed
+ * `users` collection (UUID-based) is unrelated and decommissioned by the
+ * cutover migration in Phase 6.
+ *
+ * **Native Db boundary.** `mongodbAdapter` requires the native MongoDB
+ * driver's `Db` instance. This is the one documented exception to the
+ * "no direct Mongoose / native collection access outside of
+ * IDatabaseService" rule — Better Auth is a third-party adapter that
+ * cannot consume our database abstraction. The boundary stays at the
+ * module-init layer; nothing else in the codebase should reach for a
+ * raw Db handle.
+ */
+
+import { betterAuth } from 'better-auth';
+import { mongodbAdapter } from 'better-auth/adapters/mongodb';
+import { magicLink } from 'better-auth/plugins';
+import { passkey } from '@better-auth/passkey';
+import { Resend } from 'resend';
+import type { Db } from 'mongodb';
+import type { ISystemLogService } from '@/types';
+import { env } from '../../config/env.js';
+import type { GroupService } from './services/group.service.js';
+
+/**
+ * Group id used for the seeded administrators tag.
+ *
+ * Hardcoded here so the after-create hook and tests share one constant.
+ * Later phases that allow dynamic group definitions still reserve `admin`.
+ */
+const ADMIN_GROUP_ID = 'admin';
+
+export { AUTH_USERS_COLLECTION, AUTH_COLLECTIONS } from './services/auth-constants.js';
+import { AUTH_COLLECTIONS } from './services/auth-constants.js';
+
+/**
+ * Dependencies the auth factory needs at construction time.
+ *
+ * The `Db` handle is passed explicitly (rather than imported from
+ * mongoose) so tests can inject an in-memory or mocked database without
+ * monkey-patching the mongoose singleton. See the file header for the
+ * documented exception that justifies a raw `Db` at this boundary.
+ */
+export interface ICreateAuthDependencies {
+    /**
+     * Native MongoDB `Db` instance for the Better Auth adapter.
+     * In production, sourced from `mongoose.connection.db` after
+     * `connectDatabase()` resolves.
+     */
+    db: Db;
+
+    /**
+     * GroupService used by the after-create database hook to
+     * auto-promote allowlisted email addresses into the `admin` group.
+     */
+    groupService: GroupService;
+
+    /**
+     * Pino logger for hook-side diagnostics. The factory derives a
+     * `component: 'auth'` child so log lines are filterable from other
+     * user-module diagnostics.
+     */
+    logger: ISystemLogService;
+}
+
+/**
+ * Concrete Better Auth instance type for this codebase.
+ *
+ * Derived from `ReturnType<typeof createAuth>` so the factory remains
+ * the single source of truth — consumers import this for typing their
+ * stored references without hand-maintaining a parallel definition.
+ */
+export type Auth = ReturnType<typeof createAuth>;
+
+/**
+ * Build the Better Auth instance configured for TronRelic.
+ *
+ * Provider toggling is env-driven: each social provider loads only when
+ * both its client id and secret are present, and the magic-link plugin
+ * loads only when Resend credentials are configured (or in non-prod,
+ * where a console fallback is acceptable). The after-create database
+ * hook reads the new user's verified email against the parsed
+ * `ADMIN_EMAILS` allowlist and on match calls
+ * `groupService.addMember(user.id, 'admin')`; unverified emails are
+ * ignored so a forged signup cannot inherit privilege.
+ *
+ * @param deps - {@link ICreateAuthDependencies} for the instance.
+ * @returns Configured Better Auth instance ready to mount at /api/auth/*.
+ */
+export function createAuth(deps: ICreateAuthDependencies) {
+    const log = deps.logger.child({ component: 'auth' });
+    const adminEmails = parseAdminEmails();
+    const auth = betterAuth({
+        database: mongodbAdapter(deps.db),
+        secret: env.BETTER_AUTH_SECRET,
+        baseURL: env.BETTER_AUTH_URL || env.SITE_URL,
+        emailAndPassword: { enabled: false },
+        socialProviders: buildSocialProviders(),
+        plugins: buildPlugins(log),
+        user: {
+            modelName: AUTH_COLLECTIONS.users,
+            additionalFields: {
+                groups: {
+                    type: 'string[]',
+                    required: false,
+                    defaultValue: [],
+                    input: false
+                },
+                primaryWallet: {
+                    type: 'string',
+                    required: false,
+                    input: false
+                }
+            }
+        },
+        session: { modelName: AUTH_COLLECTIONS.sessions },
+        account: { modelName: AUTH_COLLECTIONS.accounts },
+        verification: { modelName: AUTH_COLLECTIONS.verifications },
+        databaseHooks: {
+            user: {
+                create: {
+                    after: async (user): Promise<void> => {
+                        await maybePromoteToAdmin({
+                            user,
+                            adminEmails,
+                            groupService: deps.groupService,
+                            log
+                        });
+                    }
+                }
+            }
+        }
+    });
+    return auth;
+}
+
+/**
+ * Parse the comma-separated ADMIN_EMAILS env into a normalized set.
+ *
+ * Trims whitespace and lowercases each entry so comparison against
+ * `user.email` (BA stores lowercased emails) is consistent regardless
+ * of operator typography. An unset or empty value resolves to an empty
+ * set — no auto-promotion happens.
+ *
+ * @returns Set of lowercase email addresses authorised for admin promotion.
+ */
+function parseAdminEmails(): Set<string> {
+    const raw = env.ADMIN_EMAILS;
+    const entries = raw
+        ? raw
+              .split(',')
+              .map((value) => value.trim().toLowerCase())
+              .filter((value) => value.length > 0)
+        : [];
+    return new Set(entries);
+}
+
+/**
+ * Build the socialProviders config object, omitting providers whose
+ * credentials are not configured.
+ *
+ * Better Auth treats an absent provider key as "do not load this
+ * provider," so unset env vars naturally hide the corresponding
+ * sign-in route. The frontend will inspect Better Auth's client
+ * introspection to decide which provider buttons to render.
+ *
+ * @returns Partial provider config — keys present only when both id and secret are set.
+ */
+function buildSocialProviders(): {
+    google?: { clientId: string; clientSecret: string };
+    github?: { clientId: string; clientSecret: string };
+} {
+    const providers: {
+        google?: { clientId: string; clientSecret: string };
+        github?: { clientId: string; clientSecret: string };
+    } = {};
+    if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
+        providers.google = {
+            clientId: env.GOOGLE_CLIENT_ID,
+            clientSecret: env.GOOGLE_CLIENT_SECRET
+        };
+    }
+    if (env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET) {
+        providers.github = {
+            clientId: env.GITHUB_CLIENT_ID,
+            clientSecret: env.GITHUB_CLIENT_SECRET
+        };
+    }
+    return providers;
+}
+
+/**
+ * Build the plugin list for the auth instance.
+ *
+ * Passkey is always loaded — it has no env-var dependency. Magic-link
+ * loads when Resend credentials are present (real send path) or when
+ * the process is not running in production (dev console fallback).
+ * Production without Resend credentials drops magic-link entirely so
+ * plaintext sign-in URLs cannot leak to operator logs.
+ *
+ * @param log - Logger passed into the magic-link sender for fallback diagnostics.
+ * @returns Ordered list of Better Auth plugins for the instance.
+ */
+function buildPlugins(log: ISystemLogService): Array<ReturnType<typeof passkey | typeof magicLink>> {
+    const plugins: Array<ReturnType<typeof passkey | typeof magicLink>> = [passkey()];
+    const isProduction = env.NODE_ENV === 'production' || env.ENV === 'production';
+    const hasResend = Boolean(env.RESEND_API_KEY && env.RESEND_FROM_ADDRESS);
+    if (hasResend || !isProduction) {
+        plugins.push(magicLink({ sendMagicLink: buildMagicLinkSender(log) }));
+    }
+    return plugins;
+}
+
+/**
+ * Build the `sendMagicLink` callback used by the magic-link plugin.
+ *
+ * Returns a Resend-backed sender when both RESEND_API_KEY and
+ * RESEND_FROM_ADDRESS are set; otherwise returns a dev fallback that
+ * logs the sign-in URL at warn level so contributors can copy-paste
+ * the link locally. The fallback is gated out of production by
+ * {@link buildPlugins} so it can never leak credentials in deployed logs.
+ *
+ * @param log - Logger used for both Resend failures and the dev fallback.
+ * @returns Async function the magic-link plugin calls with `({ email, url })`.
+ */
+function buildMagicLinkSender(
+    log: ISystemLogService
+): (data: { email: string; url: string }) => Promise<void> {
+    let sender: (data: { email: string; url: string }) => Promise<void>;
+    if (env.RESEND_API_KEY && env.RESEND_FROM_ADDRESS) {
+        const resend = new Resend(env.RESEND_API_KEY);
+        const from = env.RESEND_FROM_ADDRESS;
+        sender = async ({ email, url }): Promise<void> => {
+            try {
+                await resend.emails.send({
+                    from,
+                    to: email,
+                    subject: 'Sign in to TronRelic',
+                    html: renderMagicLinkEmail(url)
+                });
+            } catch (error) {
+                log.error({ error, email }, 'Resend magic-link send failed');
+                throw error;
+            }
+        };
+    } else {
+        sender = async ({ email, url }): Promise<void> => {
+            log.warn(
+                { email, url },
+                'Magic-link rendered to logs (RESEND_API_KEY/RESEND_FROM_ADDRESS unset, dev fallback only)'
+            );
+        };
+    }
+    return sender;
+}
+
+/**
+ * Render the HTML body for a magic-link email.
+ *
+ * Kept intentionally minimal to avoid Resend template-rendering
+ * surprises; the layout passes spam filters and clearly shows the call
+ * to action. The URL is interpolated raw because Better Auth
+ * guarantees it is a same-origin verified link.
+ *
+ * @param url - The signed magic-link URL produced by Better Auth.
+ * @returns HTML string suitable for the Resend `html` field.
+ */
+function renderMagicLinkEmail(url: string): string {
+    const body = [
+        '<p>Click the link below to sign in to TronRelic:</p>',
+        `<p><a href="${url}">${url}</a></p>`,
+        '<p>This link expires shortly. If you didn\'t request it, you can safely ignore this email.</p>'
+    ].join('');
+    return body;
+}
+
+/**
+ * Promote a newly-created user into the admin group when their verified
+ * email matches the ADMIN_EMAILS allowlist.
+ *
+ * Verification is non-negotiable — without it an attacker could sign up
+ * with `admin@example.com` they don't control and inherit privilege.
+ * Magic-link guarantees verification by construction; OAuth providers
+ * report verification status on the BA user record and we respect what
+ * they say. Hook errors are caught and logged so a transient group-write
+ * failure cannot block legitimate signup completion.
+ *
+ * @param params.user - New user object as supplied by the BA after-create hook.
+ * @param params.adminEmails - Parsed ADMIN_EMAILS allowlist.
+ * @param params.groupService - GroupService owning admin group membership writes.
+ * @param params.log - Logger scoped to the auth component.
+ */
+async function maybePromoteToAdmin(params: {
+    user: { id: string; email?: string | null; emailVerified?: boolean };
+    adminEmails: Set<string>;
+    groupService: GroupService;
+    log: ISystemLogService;
+}): Promise<void> {
+    const { user, adminEmails, groupService, log } = params;
+    try {
+        const email = user.email?.toLowerCase();
+        const eligible = Boolean(user.emailVerified) && Boolean(email) && adminEmails.has(email!);
+        if (eligible) {
+            await groupService.addMember(user.id, ADMIN_GROUP_ID);
+            log.info(
+                { userId: user.id, email, group: ADMIN_GROUP_ID },
+                'New signup auto-promoted to admin via ADMIN_EMAILS allowlist'
+            );
+        }
+    } catch (error) {
+        log.error(
+            { error, userId: user.id },
+            'admin auto-promotion hook failed; user created without admin group'
+        );
+    }
+}

--- a/src/backend/modules/user/services/auth-constants.ts
+++ b/src/backend/modules/user/services/auth-constants.ts
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Physical collection names for the Better Auth-managed
+ * tables.
+ *
+ * Extracted into a standalone module so consumers that only need the
+ * name strings — {@link GroupService}, future admin tooling, tests —
+ * can import them without pulling Better Auth's heavy dependency tree
+ * into their module graph. `auth.ts` re-exports these constants for
+ * back-compatibility with any external code that imported them from
+ * the auth module before the split.
+ *
+ * Renaming any value here is a breaking change for every persisted
+ * record. Coordinate with a migration if the application is past Phase 1.
+ */
+
+/**
+ * Physical collection name for Better Auth's user table.
+ *
+ * Mapped via `user.modelName` on the BA options so BA's adapter writes
+ * here instead of the default `user` collection. Group membership
+ * reads/writes route through this name from {@link GroupService}.
+ */
+export const AUTH_USERS_COLLECTION = 'module_user_auth_users';
+
+/**
+ * Physical collection names for Better Auth's remaining tables.
+ *
+ * Exported as a frozen const object so dynamic-introspection callers
+ * (admin UI, migrations, debug tooling) can enumerate them without
+ * hardcoding string literals across the codebase.
+ */
+export const AUTH_COLLECTIONS = {
+    users: AUTH_USERS_COLLECTION,
+    sessions: 'module_user_auth_sessions',
+    accounts: 'module_user_auth_accounts',
+    verifications: 'module_user_auth_verifications'
+} as const;

--- a/src/backend/modules/user/services/auth-constants.ts
+++ b/src/backend/modules/user/services/auth-constants.ts
@@ -33,5 +33,6 @@ export const AUTH_COLLECTIONS = {
     users: AUTH_USERS_COLLECTION,
     sessions: 'module_user_auth_sessions',
     accounts: 'module_user_auth_accounts',
-    verifications: 'module_user_auth_verifications'
+    verifications: 'module_user_auth_verifications',
+    passkeys: 'module_user_auth_passkeys'
 } as const;

--- a/src/backend/modules/user/services/auth-facade.ts
+++ b/src/backend/modules/user/services/auth-facade.ts
@@ -1,0 +1,193 @@
+/**
+ * @fileoverview Authorization facade — the only sanctioned surface for
+ * "is this caller logged in / a member / an admin" checks across the
+ * codebase.
+ *
+ * Plugins, modules, controllers, and middleware import the four free
+ * functions exported here and never reach for `req.user`, Better Auth's
+ * client API, or the GroupService directly. The single-surface rule
+ * means later phases can swap the underlying mechanism — caching, a new
+ * session backend, role/permission overlays — without touching every
+ * call site.
+ *
+ * **Phase 1 wiring.** The facade calls `auth.api.getSession({ headers })`
+ * on every check. A per-request cache (stored on the request object
+ * under a Symbol) elides repeat queries within a single request when
+ * multiple facade calls run. Phase 2 will introduce middleware that
+ * pre-populates the cache before route handlers execute; until then
+ * the first call within a request pays one Mongo round-trip.
+ */
+
+import type { Request } from 'express';
+import { fromNodeHeaders } from 'better-auth/node';
+import { GroupService, ADMIN_GROUP_ID } from './group.service.js';
+import type { Auth } from '../auth.js';
+
+/**
+ * Per-request cache key for the resolved Better Auth session.
+ *
+ * Symbol-typed so it never collides with a legitimate property on the
+ * Express request object and remains invisible to callers that
+ * enumerate request fields.
+ */
+const SESSION_CACHE_KEY: unique symbol = Symbol('auth-facade.session');
+
+/**
+ * Shape of a successful session resolution.
+ *
+ * Derived from {@link Auth}'s `api.getSession` return type rather than
+ * imported from Better Auth's internals so a library version bump that
+ * tweaks intermediate types won't break consumers.
+ */
+type ResolvedSession = NonNullable<Awaited<ReturnType<Auth['api']['getSession']>>>;
+
+/**
+ * Module-private auth instance reference.
+ *
+ * Set once at bootstrap by {@link setAuthInstance}; consumed by every
+ * facade function. `null` until configured — accessing the facade
+ * before bootstrap surfaces a clear error rather than a silent false.
+ */
+let configuredAuth: Auth | null = null;
+
+/**
+ * Configure the facade with the application's auth instance.
+ *
+ * Called from `UserModule.init()` once the Better Auth instance has
+ * been constructed. Subsequent calls overwrite the reference — useful
+ * in test setup where the instance is rebuilt per suite.
+ *
+ * @param auth - Better Auth instance to use for session resolution.
+ */
+export function setAuthInstance(auth: Auth): void {
+    configuredAuth = auth;
+}
+
+/**
+ * Test-only escape hatch that clears the configured auth reference.
+ *
+ * @internal
+ */
+export function resetAuthInstanceForTests(): void {
+    configuredAuth = null;
+}
+
+/**
+ * Predicate: is the caller authenticated?
+ *
+ * Returns `true` when the request carries a Better Auth session
+ * cookie that resolves to a live, non-expired session. Returns
+ * `false` for anonymous callers — no cookie, expired cookie, or
+ * tampered cookie. The complementary {@link isAnonymous} is provided
+ * for readability so call sites don't pepper `!isLoggedIn` everywhere.
+ *
+ * @param req - Express request.
+ * @returns Promise resolving to the logged-in predicate.
+ */
+export async function isLoggedIn(req: Request): Promise<boolean> {
+    const session = await resolveSession(req);
+    return session !== null;
+}
+
+/**
+ * Predicate: is the caller anonymous?
+ *
+ * Inverse of {@link isLoggedIn}. Provided as its own export so call
+ * sites read naturally — `if (await isAnonymous(req)) { ... }` is
+ * clearer than `if (!await isLoggedIn(req))` at a glance.
+ *
+ * @param req - Express request.
+ * @returns Promise resolving to the anonymous predicate.
+ */
+export async function isAnonymous(req: Request): Promise<boolean> {
+    const loggedIn = await isLoggedIn(req);
+    return !loggedIn;
+}
+
+/**
+ * Predicate: is the caller a member of a given group?
+ *
+ * Anonymous callers always return `false` — group membership requires
+ * a resolved Better Auth user id. Group ids are case-sensitive.
+ *
+ * @param req - Express request.
+ * @param groupId - Group id to test.
+ * @returns Promise resolving to the membership predicate.
+ */
+export async function isInGroup(req: Request, groupId: string): Promise<boolean> {
+    const session = await resolveSession(req);
+    let result = false;
+    if (session) {
+        const groups = GroupService.getInstance();
+        result = await groups.isMember(session.user.id, groupId);
+    }
+    return result;
+}
+
+/**
+ * Predicate: is the caller an administrator?
+ *
+ * Sugar for {@link isInGroup} with the `admin` group id. Use this in
+ * preference to `isInGroup(req, 'admin')` so a future rename or
+ * compound check (e.g. layered admin tiers) needs to update only one
+ * code path. Future tiers like `super-admin` are expected to remain
+ * truthy under `isAdmin` — admin gates are inclusive of escalations.
+ *
+ * @param req - Express request.
+ * @returns Promise resolving to the admin predicate.
+ */
+export async function isAdmin(req: Request): Promise<boolean> {
+    const result = await isInGroup(req, ADMIN_GROUP_ID);
+    return result;
+}
+
+/**
+ * Resolve the Better Auth session for a request, with per-request caching.
+ *
+ * Computes the session on first call within a request and caches the
+ * result on the request object under a private Symbol. Subsequent
+ * facade calls within the same request reuse the cached value, so a
+ * handler that asks `isLoggedIn` and then `isAdmin` pays one Mongo
+ * round-trip, not two.
+ *
+ * @param req - Express request whose Better Auth cookies will be read.
+ * @returns The resolved session, or `null` when no valid session exists.
+ */
+async function resolveSession(req: Request): Promise<ResolvedSession | null> {
+    const cached = (req as unknown as { [SESSION_CACHE_KEY]?: ResolvedSession | null })[
+        SESSION_CACHE_KEY
+    ];
+    let session: ResolvedSession | null;
+    if (cached !== undefined) {
+        session = cached;
+    } else {
+        const auth = requireAuth();
+        const headers = fromNodeHeaders(req.headers);
+        const resolved = await auth.api.getSession({ headers });
+        session = resolved ?? null;
+        (req as unknown as { [SESSION_CACHE_KEY]?: ResolvedSession | null })[
+            SESSION_CACHE_KEY
+        ] = session;
+    }
+    return session;
+}
+
+/**
+ * Resolve the configured auth instance, throwing on missing config.
+ *
+ * Internal helper — every facade call funnels through here so the
+ * "facade used before bootstrap" failure surfaces as one clear error
+ * message at the actual call site rather than as a confusing `null`
+ * deref further down.
+ *
+ * @returns The configured Better Auth instance.
+ * @throws {Error} When the facade has not been configured.
+ */
+function requireAuth(): Auth {
+    if (!configuredAuth) {
+        throw new Error(
+            'Auth facade not configured — UserModule.init() must call setAuthInstance() before any facade function runs.'
+        );
+    }
+    return configuredAuth;
+}

--- a/src/backend/modules/user/services/auth-facade.ts
+++ b/src/backend/modules/user/services/auth-facade.ts
@@ -144,32 +144,27 @@ export async function isAdmin(req: Request): Promise<boolean> {
 /**
  * Resolve the Better Auth session for a request, with per-request caching.
  *
- * Computes the session on first call within a request and caches the
- * result on the request object under a private Symbol. Subsequent
- * facade calls within the same request reuse the cached value, so a
- * handler that asks `isLoggedIn` and then `isAdmin` pays one Mongo
- * round-trip, not two.
+ * Caches the *in-flight Promise* on the request object under a private
+ * Symbol, not the resolved session, so concurrent callers — e.g.
+ * `Promise.all([isLoggedIn(req), isAdmin(req)])` — share a single
+ * `auth.api.getSession` round-trip rather than racing through the
+ * "undefined cache, fetch fresh" branch in parallel. Once the Promise
+ * resolves it remains in the cache slot, so later sequential calls in
+ * the same request also reuse the result.
  *
  * @param req - Express request whose Better Auth cookies will be read.
  * @returns The resolved session, or `null` when no valid session exists.
  */
 async function resolveSession(req: Request): Promise<ResolvedSession | null> {
-    const cached = (req as unknown as { [SESSION_CACHE_KEY]?: ResolvedSession | null })[
-        SESSION_CACHE_KEY
-    ];
-    let session: ResolvedSession | null;
-    if (cached !== undefined) {
-        session = cached;
-    } else {
+    const slot = req as unknown as { [SESSION_CACHE_KEY]?: Promise<ResolvedSession | null> };
+    let pending = slot[SESSION_CACHE_KEY];
+    if (pending === undefined) {
         const auth = requireAuth();
         const headers = fromNodeHeaders(req.headers);
-        const resolved = await auth.api.getSession({ headers });
-        session = resolved ?? null;
-        (req as unknown as { [SESSION_CACHE_KEY]?: ResolvedSession | null })[
-            SESSION_CACHE_KEY
-        ] = session;
+        pending = auth.api.getSession({ headers }).then((resolved) => resolved ?? null);
+        slot[SESSION_CACHE_KEY] = pending;
     }
-    return session;
+    return pending;
 }
 
 /**

--- a/src/backend/modules/user/services/group.service.ts
+++ b/src/backend/modules/user/services/group.service.ts
@@ -1,0 +1,279 @@
+/**
+ * @fileoverview Group membership service for the Better Auth user store.
+ *
+ * Reads and writes the `groups` additional field on Better Auth's user
+ * collection (`module_user_auth_users`) so plugin authorization can be
+ * gated on lightweight named tags without inventing a parallel data
+ * model. Phase 1 reserves `admin` as the only seeded group; later
+ * phases that allow operator-defined groups still reuse this service
+ * for all read/write operations.
+ *
+ * The service follows the project's singleton pattern
+ * (`setDependencies()` / `getInstance()`) because membership state is
+ * shared application-wide and configured exactly once at bootstrap.
+ *
+ * **Storage shape.** Better Auth's `mongodbAdapter` maps the logical
+ * `id` field on the User model to MongoDB's `_id` (transparently
+ * transforming on read and write), so every query in this service
+ * filters by `{ _id: userId }`. The `groups` field is the BA
+ * additional field declared in `auth.ts`; nothing else in the codebase
+ * writes to it.
+ */
+
+import type { Collection } from 'mongodb';
+import type { IDatabaseService, ISystemLogService } from '@/types';
+import { AUTH_USERS_COLLECTION } from './auth-constants.js';
+
+/**
+ * Group id reserved for administrators.
+ *
+ * Exported for callers that want a symbolic reference rather than a
+ * bare string literal. {@link GroupService.isAdmin} delegates to
+ * {@link GroupService.isMember} with this value.
+ */
+export const ADMIN_GROUP_ID = 'admin';
+
+/**
+ * Shape of the BA user document this service touches.
+ *
+ * Restricted to the fields we read/write — BA owns the full schema.
+ * Listed explicitly so the raw collection handle is type-checked.
+ */
+interface IAuthUserDoc {
+    /**
+     * Better Auth's user id, stored as MongoDB `_id` (string, not
+     * ObjectId). The adapter remaps `id` ↔ `_id` transparently when
+     * BA itself queries, so the `_id` we see here is the same value
+     * BA returns as `user.id` from its session API.
+     */
+    _id: string;
+
+    /**
+     * Group ids the user is a member of. Empty array or missing both
+     * mean "no groups." Maintained via `$addToSet` / `$pull` /
+     * `$set` writes from this service.
+     */
+    groups?: string[];
+}
+
+/**
+ * Group membership service backed by Better Auth's user collection.
+ *
+ * Singleton; created and configured during `UserModule.init()` via
+ * {@link GroupService.setDependencies}. Subsequent calls to
+ * {@link GroupService.getInstance} return the configured instance.
+ *
+ * @example
+ * ```typescript
+ * // Bootstrap
+ * GroupService.setDependencies(database, logger);
+ * const groups = GroupService.getInstance();
+ *
+ * // Add a user to admin
+ * await groups.addMember('user_abc123', ADMIN_GROUP_ID);
+ *
+ * // Check membership
+ * if (await groups.isAdmin('user_abc123')) { /* gated work *\/ }
+ * ```
+ */
+export class GroupService {
+    /**
+     * Singleton instance reference. `null` until {@link setDependencies}
+     * runs at bootstrap.
+     */
+    private static instance: GroupService | null = null;
+
+    /**
+     * Logger scoped to this service. Created once at construction.
+     */
+    private readonly logger: ISystemLogService;
+
+    /**
+     * Injected database service. The constructor stores it; every
+     * method goes through the abstraction for raw-collection access.
+     */
+    private readonly database: IDatabaseService;
+
+    /**
+     * Construct the service.
+     *
+     * Private so the only sanctioned creation path is
+     * {@link setDependencies}, preserving the singleton contract.
+     *
+     * @param database - Database abstraction.
+     * @param logger - Logger to derive a `component: 'group-service'` child from.
+     */
+    private constructor(database: IDatabaseService, logger: ISystemLogService) {
+        this.database = database;
+        this.logger = logger.child({ component: 'group-service' });
+    }
+
+    /**
+     * Configure the singleton with its dependencies.
+     *
+     * Must be called exactly once during `UserModule.init()`. Calling
+     * a second time is a no-op (the existing instance is kept) so
+     * callers cannot accidentally swap dependencies after services
+     * have started consuming the singleton.
+     *
+     * @param database - Database service injected by the module.
+     * @param logger - Pino logger from the user module's child scope.
+     */
+    public static setDependencies(database: IDatabaseService, logger: ISystemLogService): void {
+        if (!GroupService.instance) {
+            GroupService.instance = new GroupService(database, logger);
+        }
+    }
+
+    /**
+     * Resolve the configured singleton.
+     *
+     * @returns The shared {@link GroupService} instance.
+     * @throws {Error} When called before {@link setDependencies}.
+     */
+    public static getInstance(): GroupService {
+        if (!GroupService.instance) {
+            throw new Error(
+                'GroupService.setDependencies() must be called before getInstance().'
+            );
+        }
+        return GroupService.instance;
+    }
+
+    /**
+     * Reset the singleton.
+     *
+     * Test-only escape hatch. Production code never calls this — the
+     * service lives for the process lifetime. Tests use it between
+     * suites so a fresh `setDependencies()` configures a clean instance.
+     *
+     * @internal
+     */
+    public static resetForTests(): void {
+        GroupService.instance = null;
+    }
+
+    /**
+     * Return the groups a user belongs to.
+     *
+     * Returns an empty array when the user does not exist or has no
+     * groups; missing-user and no-groups are intentionally
+     * indistinguishable at this API since callers gating on group
+     * membership only care about presence.
+     *
+     * @param userId - Better Auth user id.
+     * @returns Array of group ids, deduplicated by the underlying
+     *          $addToSet writes. Order is not guaranteed.
+     */
+    public async getUserGroups(userId: string): Promise<string[]> {
+        const collection = this.getCollection();
+        const doc = await collection.findOne(
+            { _id: userId },
+            { projection: { groups: 1 } }
+        );
+        const groups = doc?.groups ?? [];
+        return groups;
+    }
+
+    /**
+     * Test whether a user is a member of a given group.
+     *
+     * @param userId - Better Auth user id.
+     * @param groupId - Group id to check.
+     * @returns `true` when the user document contains `groupId` in its
+     *          `groups` array, `false` otherwise (including missing user).
+     */
+    public async isMember(userId: string, groupId: string): Promise<boolean> {
+        const collection = this.getCollection();
+        const count = await collection.countDocuments(
+            { _id: userId, groups: groupId },
+            { limit: 1 }
+        );
+        return count > 0;
+    }
+
+    /**
+     * Test whether a user is an administrator.
+     *
+     * Sugar for {@link isMember} with {@link ADMIN_GROUP_ID}. Kept as
+     * its own method so callers that gate on admin status read clearly
+     * and so the facade in `services/auth-facade.ts` can route
+     * `isAdmin(req)` to a single primitive.
+     *
+     * @param userId - Better Auth user id.
+     * @returns `true` when the user is in the `admin` group.
+     */
+    public async isAdmin(userId: string): Promise<boolean> {
+        const result = await this.isMember(userId, ADMIN_GROUP_ID);
+        return result;
+    }
+
+    /**
+     * Add a user to a group.
+     *
+     * Idempotent — uses `$addToSet` so repeated calls leave the
+     * `groups` array unchanged once membership is established. Throws
+     * when the underlying write fails (other than missing-user, which
+     * is silently ignored because the matched-count is zero and the
+     * upstream caller has the user context to react).
+     *
+     * @param userId - Better Auth user id.
+     * @param groupId - Group id to add.
+     */
+    public async addMember(userId: string, groupId: string): Promise<void> {
+        const collection = this.getCollection();
+        await collection.updateOne(
+            { _id: userId },
+            { $addToSet: { groups: groupId } }
+        );
+    }
+
+    /**
+     * Remove a user from a group.
+     *
+     * Idempotent — removing a non-member is a no-op via `$pull`.
+     *
+     * @param userId - Better Auth user id.
+     * @param groupId - Group id to remove.
+     */
+    public async removeMember(userId: string, groupId: string): Promise<void> {
+        const collection = this.getCollection();
+        await collection.updateOne(
+            { _id: userId },
+            { $pull: { groups: groupId } }
+        );
+    }
+
+    /**
+     * Replace the user's complete group membership atomically.
+     *
+     * Used by admin tooling that presents a checkbox list and saves
+     * the full intended state in one write. Plugins should prefer
+     * {@link addMember} / {@link removeMember} for single-group
+     * transitions because they avoid clobbering concurrent edits.
+     *
+     * @param userId - Better Auth user id.
+     * @param groupIds - Complete list of group ids the user should belong to.
+     */
+    public async setUserGroups(userId: string, groupIds: string[]): Promise<void> {
+        const collection = this.getCollection();
+        const unique = Array.from(new Set(groupIds));
+        await collection.updateOne(
+            { _id: userId },
+            { $set: { groups: unique } }
+        );
+    }
+
+    /**
+     * Resolve the raw `module_user_auth_users` collection handle.
+     *
+     * Better Auth's adapter populates this collection; we read and
+     * write the `groups` additional field directly because the
+     * Mongoose model registry is not used for BA-owned tables.
+     *
+     * @returns Typed collection handle.
+     */
+    private getCollection(): Collection<IAuthUserDoc> {
+        return this.database.getCollection<IAuthUserDoc>(AUTH_USERS_COLLECTION);
+    }
+}

--- a/src/backend/modules/user/services/group.service.ts
+++ b/src/backend/modules/user/services/group.service.ts
@@ -212,20 +212,21 @@ export class GroupService {
      * Add a user to a group.
      *
      * Idempotent — uses `$addToSet` so repeated calls leave the
-     * `groups` array unchanged once membership is established. Throws
-     * when the underlying write fails (other than missing-user, which
-     * is silently ignored because the matched-count is zero and the
-     * upstream caller has the user context to react).
+     * `groups` array unchanged once membership is established.
      *
      * @param userId - Better Auth user id.
      * @param groupId - Group id to add.
+     * @returns `true` when the user existed and the write matched,
+     *          `false` when no user matched the id (silent no-op
+     *          MongoDB would otherwise return invisibly).
      */
-    public async addMember(userId: string, groupId: string): Promise<void> {
+    public async addMember(userId: string, groupId: string): Promise<boolean> {
         const collection = this.getCollection();
-        await collection.updateOne(
+        const result = await collection.updateOne(
             { _id: userId },
             { $addToSet: { groups: groupId } }
         );
+        return result.matchedCount > 0;
     }
 
     /**
@@ -235,13 +236,16 @@ export class GroupService {
      *
      * @param userId - Better Auth user id.
      * @param groupId - Group id to remove.
+     * @returns `true` when the user existed and the write matched,
+     *          `false` when no user matched the id.
      */
-    public async removeMember(userId: string, groupId: string): Promise<void> {
+    public async removeMember(userId: string, groupId: string): Promise<boolean> {
         const collection = this.getCollection();
-        await collection.updateOne(
+        const result = await collection.updateOne(
             { _id: userId },
             { $pull: { groups: groupId } }
         );
+        return result.matchedCount > 0;
     }
 
     /**
@@ -254,14 +258,17 @@ export class GroupService {
      *
      * @param userId - Better Auth user id.
      * @param groupIds - Complete list of group ids the user should belong to.
+     * @returns `true` when the user existed and the write matched,
+     *          `false` when no user matched the id.
      */
-    public async setUserGroups(userId: string, groupIds: string[]): Promise<void> {
+    public async setUserGroups(userId: string, groupIds: string[]): Promise<boolean> {
         const collection = this.getCollection();
         const unique = Array.from(new Set(groupIds));
-        await collection.updateOne(
+        const result = await collection.updateOne(
             { _id: userId },
             { $set: { groups: unique } }
         );
+        return result.matchedCount > 0;
     }
 
     /**


### PR DESCRIPTION
## Summary

Foundation PR for the planned auth refactor. Stands up Better Auth alongside the existing UUID-based identity system; nothing is removed or rewired. The legacy `/api/user/*` surface continues unchanged. Deployable as a no-op.

## What's in it

- Better Auth wired against MongoDB with magic-link (Resend), Google/GitHub OAuth, and passkeys; each provider loads only when its env vars are present.
- `groups[]` and `primaryWallet` added as Better Auth user `additionalFields` so future middleware can augment `req.user` without an extra round-trip.
- `ADMIN_EMAILS` env allowlist auto-promotes verified signups to the `admin` group via BA's `databaseHooks.user.create.after`.
- New `GroupService` (singleton) reads/writes the BA users collection directly for membership queries.
- `isLoggedIn` / `isAnonymous` / `isInGroup` / `isAdmin` facade — the only authorization surface plugin and core code should touch going forward.
- BA collections renamed to `module_user_auth_*` to match the project's collection-prefixing convention.
- `legacy-peer-deps=true` pinned in `.npmrc` to resolve a transitive `@sveltejs/kit` peer conflict between Better Auth and vitest 4's vite range.

## What's not in it

- Phase 2 (middleware + WebSocket handshake switch).
- Phase 3 (frontend login UI).
- Phase 4 (wallets keyed by BA user id).
- Phase 5 (`tronrelic_tid` traffic cookie + referral cookie).
- Phase 6 (cutover migration + decommission of legacy code).
- Plugin sweep (still calling `req.user.identityState`).

## Operator notes for prod

- `BETTER_AUTH_SECRET` is enforced in production (mirrors the `SESSION_SECRET` pattern). Generate via `openssl rand -hex 32`.
- `ADMIN_EMAILS` should list the operator's verified email so they auto-promote on first signup.
- Magic-link delivery needs `RESEND_API_KEY` + `RESEND_FROM_ADDRESS` plus DKIM/SPF records on the from-address domain. Without them, the magic-link plugin is dropped from the BA plugin list in production.
- Full project typecheck (`npm run typecheck`) requires `NODE_OPTIONS=--max-old-space-size=8192` to avoid OOM on Node's default 2 GB heap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)