### PR TITLE
feat(types): expose Better Auth session to plugins via req.authSession

### DIFF
--- a/packages/types/src/auth/IAuthSession.ts
+++ b/packages/types/src/auth/IAuthSession.ts
@@ -33,8 +33,6 @@ export interface IAuthSessionUser {
     name?: string | null;
     /** Avatar/profile image URL, when set. */
     image?: string | null;
-    /** Primary linked TRON wallet address, when one is set. */
-    primaryWallet?: string | null;
 }
 
 /**
@@ -42,14 +40,18 @@ export interface IAuthSessionUser {
  *
  * `req.authSession` is `null` for anonymous visitors and an
  * `IAuthSession` for logged-in ones. Group ids drive membership/admin
- * gating; `primaryWallet` mirrors the user's denormalized primary wallet
- * for convenience.
+ * gating; `primaryWallet` is the account's denormalized primary wallet.
  */
 export interface IAuthSession {
     /** The authenticated Better Auth user. */
     user: IAuthSessionUser;
     /** Group ids the user belongs to (e.g. `['admin']`). */
     groups: string[];
-    /** Primary linked TRON wallet address, when one is set. */
+    /**
+     * Primary linked TRON wallet address, when one is set — the single
+     * canonical primary for the session. Mirrors core
+     * `IAugmentedSession.primaryWallet`; plugins read it here rather than
+     * from the user record.
+     */
     primaryWallet?: string | null;
 }

--- a/packages/types/src/auth/IAuthSession.ts
+++ b/packages/types/src/auth/IAuthSession.ts
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Plugin-facing Better Auth session shape.
+ *
+ * The core backend resolves the Better Auth session once per request (in
+ * the `attachAuthSession` middleware) and stores a richer internal
+ * `IAugmentedSession` on the Express request. Plugins receive that same
+ * request object (the framework adapter casts it to {@link IHttpRequest}),
+ * so this is the narrowed, dependency-free view plugins read through
+ * `req.authSession` — without importing Better Auth or any core module.
+ *
+ * It is the Better Auth successor to the legacy `req.user` surface: where
+ * plugins used to gate on `req.user.identityState === Verified`, they now
+ * gate on the presence of `req.authSession` (logged in) and its `groups`
+ * (admin / membership). Use the {@link isLoggedIn} / {@link isAdmin} /
+ * {@link isInGroup} helpers rather than poking at the fields directly.
+ */
+
+/**
+ * Better Auth user fields exposed to plugins.
+ *
+ * The full Better Auth user record carries more, but plugins only need a
+ * stable id plus the common profile fields. `id` is the Better Auth user
+ * id (not the legacy UUID) — the durable, cross-device identity key.
+ */
+export interface IAuthSessionUser {
+    /** Better Auth user id — the stable, portable identity key. */
+    id: string;
+    /** Verified email, when the account has one. */
+    email?: string | null;
+    /** Whether the email is verified. */
+    emailVerified?: boolean;
+    /** Display name, when set. */
+    name?: string | null;
+    /** Avatar/profile image URL, when set. */
+    image?: string | null;
+    /** Primary linked TRON wallet address, when one is set. */
+    primaryWallet?: string | null;
+}
+
+/**
+ * Resolved session a logged-in visitor's request carries.
+ *
+ * `req.authSession` is `null` for anonymous visitors and an
+ * `IAuthSession` for logged-in ones. Group ids drive membership/admin
+ * gating; `primaryWallet` mirrors the user's denormalized primary wallet
+ * for convenience.
+ */
+export interface IAuthSession {
+    /** The authenticated Better Auth user. */
+    user: IAuthSessionUser;
+    /** Group ids the user belongs to (e.g. `['admin']`). */
+    groups: string[];
+    /** Primary linked TRON wallet address, when one is set. */
+    primaryWallet?: string | null;
+}

