### PR TITLE
feat(types): redefine plugin useUser() on the Better Auth session

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delphian/tronrelic-types",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "Core type definitions for the TronRelic platform",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,6 @@
 export type { Block } from './Block.js';
 export type { IBaseObserver, IBaseBatchObserver, TransactionBatches, IBaseBlockObserver, IBlockData, IBlockchainObserverService, IWebSocketService, IPluginContext, IObserverStats, IPluginWebSocketManager, PluginSubscriptionHandler, PluginUnsubscribeHandler, IPluginWebSocketStats, IAggregatePluginWebSocketStats } from './observer/index.js';
-export type { IPlugin, IPluginManifest, IAdminUIConfig, IPluginDatabase, IApiRouteConfig, HttpMethod, ApiRouteHandler, ApiMiddleware, IMenuItemConfig, IPageConfig, IPluginMetadata, IPluginManagementRequest, IPluginManagementResponse, IPluginInfo, IFrontendPluginContext, IUIComponents, ILayoutComponents, IChartComponents, ISystemComponents, IApiClient, IWebSocketClient, IPluginUserState, IPluginWalletLink } from './plugin/index.js';
+export type { IPlugin, IPluginManifest, IAdminUIConfig, IPluginDatabase, IApiRouteConfig, HttpMethod, ApiRouteHandler, ApiMiddleware, IMenuItemConfig, IPageConfig, IPluginMetadata, IPluginManagementRequest, IPluginManagementResponse, IPluginInfo, IFrontendPluginContext, IUIComponents, ILayoutComponents, IChartComponents, ISystemComponents, IApiClient, IWebSocketClient, IPluginUserState } from './plugin/index.js';
 export { definePlugin } from './plugin/index.js';
 export type { ITransaction, ITransactionPersistencePayload, ITransactionCategoryFlags } from './transaction/index.js';
 export { ProcessedTransaction } from './transaction/index.js';

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -2,102 +2,60 @@ import type { ComponentType } from 'react';
 import type { Socket } from 'socket.io-client';
 
 /**
- * Wallet link information exposed to frontend plugins.
- *
- * Represents a wallet that has been linked (claimed) to a user account.
- * Wallets follow a two-step flow: connect (claim) → verify (signature).
- */
-export interface IPluginWalletLink {
-    /** TRON wallet address (base58 format) */
-    address: string;
-
-    /** Whether wallet ownership has been cryptographically verified via signature */
-    verified: boolean;
-
-    /** Whether this is the user's primary wallet */
-    isPrimary: boolean;
-
-    /** When the wallet was first linked (ISO timestamp) */
-    linkedAt: string;
-
-    /** When the wallet was last used/connected (ISO timestamp) */
-    lastUsed: string;
-
-    /** Optional user-assigned label for the wallet */
-    label?: string;
-}
-
-/**
  * User state exposed to frontend plugins.
  *
- * Provides user identity and wallet information for feature gating
- * and personalization. Designed as a stable interface that won't break
- * plugins when core user module internals are refactored.
- *
- * Identity progression:
- * 1. Anonymous - `!hasLinkedWallet`
- * 2. Registered - `hasLinkedWallet && !isVerified` (wallet linked but no live session)
- * 3. Verified - `isVerified` (wallet signed, session still within SESSION_TTL_MS)
+ * Mirrors the backend authorization surface so plugin gating reads the
+ * same way on both sides: `isLoggedIn` is the primary gate (any
+ * authenticated Better Auth account), `hasPrimaryWallet` is the single
+ * wallet check, and `primaryWallet` is the proven primary address. A
+ * present wallet is always signature-verified — the wallet store only
+ * holds wallets proven by signature — so there is no separate
+ * verified/unverified distinction.
  *
  * @example
  * ```typescript
- * const { hasLinkedWallet, isVerified, wallets } = context.useUser();
+ * const { isLoggedIn, hasPrimaryWallet, primaryWallet } = context.useUser();
  *
- * // Gate feature to verified users only
- * if (!isVerified) {
- *     return <p>Please verify your wallet to access this feature</p>;
+ * // Primary gate: any signed-in account
+ * if (!isLoggedIn) {
+ *     return <p>Please sign in to access this feature</p>;
  * }
  *
- * // Detect "registered but session aged out" state
- * if (hasLinkedWallet && !isVerified) {
- *     return <p>Please re-sign with your wallet to refresh your session</p>;
+ * // Wallet-specific gate: requires a proven primary wallet
+ * if (!hasPrimaryWallet) {
+ *     return <p>Link a TRON wallet to use this feature</p>;
  * }
  * ```
  */
 export interface IPluginUserState {
     /**
-     * User's unique identifier (UUID).
-     * Always available after initial hydration.
+     * Better Auth account id. Null until the session resolves (anonymous
+     * visitors and the pre-hydration window).
      */
     userId: string | null;
 
     /**
-     * Whether the user has at least one linked wallet (verified or not).
-     * Convenience check for `wallets.length > 0`.
+     * Primary gate — true when the visitor has an authenticated Better
+     * Auth session (email-OTP / OAuth / passkey). Mirrors the backend
+     * `isLoggedIn(req)` predicate. Use this for login-only gating.
      */
-    hasLinkedWallet: boolean;
+    isLoggedIn: boolean;
 
     /**
-     * Whether the user is in the canonical `Verified` identity state —
-     * `user.identityState === UserIdentityState.Verified`, meaning a
-     * wallet was signed and the user-level session is still within
-     * `SESSION_TTL_MS`. Freshness is enforced by the backend's lazy
-     * session-expiry pass, so this is always a live-session signal,
-     * never a historical claim. Use this for feature gating.
-     *
-     * Distinct from per-wallet `verified` (audit history that stays
-     * `true` after any past signature) — see `wallets[].verified`.
+     * True when the account has a signature-proven primary wallet.
+     * Mirrors the backend `hasPrimaryWallet(req)` predicate. Use this for
+     * wallet-gated features — a present wallet is always verified.
      */
-    isVerified: boolean;
+    hasPrimaryWallet: boolean;
 
     /**
-     * All linked wallets (both verified and unverified).
-     * Empty array if user has not linked any wallets.
-     *
-     * To get only verified wallets: `wallets.filter(w => w.verified)`
-     */
-    wallets: IPluginWalletLink[];
-
-    /**
-     * Primary wallet address if set, null otherwise.
-     * Primary is automatically computed as the most recently used verified wallet,
-     * or most recently used unverified wallet if no verified wallets exist.
+     * The proven primary wallet address, or null when none is linked.
      */
     primaryWallet: string | null;
 
     /**
-     * Whether user state has been initialized from backend.
-     * Use this to show loading states before user data is available.
+     * False until the Better Auth session has resolved. Use for loading
+     * states before identity is known.
      */
     initialized: boolean;
 }

