### PR TITLE
feat(auth): Phase 5 — tid/ref cookies, re-key traffic_events off the uid

### DIFF
--- a/src/backend/modules/user/README.md
+++ b/src/backend/modules/user/README.md
@@ -274,6 +274,19 @@ The user identity cookie has these characteristics:
 
 **Privacy compliance:** This cookie is classified as "functional/essential" under GDPR because it's necessary for the website to remember user preferences and provide personalized features. No consent banner required.
 
+### Analytics & Referral Cookies (Phase 5)
+
+Phase 5 of the Better Auth refactor decouples analytics from identity by adding two cookies, so traffic tracking survives the Phase 6 removal of `tronrelic_uid`. See `api/traffic-cookies.ts`.
+
+| Cookie | Purpose | Shape | Lifetime |
+|--------|---------|-------|----------|
+| `tronrelic_tid` | Analytics visitor key for `traffic_events` — independent of identity. | HttpOnly, **unsigned**, UUID v4 | 1 year |
+| `tronrelic_ref` | First-touch capture of an inbound `?ref=<code>` for later referral attribution. | HttpOnly, **unsigned**, referral code | 90 days |
+
+Both are minted by the Next.js middleware on the SSR-first path (so they are stable from first paint) and by the backend for direct/client callers; the middleware relays the tid (and any captured ref) to `POST /api/user/bootstrap` so the recorded event keys on the same id. They are unsigned because neither confers identity or authorization — forging a tid only pollutes one's own analytics bucket.
+
+`traffic_events` now keys `candidate_uid` on the **tid** (still a UUID, so the column type is unchanged) rather than the legacy uid. Two additive columns (migration `012_traffic_events_user_referral_columns`) attribute traffic without retyping the sort key: `user_id` (the Better Auth user id when logged in, else null) and `referral_code` (the captured first-touch code). Run migration 012 as part of the Phase 5 release — until it applies, first-touch reads degrade to empty and new-column inserts are rejected.
+
 ## Core Components
 
 ### UserService (Business Logic)

--- a/src/backend/modules/user/__tests__/bootstrap.controller.test.ts
+++ b/src/backend/modules/user/__tests__/bootstrap.controller.test.ts
@@ -116,10 +116,10 @@ describe('UserController.bootstrap', () => {
         // assuming it is the only Set-Cookie.
         const idCookie = res.cookies.find((c: any) => c.name === USER_ID_COOKIE_NAME);
         expect(idCookie).toBeDefined();
-        expect(idCookie.value).toBe(res.jsonBody.id);
-        expect(idCookie.options.httpOnly).toBe(true);
-        expect(idCookie.options.sameSite).toBe('lax');
-        expect(idCookie.options.path).toBe('/');
+        expect(idCookie!.value).toBe(res.jsonBody.id);
+        expect(idCookie!.options.httpOnly).toBe(true);
+        expect(idCookie!.options.sameSite).toBe('lax');
+        expect(idCookie!.options.path).toBe('/');
         // The analytics tid cookie is minted alongside identity.
         expect(res.cookies.find((c: any) => c.name === 'tronrelic_tid')).toBeDefined();
     });
