### PR TITLE
fix(docker): mount npmrc secret on production npm ci steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,7 @@ COPY --from=builder /app/packages/types/package.json ./packages/types/package.js
 COPY --from=builder /app/packages/types/dist ./packages/types/dist
 RUN node -e "const f='packages/types/package.json';const p=require('./'+f);if(p.scripts){delete p.scripts.prepare;delete p.scripts.prepublishOnly;}require('fs').writeFileSync(f, JSON.stringify(p,null,4)+'\n');"
 
-RUN npm ci --only=production
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc npm ci --only=production
 
 RUN npx playwright install chromium
 
@@ -202,7 +202,7 @@ COPY --from=builder /app/packages/types/package.json ./packages/types/package.js
 COPY --from=builder /app/packages/types/dist ./packages/types/dist
 RUN node -e "const f='packages/types/package.json';const p=require('./'+f);if(p.scripts){delete p.scripts.prepare;delete p.scripts.prepublishOnly;}require('fs').writeFileSync(f, JSON.stringify(p,null,4)+'\n');"
 
-RUN npm ci --only=production
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc npm ci --only=production
 
 COPY --from=builder /app/src/frontend/.next/standalone ./
 COPY --from=builder /app/src/frontend/.next/static ./src/frontend/.next/static


### PR DESCRIPTION
## Summary

The `backend` and `frontend-prod` Dockerfile stages run `npm ci --only=production` without mounting the npmrc BuildKit secret, so they never inherit `legacy-peer-deps=true`. Better Auth's transitive `better-call@1.3.5` declares `peerOptional zod@^4` while the monorepo pins `zod@^3`; npm's strict resolver rejects this in the production dependency tree, failing the prod image build at these steps.

The peer is **optional** — `better-auth` ships its own nested `zod@4` and the app's `zod@3` is untouched — so suppressing it via `legacy-peer-deps` is correct, not a workaround. This mirrors the secret-mount the `deps` stage already uses for its `npm ci`. The secret is already passed to both depot build steps in `prod-publish.yml`; the Dockerfile simply wasn't mounting it here.

Companion to the ops-repo change that added `legacy-peer-deps=true` to the generated npmrc secret.