--- a/packages/types/src/plugin/index.ts
+++ b/packages/types/src/plugin/index.ts
@@ -25,7 +25,6 @@ export type {
     ISystemComponents,
     IApiClient,
     IWebSocketClient,
-    IPluginUserState,
-    IPluginWalletLink
+    IPluginUserState
 } from './IFrontendPluginContext.js';
 export { definePlugin } from './definePlugin.js';

--- a/src/frontend/lib/frontendPluginContext.tsx
+++ b/src/frontend/lib/frontendPluginContext.tsx
@@ -9,8 +9,7 @@ import type {
     ISystemComponents,
     IApiClient,
     IWebSocketClient,
-    IPluginUserState,
-    IPluginWalletLink
+    IPluginUserState
 } from '@/types';
 import { Card } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
@@ -28,14 +27,7 @@ import { useToast as useToastHook } from '../components/ui/ToastProvider';
 import { LineChart } from '../features/charts/components/LineChart';
 import { SchedulerMonitor } from '../modules/scheduler';
 import { Page, PageHeader, Stack, Grid, Section } from '../components/layout';
-import { useAppSelector } from '../store/hooks';
-import {
-    selectUserId,
-    selectUserData,
-    selectUserInitialized,
-    selectIsVerified,
-    selectPrimaryWallet
-} from '../modules/user/slice';
+import { useAuthSession } from '../modules/user/components/SessionProvider';
 import { getSocket } from './socketClient';
 import { getRuntimeConfig } from './runtimeConfig';
 
