### PR TITLE
fix(compose): pass Better Auth env vars into the backend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,18 @@ services:
             - TRONGRID_API_KEY_2=${TRONGRID_API_KEY_2}
             - TRONGRID_API_KEY_3=${TRONGRID_API_KEY_3}
 
+            # Better Auth (BETTER_AUTH_SECRET is required in production; the
+            # rest are optional and default to empty when unset in .env)
+            - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
+            - BETTER_AUTH_URL=${BETTER_AUTH_URL:-}
+            - ADMIN_EMAILS=${ADMIN_EMAILS:-}
+            - RESEND_API_KEY=${RESEND_API_KEY:-}
+            - RESEND_FROM_ADDRESS=${RESEND_FROM_ADDRESS:-}
+            - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
+            - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
+            - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
+            - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
+
             # Site Configuration
             - SITE_URL=${SITE_URL}
             - SITE_WS=${SITE_WS}


### PR DESCRIPTION
## Summary

The backend service's `environment:` block in `docker-compose.yml` enumerates env vars explicitly (it does not use `env_file`). `BETTER_AUTH_SECRET` — required in production since the Better Auth merge — was set in the droplet's `.env` but **never passed into the container**, so the new image crash-looped on boot (`Error: BETTER_AUTH_SECRET is required in production`), taking prod down during deploy.

Wires `BETTER_AUTH_SECRET` through, plus the optional Better Auth vars (`BETTER_AUTH_URL`, `ADMIN_EMAILS`, `RESEND_API_KEY`, `RESEND_FROM_ADDRESS`, `GOOGLE_CLIENT_ID/SECRET`, `GITHUB_CLIENT_ID/SECRET`) which default to empty when unset so they're harmless on deployments that haven't configured them.

This compose fix has already been applied to the prod droplet via the deploy (which scp's this file) and verified healthy; this PR persists it so a fresh deploy doesn't reintroduce the outage.