### PR TITLE
feat(auth): Phase 4 — Better Auth-keyed wallet store + /api/user/wallets

### DIFF
--- a/src/backend/modules/user/README.md
+++ b/src/backend/modules/user/README.md
@@ -640,6 +640,41 @@ interface IUserGroupDocument {
 
 **Seeded rows:** the user module seeds the `admin` row (with `system: true`) on every boot. The reserved-admin slug pattern (`admin`, `admins`, `super-admin(s)`, `administrator(s)`, `sub-admin(s)`, `superadmin(s)`, `root(s)`) blocks operators from creating or renaming rows matching it — only the platform may seed them.
 
+## Better Auth Wallet Store (Phase 4)
+
+> **Coexistence note.** Everything above describes the *legacy* UUID-keyed wallet flow (`users.wallets[]`, two-stage register/verify, cross-browser reconciliation). Phase 4 of the Better Auth refactor adds a parallel, Better-Auth-keyed wallet store. Both run side by side until the Phase 6 cutover removes the legacy flow. New code consumes the surfaces in this section; the legacy `/api/user/:id/wallet/*` routes remain only for the in-transition UI.
+
+Wallets are an opt-in post-login profile feature keyed by the Better Auth user id, not a browser-local UUID. Better Auth identity is already portable across devices (email-OTP / OAuth / passkey), so the new model drops the legacy "registered (unverified)" stage and the winner/loser identity merge: a wallet attaches only after a signature proves ownership, and a wallet already held by another account is a hard conflict, never a merge.
+
+`WalletService` (singleton, `services/wallet.service.ts`) owns the `module_user_wallets` collection and reuses `SignatureService` and `WalletChallengeService` for the same challenge → sign → verify contract the legacy flow uses. On every mutation it denormalizes the account's primary address onto the Better Auth user record's `primaryWallet` additional field (declared in `auth.ts`), so the authorization facade surfaces `session.primaryWallet` without a second query — the same pattern `GroupService` uses for `groups`.
+
+### `module_user_wallets` Collection
+
+```typescript
+interface IWalletDocument {
+    _id: ObjectId;
+    userId: string;     // Better Auth user id (module_user_auth_users._id)
+    address: string;    // normalized base58 TRON address (globally unique)
+    isPrimary: boolean; // exactly one primary per account
+    linkedAt: Date;
+    lastUsedAt: Date;
+}
+```
+
+**Indexes:** `address` (unique — a wallet belongs to exactly one account), `userId` (per-account list).
+
+### Routes (`/api/user/wallets`, Better Auth session)
+
+These routes resolve the caller from `req.authSession` (the `attachAuthSession` middleware), **not** a cookie-validated `:id` path param, so no user id appears on the wire. Anonymous callers get 401. The router mounts *before* the legacy `/api/user` router so the literal `wallets` segment is not captured by that router's `/:id` cookie middleware. All routes are rate-limited at the wallet-mutation tier (10 req/min).
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/user/wallets` | List the signed-in account's linked wallets |
+| `POST` | `/api/user/wallets/challenge` | Mint a single-use nonce. Body: `{ action: 'link' \| 'unlink' \| 'set-primary', address }` |
+| `POST` | `/api/user/wallets` | Link a wallet. Body: `{ address, message, signature, nonce }` |
+| `DELETE` | `/api/user/wallets/:address` | Unlink a wallet. Body: `{ message, signature, nonce }` |
+| `PATCH` | `/api/user/wallets/:address/primary` | Set primary (step-up). Body: `{ message, signature, nonce }` |
+
 ## Module Lifecycle
 
 The user module implements the `IModule` interface with two-phase initialization:

--- a/src/backend/modules/user/UserModule.ts
+++ b/src/backend/modules/user/UserModule.ts
@@ -30,6 +30,7 @@ import { logger } from '../../lib/logger.js';
 import { MAIN_SYSTEM_CONTAINER_ID } from '../menu/index.js';
 import { TronGridClient } from '../blockchain/tron-grid.client.js';
 import { UserService } from './services/user.service.js';
+import { WalletService } from './services/wallet.service.js';
 import { GscService } from './services/gsc.service.js';
 import { TrafficService } from './services/traffic.service.js';
 import { UserGroupService } from './services/user-group.service.js';
@@ -37,9 +38,11 @@ import { GroupService } from './services/group.service.js';
 import { setAuthInstance } from './services/auth-facade.js';
 import { initGeoIP } from './services/geo.service.js';
 import { UserController } from './api/user.controller.js';
+import { WalletController } from './api/wallet.controller.js';
 import { UserGroupController } from './api/user-group.controller.js';
 import { TrafficController } from './api/traffic.controller.js';
 import { createUserRouter, createAdminUserRouter, createProfileRouter } from './api/user.routes.js';
+import { createWalletRouter } from './api/wallet.routes.js';
 import { createAdminUserGroupRouter } from './api/user-group.routes.js';
 import { createAdminTrafficRouter } from './api/traffic.routes.js';
 import { requireAdmin } from '../../api/middleware/admin-auth.js';
@@ -172,10 +175,12 @@ export class UserModule implements IModule<IUserModuleDependencies> {
      * Services created during init() phase.
      */
     private userService!: UserService;
+    private walletService!: WalletService;
     private gscService!: GscService;
     private trafficService!: TrafficService;
     private userGroupService!: UserGroupService;
     private controller!: UserController;
+    private walletController!: WalletController;
     private groupController!: UserGroupController;
     private trafficController!: TrafficController;
 
@@ -239,6 +244,15 @@ export class UserModule implements IModule<IUserModuleDependencies> {
         // Create database indexes
         await this.userService.createIndexes();
 
+        // Initialize WalletService singleton (Phase 4 of the Better Auth
+        // refactor). Owns the BA-user-keyed `module_user_wallets` store,
+        // reusing the same TronWeb instance for signature verification.
+        // Replaces the legacy UUID-keyed `users.wallets[]` flow, which the
+        // Phase 6 cutover removes.
+        WalletService.setDependencies(this.database, this.cacheService, this.logger, tronWeb);
+        this.walletService = WalletService.getInstance();
+        await this.walletService.createIndexes();
+
         // Initialize GscService singleton with dependencies
         GscService.setDependencies(
             this.database,
@@ -282,6 +296,10 @@ export class UserModule implements IModule<IUserModuleDependencies> {
             this.trafficService,
             this.logger
         );
+
+        // Create wallet controller (Phase 4). Resolves the caller from the
+        // Better Auth session rather than a cookie-validated :id param.
+        this.walletController = new WalletController(this.walletService, this.logger);
 
         // Create group controller with singleton service
         this.groupController = new UserGroupController(this.userGroupService, this.logger);
@@ -379,6 +397,15 @@ export class UserModule implements IModule<IUserModuleDependencies> {
         // remove in Phase 6.
         this.app.all('/api/auth/*', toNodeHandler(this.auth));
         this.logger.info('Better Auth handler mounted at /api/auth/*');
+
+        // Mount the Better Auth-keyed wallet router (Phase 4). Must be
+        // registered BEFORE the `/api/user` public router so the literal
+        // `wallets` segment is matched here and never falls through to
+        // that router's `/:id` cookie-validation middleware (which would
+        // treat "wallets" as a UUID and 403).
+        const walletRouter = createWalletRouter(this.walletController);
+        this.app.use('/api/user/wallets', walletRouter);
+        this.logger.info('Wallet router mounted at /api/user/wallets');
 
         // Create and mount public router (IoC - module attaches itself to app)
         const publicRouter = this.createPublicRouter();

--- a/src/backend/modules/user/__tests__/wallet.service.test.ts
+++ b/src/backend/modules/user/__tests__/wallet.service.test.ts
@@ -200,6 +200,23 @@ describe('WalletService', () => {
                 })
             ).rejects.toThrow(/canonical challenge form/i);
         });
+
+        it('recovers from a concurrent-primary duplicate-key race by linking as non-primary', async () => {
+            // Simulate the partial { userId, isPrimary:true } unique index
+            // rejecting the first insert (a concurrent first-link already
+            // claimed primary). The service must catch E11000, find no
+            // address dup, and re-insert the wallet as non-primary rather
+            // than leaking the raw error.
+            const e11000 = Object.assign(new Error('E11000 duplicate key'), { code: 11000 });
+            mockDatabase.injectError(WALLETS_COLLECTION, 'insertOne', e11000);
+
+            const wallets = await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_1));
+
+            expect(wallets).toHaveLength(1);
+            expect(wallets[0]).toMatchObject({ address: WALLET_1, isPrimary: false });
+            // A non-primary link must not denormalize primaryWallet.
+            expect(authPrimary(USER_A)).toBeNull();
+        });
     });
 
     describe('setPrimaryWallet', () => {

--- a/src/backend/modules/user/__tests__/wallet.service.test.ts
+++ b/src/backend/modules/user/__tests__/wallet.service.test.ts
@@ -1,0 +1,283 @@
+/// <reference types="vitest" />
+
+/**
+ * @fileoverview Phase 4 unit tests for {@link WalletService}.
+ *
+ * Exercises the Better Auth-keyed wallet store against the shared
+ * in-memory `createMockDatabaseService` mock plus a minimal cache double
+ * (so the internal {@link WalletChallengeService} round-trips). The
+ * SignatureService is mocked module-wide — address normalization is
+ * identity and signature recovery returns the submitted address — so the
+ * tests focus on the store's link/unlink/set-primary/conflict logic and
+ * the denormalized `primaryWallet` write onto the BA user row, not on
+ * TRON cryptography.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { ICacheService, ISystemLogService } from '@/types';
+import { WalletService, WALLETS_COLLECTION } from '../services/wallet.service.js';
+import { WalletChallengeService } from '../services/wallet-challenge.service.js';
+import { AUTH_USERS_COLLECTION } from '../services/auth-constants.js';
+import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+
+// Mock SignatureService so unit tests don't need a real TronWeb instance.
+// normalizeAddress is identity; verifyMessage echoes the submitted
+// address back as the recovered signer (the signature is mock-trusted).
+vi.mock('../../auth/signature.service.js', () => {
+    return {
+        SignatureService: class MockSignatureService {
+            normalizeAddress(address: string): string {
+                return address;
+            }
+            async verifyMessage(address: string): Promise<string> {
+                return address;
+            }
+        }
+    };
+});
+
+/**
+ * Minimal in-memory ICacheService double for the challenge round-trip.
+ * `del()` returns 1 only for the caller that removed the key, matching
+ * the single-use semantics the challenge service relies on.
+ */
+class MockCacheService implements ICacheService {
+    private store = new Map<string, { value: any; expiresAt?: number }>();
+
+    async get<T>(key: string): Promise<T | null> {
+        const entry = this.store.get(key);
+        if (!entry) return null;
+        if (entry.expiresAt && entry.expiresAt < Date.now()) {
+            this.store.delete(key);
+            return null;
+        }
+        return entry.value as T;
+    }
+
+    async set<T>(key: string, value: T, ttlSeconds?: number): Promise<void> {
+        this.store.set(key, {
+            value,
+            expiresAt: ttlSeconds ? Date.now() + ttlSeconds * 1000 : undefined
+        });
+    }
+
+    async del(key: string): Promise<number> {
+        return this.store.delete(key) ? 1 : 0;
+    }
+
+    async invalidate(): Promise<void> {}
+    async keys(): Promise<string[]> { return []; }
+}
+
+/**
+ * Stub logger — WalletService only emits info/error breadcrumbs.
+ */
+class StubLogger implements ISystemLogService {
+    public level = 'info';
+    info(): void {}
+    warn(): void {}
+    error(): void {}
+    debug(): void {}
+    trace(): void {}
+    fatal(): void {}
+    child(): ISystemLogService { return this; }
+    async initialize(): Promise<void> {}
+    async saveLog(): Promise<void> {}
+    async getLogs(): Promise<any> {
+        return { logs: [], total: 0, page: 1, limit: 50, totalPages: 0, hasNextPage: false, hasPrevPage: false };
+    }
+    async markAsResolved(): Promise<void> {}
+    async cleanup(): Promise<number> { return 0; }
+    async getStatistics(): Promise<any> { return { total: 0, byLevel: {}, byService: {}, unresolved: 0 }; }
+    async getLogById(): Promise<any> { return null; }
+    async markAsUnresolved(): Promise<any> { return null; }
+    async deleteAllLogs(): Promise<number> { return 0; }
+    async getStats(): Promise<any> { return { total: 0, byLevel: {}, resolved: 0, unresolved: 0 }; }
+}
+
+const USER_A = 'user_aaa';
+const USER_B = 'user_bbb';
+const WALLET_1 = 'TWallet1111111111111111111111111111';
+const WALLET_2 = 'TWallet2222222222222222222222222222';
+
+describe('WalletService', () => {
+    let mockDatabase: ReturnType<typeof createMockDatabaseService>;
+    let cache: MockCacheService;
+    let service: WalletService;
+
+    /**
+     * Mint a challenge through the service and build the signed mutation
+     * input a caller would submit. The mock signature service trusts any
+     * signature, so a fixed placeholder string suffices.
+     */
+    async function buildInput(userId: string, action: 'link' | 'unlink' | 'set-primary', address: string) {
+        const challenge = await service.issueChallenge(userId, action, address);
+        return { address, message: challenge.message, signature: 'sig', nonce: challenge.nonce };
+    }
+
+    /** Read the denormalized primaryWallet from the seeded BA user row. */
+    function authPrimary(userId: string): string | null | undefined {
+        const row = mockDatabase
+            .getCollectionData(AUTH_USERS_COLLECTION)
+            .find((d: any) => d._id === userId);
+        return row ? row.primaryWallet : undefined;
+    }
+
+    beforeEach(() => {
+        mockDatabase = createMockDatabaseService();
+        cache = new MockCacheService();
+        // Seed BA user rows so the denormalized primaryWallet write lands.
+        mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({ _id: USER_A, primaryWallet: null });
+        mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({ _id: USER_B, primaryWallet: null });
+        WalletService.resetForTests();
+        WalletService.setDependencies(mockDatabase, cache, new StubLogger(), {} as any);
+        service = WalletService.getInstance();
+    });
+
+    afterEach(() => {
+        WalletService.resetForTests();
+        mockDatabase.clear();
+    });
+
+    describe('singleton contract', () => {
+        it('throws when getInstance() runs before setDependencies()', () => {
+            WalletService.resetForTests();
+            expect(() => WalletService.getInstance()).toThrow(/setDependencies/i);
+        });
+
+        it('keeps the first dependencies on a second setDependencies() call', () => {
+            const first = WalletService.getInstance();
+            WalletService.setDependencies(createMockDatabaseService(), new MockCacheService(), new StubLogger(), {} as any);
+            expect(WalletService.getInstance()).toBe(first);
+        });
+    });
+
+    describe('linkWallet', () => {
+        it('links the first wallet and marks it primary', async () => {
+            const wallets = await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_1));
+            expect(wallets).toHaveLength(1);
+            expect(wallets[0]).toMatchObject({ address: WALLET_1, isPrimary: true });
+            expect(authPrimary(USER_A)).toBe(WALLET_1);
+        });
+
+        it('links a second wallet as non-primary and leaves primary unchanged', async () => {
+            await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_1));
+            const wallets = await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_2));
+            expect(wallets).toHaveLength(2);
+            const second = wallets.find(w => w.address === WALLET_2);
+            expect(second?.isPrimary).toBe(false);
+            expect(authPrimary(USER_A)).toBe(WALLET_1);
+        });
+
+        it('rejects a wallet already linked to another account', async () => {
+            await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_1));
+            await expect(
+                service.linkWallet(USER_B, await buildInput(USER_B, 'link', WALLET_1))
+            ).rejects.toThrow(/already linked to another account/i);
+        });
+
+        it('is idempotent when the same account re-links a held wallet', async () => {
+            await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_1));
+            const wallets = await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_1));
+            expect(wallets).toHaveLength(1);
+            expect(mockDatabase.getCollectionData(WALLETS_COLLECTION)).toHaveLength(1);
+        });
+
+        it('rejects a replayed nonce', async () => {
+            const input = await buildInput(USER_A, 'link', WALLET_1);
+            await service.linkWallet(USER_A, input);
+            await expect(service.linkWallet(USER_A, input)).rejects.toThrow(/expired or already used/i);
+        });
+
+        it('rejects a tampered (non-canonical) message', async () => {
+            const challenge = await service.issueChallenge(USER_A, 'link', WALLET_1);
+            await expect(
+                service.linkWallet(USER_A, {
+                    address: WALLET_1,
+                    message: 'not the canonical message',
+                    signature: 'sig',
+                    nonce: challenge.nonce
+                })
+            ).rejects.toThrow(/canonical challenge form/i);
+        });
+    });
+
+    describe('setPrimaryWallet', () => {
+        it('moves primary to the chosen wallet', async () => {
+            await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_1));
+            await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_2));
+
+            const wallets = await service.setPrimaryWallet(USER_A, await buildInput(USER_A, 'set-primary', WALLET_2));
+            expect(wallets.find(w => w.address === WALLET_2)?.isPrimary).toBe(true);
+            expect(wallets.find(w => w.address === WALLET_1)?.isPrimary).toBe(false);
+            expect(authPrimary(USER_A)).toBe(WALLET_2);
+        });
+
+        it('rejects when the wallet is not linked', async () => {
+            await expect(
+                service.setPrimaryWallet(USER_A, await buildInput(USER_A, 'set-primary', WALLET_1))
+            ).rejects.toThrow(/not linked/i);
+        });
+    });
+
+    describe('unlinkWallet', () => {
+        it('promotes the most recently used remaining wallet when primary is removed', async () => {
+            await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_1));
+            await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_2));
+            // WALLET_1 is primary; remove it.
+            const wallets = await service.unlinkWallet(USER_A, await buildInput(USER_A, 'unlink', WALLET_1));
+            expect(wallets).toHaveLength(1);
+            expect(wallets[0]).toMatchObject({ address: WALLET_2, isPrimary: true });
+            expect(authPrimary(USER_A)).toBe(WALLET_2);
+        });
+
+        it('clears the denormalized primary when the last wallet is removed', async () => {
+            await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_1));
+            const wallets = await service.unlinkWallet(USER_A, await buildInput(USER_A, 'unlink', WALLET_1));
+            expect(wallets).toHaveLength(0);
+            expect(authPrimary(USER_A)).toBeNull();
+        });
+
+        it('rejects when the wallet is not linked', async () => {
+            await expect(
+                service.unlinkWallet(USER_A, await buildInput(USER_A, 'unlink', WALLET_1))
+            ).rejects.toThrow(/not linked/i);
+        });
+    });
+
+    describe('listWallets', () => {
+        it('returns an empty array for an account with no wallets', async () => {
+            expect(await service.listWallets(USER_A)).toEqual([]);
+        });
+
+        it('scopes the list to the requested account', async () => {
+            await service.linkWallet(USER_A, await buildInput(USER_A, 'link', WALLET_1));
+            await service.linkWallet(USER_B, await buildInput(USER_B, 'link', WALLET_2));
+            const aWallets = await service.listWallets(USER_A);
+            expect(aWallets).toHaveLength(1);
+            expect(aWallets[0].address).toBe(WALLET_1);
+        });
+    });
+
+    describe('challenge scoping', () => {
+        it('does not let one account consume another account nonce', async () => {
+            // USER_B mints a challenge for WALLET_2, USER_A tries to use it.
+            const challenge = await service.issueChallenge(USER_B, 'link', WALLET_2);
+            await expect(
+                service.linkWallet(USER_A, {
+                    address: WALLET_2,
+                    message: challenge.message,
+                    signature: 'sig',
+                    nonce: challenge.nonce
+                })
+            ).rejects.toThrow(/expired or already used/i);
+        });
+
+        it('builds the canonical message for the action/address/nonce tuple', async () => {
+            const challenge = await service.issueChallenge(USER_A, 'link', WALLET_1);
+            expect(challenge.message).toBe(
+                WalletChallengeService.buildMessage('link', WALLET_1, challenge.nonce)
+            );
+        });
+    });
+});

--- a/src/backend/modules/user/api/index.ts
+++ b/src/backend/modules/user/api/index.ts
@@ -1,5 +1,7 @@
 export { UserController } from './user.controller.js';
 export { createUserRouter, createAdminUserRouter } from './user.routes.js';
+export { WalletController } from './wallet.controller.js';
+export { createWalletRouter } from './wallet.routes.js';
 export { UserGroupController } from './user-group.controller.js';
 export { createAdminUserGroupRouter } from './user-group.routes.js';
 export { TrafficController } from './traffic.controller.js';

--- a/src/backend/modules/user/api/wallet.controller.ts
+++ b/src/backend/modules/user/api/wallet.controller.ts
@@ -1,0 +1,245 @@
+/**
+ * @fileoverview HTTP interface for the Better Auth-keyed wallet store.
+ *
+ * Phase 4 of the Better Auth refactor. Unlike the legacy wallet
+ * endpoints under `/api/user/:id/wallet/*` — which validate a
+ * `tronrelic_uid` cookie against a UUID path param — these routes
+ * resolve the caller from the Better Auth session (`req.authSession`,
+ * populated by the `attachAuthSession` middleware) and carry no id in
+ * the path. Anonymous callers get 401; the account is never named on
+ * the wire because it is implied by the session.
+ *
+ * The controller is a thin HTTP adapter: it resolves the session user
+ * id, validates the request body, delegates to {@link WalletService},
+ * and maps service errors to 4xx. All wallet business logic — challenge
+ * verification, signature recovery, primary recomputation — lives in
+ * the service.
+ */
+
+import type { Request, Response } from 'express';
+import type { ISystemLogService } from '@/types';
+import type { WalletService, WalletAction } from '../services/wallet.service.js';
+
+/**
+ * Wallet operations a challenge may be minted for.
+ *
+ * Mirrors {@link WalletAction}; declared as a runtime set so the
+ * challenge endpoint can reject unknown actions with a 400 instead of
+ * forwarding them to the service.
+ */
+const CHALLENGE_ACTIONS: ReadonlySet<WalletAction> = new Set<WalletAction>([
+    'link',
+    'unlink',
+    'set-primary'
+]);
+
+/**
+ * Controller for `/api/user/wallets/*`.
+ *
+ * Constructed in `UserModule.init()` with the {@link WalletService}
+ * singleton and the module logger.
+ */
+export class WalletController {
+    /**
+     * @param walletService - Wallet store service.
+     * @param logger - Module logger; a `component: 'wallet-controller'` child is derived.
+     */
+    constructor(
+        private readonly walletService: WalletService,
+        private readonly logger: ISystemLogService
+    ) {
+        this.logger = logger.child({ component: 'wallet-controller' });
+    }
+
+    /**
+     * GET /api/user/wallets — list the signed-in account's wallets.
+     */
+    async list(req: Request, res: Response): Promise<void> {
+        const userId = this.requireUserId(req, res);
+        if (!userId) {
+            return;
+        }
+        try {
+            const wallets = await this.walletService.listWallets(userId);
+            res.json({ wallets });
+        } catch (error) {
+            this.logger.error({ error, userId }, 'Failed to list wallets');
+            res.status(500).json({ error: 'Failed to list wallets' });
+        }
+    }
+
+    /**
+     * POST /api/user/wallets/challenge — mint a single-use challenge.
+     *
+     * Body: { action: 'link' | 'unlink' | 'set-primary', address }
+     */
+    async issueChallenge(req: Request, res: Response): Promise<void> {
+        const userId = this.requireUserId(req, res);
+        if (!userId) {
+            return;
+        }
+        try {
+            const { action, address } = req.body ?? {};
+            if (!action || !CHALLENGE_ACTIONS.has(action)) {
+                res.status(400).json({
+                    error: 'Invalid action',
+                    message: "action must be one of 'link', 'unlink', 'set-primary'"
+                });
+                return;
+            }
+            if (!address) {
+                res.status(400).json({ error: 'Missing required field', message: 'address is required' });
+                return;
+            }
+            const challenge = await this.walletService.issueChallenge(userId, action, address);
+            res.json(challenge);
+        } catch (error) {
+            this.logger.error({ error, userId }, 'Failed to issue wallet challenge');
+            res.status(400).json({
+                error: 'Failed to issue wallet challenge',
+                message: error instanceof Error ? error.message : 'Unknown error'
+            });
+        }
+    }
+
+    /**
+     * POST /api/user/wallets — link a wallet after proving ownership.
+     *
+     * Body: { address, message, signature, nonce }
+     */
+    async link(req: Request, res: Response): Promise<void> {
+        const userId = this.requireUserId(req, res);
+        if (!userId) {
+            return;
+        }
+        try {
+            const input = this.parseMutationBody(req, res);
+            if (!input) {
+                return;
+            }
+            const wallets = await this.walletService.linkWallet(userId, input);
+            res.json({ wallets });
+        } catch (error) {
+            this.logger.error({ error, userId }, 'Failed to link wallet');
+            res.status(400).json({
+                error: 'Failed to link wallet',
+                message: error instanceof Error ? error.message : 'Unknown error'
+            });
+        }
+    }
+
+    /**
+     * DELETE /api/user/wallets/:address — unlink a wallet.
+     *
+     * Body: { message, signature, nonce } — the address comes from the path.
+     */
+    async unlink(req: Request, res: Response): Promise<void> {
+        const userId = this.requireUserId(req, res);
+        if (!userId) {
+            return;
+        }
+        try {
+            const { message, signature, nonce } = req.body ?? {};
+            if (!message || !signature || !nonce) {
+                res.status(400).json({
+                    error: 'Missing required fields',
+                    message: 'Request must include message, signature, and nonce'
+                });
+                return;
+            }
+            const wallets = await this.walletService.unlinkWallet(userId, {
+                address: req.params.address,
+                message,
+                signature,
+                nonce
+            });
+            res.json({ wallets });
+        } catch (error) {
+            this.logger.error({ error, userId }, 'Failed to unlink wallet');
+            res.status(400).json({
+                error: 'Failed to unlink wallet',
+                message: error instanceof Error ? error.message : 'Unknown error'
+            });
+        }
+    }
+
+    /**
+     * PATCH /api/user/wallets/:address/primary — set the account's primary wallet.
+     *
+     * Body: { message, signature, nonce } — the address comes from the path.
+     */
+    async setPrimary(req: Request, res: Response): Promise<void> {
+        const userId = this.requireUserId(req, res);
+        if (!userId) {
+            return;
+        }
+        try {
+            const { message, signature, nonce } = req.body ?? {};
+            if (!message || !signature || !nonce) {
+                res.status(400).json({
+                    error: 'Missing required fields',
+                    message: 'Request must include message, signature, and nonce'
+                });
+                return;
+            }
+            const wallets = await this.walletService.setPrimaryWallet(userId, {
+                address: req.params.address,
+                message,
+                signature,
+                nonce
+            });
+            res.json({ wallets });
+        } catch (error) {
+            this.logger.error({ error, userId }, 'Failed to set primary wallet');
+            res.status(400).json({
+                error: 'Failed to set primary wallet',
+                message: error instanceof Error ? error.message : 'Unknown error'
+            });
+        }
+    }
+
+    /**
+     * Resolve the Better Auth user id from the request session.
+     *
+     * Sends 401 and returns `null` when no session is present, so each
+     * handler can guard with `if (!userId) return;`. Reads the
+     * middleware-populated `req.authSession`; never touches the facade or
+     * cookies directly.
+     *
+     * @param req - Express request.
+     * @param res - Express response (used to send 401 on miss).
+     * @returns The signed-in user id, or `null` when anonymous.
+     */
+    private requireUserId(req: Request, res: Response): string | null {
+        const userId = req.authSession?.user?.id ?? null;
+        if (!userId) {
+            res.status(401).json({ error: 'Unauthorized', message: 'Sign in required' });
+            return null;
+        }
+        return userId;
+    }
+
+    /**
+     * Validate the shared link/unlink/set-primary mutation body.
+     *
+     * Sends 400 and returns `null` when any required field is missing.
+     *
+     * @param req - Express request whose body carries the signed mutation.
+     * @param res - Express response (used to send 400 on miss).
+     * @returns The validated mutation input, or `null` when invalid.
+     */
+    private parseMutationBody(
+        req: Request,
+        res: Response
+    ): { address: string; message: string; signature: string; nonce: string } | null {
+        const { address, message, signature, nonce } = req.body ?? {};
+        if (!address || !message || !signature || !nonce) {
+            res.status(400).json({
+                error: 'Missing required fields',
+                message: 'Request must include address, message, signature, and nonce'
+            });
+            return null;
+        }
+        return { address, message, signature, nonce };
+    }
+}

--- a/src/backend/modules/user/api/wallet.routes.ts
+++ b/src/backend/modules/user/api/wallet.routes.ts
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview Router factory for the Better Auth-keyed wallet endpoints.
+ *
+ * Mounted at `/api/user/wallets` (Phase 4). These routes resolve the
+ * caller from the Better Auth session via {@link WalletController}, not
+ * from a cookie-validated `:id` path param, so they carry no user id in
+ * the URL. The mount point must be registered *before* the legacy
+ * `/api/user` public router so the literal `wallets` segment is not
+ * captured by that router's `/:id` cookie-validation middleware.
+ */
+
+import { Router } from 'express';
+import type { WalletController } from './wallet.controller.js';
+import { createRateLimiter } from '../../../api/middleware/rate-limit.js';
+
+/**
+ * Create the Express router for Better Auth-keyed wallet endpoints.
+ *
+ * All routes are per-IP rate-limited at the wallet-mutation tier (10
+ * req/min) — wallet operations are infrequent and signature-gated, so a
+ * tight ceiling is appropriate. Authorization (401 for anonymous
+ * callers) is enforced inside the controller off `req.authSession`.
+ *
+ * @param controller - Wallet controller instance.
+ * @returns Express router to mount at `/api/user/wallets`.
+ */
+export function createWalletRouter(controller: WalletController): Router {
+    const router = Router();
+
+    const walletRateLimiter = createRateLimiter({
+        windowSeconds: 60,
+        maxRequests: 10,
+        keyPrefix: 'user:wallets'
+    });
+
+    /**
+     * GET /api/user/wallets
+     * List the signed-in account's linked wallets.
+     */
+    router.get('/', walletRateLimiter, controller.list.bind(controller));
+
+    /**
+     * POST /api/user/wallets/challenge
+     * Mint a single-use challenge for a wallet operation. Mounted before
+     * the bare `/` POST so its specific path wins.
+     */
+    router.post('/challenge', walletRateLimiter, controller.issueChallenge.bind(controller));
+
+    /**
+     * POST /api/user/wallets
+     * Link a wallet after proving ownership via signature.
+     */
+    router.post('/', walletRateLimiter, controller.link.bind(controller));
+
+    /**
+     * DELETE /api/user/wallets/:address
+     * Unlink a wallet (requires a fresh unlink challenge + signature).
+     */
+    router.delete('/:address', walletRateLimiter, controller.unlink.bind(controller));
+
+    /**
+     * PATCH /api/user/wallets/:address/primary
+     * Set an already-linked wallet as primary (step-up: challenge + signature).
+     */
+    router.patch('/:address/primary', walletRateLimiter, controller.setPrimary.bind(controller));
+
+    return router;
+}

--- a/src/backend/modules/user/database/IWalletDocument.ts
+++ b/src/backend/modules/user/database/IWalletDocument.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview MongoDB document interface for Better Auth-keyed wallet links.
+ *
+ * Phase 4 of the Better Auth refactor introduces a dedicated
+ * `module_user_wallets` collection keyed by the Better Auth user id,
+ * replacing the legacy `users.wallets[]` embedded array that was keyed
+ * by the UUID identity. The legacy embedded model carried a
+ * register/verify two-stage flow and cross-browser identity
+ * reconciliation because UUIDs were browser-local; Better Auth identity
+ * is portable across devices via email-OTP / OAuth / passkey, so the
+ * new model is deliberately simpler:
+ *
+ * - A wallet is only stored after a signature proves ownership, so
+ *   there is no "registered (unverified)" wallet state and no `verified`
+ *   flag — every persisted row is verified by construction.
+ * - A wallet belongs to exactly one Better Auth account (unique index
+ *   on `address`); claiming a wallet already linked elsewhere is a hard
+ *   conflict, not a merge.
+ *
+ * The user's primary wallet is denormalized onto the Better Auth user
+ * record's `primaryWallet` additional field (see `auth.ts`) so it
+ * surfaces on the session without a second query; this collection holds
+ * the full list and is the source of truth the denormalized pointer is
+ * derived from.
+ */
+
+import type { ObjectId } from 'mongodb';
+
+/**
+ * Persisted wallet link, keyed by Better Auth user id.
+ *
+ * One document per (account, address). All rows are verified —
+ * ownership is proven by a TronLink signature over a server-issued
+ * challenge before the row is written.
+ */
+export interface IWalletDocument {
+    /** MongoDB primary key. */
+    _id: ObjectId;
+
+    /**
+     * Better Auth user id (the `module_user_auth_users._id` value, also
+     * returned as `user.id` from the BA session API). Not a UUID — the
+     * legacy UUID identity is decommissioned in Phase 6.
+     */
+    userId: string;
+
+    /** Normalized base58 TRON address. Globally unique across accounts. */
+    address: string;
+
+    /** Whether this is the account's primary wallet. Exactly one per account. */
+    isPrimary: boolean;
+
+    /** When the wallet was first linked to this account. */
+    linkedAt: Date;
+
+    /** Most recent signature/use timestamp; drives primary recomputation on unlink. */
+    lastUsedAt: Date;
+}
+
+/**
+ * Public wire shape returned by the wallet service and API.
+ *
+ * Strips the Mongo `_id` and `userId` (implied by the authenticated
+ * session) and exposes only what the profile UI needs. Date fields are
+ * serialized to ISO strings by Express `res.json`.
+ */
+export interface ILinkedWallet {
+    /** Normalized base58 TRON address. */
+    address: string;
+
+    /** Whether this is the account's primary wallet. */
+    isPrimary: boolean;
+
+    /** When the wallet was first linked to this account. */
+    linkedAt: Date;
+
+    /** Most recent signature/use timestamp. */
+    lastUsedAt: Date;
+}

--- a/src/backend/modules/user/database/index.ts
+++ b/src/backend/modules/user/database/index.ts
@@ -18,3 +18,5 @@ export type {
 } from './IUserDocument.js';
 
 export type { IUserGroupDocument } from './IUserGroupDocument.js';
+
+export type { IWalletDocument, ILinkedWallet } from './IWalletDocument.js';

--- a/src/backend/modules/user/services/auth-facade.ts
+++ b/src/backend/modules/user/services/auth-facade.ts
@@ -80,9 +80,11 @@ export interface IAugmentedSession {
     groups: string[];
 
     /**
-     * Primary TRON wallet address linked to the user, when one has
-     * been verified. Always `undefined` in Phase 2 — wallet storage
-     * lands in Phase 4.
+     * Primary TRON wallet address linked to the user, when one is set.
+     * Sourced from the Better Auth user record's `primaryWallet`
+     * additional field (Phase 4), which {@link WalletService} maintains
+     * on every link / unlink / set-primary. `undefined` when the account
+     * has no linked wallet.
      */
     primaryWallet?: string;
 }
@@ -295,11 +297,17 @@ export async function getSessionFromHeaders(
     let augmented: IAugmentedSession | null = null;
     if (resolved) {
         const groups = await GroupService.getInstance().getUserGroups(resolved.user.id);
+        // `primaryWallet` is a Better Auth additional field (declared in
+        // auth.ts, maintained by WalletService) so it rides along on the
+        // resolved user record — no extra round-trip. Read defensively
+        // because BA's inferred user type does not surface custom fields.
+        const primaryWallet =
+            (resolved.user as { primaryWallet?: string | null }).primaryWallet ?? undefined;
         augmented = {
             user: resolved.user,
             session: resolved.session,
             groups,
-            primaryWallet: undefined
+            primaryWallet
         };
     }
     return augmented;

--- a/src/backend/modules/user/services/index.ts
+++ b/src/backend/modules/user/services/index.ts
@@ -2,6 +2,8 @@ export { UserService } from './user.service.js';
 export type { IUserStats, IConnectWalletResult, ILinkWalletResult, IPublicProfile, IVisitorOrigin, IDateRange, IAnalyticsRangeQuery } from './user.service.js';
 export { WalletChallengeService } from './wallet-challenge.service.js';
 export type { IWalletChallenge, WalletChallengeAction } from './wallet-challenge.service.js';
+export { WalletService, WALLETS_COLLECTION } from './wallet.service.js';
+export type { WalletAction, IWalletMutationInput } from './wallet.service.js';
 export { UserGroupService, RESERVED_ADMIN_PATTERN, SYSTEM_ADMIN_GROUP_ID } from './user-group.service.js';
 export { computeUserAuthStatus, withAuthStatus } from './auth-status.js';
 export { GscService } from './gsc.service.js';

--- a/src/backend/modules/user/services/wallet.service.ts
+++ b/src/backend/modules/user/services/wallet.service.ts
@@ -1,0 +1,425 @@
+/**
+ * @fileoverview Wallet linking service keyed by Better Auth user id.
+ *
+ * Phase 4 of the Better Auth refactor. Owns the `module_user_wallets`
+ * collection — the post-login profile feature that lets an authenticated
+ * Better Auth account attach one or more TRON wallets it has proven
+ * ownership of. This replaces the legacy UUID-keyed `users.wallets[]`
+ * embedded array (and its register/verify two-stage flow plus
+ * cross-browser identity reconciliation), which the Phase 6 cutover
+ * removes.
+ *
+ * **Why simpler than the legacy flow.** UUID identity was browser-local,
+ * so the legacy code needed "registered (unverified)" wallets and a
+ * winner/loser merge to bridge a wallet across browsers. Better Auth
+ * identity is already portable (email-OTP / OAuth / passkey), so a
+ * wallet is purely a profile attachment: prove ownership with a
+ * signature, attach it, done. A wallet already held by another account
+ * is a hard conflict, never a merge.
+ *
+ * **Identity boundary.** Callers resolve the Better Auth user id from
+ * the session (`req.authSession.user.id`) *before* invoking this
+ * service — the service never reads cookies or sessions. Every method
+ * takes the resolved `userId` as its first argument, mirroring
+ * {@link GroupService}.
+ *
+ * **Denormalized primary.** On every mutation the service writes the
+ * account's primary address onto the Better Auth user record's
+ * `primaryWallet` additional field (declared in `auth.ts`) so the
+ * authorization facade can surface it on the session without a second
+ * query. This collection remains the source of truth; the BA field is a
+ * derived pointer, maintained the same way {@link GroupService}
+ * maintains `groups`.
+ *
+ * **Singleton.** Follows the project's `setDependencies()` /
+ * `getInstance()` pattern because the wallet store is shared
+ * application state configured once at bootstrap.
+ */
+
+import { ObjectId, type Collection } from 'mongodb';
+import type TronWeb from 'tronweb';
+import type { ICacheService, IDatabaseService, ISystemLogService } from '@/types';
+import { SignatureService } from '../../auth/signature.service.js';
+import { WalletChallengeService } from './wallet-challenge.service.js';
+import type { WalletChallengeAction, IWalletChallenge } from './wallet-challenge.service.js';
+import type { IWalletDocument, ILinkedWallet } from '../database/IWalletDocument.js';
+import { AUTH_USERS_COLLECTION } from './auth-constants.js';
+
+/**
+ * Physical collection name for the Better Auth-keyed wallet store.
+ *
+ * Follows the `module_{module-id}_{collection}` convention. Renaming is
+ * a breaking change for persisted records — coordinate with a migration.
+ */
+export const WALLETS_COLLECTION = 'module_user_wallets';
+
+/**
+ * Wallet operations the new flow supports.
+ *
+ * Narrower than the legacy {@link WalletChallengeAction} set — there is
+ * no `refresh-verification` because Better Auth owns session freshness;
+ * a wallet's only states are linked or not.
+ */
+export type WalletAction = Extract<WalletChallengeAction, 'link' | 'unlink' | 'set-primary'>;
+
+/**
+ * Signed-mutation input common to link / unlink / set-primary.
+ *
+ * `message` must equal the canonical challenge form for `(action,
+ * normalizedAddress, nonce)`; `signature` must recover to the same
+ * address. The service reconstructs and verifies both before mutating.
+ */
+export interface IWalletMutationInput {
+    /** Submitted TRON address (hex or base58); normalized internally. */
+    address: string;
+    /** Canonical challenge message the client signed verbatim. */
+    message: string;
+    /** TronLink signature over `message`. */
+    signature: string;
+    /** Single-use nonce minted by {@link issueChallenge}. */
+    nonce: string;
+}
+
+/**
+ * Shape of the Better Auth user row this service denormalizes onto.
+ *
+ * Restricted to the field written here — BA owns the full schema. The
+ * adapter maps the logical `id` to MongoDB `_id`, so writes filter by
+ * `{ _id: userId }` (same boundary {@link GroupService} uses).
+ */
+interface IAuthUserPrimaryWallet {
+    _id: string;
+    primaryWallet?: string | null;
+}
+
+/**
+ * Better Auth-keyed wallet linking service.
+ *
+ * Singleton; configured during `UserModule.init()` via
+ * {@link WalletService.setDependencies}.
+ */
+export class WalletService {
+    /** Singleton instance. `null` until {@link setDependencies} runs. */
+    private static instance: WalletService | null = null;
+
+    /** `module_user_wallets` collection handle. */
+    private readonly collection: Collection<IWalletDocument>;
+
+    /** Better Auth user collection, for the denormalized `primaryWallet` write. */
+    private readonly authUsers: Collection<IAuthUserPrimaryWallet>;
+
+    /** Signature verification + address normalization. */
+    private readonly signatureService: SignatureService;
+
+    /** Single-use challenge mint/consume, scoped per (userId, action, address). */
+    private readonly walletChallengeService: WalletChallengeService;
+
+    /** Logger scoped to this service. */
+    private readonly logger: ISystemLogService;
+
+    /**
+     * @param database - Database abstraction (Tier-1 collection access).
+     * @param cacheService - Backs {@link WalletChallengeService} nonce storage.
+     * @param logger - Derives a `component: 'wallet-service'` child.
+     * @param tronWeb - Configured TronWeb for {@link SignatureService}.
+     */
+    private constructor(
+        database: IDatabaseService,
+        cacheService: ICacheService,
+        logger: ISystemLogService,
+        tronWeb: TronWeb
+    ) {
+        this.collection = database.getCollection<IWalletDocument>(WALLETS_COLLECTION);
+        this.authUsers = database.getCollection<IAuthUserPrimaryWallet>(AUTH_USERS_COLLECTION);
+        this.signatureService = new SignatureService(tronWeb);
+        this.walletChallengeService = new WalletChallengeService(cacheService);
+        this.logger = logger.child({ component: 'wallet-service' });
+    }
+
+    /**
+     * Configure the singleton with its dependencies.
+     *
+     * Idempotent — a second call keeps the first instance, so callers
+     * cannot swap dependencies after consumers have started using it.
+     *
+     * @param database - Database service injected by the module.
+     * @param cacheService - Cache service for challenge storage.
+     * @param logger - User-module child logger.
+     * @param tronWeb - TronWeb instance for signature verification.
+     */
+    public static setDependencies(
+        database: IDatabaseService,
+        cacheService: ICacheService,
+        logger: ISystemLogService,
+        tronWeb: TronWeb
+    ): void {
+        if (!WalletService.instance) {
+            WalletService.instance = new WalletService(database, cacheService, logger, tronWeb);
+        }
+    }
+
+    /**
+     * Resolve the configured singleton.
+     *
+     * @returns The shared {@link WalletService} instance.
+     * @throws {Error} When called before {@link setDependencies}.
+     */
+    public static getInstance(): WalletService {
+        if (!WalletService.instance) {
+            throw new Error('WalletService.setDependencies() must be called before getInstance().');
+        }
+        return WalletService.instance;
+    }
+
+    /**
+     * Reset the singleton. Test-only escape hatch.
+     *
+     * @internal
+     */
+    public static resetForTests(): void {
+        WalletService.instance = null;
+    }
+
+    /**
+     * Create the collection indexes.
+     *
+     * `address` is globally unique so a wallet can belong to exactly one
+     * Better Auth account; `userId` speeds the per-account list read.
+     */
+    public async createIndexes(): Promise<void> {
+        await this.collection.createIndex({ address: 1 }, { unique: true });
+        await this.collection.createIndex({ userId: 1 });
+        this.logger.info('Wallet indexes created');
+    }
+
+    /**
+     * List an account's linked wallets, oldest first.
+     *
+     * @param userId - Better Auth user id.
+     * @returns Public wallet rows for the account (empty when none linked).
+     */
+    public async listWallets(userId: string): Promise<ILinkedWallet[]> {
+        const docs = await this.collection.find({ userId }).sort({ linkedAt: 1 }).toArray();
+        return docs.map(WalletService.toLinkedWallet);
+    }
+
+    /**
+     * Mint a single-use challenge for a wallet operation.
+     *
+     * The client signs the returned `message` verbatim with TronLink and
+     * submits `(message, signature, nonce)` to the matching mutation
+     * within the TTL window. The nonce is scoped to the Better Auth user
+     * id, the action, and the normalized address.
+     *
+     * @param userId - Better Auth user id.
+     * @param action - Operation the challenge will gate.
+     * @param address - Submitted TRON address (hex or base58).
+     * @returns Challenge with nonce, canonical message, and expiry.
+     * @throws {Error} When the address is malformed.
+     */
+    public async issueChallenge(
+        userId: string,
+        action: WalletAction,
+        address: string
+    ): Promise<IWalletChallenge> {
+        const normalizedAddress = this.signatureService.normalizeAddress(address);
+        return this.walletChallengeService.issue(userId, action, normalizedAddress);
+    }
+
+    /**
+     * Link a wallet to the account after proving ownership.
+     *
+     * Verifies the challenge + signature, then attaches the wallet. The
+     * first wallet an account links becomes its primary. A wallet already
+     * linked to a *different* account is rejected — Better Auth identity
+     * is portable, so there is no merge; the user must log into the
+     * account that owns the wallet instead.
+     *
+     * @param userId - Better Auth user id.
+     * @param input - Address, signed canonical message, signature, nonce.
+     * @returns The account's wallet list after the link.
+     * @throws {Error} On challenge/signature failure or cross-account conflict.
+     */
+    public async linkWallet(userId: string, input: IWalletMutationInput): Promise<ILinkedWallet[]> {
+        const normalizedAddress = await this.verifyAction(userId, 'link', input);
+        const now = new Date();
+
+        const existing = await this.collection.findOne({ address: normalizedAddress });
+        if (existing && existing.userId !== userId) {
+            throw new Error('This wallet is already linked to another account.');
+        }
+
+        if (existing) {
+            // Idempotent re-link by the same account — just bump usage.
+            await this.collection.updateOne(
+                { userId, address: normalizedAddress },
+                { $set: { lastUsedAt: now } }
+            );
+        } else {
+            const existingCount = await this.collection.countDocuments({ userId });
+            const isPrimary = existingCount === 0;
+            await this.collection.insertOne({
+                _id: new ObjectId(),
+                userId,
+                address: normalizedAddress,
+                isPrimary,
+                linkedAt: now,
+                lastUsedAt: now
+            });
+            if (isPrimary) {
+                await this.setAuthPrimary(userId, normalizedAddress);
+            }
+        }
+
+        this.logger.info({ userId, wallet: normalizedAddress }, 'Wallet linked to account');
+        return this.listWallets(userId);
+    }
+
+    /**
+     * Unlink a wallet from the account.
+     *
+     * Requires a fresh `unlink` challenge + signature over the target
+     * address. When the removed wallet was primary, the most recently
+     * used remaining wallet is promoted; if none remain the denormalized
+     * `primaryWallet` is cleared.
+     *
+     * @param userId - Better Auth user id.
+     * @param input - Address, signed canonical message, signature, nonce.
+     * @returns The account's wallet list after the unlink.
+     * @throws {Error} On challenge/signature failure or when not linked.
+     */
+    public async unlinkWallet(userId: string, input: IWalletMutationInput): Promise<ILinkedWallet[]> {
+        const normalizedAddress = await this.verifyAction(userId, 'unlink', input);
+
+        const target = await this.collection.findOne({ userId, address: normalizedAddress });
+        if (!target) {
+            throw new Error('Wallet is not linked to this account.');
+        }
+
+        await this.collection.deleteOne({ userId, address: normalizedAddress });
+
+        if (target.isPrimary) {
+            const remaining = await this.collection.find({ userId }).sort({ lastUsedAt: -1 }).toArray();
+            const next = remaining[0];
+            if (next) {
+                await this.collection.updateOne(
+                    { userId, address: next.address },
+                    { $set: { isPrimary: true } }
+                );
+                await this.setAuthPrimary(userId, next.address);
+            } else {
+                await this.setAuthPrimary(userId, null);
+            }
+        }
+
+        this.logger.info({ userId, wallet: normalizedAddress }, 'Wallet unlinked from account');
+        return this.listWallets(userId);
+    }
+
+    /**
+     * Set an already-linked wallet as the account's primary.
+     *
+     * Step-up authentication: a fresh `set-primary` challenge + signature
+     * is required because the primary wallet drives downstream
+     * attribution and a captured session cookie alone should not steer
+     * it. The wallet must already be linked.
+     *
+     * @param userId - Better Auth user id.
+     * @param input - Address, signed canonical message, signature, nonce.
+     * @returns The account's wallet list after the change.
+     * @throws {Error} On challenge/signature failure or when not linked.
+     */
+    public async setPrimaryWallet(userId: string, input: IWalletMutationInput): Promise<ILinkedWallet[]> {
+        const normalizedAddress = await this.verifyAction(userId, 'set-primary', input);
+
+        const target = await this.collection.findOne({ userId, address: normalizedAddress });
+        if (!target) {
+            throw new Error('Wallet is not linked to this account.');
+        }
+
+        const now = new Date();
+        await this.collection.updateMany({ userId }, { $set: { isPrimary: false } });
+        await this.collection.updateOne(
+            { userId, address: normalizedAddress },
+            { $set: { isPrimary: true, lastUsedAt: now } }
+        );
+        await this.setAuthPrimary(userId, normalizedAddress);
+
+        this.logger.info({ userId, wallet: normalizedAddress }, 'Primary wallet updated');
+        return this.listWallets(userId);
+    }
+
+    /**
+     * Verify a wallet challenge and signature, returning the normalized address.
+     *
+     * Mirrors the legacy `verifyWalletAction` order so a malformed message
+     * cannot waste the user's nonce: normalize, assert the canonical
+     * message form, consume the nonce atomically, then verify the
+     * signature recovers to the same address.
+     *
+     * @param userId - Better Auth user id the nonce is scoped to.
+     * @param action - Action the nonce was minted for.
+     * @param input - Address, message, signature, nonce.
+     * @returns Normalized base58 address.
+     * @throws {Error} On any mismatch — caller handles only the success case.
+     */
+    private async verifyAction(
+        userId: string,
+        action: WalletAction,
+        input: IWalletMutationInput
+    ): Promise<string> {
+        const normalizedAddress = this.signatureService.normalizeAddress(input.address);
+
+        if (!input.nonce) {
+            throw new Error('Wallet challenge nonce is required.');
+        }
+        const expected = WalletChallengeService.buildMessage(action, normalizedAddress, input.nonce);
+        if (input.message !== expected) {
+            throw new Error('Signed message does not match the canonical challenge form.');
+        }
+        const consumed = await this.walletChallengeService.consume(userId, action, normalizedAddress, input.nonce);
+        if (!consumed) {
+            throw new Error('Wallet challenge expired or already used. Request a new challenge.');
+        }
+
+        const recovered = await this.signatureService.verifyMessage(
+            normalizedAddress,
+            input.message,
+            input.signature
+        );
+        if (recovered !== normalizedAddress) {
+            throw new Error('Signature address does not match submitted address.');
+        }
+
+        return normalizedAddress;
+    }
+
+    /**
+     * Write the denormalized primary wallet onto the Better Auth user row.
+     *
+     * `null` clears it (last wallet unlinked). The session augmentation in
+     * the auth facade reads this field, so the primary surfaces without
+     * touching this collection.
+     *
+     * @param userId - Better Auth user id (BA `_id`).
+     * @param address - Primary address, or `null` to clear.
+     */
+    private async setAuthPrimary(userId: string, address: string | null): Promise<void> {
+        await this.authUsers.updateOne({ _id: userId }, { $set: { primaryWallet: address } });
+    }
+
+    /**
+     * Project a stored wallet document to its public wire shape.
+     *
+     * @param doc - Stored wallet document.
+     * @returns Public {@link ILinkedWallet} without Mongo/internal fields.
+     */
+    private static toLinkedWallet(doc: IWalletDocument): ILinkedWallet {
+        return {
+            address: doc.address,
+            isPrimary: doc.isPrimary,
+            linkedAt: doc.linkedAt,
+            lastUsedAt: doc.lastUsedAt
+        };
+    }
+}

--- a/src/backend/modules/user/services/wallet.service.ts
+++ b/src/backend/modules/user/services/wallet.service.ts
@@ -184,11 +184,21 @@ export class WalletService {
      * Create the collection indexes.
      *
      * `address` is globally unique so a wallet can belong to exactly one
-     * Better Auth account; `userId` speeds the per-account list read.
+     * Better Auth account; `userId` speeds the per-account list read. The
+     * partial unique index on `{ userId, isPrimary }` (filtered to
+     * `isPrimary: true`) enforces *at most one primary wallet per account*
+     * at the database level, so a concurrent first-link race cannot leave
+     * two `isPrimary: true` rows — the losing insert surfaces a duplicate-
+     * key error that {@link linkWallet} recovers from by attaching the
+     * wallet as non-primary.
      */
     public async createIndexes(): Promise<void> {
         await this.collection.createIndex({ address: 1 }, { unique: true });
         await this.collection.createIndex({ userId: 1 });
+        await this.collection.createIndex(
+            { userId: 1, isPrimary: 1 },
+            { unique: true, partialFilterExpression: { isPrimary: true } }
+        );
         this.logger.info('Wallet indexes created');
     }
 
@@ -257,22 +267,83 @@ export class WalletService {
             );
         } else {
             const existingCount = await this.collection.countDocuments({ userId });
-            const isPrimary = existingCount === 0;
-            await this.collection.insertOne({
-                _id: new ObjectId(),
-                userId,
-                address: normalizedAddress,
-                isPrimary,
-                linkedAt: now,
-                lastUsedAt: now
-            });
-            if (isPrimary) {
+            const wantPrimary = existingCount === 0;
+            const becamePrimary = await this.insertLinkedWallet(userId, normalizedAddress, wantPrimary, now);
+            if (becamePrimary) {
                 await this.setAuthPrimary(userId, normalizedAddress);
             }
         }
 
         this.logger.info({ userId, wallet: normalizedAddress }, 'Wallet linked to account');
         return this.listWallets(userId);
+    }
+
+    /**
+     * Insert a new wallet row, recovering from the two duplicate-key races
+     * the unique indexes can surface so a concurrent link never leaks a raw
+     * E11000 out of the API.
+     *
+     * - **Address unique index** — the same wallet was linked concurrently
+     *   between this method's caller `findOne` pre-check and the insert. If
+     *   it now belongs to another account, reject with the friendly
+     *   cross-account conflict; if to this account, treat as idempotent and
+     *   bump usage.
+     * - **Partial `{ userId, isPrimary: true }` index** — a concurrent
+     *   first-link already claimed primary. Re-insert this wallet as
+     *   non-primary so the at-most-one-primary invariant holds.
+     *
+     * @param userId - Better Auth user id.
+     * @param address - Normalized base58 address.
+     * @param wantPrimary - Whether this would be the account's first (primary) wallet.
+     * @param now - Shared timestamp for linkedAt/lastUsedAt.
+     * @returns Whether the row was ultimately stored as the account's primary.
+     */
+    private async insertLinkedWallet(
+        userId: string,
+        address: string,
+        wantPrimary: boolean,
+        now: Date
+    ): Promise<boolean> {
+        try {
+            await this.collection.insertOne({
+                _id: new ObjectId(),
+                userId,
+                address,
+                isPrimary: wantPrimary,
+                linkedAt: now,
+                lastUsedAt: now
+            });
+            return wantPrimary;
+        } catch (error) {
+            if (!isDuplicateKeyError(error)) {
+                throw error;
+            }
+            const dup = await this.collection.findOne({ address });
+            if (dup) {
+                // Address unique index: the same wallet was inserted
+                // concurrently. Mirror the caller's pre-check semantics.
+                if (dup.userId !== userId) {
+                    throw new Error('This wallet is already linked to another account.');
+                }
+                await this.collection.updateOne(
+                    { userId, address },
+                    { $set: { lastUsedAt: now } }
+                );
+                return dup.isPrimary;
+            }
+            // The address is absent, so the conflict was the partial
+            // primary index — another concurrent first-link already became
+            // primary. Attach this wallet as non-primary.
+            await this.collection.insertOne({
+                _id: new ObjectId(),
+                userId,
+                address,
+                isPrimary: false,
+                linkedAt: now,
+                lastUsedAt: now
+            });
+            return false;
+        }
     }
 
     /**
@@ -298,18 +369,25 @@ export class WalletService {
 
         await this.collection.deleteOne({ userId, address: normalizedAddress });
 
-        if (target.isPrimary) {
-            const remaining = await this.collection.find({ userId }).sort({ lastUsedAt: -1 }).toArray();
+        // Recompute the primary from the post-deletion state on every
+        // unlink rather than trusting the pre-deletion `target.isPrimary`.
+        // Two concurrent unlinks (primary + non-primary) could otherwise
+        // both read stale `isPrimary` flags: the non-primary request, having
+        // seen `isPrimary === false` before the primary was deleted and
+        // promoted, would delete the freshly-promoted wallet yet skip the
+        // promotion block — stranding `authUsers.primaryWallet` on an
+        // already-deleted address. Re-reading here closes that window and
+        // also self-heals a collection that has ended up with no primary.
+        const remaining = await this.collection.find({ userId }).sort({ lastUsedAt: -1 }).toArray();
+        if (remaining.length === 0) {
+            await this.setAuthPrimary(userId, null);
+        } else if (!remaining.some(w => w.isPrimary)) {
             const next = remaining[0];
-            if (next) {
-                await this.collection.updateOne(
-                    { userId, address: next.address },
-                    { $set: { isPrimary: true } }
-                );
-                await this.setAuthPrimary(userId, next.address);
-            } else {
-                await this.setAuthPrimary(userId, null);
-            }
+            await this.collection.updateOne(
+                { userId, address: next.address },
+                { $set: { isPrimary: true } }
+            );
+            await this.setAuthPrimary(userId, next.address);
         }
 
         this.logger.info({ userId, wallet: normalizedAddress }, 'Wallet unlinked from account');
@@ -422,4 +500,21 @@ export class WalletService {
             lastUsedAt: doc.lastUsedAt
         };
     }
+}
+
+/**
+ * True for a MongoDB duplicate-key (E11000) error, regardless of which
+ * unique index raised it. Kept structural (a `code === 11000` check rather
+ * than an `instanceof`) so a driver-version change in the error class
+ * doesn't silently break detection.
+ *
+ * @param error - Caught error of unknown type.
+ * @returns Whether it is a duplicate-key violation.
+ */
+function isDuplicateKeyError(error: unknown): boolean {
+    return (
+        typeof error === 'object' &&
+        error !== null &&
+        (error as { code?: unknown }).code === 11000
+    );
 }

--- a/src/frontend/modules/user/lib/session-server.ts
+++ b/src/frontend/modules/user/lib/session-server.ts
@@ -34,7 +34,11 @@ export interface ISSRSession {
         image?: string | null;
         /** Group ids from the BA additionalFields config. */
         groups?: string[];
-        /** Primary wallet — reserved for Phase 4, currently always absent. */
+        /**
+         * Primary wallet address from the BA `primaryWallet` additional
+         * field (Phase 4), maintained by the backend WalletService.
+         * Absent/null when the account has no linked wallet.
+         */
         primaryWallet?: string | null;
     };
     session: {


### PR DESCRIPTION
## Summary

Phase 4 of the Better Auth refactor. Introduces a parallel, Better-Auth-keyed wallet store alongside the legacy UUID-keyed `users.wallets[]` flow. Both coexist until the Phase 6 cutover removes the legacy path. This is a backend-foundational phase (like Phases 1–2) — no functional UI change yet.

- **New `module_user_wallets` collection** (`IWalletDocument`) keyed by the Better Auth user id. Unique index on `address` so a wallet belongs to exactly one account; index on `userId` for the per-account list.
- **`WalletService`** (singleton, `setDependencies`/`getInstance`) owns link / unlink / set-primary / list, reusing `SignatureService` + `WalletChallengeService` for the same challenge → sign → verify contract the legacy flow uses. Because BA identity is portable across devices, the new model drops the legacy register/verify two-stage and the winner/loser identity merge: a wallet attaches only after a signature, and a wallet already held by another account is a **hard conflict, never a merge**. On every mutation it denormalizes the account's primary address onto the BA user's `primaryWallet` additional field (same pattern `GroupService` uses for `groups`).
- **`WalletController` + `/api/user/wallets` router** resolve the caller from the BA session (`req.authSession`), not a cookie-validated `:id` param, so no user id appears on the wire (401 for anonymous). Mounted **before** the legacy `/api/user` router so the literal `wallets` segment isn't captured by that router's `/:id` cookie middleware.
- **Auth facade** now populates `IAugmentedSession.primaryWallet` from the resolved BA user record (previously hardcoded `undefined`). The SSR session helper already picks `primaryWallet`, so it flows to the client automatically.
- **Tests:** `WalletService` unit suite covers link/unlink/set-primary, primary recomputation on unlink, cross-account conflict, idempotent re-link, and nonce replay/scoping (17 tests). Full user-module suite (285) green; backend typecheck clean.

## Notes

No frontend wallet-management UI ships here. The legacy `WalletCard` continues to serve wallet management during coexistence; the BA-session-driven profile wallet UI lands with the Phase 6 cutover to avoid two parallel TronLink signing surfaces.

Next: Phase 5 (analytics/referral cookies + traffic_events re-key), then Phase 6 (destructive cutover).