@@ -283,45 +275,26 @@ class WebSocketClient implements IWebSocketClient {
 /**
  * Hook providing user state to frontend plugins.
  *
- * Wraps Redux selectors to provide a stable interface that won't break
- * plugins when the internal user module is refactored. Returns reactive
- * state that automatically updates when user data changes.
+ * Mirrors the backend authorization surface: `isLoggedIn` is the primary
+ * gate (any authenticated Better Auth account), `hasPrimaryWallet` is the
+ * single wallet check, and `primaryWallet` is the proven primary address.
+ * A present `primaryWallet` is always signature-verified — the wallet store
+ * only holds wallets proven by signature — so there is no separate
+ * verified/unverified distinction. Sourced from the Better Auth session
+ * (SSR-seeded via SessionProvider), not the legacy UUID identity slice.
  *
- * @returns Plugin-safe user state with identity, wallets, and verification status
+ * @returns Plugin-safe user state: login flag, primary-wallet flag + address
  */
 function usePluginUser(): IPluginUserState {
-    const userId = useAppSelector(selectUserId);
-    const userData = useAppSelector(selectUserData);
-    const initialized = useAppSelector(selectUserInitialized);
-    const isUserVerified = useAppSelector(selectIsVerified);
-    const primaryWallet = useAppSelector(selectPrimaryWallet);
-
-    // Transform wallets to plugin-safe format
-    const wallets: IPluginWalletLink[] = (userData?.wallets ?? []).map(w => ({
-        address: w.address,
-        verified: w.verified,
-        isPrimary: w.isPrimary,
-        linkedAt: w.linkedAt,
-        lastUsed: w.lastUsed,
-        label: w.label
-    }));
-
-    // `isVerified` mirrors the canonical `UserIdentityState.Verified`
-    // — already resolved through the backend's lazy session-expiry
-    // pass — rather than scanning per-wallet `verified` flags. A user
-    // with a historically-verified wallet whose session has expired
-    // reads as `isVerified: false`; the per-wallet flag is audit
-    // history, not session state.
-    const hasLinkedWallet = wallets.length > 0;
-    const isVerified = isUserVerified;
+    const { session, isLoggedIn, isPending } = useAuthSession();
+    const primaryWallet = session?.user?.primaryWallet ?? null;
 
     return {
-        userId,
-        hasLinkedWallet,
-        isVerified,
-        wallets,
+        userId: session?.user?.id ?? null,
+        isLoggedIn,
+        hasPrimaryWallet: primaryWallet !== null,
         primaryWallet,
-        initialized
+        initialized: !isPending
     };
 }
 


### PR DESCRIPTION
## Summary

The keystone of the Better Auth frontend migration. Reworks the plugin-facing `useUser()` hook and its `IPluginUserState` contract to mirror the backend authorization surface, and re-sources it from the Better Auth session instead of the legacy UUID Redux slice.

**New `IPluginUserState`:**
- `isLoggedIn` — primary gate, any authenticated BA account (mirrors backend `isLoggedIn(req)`)
- `hasPrimaryWallet` — single wallet check (mirrors backend `hasPrimaryWallet(req)`)
- `primaryWallet` — the proven primary wallet address
- `userId`, `initialized`

**Removed:** `isVerified`, `hasLinkedWallet`, `wallets[]`, and the `IPluginWalletLink` type. A present wallet is always signature-verified (the Phase-4 wallet store only holds proven wallets), so there is no verified/unverified distinction to model.

`usePluginUser` now reads `useAuthSession()` (the SSR-seeded `SessionProvider`) — `primaryWallet` comes straight off the BA session's denormalized field, no extra fetch.

Minor bump to **2.2.0**; plugins on `^2.x` absorb it with no range change.

### Dependent plugin frontend PRs (gated on this publishing)

Plugin frontends move to the new fields once 2.2.0 publishes:
- forum → `hasPrimaryWallet` (wallet-required UI)
- memo-tracker + dust-tracker → `isLoggedIn` (login-only UI)
- bazi-fortune → unchanged (reads `primaryWallet`, which survives)

Validation: types build clean; core frontend `tsc` clean (covers `useUser` + forum's source-mode TSX); memo/dust plugin-frontend `tsc` clean.