--- a/packages/types/src/auth/authPredicates.ts
+++ b/packages/types/src/auth/authPredicates.ts
@@ -41,10 +41,16 @@ export interface IHasAuthSession {
  *
  * `true` when the request carries a resolved Better Auth session.
  *
+ * Acts as a TypeScript type guard: on the truthy branch `req.authSession`
+ * narrows to {@link IAuthSession}, so plugins read `req.authSession.user.id`
+ * without a non-null assertion.
+ *
  * @param req - Request-like object with an `authSession`.
  * @returns Whether a session is present.
  */
-export function isLoggedIn(req: IHasAuthSession): boolean {
+export function isLoggedIn<T extends IHasAuthSession>(
+    req: T
+): req is T & { authSession: IAuthSession } {
     return req.authSession != null;
 }
 
@@ -54,7 +60,9 @@ export function isLoggedIn(req: IHasAuthSession): boolean {
  * @param req - Request-like object with an `authSession`.
  * @returns Whether the caller has no session.
  */
-export function isAnonymous(req: IHasAuthSession): boolean {
+export function isAnonymous<T extends IHasAuthSession>(
+    req: T
+): req is T & { authSession: null | undefined } {
     return req.authSession == null;
 }
 
@@ -67,7 +75,10 @@ export function isAnonymous(req: IHasAuthSession): boolean {
  * @param groupId - Group id to test.
  * @returns Whether the session's groups include `groupId`.
  */
-export function isInGroup(req: IHasAuthSession, groupId: string): boolean {
+export function isInGroup<T extends IHasAuthSession>(
+    req: T,
+    groupId: string
+): req is T & { authSession: IAuthSession } {
     return req.authSession != null && req.authSession.groups.includes(groupId);
 }
 
@@ -80,6 +91,29 @@ export function isInGroup(req: IHasAuthSession, groupId: string): boolean {
  * @param req - Request-like object with an `authSession`.
  * @returns Whether the caller is in the `admin` group.
  */
-export function isAdmin(req: IHasAuthSession): boolean {
+export function isAdmin<T extends IHasAuthSession>(
+    req: T
+): req is T & { authSession: IAuthSession } {
     return isInGroup(req, ADMIN_GROUP_ID);
+}
+
+/**
+ * Does the caller have a linked primary TRON wallet?
+ *
+ * Better Auth separates "logged in" from "owns a wallet": a visitor can
+ * authenticate via email-OTP / OAuth / passkey with no wallet at all.
+ * Plugin routes that previously gated on the legacy
+ * `req.user.identityState === Verified` — which implied a signature-proven
+ * wallet — must migrate to THIS predicate, not {@link isLoggedIn}, or they
+ * would open to wallet-less accounts. Every wallet in the Phase-4 store is
+ * signature-proven at link time, so a present `primaryWallet` is a proven
+ * wallet.
+ *
+ * @param req - Request-like object with an `authSession`.
+ * @returns Whether a logged-in caller has a primary wallet set.
+ */
+export function hasPrimaryWallet<T extends IHasAuthSession>(
+    req: T
+): req is T & { authSession: IAuthSession } {
+    return req.authSession != null && req.authSession.primaryWallet != null;
 }

--- a/packages/types/src/auth/authPredicates.ts
+++ b/packages/types/src/auth/authPredicates.ts
@@ -1,0 +1,85 @@
+/**
+ * @fileoverview Synchronous, plugin-facing authorization predicates.
+ *
+ * Plugins cannot import the core backend's authorization facade (it
+ * depends on Better Auth and lives outside the plugin workspace), so
+ * these dependency-free helpers read the pre-resolved
+ * {@link IAuthSession} the core middleware already attached to the
+ * request. They are the Better Auth replacement for the legacy
+ * `req.user.identityState === Verified` checks plugins used to write.
+ *
+ * Unlike the core facade's async `isLoggedIn(req)` (which resolves the
+ * session from cookies), these are synchronous pure reads of
+ * `req.authSession` — the session was resolved once by the
+ * `attachAuthSession` middleware before the request reached the plugin.
+ */
+
+import type { IAuthSession } from './IAuthSession.js';
+
+/**
+ * Group id reserved for administrators.
+ *
+ * Mirrors the core `ADMIN_GROUP_ID`. Exported so callers reference a
+ * symbol rather than a bare `'admin'` literal.
+ */
+export const ADMIN_GROUP_ID = 'admin';
+
+/**
+ * Minimal request shape these predicates read.
+ *
+ * Declared structurally (rather than importing `IHttpRequest`) so the
+ * helpers also accept any object carrying an `authSession` — test stubs,
+ * the core Express request, a websocket-derived context.
+ */
+export interface IHasAuthSession {
+    /** Resolved session: `null`/absent for anonymous, populated for logged-in. */
+    authSession?: IAuthSession | null;
+}
+
+/**
+ * Is the caller authenticated?
+ *
+ * `true` when the request carries a resolved Better Auth session.
+ *
+ * @param req - Request-like object with an `authSession`.
+ * @returns Whether a session is present.
+ */
+export function isLoggedIn(req: IHasAuthSession): boolean {
+    return req.authSession != null;
+}
+
+/**
+ * Is the caller anonymous? Inverse of {@link isLoggedIn}.
+ *
+ * @param req - Request-like object with an `authSession`.
+ * @returns Whether the caller has no session.
+ */
+export function isAnonymous(req: IHasAuthSession): boolean {
+    return req.authSession == null;
+}
+
+/**
+ * Is the caller a member of a given group?
+ *
+ * Anonymous callers are always `false`. Group ids are case-sensitive.
+ *
+ * @param req - Request-like object with an `authSession`.
+ * @param groupId - Group id to test.
+ * @returns Whether the session's groups include `groupId`.
+ */
+export function isInGroup(req: IHasAuthSession, groupId: string): boolean {
+    return req.authSession != null && req.authSession.groups.includes(groupId);
+}
+
+/**
+ * Is the caller an administrator?
+ *
+ * Sugar for {@link isInGroup} with {@link ADMIN_GROUP_ID}, mirroring the
+ * core facade so a future admin-tier change updates one place.
+ *
+ * @param req - Request-like object with an `authSession`.
+ * @returns Whether the caller is in the `admin` group.
+ */
+export function isAdmin(req: IHasAuthSession): boolean {
+    return isInGroup(req, ADMIN_GROUP_ID);
+}

--- a/packages/types/src/auth/index.ts
+++ b/packages/types/src/auth/index.ts
@@ -12,5 +12,6 @@ export {
     isAnonymous,
     isInGroup,
     isAdmin,
+    hasPrimaryWallet,
     type IHasAuthSession
 } from './authPredicates.js';

--- a/packages/types/src/auth/index.ts
+++ b/packages/types/src/auth/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @fileoverview Barrel for the plugin-facing Better Auth authorization
+ * surface: the {@link IAuthSession} shape carried on `req.authSession`
+ * and the synchronous {@link isLoggedIn} / {@link isAdmin} predicates
+ * plugins use in place of the retired `req.user.identityState` checks.
+ */
+
+export type { IAuthSession, IAuthSessionUser } from './IAuthSession.js';
+export {
+    ADMIN_GROUP_ID,
+    isLoggedIn,
+    isAnonymous,
+    isInGroup,
+    isAdmin,
+    type IHasAuthSession
+} from './authPredicates.js';

--- a/packages/types/src/http/IHttpRequest.ts
+++ b/packages/types/src/http/IHttpRequest.ts
@@ -1,4 +1,5 @@
 import type { IUser } from '../user/IUser.js';
+import type { IAuthSession } from '../auth/IAuthSession.js';
 
 /**
  * Framework-agnostic HTTP request interface.
@@ -202,4 +203,32 @@ export interface IHttpRequest<
      * ```
      */
     user?: IUser;
+
+    /**
+     * Resolved Better Auth session, attached by the core
+     * `attachAuthSession` middleware before requests reach plugin routes.
+     *
+     * `null` for anonymous visitors, an {@link IAuthSession} for
+     * logged-in ones, `undefined` only if the middleware did not run
+     * (test stubs). This is the Better Auth successor to {@link user}:
+     * gate authenticated plugin routes on `req.authSession` via the
+     * `isLoggedIn` / `isAdmin` / `isInGroup` predicates rather than the
+     * legacy `req.user.identityState` reads.
+     *
+     * @example
+     * ```typescript
+     * import { isLoggedIn, isAdmin } from '@delphian/tronrelic-types';
+     *
+     * handler: async (req, res) => {
+     *     if (!isLoggedIn(req)) {
+     *         return res.status(401).json({ error: 'Authentication required' });
+     *     }
+     *     if (!isAdmin(req)) {
+     *         return res.status(403).json({ error: 'Admin required' });
+     *     }
+     *     const userId = req.authSession!.user.id;
+     * }
+     * ```
+     */
+    authSession?: IAuthSession | null;
 }

--- a/packages/types/src/http/IHttpRequest.ts
+++ b/packages/types/src/http/IHttpRequest.ts
@@ -209,11 +209,14 @@ export interface IHttpRequest<
      * `attachAuthSession` middleware before requests reach plugin routes.
      *
      * `null` for anonymous visitors, an {@link IAuthSession} for
-     * logged-in ones, `undefined` only if the middleware did not run
-     * (test stubs). This is the Better Auth successor to {@link user}:
-     * gate authenticated plugin routes on `req.authSession` via the
-     * `isLoggedIn` / `isAdmin` / `isInGroup` predicates rather than the
-     * legacy `req.user.identityState` reads.
+     * logged-in ones. It is `undefined` only outside the middleware's
+     * reach — test stubs, or the middleware's own bypassed paths (it
+     * early-returns on `/api/auth/*`). Plugin routes always run after the
+     * middleware, so for plugin handlers `authSession` is always set
+     * (`null` or populated), never `undefined`. This is the Better Auth
+     * successor to {@link user}: gate authenticated plugin routes on
+     * `req.authSession` via the `isLoggedIn` / `isAdmin` / `isInGroup`
+     * predicates rather than the legacy `req.user.identityState` reads.
      *
      * @example
      * ```typescript
@@ -226,7 +229,7 @@ export interface IHttpRequest<
      *     if (!isAdmin(req)) {
      *         return res.status(403).json({ error: 'Admin required' });
      *     }
-     *     const userId = req.authSession!.user.id;
+     *     const userId = req.authSession.user.id;
      * }
      * ```
      */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,7 +6,7 @@ export type { ITransaction, ITransactionPersistencePayload, ITransactionCategory
 export { ProcessedTransaction } from './transaction/index.js';
 export type { IHttpRequest, IHttpResponse, IHttpNext } from './http/index.js';
 export type { IAuthSession, IAuthSessionUser, IHasAuthSession } from './auth/index.js';
-export { ADMIN_GROUP_ID, isLoggedIn, isAnonymous, isInGroup, isAdmin } from './auth/index.js';
+export { ADMIN_GROUP_ID, isLoggedIn, isAnonymous, isInGroup, isAdmin, hasPrimaryWallet } from './auth/index.js';
 // ILogger removed - use ISystemLogService instead (exported from './system-log/index.js')
 export type { IChainParameters } from './chain-parameters/IChainParameters.js';
 export type { IChainParametersService } from './chain-parameters/IChainParametersService.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,6 +5,8 @@ export { definePlugin } from './plugin/index.js';
 export type { ITransaction, ITransactionPersistencePayload, ITransactionCategoryFlags } from './transaction/index.js';
 export { ProcessedTransaction } from './transaction/index.js';
 export type { IHttpRequest, IHttpResponse, IHttpNext } from './http/index.js';
+export type { IAuthSession, IAuthSessionUser, IHasAuthSession } from './auth/index.js';
+export { ADMIN_GROUP_ID, isLoggedIn, isAnonymous, isInGroup, isAdmin } from './auth/index.js';
 // ILogger removed - use ISystemLogService instead (exported from './system-log/index.js')
 export type { IChainParameters } from './chain-parameters/IChainParameters.js';
 export type { IChainParametersService } from './chain-parameters/IChainParametersService.js';


### PR DESCRIPTION
## Summary

Plugin-auth-surface **enabler** for the Better Auth Phase 6 cutover. Phase 6 retires the legacy `UserIdentityState` enum and `req.user`, but three plugins (`trp-forum`, `trp-memo-tracker`, `trp-bazi-fortune`) still import `UserIdentityState` from `@delphian/tronrelic-types` and gate on `req.user.identityState === Verified`. They need a Better Auth-based surface to migrate onto *before* Phase 6 can remove the legacy one. This PR adds that surface.

Because the core `attachAuthSession` middleware already resolves the BA session onto the Express request, and the plugin route adapter (`adaptRequest`) hands plugins that **same** request object, this is a pure types-package addition with **no core runtime change**:

- New plugin-facing **`IAuthSession` / `IAuthSessionUser`** — the narrowed, Better-Auth-dependency-free view of the resolved session that plugins read via `req.authSession`.
- New synchronous **`isLoggedIn(req)` / `isAnonymous(req)` / `isInGroup(req, id)` / `isAdmin(req)`** predicates (read `req.authSession`) — the Better Auth replacement for the legacy `req.user.identityState === Verified` checks. (Distinct from the core facade's async variants, which resolve from cookies; these read the pre-resolved session.)
- **`authSession?: IAuthSession | null`** added to `IHttpRequest`.

Additive and backwards-compatible (optional field, new exports). Types package builds; backend + frontend typecheck clean.

## Sequencing (publish-gated)

This is step A of the Phase 7→6 program: **(A) this enabler → merge + publish types → (B) bump each plugin to the new types and sweep it onto `req.authSession`/`isLoggedIn`/`isAdmin` (one PR per plugin repo) → (C) full Phase 6 cutover.** Steps B–C can't build until this merges and `@delphian/tronrelic-types` publishes.