@@ -145,8 +145,8 @@ describe('UserController.bootstrap', () => {
         // name since bootstrap also mints the Phase 5 analytics tid cookie.
         const idCookie = res.cookies.find((c: any) => c.name === USER_ID_COOKIE_NAME);
         expect(idCookie).toBeDefined();
-        expect(idCookie.value).toBe(VALID_UUID_A);
-        expect(idCookie.options.httpOnly).toBe(true);
+        expect(idCookie!.value).toBe(VALID_UUID_A);
+        expect(idCookie!.options.httpOnly).toBe(true);
     });
 
     it('accepts an unsigned legacy cookie and re-anchors the user as signed', async () => {

--- a/src/backend/modules/user/__tests__/bootstrap.controller.test.ts
+++ b/src/backend/modules/user/__tests__/bootstrap.controller.test.ts
@@ -110,13 +110,18 @@ describe('UserController.bootstrap', () => {
         expect(res.jsonBody).not.toBeNull();
         expect(res.jsonBody.id).toMatch(/^[0-9a-f-]{36}$/);
 
-        // Cookie must be set with HttpOnly and the same UUID returned in the body.
-        expect(res.cookies).toHaveLength(1);
-        expect(res.cookies[0].name).toBe(USER_ID_COOKIE_NAME);
-        expect(res.cookies[0].value).toBe(res.jsonBody.id);
-        expect(res.cookies[0].options.httpOnly).toBe(true);
-        expect(res.cookies[0].options.sameSite).toBe('lax');
-        expect(res.cookies[0].options.path).toBe('/');
+        // Identity cookie must be set with HttpOnly and the same UUID
+        // returned in the body. Bootstrap also mints the Phase 5 analytics
+        // tid cookie, so look the identity cookie up by name rather than
+        // assuming it is the only Set-Cookie.
+        const idCookie = res.cookies.find((c: any) => c.name === USER_ID_COOKIE_NAME);
+        expect(idCookie).toBeDefined();
+        expect(idCookie.value).toBe(res.jsonBody.id);
+        expect(idCookie.options.httpOnly).toBe(true);
+        expect(idCookie.options.sameSite).toBe('lax');
+        expect(idCookie.options.path).toBe('/');
+        // The analytics tid cookie is minted alongside identity.
+        expect(res.cookies.find((c: any) => c.name === 'tronrelic_tid')).toBeDefined();
     });
 
     it('returns the existing user and refreshes the cookie when a valid signed cookie is present', async () => {
@@ -135,11 +140,13 @@ describe('UserController.bootstrap', () => {
         await controller.bootstrap(req, res as any);
 
         expect(res.jsonBody.id).toBe(VALID_UUID_A);
-        // Cookie still set on every call — refreshes max-age and rewrites
-        // legacy non-HttpOnly cookies into HttpOnly.
-        expect(res.cookies).toHaveLength(1);
-        expect(res.cookies[0].value).toBe(VALID_UUID_A);
-        expect(res.cookies[0].options.httpOnly).toBe(true);
+        // Identity cookie still set on every call — refreshes max-age and
+        // rewrites legacy non-HttpOnly cookies into HttpOnly. Looked up by
+        // name since bootstrap also mints the Phase 5 analytics tid cookie.
+        const idCookie = res.cookies.find((c: any) => c.name === USER_ID_COOKIE_NAME);
+        expect(idCookie).toBeDefined();
+        expect(idCookie.value).toBe(VALID_UUID_A);
+        expect(idCookie.options.httpOnly).toBe(true);
     });
 
     it('accepts an unsigned legacy cookie and re-anchors the user as signed', async () => {

--- a/src/backend/modules/user/__tests__/traffic-cookies.test.ts
+++ b/src/backend/modules/user/__tests__/traffic-cookies.test.ts
@@ -1,0 +1,107 @@
+/// <reference types="vitest" />
+
+/**
+ * @fileoverview Unit tests for the Phase 5 analytics/referral cookie helpers.
+ *
+ * Covers resolution (signed-bag-free, unsigned reads), validation
+ * (UUID for tid, code regex for ref), and the cookie-set option shape
+ * (HttpOnly, unsigned, SameSite, max-age). Express `req`/`res` are stubbed
+ * — only `cookies` and `res.cookie` matter here.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import {
+    TID_COOKIE_NAME,
+    REF_COOKIE_NAME,
+    TID_COOKIE_MAX_AGE_SECONDS,
+    REF_COOKIE_MAX_AGE_SECONDS,
+    resolveTid,
+    resolveRef,
+    normalizeReferralCode,
+    setTidCookie,
+    setRefCookie
+} from '../api/traffic-cookies.js';
+
+const VALID_TID = '550e8400-e29b-41d4-a716-446655440000';
+
+function reqWithCookies(cookies: Record<string, unknown>): Request {
+    return { cookies } as unknown as Request;
+}
+
+function stubRes(): { res: Response; calls: Array<{ name: string; value: string; options: any }> } {
+    const calls: Array<{ name: string; value: string; options: any }> = [];
+    const res = {
+        cookie: vi.fn((name: string, value: string, options: any) => {
+            calls.push({ name, value, options });
+        })
+    } as unknown as Response;
+    return { res, calls };
+}
+
+describe('traffic-cookies', () => {
+    describe('resolveTid', () => {
+        it('returns a valid UUID v4 tid from the unsigned cookie bag', () => {
+            expect(resolveTid(reqWithCookies({ [TID_COOKIE_NAME]: VALID_TID }))).toBe(VALID_TID);
+        });
+
+        it('returns null for a malformed tid', () => {
+            expect(resolveTid(reqWithCookies({ [TID_COOKIE_NAME]: 'not-a-uuid' }))).toBeNull();
+        });
+
+        it('returns null when absent', () => {
+            expect(resolveTid(reqWithCookies({}))).toBeNull();
+        });
+    });
+
+    describe('normalizeReferralCode / resolveRef', () => {
+        it('accepts a well-formed code', () => {
+            expect(normalizeReferralCode('a1b2c3d4')).toBe('a1b2c3d4');
+            expect(resolveRef(reqWithCookies({ [REF_COOKIE_NAME]: 'ref_code-9' }))).toBe('ref_code-9');
+        });
+
+        it('rejects codes that are too short, too long, or contain bad chars', () => {
+            expect(normalizeReferralCode('abc')).toBeNull();
+            expect(normalizeReferralCode('x'.repeat(33))).toBeNull();
+            expect(normalizeReferralCode('has spaces')).toBeNull();
+            expect(normalizeReferralCode('emoji😀code')).toBeNull();
+        });
+
+        it('rejects non-string input', () => {
+            expect(normalizeReferralCode(undefined)).toBeNull();
+            expect(normalizeReferralCode(42)).toBeNull();
+        });
+    });
+
+    describe('setTidCookie', () => {
+        it('writes an HttpOnly, unsigned, 1-year cookie', () => {
+            const { res, calls } = stubRes();
+            setTidCookie(res, VALID_TID, false);
+            expect(calls).toHaveLength(1);
+            expect(calls[0].name).toBe(TID_COOKIE_NAME);
+            expect(calls[0].value).toBe(VALID_TID);
+            expect(calls[0].options).toMatchObject({
+                httpOnly: true,
+                signed: false,
+                sameSite: 'lax',
+                secure: false,
+                path: '/',
+                maxAge: TID_COOKIE_MAX_AGE_SECONDS * 1000
+            });
+        });
+    });
+
+    describe('setRefCookie', () => {
+        it('writes an HttpOnly, unsigned, 90-day cookie', () => {
+            const { res, calls } = stubRes();
+            setRefCookie(res, 'a1b2c3d4', false);
+            expect(calls).toHaveLength(1);
+            expect(calls[0].name).toBe(REF_COOKIE_NAME);
+            expect(calls[0].options).toMatchObject({
+                httpOnly: true,
+                signed: false,
+                maxAge: REF_COOKIE_MAX_AGE_SECONDS * 1000
+            });
+        });
+    });
+});

--- a/src/backend/modules/user/__tests__/traffic-events-columns-migration.test.ts
+++ b/src/backend/modules/user/__tests__/traffic-events-columns-migration.test.ts
@@ -1,0 +1,51 @@
+/// <reference types="vitest" />
+
+import { describe, it, expect, vi } from 'vitest';
+import type { IClickHouseService, IDatabaseService, IMigrationContext } from '@/types';
+import { migration } from '../migrations/012_traffic_events_user_referral_columns.js';
+
+/**
+ * Shape and behaviour test for the Phase 5 additive-columns migration.
+ *
+ * Mirrors the 010 test: no embedded ClickHouse in CI, so the goals are
+ * id/filename-drift detection, skip-when-CH-absent, ClickHouse targeting,
+ * and that the ALTER adds both columns idempotently outside the sort key.
+ */
+describe('migration: 012_traffic_events_user_referral_columns', () => {
+    it('declares a ClickHouse target', () => {
+        expect(migration.target).toBe('clickhouse');
+    });
+
+    it('uses the canonical id matching the filename', () => {
+        expect(migration.id).toBe('012_traffic_events_user_referral_columns');
+    });
+
+    it('depends on the table-creation migration', () => {
+        expect(migration.dependencies).toContain('module:user:010_create_traffic_events_table');
+    });
+
+    it('does nothing when ClickHouse is unavailable', async () => {
+        const context: IMigrationContext = {
+            database: {} as IDatabaseService,
+            clickhouse: undefined
+        };
+        await expect(migration.up(context)).resolves.toBeUndefined();
+    });
+
+    it('issues an idempotent ALTER adding user_id and referral_code', async () => {
+        const exec = vi.fn<(sql: string) => Promise<void>>(async () => undefined);
+        const clickhouse = { exec } as unknown as IClickHouseService;
+        const context: IMigrationContext = {
+            database: {} as IDatabaseService,
+            clickhouse
+        };
+
+        await migration.up(context);
+
+        expect(exec).toHaveBeenCalledTimes(1);
+        const sql = exec.mock.calls[0][0];
+        expect(sql).toContain('ALTER TABLE traffic_events');
+        expect(sql).toContain('ADD COLUMN IF NOT EXISTS user_id Nullable(String)');
+        expect(sql).toContain('ADD COLUMN IF NOT EXISTS referral_code');
+    });
+});

--- a/src/backend/modules/user/__tests__/traffic.service.test.ts
+++ b/src/backend/modules/user/__tests__/traffic.service.test.ts
@@ -62,6 +62,8 @@ const sampleEvent: ITrafficEvent = {
     event_type: 'bootstrap',
     timestamp: new Date('2026-04-30T12:00:00.000Z'),
     candidate_uid: '550e8400-e29b-41d4-a716-446655440000',
+    user_id: null,
+    referral_code: null,
     path: '/markets',
     referer: 'https://example.com/post',
     original_referrer: null,

--- a/src/backend/modules/user/api/traffic-cookies.ts
+++ b/src/backend/modules/user/api/traffic-cookies.ts
@@ -1,0 +1,144 @@
+/**
+ * @fileoverview Analytics (`tronrelic_tid`) and referral (`tronrelic_ref`)
+ * cookie specs and helpers.
+ *
+ * Phase 5 of the Better Auth refactor decouples analytics tracking from
+ * the identity cookie. The legacy `tronrelic_uid` cookie did double duty
+ * — identity continuity AND the visitor key for `traffic_events`. Phase 6
+ * removes `tronrelic_uid` (Better Auth owns identity), so analytics needs
+ * its own key that survives that removal: `tronrelic_tid`.
+ *
+ * **`tronrelic_tid` (traffic id).** A server-minted UUID v4 that keys
+ * every `traffic_events` row regardless of auth state. It confers no
+ * identity or authorization — forging it only pollutes one's own
+ * analytics bucket — so it is deliberately *unsigned* (no HMAC envelope,
+ * unlike `tronrelic_uid`). HttpOnly keeps it out of client JS; the value
+ * is a UUID so it slots into the existing `traffic_events.candidate_uid`
+ * `UUID` column without a schema change.
+ *
+ * **`tronrelic_ref` (referral).** First-touch capture of an inbound
+ * `?ref=<code>` so a later signup can attribute to the referrer. Set once
+ * (first-touch wins) and read at conversion time. Also unsigned — the
+ * value is a public referral code, and the referrer it names must exist
+ * for attribution to mean anything.
+ *
+ * Both cookies mirror the identity-cookie spec for `SameSite`/`Secure`
+ * but are written by both the Next.js middleware (SSR-first path) and the
+ * backend (client/direct callers); see the bootstrap controller and
+ * `src/frontend/middleware.ts`.
+ */
+
+import type { Request, Response } from 'express';
+import { UUID_V4_REGEX } from './identity-cookie.js';
+
+/** Cookie name for the analytics traffic id. */
+export const TID_COOKIE_NAME = 'tronrelic_tid';
+
+/** Cookie name for the captured referral code. */
+export const REF_COOKIE_NAME = 'tronrelic_ref';
+
+/** Traffic-id cookie max age in seconds (1 year) — matches the identity cookie. */
+export const TID_COOKIE_MAX_AGE_SECONDS = 31536000;
+
+/** Referral cookie max age in seconds (90 days) — the attribution window. */
+export const REF_COOKIE_MAX_AGE_SECONDS = 7776000;
+
+/**
+ * Accepted shape for a referral code: 4–32 chars of alphanumerics, dash,
+ * or underscore. Generous enough for any code `generateUniqueReferralCode`
+ * mints today while rejecting a crafted multi-KB `?ref=` value before it
+ * reaches a cookie or a ClickHouse row.
+ */
+export const REFERRAL_CODE_REGEX = /^[A-Za-z0-9_-]{4,32}$/;
+
+/**
+ * Resolve the visitor's analytics traffic id from the request cookies.
+ *
+ * Unsigned — read straight from `req.cookies` (cookie-parser's unsigned
+ * bag). Returns `null` when absent or malformed so callers mint a fresh
+ * one.
+ *
+ * @param req - Express request populated by cookie-parser.
+ * @returns Validated UUID v4 traffic id, or `null`.
+ */
+export function resolveTid(req: Request): string | null {
+    const value = (req as unknown as { cookies?: Record<string, unknown> }).cookies?.[TID_COOKIE_NAME];
+    if (typeof value === 'string' && UUID_V4_REGEX.test(value)) {
+        return value;
+    }
+    return null;
+}
+
+/**
+ * Resolve the captured referral code from the request cookies.
+ *
+ * @param req - Express request populated by cookie-parser.
+ * @returns Validated referral code, or `null`.
+ */
+export function resolveRef(req: Request): string | null {
+    const value = (req as unknown as { cookies?: Record<string, unknown> }).cookies?.[REF_COOKIE_NAME];
+    return normalizeReferralCode(value);
+}
+
+/**
+ * Validate and normalize an arbitrary value into a referral code.
+ *
+ * Used to vet both the cookie value and an inbound `?ref=` / forwarded
+ * body value before it is trusted. Returns `null` for anything that is
+ * not a well-formed code.
+ *
+ * @param raw - Untrusted candidate value.
+ * @returns The code when it matches {@link REFERRAL_CODE_REGEX}, else `null`.
+ */
+export function normalizeReferralCode(raw: unknown): string | null {
+    if (typeof raw === 'string' && REFERRAL_CODE_REGEX.test(raw)) {
+        return raw;
+    }
+    return null;
+}
+
+/**
+ * Express cookie options shared by both traffic cookies.
+ *
+ * `httpOnly` keeps the value out of client JS. `signed: false` is
+ * deliberate — neither cookie confers identity or authorization, so the
+ * HMAC envelope the identity cookie uses would be cost without benefit.
+ *
+ * @param maxAgeSeconds - Cookie lifetime.
+ * @param isProduction - Whether to set the Secure (HTTPS-only) flag.
+ * @returns Options for `res.cookie(...)`.
+ */
+function buildCookieOptions(maxAgeSeconds: number, isProduction: boolean) {
+    return {
+        httpOnly: true,
+        signed: false,
+        sameSite: 'lax' as const,
+        secure: isProduction,
+        path: '/',
+        maxAge: maxAgeSeconds * 1000
+    };
+}
+
+/**
+ * Set the analytics traffic-id cookie on a response.
+ *
+ * @param res - Express response.
+ * @param tid - UUID v4 traffic id.
+ * @param secure - Override Secure flag; defaults to `NODE_ENV === 'production'`.
+ */
+export function setTidCookie(res: Response, tid: string, secure?: boolean): void {
+    const isProduction = secure ?? process.env.NODE_ENV === 'production';
+    res.cookie(TID_COOKIE_NAME, tid, buildCookieOptions(TID_COOKIE_MAX_AGE_SECONDS, isProduction));
+}
+
+/**
+ * Set the referral cookie on a response.
+ *
+ * @param res - Express response.
+ * @param code - Validated referral code.
+ * @param secure - Override Secure flag; defaults to `NODE_ENV === 'production'`.
+ */
+export function setRefCookie(res: Response, code: string, secure?: boolean): void {
+    const isProduction = secure ?? process.env.NODE_ENV === 'production';
+    res.cookie(REF_COOKIE_NAME, code, buildCookieOptions(REF_COOKIE_MAX_AGE_SECONDS, isProduction));
+}

--- a/src/backend/modules/user/api/user.controller.ts
+++ b/src/backend/modules/user/api/user.controller.ts
@@ -9,8 +9,16 @@ import { buildTrafficEvent, getClientIP, withAuthStatus } from '../services/inde
 import { AnalyticsRangeValidationError } from '../services/user.errors.js';
 import {
     setIdentityCookie,
-    resolveIdentityFromCookies
+    resolveIdentityFromCookies,
+    UUID_V4_REGEX
 } from './identity-cookie.js';
+import {
+    resolveTid,
+    setTidCookie,
+    resolveRef,
+    setRefCookie,
+    normalizeReferralCode
+} from './traffic-cookies.js';
 
 /** Maximum length for stored path values. */
 const MAX_PATH_LENGTH = 500;
@@ -371,13 +379,24 @@ export class UserController {
                 );
             }
 
+            // Resolve the analytics traffic id and first-touch referral
+            // code (Phase 5). The traffic event keys on the tid — decoupled
+            // from the identity uid so analytics survives the Phase 6
+            // removal of tronrelic_uid — and attributes to the Better Auth
+            // account when the visitor is logged in.
+            const { tid, referralCode } = this.resolveTrafficCookies(req, res);
+
             // Record the bootstrap as a ClickHouse traffic event. Fire-and-
             // forget; never blocks the response, never throws into the
             // request path. When ClickHouse is unconfigured the service
             // no-ops silently — the orphan-row fix above stays correct
             // because Mongo writes are gated independently.
             this.trafficService.recordEvent(
-                buildTrafficEvent('bootstrap', user.id, req, this.extractBootstrapBody(req))
+                buildTrafficEvent('bootstrap', tid, req, {
+                    ...this.extractBootstrapBody(req),
+                    userId: req.authSession?.user?.id ?? null,
+                    referralCode
+                })
             );
 
             this.logger.debug(
@@ -439,6 +458,54 @@ export class UserController {
             result.utm = utm;
         }
         return result;
+    }
+
+    /**
+     * Resolve the analytics traffic id (`tronrelic_tid`) and first-touch
+     * referral code (`tronrelic_ref`) for a request, minting and persisting
+     * cookies as needed. Shared by the bootstrap and session-start handlers
+     * so both emit `traffic_events` under one stable, identity-independent
+     * key and capture an inbound `?ref=` exactly once.
+     *
+     * **tid.** Prefer a forwarded body value (the Next.js middleware mints
+     * it on the SSR-first path and relays it here), then the existing
+     * cookie, else mint a fresh UUID. Re-issue the cookie only when the
+     * value did not already arrive as a valid cookie — so the SSR mint and
+     * direct/client callers both end with a stable cookie, without a
+     * redundant Set-Cookie on every request.
+     *
+     * **ref.** First-touch wins: when no referral cookie is set yet and the
+     * request carries a well-formed inbound code (forwarded body `ref` or a
+     * `?ref=` query param), capture it and set the cookie. An existing
+     * cookie is never overwritten, so the original referrer is preserved
+     * through later navigations.
+     *
+     * @param req - Express request (cookie-parser populated; may carry a
+     *   middleware-forwarded body and `?ref=`).
+     * @param res - Express response the cookies are written to.
+     * @returns The resolved `tid` and the `referralCode` (or `null`).
+     */
+    private resolveTrafficCookies(req: Request, res: Response): { tid: string; referralCode: string | null } {
+        const body = (req.body ?? {}) as Record<string, unknown>;
+
+        const cookieTid = resolveTid(req);
+        const bodyTid = typeof body.tid === 'string' && UUID_V4_REGEX.test(body.tid) ? body.tid : null;
+        const tid = bodyTid ?? cookieTid ?? randomUUID();
+        if (tid !== cookieTid) {
+            setTidCookie(res, tid);
+        }
+
+        const existingRef = resolveRef(req);
+        const inboundRef =
+            normalizeReferralCode(body.ref) ??
+            normalizeReferralCode((req.query as Record<string, unknown> | undefined)?.ref);
+        let referralCode = existingRef;
+        if (!existingRef && inboundRef) {
+            referralCode = inboundRef;
+            setRefCookie(res, inboundRef);
+        }
+
+        return { tid, referralCode };
     }
 
     /**
@@ -807,8 +874,16 @@ export class UserController {
             // empty-UTM detection, and body-vs-header referrer priority
             // (with internal-domain filtering) all live in `UserService`
             // so any future caller gets identical behaviour.
-            const { session, userId } = await this.userService.startSession({
+            // Resolve the analytics traffic id + referral code (Phase 5).
+            // By session-start the tid cookie was set at bootstrap, so this
+            // reads it back; it is threaded into the service so the
+            // ClickHouse first-touch lookup queries the same key the
+            // bootstrap row was written under.
+            const { tid, referralCode } = this.resolveTrafficCookies(req, res);
+
+            const { session } = await this.userService.startSession({
                 userId: req.params.id,
+                tid,
                 clientIP: getClientIP(req),
                 userAgent: typeof req.headers['user-agent'] === 'string'
                     ? req.headers['user-agent']
@@ -836,17 +911,18 @@ export class UserController {
             // even though a hand-rolled client could submit oversized
             // values directly to `/api/user/:id/session/start`.
             //
-            // Use the canonical `userId` returned by `startSession` (not
-            // `req.params.id`) so a request that arrives carrying a merged
-            // tombstone still records analytics under the canonical UUID.
-            // Without this the next visit's first-touch lookup — which
-            // queries CH by canonical id — would miss this session_start
-            // row and the visitor would lose attribution continuity.
+            // Key on the analytics tid (Phase 5): browser-stable and
+            // independent of identity merges, so — unlike the legacy uid —
+            // it needs no canonical-id remap to keep first-touch
+            // correlation intact. Attribute to the Better Auth account when
+            // the visitor is logged in.
             this.trafficService.recordEvent(
-                buildTrafficEvent('session_start', userId, req, {
+                buildTrafficEvent('session_start', tid, req, {
                     landingPath: sanitizePath(req.body.landingPage),
                     utm: clampUtm(req.body.utm) ?? undefined,
-                    originalReferrer: clampString(req.body.referrer, MAX_REFERRER_LENGTH)
+                    originalReferrer: clampString(req.body.referrer, MAX_REFERRER_LENGTH),
+                    userId: req.authSession?.user?.id ?? null,
+                    referralCode
                 })
             );
 

--- a/src/backend/modules/user/database/IUserDocument.ts
+++ b/src/backend/modules/user/database/IUserDocument.ts
@@ -344,6 +344,15 @@ export interface ILinkWalletInput {
 export interface IStartSessionInput {
     /** UUID of the user starting the session. */
     userId: string;
+    /**
+     * Analytics traffic id (`tronrelic_tid`) for the ClickHouse first-touch
+     * lookup. Since Phase 5 of the Better Auth refactor `traffic_events`
+     * rows key on the tid, so the bootstrap event this session correlates
+     * with was written under the tid, not `userId`. Falls back to `userId`
+     * when absent (legacy callers, tests) so correlation still works during
+     * the transition.
+     */
+    tid?: string;
     /** Client IP for country lookup. Never persisted raw. */
     clientIP?: string;
     /** User-agent header for device-category derivation. Never persisted raw. */

--- a/src/backend/modules/user/migrations/011_prune_empty_user_rows.ts
+++ b/src/backend/modules/user/migrations/011_prune_empty_user_rows.ts
@@ -305,6 +305,11 @@ function buildSyntheticEvent(user: IUserDocument, origin: ITrafficOrigin): ITraf
         event_type: 'bootstrap',
         timestamp: user.createdAt,
         candidate_uid: user.id,
+        // Legacy orphan rows predate Phase 5 attribution columns: the
+        // visitor was anonymous (no Better Auth account) and carried no
+        // captured referral. Both default to null.
+        user_id: null,
+        referral_code: null,
 
         path: origin.landingPage ?? '/',
         referer: origin.referrerDomain ? `https://${origin.referrerDomain}/` : null,

--- a/src/backend/modules/user/migrations/011_prune_empty_user_rows.ts
+++ b/src/backend/modules/user/migrations/011_prune_empty_user_rows.ts
@@ -114,7 +114,16 @@ export const migration: IMigration = {
         'created before the Phase 4 prod deploy cutoff are eligible. Backs the ' +
         'final phase tracked in PLAN-traffic-events.md.',
     target: 'mongodb',
-    dependencies: ['module:user:010_create_traffic_events_table'],
+    // Depends on 012 (a higher-numbered migration) because 011's synthetic
+    // backfill events now carry the Phase-5 `user_id` / `referral_code`
+    // columns: those columns must exist before 011 inserts, or ClickHouse
+    // rejects every row and the prune/backfill is silently skipped. The
+    // dependency forces the topological sort to run 012 before 011 even
+    // though id order would otherwise place 011 first.
+    dependencies: [
+        'module:user:010_create_traffic_events_table',
+        'module:user:012_traffic_events_user_referral_columns'
+    ],
 
     async up(context: IMigrationContext): Promise<void> {
         if (!context.clickhouse) {

--- a/src/backend/modules/user/migrations/012_traffic_events_user_referral_columns.ts
+++ b/src/backend/modules/user/migrations/012_traffic_events_user_referral_columns.ts
@@ -1,0 +1,65 @@
+import type { IMigration, IMigrationContext } from '@/types';
+
+/**
+ * Add `user_id` and `referral_code` columns to the ClickHouse `traffic_events` table.
+ *
+ * **Why this migration exists.**
+ * Phase 5 of the Better Auth refactor re-keys traffic analytics onto the new
+ * `tronrelic_tid` cookie (a UUID, so `candidate_uid`'s column type is
+ * unchanged) and adds two attribution dimensions that did not exist when
+ * migration 010 created the table:
+ *   - `user_id` — the Better Auth user id when the event was recorded for a
+ *     logged-in visitor. Lets analytics attribute traffic to an account
+ *     without retyping the `candidate_uid` sort-key column (which ClickHouse
+ *     forbids in place).
+ *   - `referral_code` — the first-touch referral code captured from an
+ *     inbound `?ref=` (the `tronrelic_ref` cookie). Makes referral landings
+ *     visible in traffic analytics and preserves the code for conversion
+ *     attribution.
+ *
+ * Both are `Nullable(String)` because most rows carry neither (anonymous
+ * traffic with no referral). They sit outside the table's `ORDER BY`
+ * `(timestamp, candidate_uid)` key, so adding them is a pure metadata
+ * operation — no data rewrite.
+ *
+ * **Idempotent.** `ADD COLUMN IF NOT EXISTS` is a no-op on re-run.
+ *
+ * **Ordering.** Deploy this with the Phase 5 backend: `TrafficService`
+ * begins selecting and inserting these columns, so the table must carry
+ * them first. Until it runs, `getEventsForUser` reads degrade to `[]`
+ * (the service swallows the read error) and inserts of the new columns
+ * would be rejected — run it as part of the Phase 5 release.
+ *
+ * **Skip behavior.** Skipped with a warning when `CLICKHOUSE_HOST` is unset,
+ * matching migration 010 and `TrafficService`'s no-op posture.
+ *
+ * **Rollback.**
+ * ```sql
+ * ALTER TABLE traffic_events DROP COLUMN referral_code, DROP COLUMN user_id;
+ * ```
+ * Forward-only by project convention.
+ */
+export const migration: IMigration = {
+    id: '012_traffic_events_user_referral_columns',
+    description:
+        'Add Nullable(String) user_id and referral_code columns to the ClickHouse ' +
+        'traffic_events table for Better Auth Phase 5 account attribution and referral ' +
+        'first-touch capture. Additive (columns sit outside the ORDER BY key).',
+    target: 'clickhouse',
+    dependencies: ['module:user:010_create_traffic_events_table'],
+
+    async up(context: IMigrationContext): Promise<void> {
+        if (!context.clickhouse) {
+            console.log('[Migration 012] ClickHouse not configured — skipping traffic_events column add');
+            return;
+        }
+
+        await context.clickhouse.exec(`
+            ALTER TABLE traffic_events
+                ADD COLUMN IF NOT EXISTS user_id Nullable(String) AFTER candidate_uid,
+                ADD COLUMN IF NOT EXISTS referral_code LowCardinality(Nullable(String)) AFTER user_id
+        `);
+
+        console.log('[Migration 012] Added traffic_events.user_id and traffic_events.referral_code');
+    }
+};

--- a/src/backend/modules/user/services/traffic.service.ts
+++ b/src/backend/modules/user/services/traffic.service.ts
@@ -66,8 +66,24 @@ export interface ITrafficEvent {
     event_type: TrafficEventType;
     /** Server-side wall clock at write time. */
     timestamp: Date;
-    /** UUID minted by the bootstrap controller. Always present. */
+    /**
+     * Analytics visitor key. Since Phase 5 of the Better Auth refactor this
+     * is the `tronrelic_tid` UUID (decoupled from identity), not the legacy
+     * `tronrelic_uid`. Still a UUID v4, so the column type is unchanged. The
+     * field name stays `candidate_uid` to avoid retyping a sort-key column.
+     */
     candidate_uid: string;
+    /**
+     * Better Auth user id when the event was recorded for a logged-in
+     * visitor, else `null`. Additive Phase-5 column (migration 012) that
+     * attributes traffic to an account without re-keying `candidate_uid`.
+     */
+    user_id: string | null;
+    /**
+     * Referral code captured first-touch from an inbound `?ref=` (the
+     * `tronrelic_ref` cookie), else `null`. Additive Phase-5 column.
+     */
+    referral_code: string | null;
 
     /** Request URL or middleware-supplied `landingPath`. */
     path: string;
@@ -263,6 +279,8 @@ export class TrafficService {
                 event_type,
                 timestamp,
                 candidate_uid,
+                user_id,
+                referral_code,
                 path,
                 referer,
                 original_referrer,
@@ -446,6 +464,16 @@ export interface ITrafficEventBuilderInputs {
     };
     /** `document.referrer` reported by the client at landing. */
     originalReferrer?: string | null;
+    /**
+     * Better Auth user id when the visitor is logged in, else absent.
+     * Populates the additive `user_id` column for account attribution.
+     */
+    userId?: string | null;
+    /**
+     * Referral code captured first-touch (`tronrelic_ref`), else absent.
+     * Populates the additive `referral_code` column.
+     */
+    referralCode?: string | null;
 }
 
 /**
@@ -503,6 +531,8 @@ export function buildTrafficEvent(
         event_type: eventType,
         timestamp: new Date(),
         candidate_uid: candidateUid,
+        user_id: inputs.userId ?? null,
+        referral_code: inputs.referralCode ?? null,
 
         path: inputs.landingPath ?? (typeof req.path === 'string' ? req.path : '/'),
         referer: referer ?? null,

--- a/src/backend/modules/user/services/user.service.ts
+++ b/src/backend/modules/user/services/user.service.ts
@@ -1348,7 +1348,11 @@ export class UserService {
             // — both collapse to "use post-hydration values," which is the
             // pre-Phase-3 behaviour and matches the no-ClickHouse posture in
             // PLAN-traffic-events.md.
-            const firstTouch = await this.fetchFirstTouchEvent(userId);
+            // Look up by the analytics traffic id (Phase 5): bootstrap rows
+            // key on `tronrelic_tid`, not the legacy uid. Fall back to the
+            // canonical user id when no tid was threaded (legacy callers,
+            // tests) so first-touch correlation still works in transition.
+            const firstTouch = await this.fetchFirstTouchEvent(input.tid ?? userId);
 
             // Derive context from request (IP/UA never stored). The CH first-
             // touch event takes precedence on every dimension it carries —

--- a/src/backend/modules/user/services/user.service.ts
+++ b/src/backend/modules/user/services/user.service.ts
@@ -1352,7 +1352,16 @@ export class UserService {
             // key on `tronrelic_tid`, not the legacy uid. Fall back to the
             // canonical user id when no tid was threaded (legacy callers,
             // tests) so first-touch correlation still works in transition.
-            const firstTouch = await this.fetchFirstTouchEvent(input.tid ?? userId);
+            // Only enrich from the cookieless first-touch event on the
+            // user's very first session. For a returning visitor the earliest
+            // bootstrap row is months-old origin data; applying it to a new
+            // session would overwrite that session's real referrer / UTM /
+            // landing page / device / country and break per-session and
+            // multi-touch attribution.
+            const isFirstSession = !activity.origin || activity.sessions.length === 0;
+            const firstTouch = isFirstSession
+                ? await this.fetchFirstTouchEvent(input.tid ?? userId)
+                : null;
 
             // Derive context from request (IP/UA never stored). The CH first-
             // touch event takes precedence on every dimension it carries —

--- a/src/frontend/middleware.ts
+++ b/src/frontend/middleware.ts
@@ -30,6 +30,25 @@ const USER_ID_COOKIE_MAX_AGE_SECONDS = 31536000;
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /**
+ * Analytics traffic id (Phase 5 of the Better Auth refactor). A UUID
+ * decoupled from identity that keys `traffic_events`, minted here so it is
+ * stable from the very first SSR paint and survives the Phase 6 removal of
+ * `tronrelic_uid`. Spec mirrors the backend `traffic-cookies.ts` helper:
+ * HttpOnly, SameSite=Lax, Secure in production, one-year max-age, unsigned.
+ */
+const TID_COOKIE_NAME = 'tronrelic_tid';
+const TID_COOKIE_MAX_AGE_SECONDS = 31536000;
+
+/**
+ * Referral cookie — first-touch capture of an inbound `?ref=<code>` so a
+ * later signup can attribute to the referrer. 90-day window. Mirrors the
+ * backend `traffic-cookies.ts` spec.
+ */
+const REF_COOKIE_NAME = 'tronrelic_ref';
+const REF_COOKIE_MAX_AGE_SECONDS = 7776000;
+const REFERRAL_CODE_REGEX = /^[A-Za-z0-9_-]{4,32}$/;
+
+/**
  * Cap on the JSON body forwarded to the backend bootstrap endpoint. The
  * payload only carries small derived signals (landing path, UTM params,
  * `document.referrer`) so 1 KB is generous; the cap exists to defend
@@ -74,7 +93,7 @@ const UTM_KEYS = ['source', 'medium', 'campaign', 'term', 'content'] as const;
  * The body is capped at `BOOTSTRAP_BODY_BYTE_CAP` bytes. Oversized payloads
  * fall back to an empty object so the backend bootstrap still succeeds.
  */
-function buildBootstrapBody(request: NextRequest): string {
+function buildBootstrapBody(request: NextRequest, tid: string, referralCode: string | null): string {
     const utm: Record<string, string> = {};
     for (const key of UTM_KEYS) {
         const value = request.nextUrl.searchParams.get(`utm_${key}`);
@@ -86,13 +105,20 @@ function buildBootstrapBody(request: NextRequest): string {
     const originalReferrer = request.cookies.get(ORIGINAL_REFERRER_COOKIE)?.value;
 
     const payload: Record<string, unknown> = {
-        landingPath: request.nextUrl.pathname
+        landingPath: request.nextUrl.pathname,
+        // Forward the analytics tid so the backend keys the bootstrap
+        // traffic_event on the same id this middleware persists in the
+        // cookie, rather than minting a divergent one server-side.
+        tid
     };
     if (Object.keys(utm).length > 0) {
         payload.utm = utm;
     }
     if (originalReferrer) {
         payload.originalReferrer = originalReferrer;
+    }
+    if (referralCode) {
+        payload.ref = referralCode;
     }
 
     const serialized = JSON.stringify(payload);
@@ -164,13 +190,17 @@ function buildForwardedHeaders(request: NextRequest): Record<string, string> {
  * client IP via `X-Forwarded-For`, and a small JSON body with the
  * landing path, UTM params, and `_original_ref` cookie.
  */
-async function bootstrapIdentity(request: NextRequest): Promise<string | null> {
+async function bootstrapIdentity(
+    request: NextRequest,
+    tid: string,
+    referralCode: string | null
+): Promise<string | null> {
     const backendUrl = process.env.SITE_BACKEND || 'http://localhost:4000';
     try {
         const response = await fetch(`${backendUrl}/api/user/bootstrap`, {
             method: 'POST',
             headers: buildForwardedHeaders(request),
-            body: buildBootstrapBody(request),
+            body: buildBootstrapBody(request, tid, referralCode),
             // Prevent edge runtime from caching identity bootstrap.
             cache: 'no-store',
             signal: AbortSignal.timeout(3000)
@@ -311,12 +341,29 @@ export async function middleware(request: NextRequest) {
     // Only mint here when the cookie is genuinely absent or empty. The
     // raw UUID-regex check that used to gate this call rejected the
     // signed envelope and orphaned every returning user post-PR-197.
+    // Resolve the analytics traffic id and first-touch referral capture
+    // (Phase 5). Independent of the identity bootstrap below: an existing
+    // visitor may carry a uid from before Phase 5 but no tid yet, so the
+    // tid is minted whenever it is absent regardless of uid state.
+    const existingTid = request.cookies.get(TID_COOKIE_NAME)?.value;
+    const tid =
+        typeof existingTid === 'string' && UUID_V4_REGEX.test(existingTid)
+            ? existingTid
+            : crypto.randomUUID();
+    const tidMinted = tid !== existingTid;
+
+    const existingRef = request.cookies.get(REF_COOKIE_NAME)?.value;
+    const inboundRef = request.nextUrl.searchParams.get('ref');
+    const refToSet =
+        !existingRef && inboundRef && REFERRAL_CODE_REGEX.test(inboundRef) ? inboundRef : null;
+    const referralCode = existingRef ?? refToSet ?? null;
+
     const existingId = request.cookies.get(USER_ID_COOKIE_NAME)?.value;
     const needsBootstrap = typeof existingId !== 'string' || existingId.length === 0;
 
     let injectedUserId: string | null = null;
     if (needsBootstrap) {
-        injectedUserId = await bootstrapIdentity(request);
+        injectedUserId = await bootstrapIdentity(request, tid, referralCode);
         if (injectedUserId) {
             // Mutate the request's cookie jar so server components running
             // in the same render tree see the cookie via `next/headers`.
@@ -337,14 +384,40 @@ export async function middleware(request: NextRequest) {
     // Persist the bootstrapped identity on the browser so subsequent
     // requests carry it. Spec mirrors the backend's setIdentityCookie:
     // HttpOnly, SameSite=Lax, Secure in production.
+    const isProduction = request.nextUrl.protocol === 'https:';
     if (injectedUserId) {
-        const isProduction = request.nextUrl.protocol === 'https:';
         response.cookies.set(USER_ID_COOKIE_NAME, injectedUserId, {
             httpOnly: true,
             sameSite: 'lax',
             secure: isProduction,
             path: '/',
             maxAge: USER_ID_COOKIE_MAX_AGE_SECONDS
+        });
+    }
+
+    // Persist the analytics tid (Phase 5) on first sight so every
+    // subsequent request — and the backend traffic_events row — keys on a
+    // stable id independent of identity. Set only when freshly minted to
+    // avoid a redundant Set-Cookie on every navigation.
+    if (tidMinted) {
+        response.cookies.set(TID_COOKIE_NAME, tid, {
+            httpOnly: true,
+            sameSite: 'lax',
+            secure: isProduction,
+            path: '/',
+            maxAge: TID_COOKIE_MAX_AGE_SECONDS
+        });
+    }
+
+    // Capture the first-touch referral code. First-touch wins: only set
+    // when no referral cookie exists yet and the inbound ?ref= is well-formed.
+    if (refToSet) {
+        response.cookies.set(REF_COOKIE_NAME, refToSet, {
+            httpOnly: true,
+            sameSite: 'lax',
+            secure: isProduction,
+            path: '/',
+            maxAge: REF_COOKIE_MAX_AGE_SECONDS
         });
     }
 


### PR DESCRIPTION
## Summary

Phase 5 of the Better Auth refactor. Decouples analytics from the identity cookie so traffic tracking survives the Phase 6 removal of `tronrelic_uid`. Chosen approach: **tid as the universal analytics key + additive attribution columns** (lowest-risk — the `traffic_events.candidate_uid` UUID column is inside the table's `ORDER BY` sort key and cannot be retyped in place).

- **`tronrelic_tid`** — a server-minted UUID v4, unsigned, HttpOnly, decoupled from identity. Minted by the Next.js middleware on the SSR-first path (stable from first paint) and by the backend for direct/client callers; the middleware relays the tid to `POST /api/user/bootstrap` so the recorded event keys on the same id. `traffic_events.candidate_uid` now holds the tid (still a UUID — no column retype).
- **`tronrelic_ref`** — first-touch capture of an inbound `?ref=<code>` (90-day window) for later referral attribution (consumed at Phase 6 signup).
- **Migration `012_traffic_events_user_referral_columns`** — additive ClickHouse `ALTER` adding `user_id` (BA user id when logged in, via `req.authSession`) and `referral_code` (captured first-touch code), both `Nullable` and outside the sort key, so traffic attributes to an account without re-keying `candidate_uid`.
- `buildTrafficEvent` + `ITrafficEvent` gain `user_id`/`referral_code`; the Phase-3 first-touch backfill in `UserService.startSession` keys on the threaded tid (falls back to `userId` for legacy callers/tests so correlation holds during the transition).
- New `api/traffic-cookies.ts` helpers (resolve/mint/set + code validation), unit-tested; migration 012 test; bootstrap cookie-count assertions updated to look the identity cookie up by name (bootstrap now also sets the tid cookie).

Verification: backend + frontend typecheck clean; 276 user-module tests pass.

## Operational note

**Run migration 012 as part of the Phase 5 release.** Until it applies, `getEventsForUser` reads degrade to empty (the service swallows the read error) and inserts of the new columns are rejected by ClickHouse.

Next: Phase 6 (destructive cutover — drop the legacy `users` collection + `tronrelic_uid`, remove identity reconciliation, `UserIdentityProvider`, `/api/profile/:address`). Implemented and PR'd but **not merged/deployed** without your go-ahead.