### PR TITLE
feat(auth): replace magic-link sign-in with email OTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,7 +87,7 @@ GITHUB_USERNAME=
 # Generate with: openssl rand -hex 32
 BETTER_AUTH_SECRET=
 
-# Optional - canonical base URL for OAuth redirect URIs and magic-link URLs
+# Optional - canonical base URL for OAuth redirect URIs
 # Defaults to SITE_URL when unset
 BETTER_AUTH_URL=
 
@@ -98,7 +98,7 @@ ADMIN_EMAILS=
 # ==============================================
 # Email Delivery (Resend)
 # ==============================================
-# Used for Better Auth magic-link emails
+# Used for Better Auth sign-in code (OTP) emails
 # Get an API key at https://resend.com
 RESEND_API_KEY=
 RESEND_FROM_ADDRESS=

--- a/src/backend/api/middleware/admin-auth.ts
+++ b/src/backend/api/middleware/admin-auth.ts
@@ -226,7 +226,7 @@ export async function isAdmin(req: Request): Promise<boolean> {
 export async function requireAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
         // Phase 2: prefer the Better Auth session path. Operators who
-        // sign in through BA (magic-link / OAuth / passkey) are
+        // sign in through BA (email-OTP / OAuth / passkey) are
         // attributed by their BA user id; this becomes the canonical
         // operator identity once Phase 6 retires the legacy cookie.
         const baResult = await tryBetterAuthAdminAuth(req);

--- a/src/backend/api/middleware/auth-session.ts
+++ b/src/backend/api/middleware/auth-session.ts
@@ -47,7 +47,7 @@ export const attachAuthSession: RequestHandler = async (
     // Better Auth's own handler runs on /api/auth/*; it resolves the
     // session internally and never reads req.authSession. Skipping
     // the middleware on those paths avoids a duplicate round-trip for
-    // every magic-link/OAuth/passkey call.
+    // every email-OTP/OAuth/passkey call.
     if (req.path === '/api/auth' || req.path.startsWith('/api/auth/')) {
         next();
         return;

--- a/src/backend/config/env.ts
+++ b/src/backend/config/env.ts
@@ -37,8 +37,8 @@ const envSchema = z.object({
    */
   BETTER_AUTH_SECRET: z.string().optional(),
   /**
-   * Canonical base URL Better Auth uses to construct OAuth redirect URIs and
-   * email magic-link URLs. Optional — falls back to SITE_URL when unset.
+   * Canonical base URL Better Auth uses to construct OAuth redirect URIs.
+   * Optional — falls back to SITE_URL when unset.
    */
   BETTER_AUTH_URL: z.string().optional(),
   /**
@@ -48,9 +48,9 @@ const envSchema = z.object({
    */
   ADMIN_EMAILS: z.string().optional(),
   /**
-   * Resend API key used to send magic-link emails. When unset, the magic-link
-   * plugin still mints links but the send callback logs them to console for
-   * development. Set in any environment where real users sign in.
+   * Resend API key used to send sign-in code (OTP) emails. When unset, the
+   * email-OTP plugin logs codes to the console for development. Set in any
+   * environment where real users sign in.
    */
   RESEND_API_KEY: z.string().optional(),
   /**

--- a/src/backend/loaders/express.ts
+++ b/src/backend/loaders/express.ts
@@ -31,8 +31,8 @@ export function createExpressApp(): Express {
   // `req.signedCookies` to close the cookie-forgery vector.
   app.use(cookieParser(env.SESSION_SECRET));
   // Body parsers consume the raw request stream, but Better Auth's
-  // Node integration needs the original body to validate magic-link
-  // tokens, OAuth callbacks, and passkey assertions. Skip them on
+  // Node integration needs the original body to validate email-OTP
+  // codes, OAuth callbacks, and passkey assertions. Skip them on
   // `/api/auth/*` so `toNodeHandler` (mounted by UserModule.run()) can
   // read the body itself. Cookie-parser above is safe to leave global
   // because it only reads headers.

--- a/src/backend/modules/user/auth.ts
+++ b/src/backend/modules/user/auth.ts
@@ -24,7 +24,7 @@
 
 import { betterAuth } from 'better-auth';
 import { mongodbAdapter } from 'better-auth/adapters/mongodb';
-import { magicLink } from 'better-auth/plugins';
+import { emailOTP } from 'better-auth/plugins';
 import { passkey } from '@better-auth/passkey';
 import { Resend } from 'resend';
 import type { Db } from 'mongodb';
@@ -86,7 +86,7 @@ export type Auth = ReturnType<typeof createAuth>;
  * Build the Better Auth instance configured for TronRelic.
  *
  * Provider toggling is env-driven: each social provider loads only when
- * both its client id and secret are present, and the magic-link plugin
+ * both its client id and secret are present, and the email-OTP plugin
  * loads only when Resend credentials are configured (or in non-prod,
  * where a console fallback is acceptable). The after-create database
  * hook reads the new user's verified email against the parsed
@@ -202,17 +202,17 @@ function buildSocialProviders(): {
 /**
  * Build the plugin list for the auth instance.
  *
- * Passkey is always loaded — it has no env-var dependency. Magic-link
+ * Passkey is always loaded — it has no env-var dependency. Email-OTP
  * loads when Resend credentials are present (real send path) or when
  * the process is not running in production (dev console fallback).
- * Production without Resend credentials drops magic-link entirely so
- * plaintext sign-in URLs cannot leak to operator logs.
+ * Production without Resend credentials drops email-OTP entirely so
+ * sign-in codes cannot leak to operator logs.
  *
- * @param log - Logger passed into the magic-link sender for fallback diagnostics.
+ * @param log - Logger passed into the OTP sender for fallback diagnostics.
  * @returns Ordered list of Better Auth plugins for the instance.
  */
-function buildPlugins(log: ISystemLogService): Array<ReturnType<typeof passkey | typeof magicLink>> {
-    const plugins: Array<ReturnType<typeof passkey | typeof magicLink>> = [
+function buildPlugins(log: ISystemLogService): Array<ReturnType<typeof passkey | typeof emailOTP>> {
+    const plugins: Array<ReturnType<typeof passkey | typeof emailOTP>> = [
         passkey({
             // Remap the plugin's owned `passkey` table to the project's
             // `module_user_auth_*` convention so it sits alongside the
@@ -223,35 +223,49 @@ function buildPlugins(log: ISystemLogService): Array<ReturnType<typeof passkey |
     const isProduction = env.NODE_ENV === 'production' || env.ENV === 'production';
     const hasResend = Boolean(env.RESEND_API_KEY && env.RESEND_FROM_ADDRESS);
     if (hasResend || !isProduction) {
-        plugins.push(magicLink({ sendMagicLink: buildMagicLinkSender(log) }));
+        plugins.push(
+            emailOTP({
+                sendVerificationOTP: buildOtpSender(log),
+                otpLength: 6,
+                // Five minutes balances inbox-delivery latency against the
+                // exposure window of a code sitting in an inbox.
+                expiresIn: 300
+            })
+        );
     } else {
         log.warn(
-            'Magic-link plugin DISABLED in production: RESEND_API_KEY and/or RESEND_FROM_ADDRESS unset. Sign-in via magic-link is not available until these are configured.'
+            'Email-OTP plugin DISABLED in production: RESEND_API_KEY and/or RESEND_FROM_ADDRESS unset. Sign-in via email code is not available until these are configured.'
         );
     }
     return plugins;
 }
 
 /**
- * Build the `sendMagicLink` callback used by the magic-link plugin.
+ * Build the `sendVerificationOTP` callback used by the email-OTP plugin.
  *
  * Returns a Resend-backed sender when both RESEND_API_KEY and
  * RESEND_FROM_ADDRESS are set; otherwise returns a dev fallback that
- * logs the sign-in URL at warn level so contributors can copy-paste
- * the link locally. The fallback is gated out of production by
- * {@link buildPlugins} so it can never leak credentials in deployed logs.
+ * logs the code at warn level so contributors can read it from the
+ * console locally. The fallback is gated out of production by
+ * {@link buildPlugins} so a sign-in code can never leak in deployed logs.
+ *
+ * A code (not a link) is used so sign-in completes in the browser tab
+ * where the user started: email clients open links in in-app webviews,
+ * which would set the session in a sandbox separate from the user's
+ * real browser, and email link-scanners can pre-consume single-use
+ * verify URLs. Typing a code back into the original tab avoids both.
  *
  * @param log - Logger used for both Resend failures and the dev fallback.
- * @returns Async function the magic-link plugin calls with `({ email, url })`.
+ * @returns Async function the plugin calls with `({ email, otp, type })`.
  */
-function buildMagicLinkSender(
+function buildOtpSender(
     log: ISystemLogService
-): (data: { email: string; url: string }) => Promise<void> {
-    let sender: (data: { email: string; url: string }) => Promise<void>;
+): (data: { email: string; otp: string; type: string }) => Promise<void> {
+    let sender: (data: { email: string; otp: string; type: string }) => Promise<void>;
     if (env.RESEND_API_KEY && env.RESEND_FROM_ADDRESS) {
         const resend = new Resend(env.RESEND_API_KEY);
         const from = env.RESEND_FROM_ADDRESS;
-        sender = async ({ email, url }): Promise<void> => {
+        sender = async ({ email, otp }): Promise<void> => {
             try {
                 // The Resend SDK does not throw on API-level failures
                 // (invalid key, unverified domain, quota exceeded). It
@@ -261,22 +275,22 @@ function buildMagicLinkSender(
                 const { error: resendError } = await resend.emails.send({
                     from,
                     to: email,
-                    subject: 'Sign in to TronRelic',
-                    html: renderMagicLinkEmail(url)
+                    subject: 'Your TronRelic sign-in code',
+                    html: renderOtpEmail(otp)
                 });
                 if (resendError) {
                     throw new Error(resendError.message || 'Unknown Resend error');
                 }
             } catch (error) {
-                log.error({ error, email }, 'Resend magic-link send failed');
+                log.error({ error, email }, 'Resend OTP send failed');
                 throw error;
             }
         };
     } else {
-        sender = async ({ email, url }): Promise<void> => {
+        sender = async ({ email, otp }): Promise<void> => {
             log.warn(
-                { email, url },
-                'Magic-link rendered to logs (RESEND_API_KEY/RESEND_FROM_ADDRESS unset, dev fallback only)'
+                { email, otp },
+                'Sign-in OTP rendered to logs (RESEND_API_KEY/RESEND_FROM_ADDRESS unset, dev fallback only)'
             );
         };
     }
@@ -284,21 +298,20 @@ function buildMagicLinkSender(
 }
 
 /**
- * Render the HTML body for a magic-link email.
+ * Render the HTML body for a sign-in OTP email.
  *
  * Kept intentionally minimal to avoid Resend template-rendering
- * surprises; the layout passes spam filters and clearly shows the call
- * to action. The URL is interpolated raw because Better Auth
- * guarantees it is a same-origin verified link.
+ * surprises; the layout passes spam filters and shows the code
+ * prominently. The code is plugin-generated digits, safe to interpolate.
  *
- * @param url - The signed magic-link URL produced by Better Auth.
+ * @param otp - The one-time code produced by Better Auth.
  * @returns HTML string suitable for the Resend `html` field.
  */
-function renderMagicLinkEmail(url: string): string {
+function renderOtpEmail(otp: string): string {
     const body = [
-        '<p>Click the link below to sign in to TronRelic:</p>',
-        `<p><a href="${url}">${url}</a></p>`,
-        '<p>This link expires shortly. If you didn\'t request it, you can safely ignore this email.</p>'
+        '<p>Your TronRelic sign-in code is:</p>',
+        `<p style="font-size:28px;font-weight:bold;letter-spacing:4px;">${otp}</p>`,
+        '<p>Enter it in the tab where you started signing in. This code expires in 5 minutes. If you didn\'t request it, you can safely ignore this email.</p>'
     ].join('');
     return body;
 }
@@ -309,9 +322,10 @@ function renderMagicLinkEmail(url: string): string {
  *
  * Verification is non-negotiable — without it an attacker could sign up
  * with `admin@example.com` they don't control and inherit privilege.
- * Magic-link guarantees verification by construction; OAuth providers
- * report verification status on the BA user record and we respect what
- * they say. Hook errors are caught and logged so a transient group-write
+ * Email-OTP guarantees verification by construction (the user proved
+ * inbox control by entering the emailed code); OAuth providers report
+ * verification status on the BA user record and we respect what they
+ * say. Hook errors are caught and logged so a transient group-write
  * failure cannot block legitimate signup completion.
  *
  * @param params.user - New user object as supplied by the BA after-create hook.

--- a/src/frontend/modules/user/components/AuthModal/AuthModal.tsx
+++ b/src/frontend/modules/user/components/AuthModal/AuthModal.tsx
@@ -1,23 +1,29 @@
 'use client';
 
 /**
- * @fileoverview Sign-in modal offering magic-link, OAuth, and passkey.
+ * @fileoverview Sign-in modal offering email-OTP, OAuth, and passkey.
  *
- * Mounts inside `useModal()` from the global ModalProvider. Calls
- * Better Auth client methods directly — magic-link prompts for an
- * email and asks the backend to mail a one-time URL; OAuth redirects
+ * Mounts inside `useModal()` from the global ModalProvider. Calls Better
+ * Auth client methods directly. The email path is a two-step code flow:
+ * the user enters an email and we mail a one-time code, then they type
+ * the code back into this same tab to complete sign-in. OAuth redirects
  * the browser to the provider; passkey invokes the WebAuthn flow.
  *
- * The modal never closes itself for the magic-link branch (the success
- * state stays open showing "check your email"); OAuth and passkey
- * close on success — OAuth via the post-redirect callback URL, passkey
- * via the success handler that closes the modal explicitly.
+ * Why a code instead of a magic link: email clients (notably Gmail
+ * mobile) open links in an in-app webview, which would set the session
+ * in a sandbox separate from the user's real browser, and link-scanners
+ * can pre-consume single-use verify URLs. A code typed back into the
+ * originating tab signs in exactly where the user started.
+ *
+ * The modal closes on success for every path: email-OTP and passkey via
+ * the explicit success handler after the session is created in-tab,
+ * OAuth via the post-redirect callback URL.
  *
  * Provider availability is not introspected client-side: if the server
- * has Google/GitHub credentials unset, those `signIn.social` calls
- * return an error which the modal surfaces via toast. The buttons
- * stay rendered so deployment misconfiguration is visible to operators
- * rather than silently hidden.
+ * has Google/GitHub credentials unset (or email-OTP disabled because
+ * Resend is unconfigured), those calls return an error which the modal
+ * surfaces via toast. The buttons stay rendered so deployment
+ * misconfiguration is visible to operators rather than silently hidden.
  */
 
 import { useCallback, useState, type FormEvent } from 'react';
@@ -25,37 +31,37 @@ import { useRouter } from 'next/navigation';
 import { Github, KeyRound, Mail, Loader2 } from 'lucide-react';
 import { Button } from '../../../../components/ui/Button';
 import { useToast } from '../../../../components/ui/ToastProvider';
-import { signIn } from '../../lib/auth-client';
+import { signIn, emailOtp } from '../../lib/auth-client';
 import styles from './AuthModal.module.scss';
 
 /**
  * Props for the AuthModal body.
  *
- * `onSuccess` is invoked after a sign-in completes locally
- * (passkey only — OAuth and magic-link complete out-of-band).
- * Callers typically pass `() => closeModal(id)` so the modal
- * dismisses itself after a successful passkey ceremony.
+ * `onSuccess` is invoked after a sign-in completes in this tab (email-OTP
+ * and passkey). OAuth completes out-of-band via redirect. Callers
+ * typically pass `() => closeModal(id)` so the modal dismisses itself.
  */
 export interface IAuthModalProps {
     /**
-     * URL to land on after a successful out-of-band sign-in (magic-link
-     * click, OAuth callback). Defaults to the current path so the user
-     * returns where they started. Pass an explicit path for flows that
-     * should redirect somewhere specific (e.g. `/system` after admin
-     * login).
+     * URL to land on after a successful OAuth redirect. Defaults to the
+     * current path so the user returns where they started. Pass an
+     * explicit path for flows that should redirect somewhere specific
+     * (e.g. `/system` after admin login). Unused by the email-OTP and
+     * passkey paths, which complete in-tab.
      */
     callbackURL?: string;
 
     /**
      * Invoked when sign-in completes synchronously inside the modal
-     * (passkey). The modal cannot close itself reliably without this
-     * callback because the global ModalProvider owns the close handle.
+     * (email-OTP, passkey). The modal cannot close itself reliably
+     * without this callback because the global ModalProvider owns the
+     * close handle.
      */
     onSuccess?: () => void;
 }
 
 /**
- * Magic-link / OAuth / passkey sign-in modal.
+ * Email-OTP / OAuth / passkey sign-in modal.
  *
  * @param props - {@link IAuthModalProps}.
  */
@@ -63,8 +69,9 @@ export function AuthModal({ callbackURL, onSuccess }: IAuthModalProps) {
     const router = useRouter();
     const { push } = useToast();
     const [email, setEmail] = useState('');
-    const [pendingMethod, setPendingMethod] = useState<'magic-link' | 'google' | 'github' | 'passkey' | null>(null);
-    const [magicLinkSent, setMagicLinkSent] = useState(false);
+    const [code, setCode] = useState('');
+    const [pendingMethod, setPendingMethod] = useState<'email' | 'verify' | 'google' | 'github' | 'passkey' | null>(null);
+    const [otpSent, setOtpSent] = useState(false);
 
     const isBusy = pendingMethod !== null;
 
@@ -86,30 +93,63 @@ export function AuthModal({ callbackURL, onSuccess }: IAuthModalProps) {
         [push]
     );
 
-    const handleMagicLink = useCallback(
+    const handleSendCode = useCallback(
         async (event: FormEvent<HTMLFormElement>) => {
             event.preventDefault();
             const trimmed = email.trim();
             if (!trimmed) {
-                push({ tone: 'warning', title: 'Email required', description: 'Enter an email to receive the sign-in link.' });
+                push({ tone: 'warning', title: 'Email required', description: 'Enter an email to receive a sign-in code.' });
                 return;
             }
-            setPendingMethod('magic-link');
+            setPendingMethod('email');
             try {
-                const result = await signIn.magicLink({ email: trimmed, callbackURL: resolveCallback() });
+                const result = await emailOtp.sendVerificationOtp({ email: trimmed, type: 'sign-in' });
                 if (result?.error) {
-                    showError('Magic link failed', result.error.message ?? 'The server rejected the request.');
+                    showError('Could not send code', result.error.message ?? 'The server rejected the request.');
                     return;
                 }
-                setMagicLinkSent(true);
+                setOtpSent(true);
             } catch (error) {
-                showError('Magic link failed', error);
+                showError('Could not send code', error);
             } finally {
                 setPendingMethod(null);
             }
         },
-        [email, push, resolveCallback, showError]
+        [email, push, showError]
     );
+
+    const handleVerifyCode = useCallback(
+        async (event: FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+            const trimmedEmail = email.trim();
+            const trimmedCode = code.trim();
+            if (!trimmedCode) {
+                push({ tone: 'warning', title: 'Code required', description: 'Enter the code from your email.' });
+                return;
+            }
+            setPendingMethod('verify');
+            try {
+                const result = await signIn.emailOtp({ email: trimmedEmail, otp: trimmedCode });
+                if (result?.error) {
+                    showError('Sign-in failed', result.error.message ?? 'That code is invalid or expired.');
+                    return;
+                }
+                push({ tone: 'success', title: 'Signed in', description: 'Welcome back.' });
+                router.refresh();
+                onSuccess?.();
+            } catch (error) {
+                showError('Sign-in failed', error);
+            } finally {
+                setPendingMethod(null);
+            }
+        },
+        [code, email, onSuccess, push, router, showError]
+    );
+
+    const handleChangeEmail = useCallback(() => {
+        setOtpSent(false);
+        setCode('');
+    }, []);
 
     const handleSocial = useCallback(
         async (provider: 'google' | 'github') => {
@@ -147,20 +187,46 @@ export function AuthModal({ callbackURL, onSuccess }: IAuthModalProps) {
         }
     }, [onSuccess, push, router, showError]);
 
-    if (magicLinkSent) {
+    if (otpSent) {
         return (
             <div className={styles.modal}>
-                <p className={styles.success}>
-                    Check <strong>{email.trim()}</strong> for your sign-in link.
-                </p>
-                <p className={styles.hint}>The link expires in a few minutes. You can close this window — clicking the email will log you in here.</p>
+                <form className={styles.form} onSubmit={handleVerifyCode} noValidate>
+                    <p className={styles.hint}>
+                        Enter the code we emailed to <strong>{email.trim()}</strong>.
+                    </p>
+                    <label className={styles.label} htmlFor="auth-modal-code">
+                        Sign-in code
+                    </label>
+                    <input
+                        id="auth-modal-code"
+                        className={styles.input}
+                        type="text"
+                        inputMode="numeric"
+                        autoComplete="one-time-code"
+                        placeholder="123456"
+                        maxLength={6}
+                        value={code}
+                        onChange={(e) => setCode(e.target.value)}
+                        disabled={isBusy}
+                        autoFocus
+                        required
+                    />
+                    <Button type="submit" variant="primary" loading={pendingMethod === 'verify'} disabled={isBusy && pendingMethod !== 'verify'}>
+                        Verify &amp; sign in
+                    </Button>
+                </form>
+                <div className={styles.providers}>
+                    <Button variant="ghost" onClick={handleChangeEmail} disabled={isBusy}>
+                        Use a different email
+                    </Button>
+                </div>
             </div>
         );
     }
 
     return (
         <div className={styles.modal}>
-            <form className={styles.form} onSubmit={handleMagicLink} noValidate>
+            <form className={styles.form} onSubmit={handleSendCode} noValidate>
                 <label className={styles.label} htmlFor="auth-modal-email">
                     Email
                 </label>
@@ -175,8 +241,8 @@ export function AuthModal({ callbackURL, onSuccess }: IAuthModalProps) {
                     disabled={isBusy}
                     required
                 />
-                <Button type="submit" variant="primary" loading={pendingMethod === 'magic-link'} disabled={isBusy && pendingMethod !== 'magic-link'}>
-                    <Mail size={16} aria-hidden /> Send magic link
+                <Button type="submit" variant="primary" loading={pendingMethod === 'email'} disabled={isBusy && pendingMethod !== 'email'}>
+                    <Mail size={16} aria-hidden /> Send code
                 </Button>
             </form>
 

--- a/src/frontend/modules/user/components/WalletButton/WalletButton.tsx
+++ b/src/frontend/modules/user/components/WalletButton/WalletButton.tsx
@@ -4,7 +4,7 @@
  * @fileoverview Header button driving the Phase 3 auth surface.
  *
  * Anonymous visitors see "Sign in" — clicking opens `AuthModal` with
- * magic-link, OAuth, and passkey options. Logged-in visitors see a
+ * email-code, OAuth, and passkey options. Logged-in visitors see a
  * short identity pill — clicking opens `ProfileMenu` for sign-out
  * and (legacy) wallet actions.
  *

--- a/src/frontend/modules/user/lib/auth-client.ts
+++ b/src/frontend/modules/user/lib/auth-client.ts
@@ -19,29 +19,30 @@
 'use client';
 
 import { createAuthClient } from 'better-auth/react';
-import { magicLinkClient } from 'better-auth/client/plugins';
+import { emailOTPClient } from 'better-auth/client/plugins';
 import { passkeyClient } from '@better-auth/passkey/client';
 
 /**
  * Configured Better Auth client.
  *
  * Plugin list mirrors the backend `auth.ts` plugin list — passkey is
- * always loaded, magic-link client method is registered so the modal
- * can call it whether or not the server side has Resend wired
- * (the server returns an error if magic-link is disabled, which the
- * modal surfaces as a toast).
+ * always loaded, the email-OTP client methods are registered so the
+ * modal can request and verify codes whether or not the server side
+ * has Resend wired (the server returns an error if email-OTP is
+ * disabled, which the modal surfaces as a toast).
  */
 export const authClient = createAuthClient({
-    plugins: [magicLinkClient(), passkeyClient()]
+    plugins: [emailOTPClient(), passkeyClient()]
 });
 
 /**
- * Reactive session hook re-exported from the configured client.
+ * Reactive session hook plus the auth actions used across the app.
  *
- * Returns `{ data, isPending, error, refetch }`. Components that need
- * SSR fallback should prefer `useAuthSession` from `SessionProvider` —
- * it merges the SSR-resolved session with this hook's live value so
- * the first render is never a "signed out" flash for users who
- * arrived with a valid Better Auth cookie.
+ * `emailOtp.sendVerificationOtp({ email, type: 'sign-in' })` mails a
+ * code; `signIn.emailOtp({ email, otp })` verifies it and creates the
+ * session. Components that need SSR fallback should prefer
+ * `useAuthSession` from `SessionProvider` — it merges the SSR-resolved
+ * session with `useSession`'s live value so the first render is never a
+ * "signed out" flash for users who arrived with a valid BA cookie.
  */
-export const { useSession, signIn, signUp, signOut } = authClient;
+export const { useSession, signIn, signUp, signOut, emailOtp } = authClient;


### PR DESCRIPTION
## Summary

Replaces the magic-link email sign-in with a 6-digit email OTP code.

**Why:** Email clients — notably the Gmail mobile app — open magic links in an in-app webview, so Better Auth set the session in a sandbox separate from the user's real browser (they appeared signed out where they started). Email link-scanners can also pre-fetch and consume single-use verify URLs before the user clicks. A code typed back into the originating tab eliminates both failure modes.

**Changes:**
- **Backend** (`auth.ts`): swap the `magicLink` plugin for `emailOTP` (6-digit, 5-minute expiry). Resend-backed sender emails the code; dev fallback logs it to console when Resend is unconfigured. Same passwordless / auto-register / email-verified semantics, so the `ADMIN_EMAILS` auto-promotion hook still works. Production without Resend drops the plugin (as magic-link did), so OAuth/passkey remain.
- **Client** (`auth-client.ts`): `magicLinkClient` → `emailOTPClient`; export the `emailOtp` namespace.
- **UI** (`AuthModal.tsx`): two-step email flow — enter email → "Send code" → enter the 6-digit code → "Verify & sign in" (completes in-tab via `router.refresh()`), plus a "Use a different email" back action. OAuth and passkey paths unchanged.
- Comment/doc cleanup: `env.ts`, `.env.example`, `WalletButton`, and three middleware files no longer reference magic-link.

Typecheck clean; 934 core tests pass. The `RESEND_*` env vars are already wired through the compose backend `environment:` block (PR #271), so prod email delivery works when configured.

**Not yet verified:** the live round-trip (request → receive code → verify → signed in) in a browser.