### PR TITLE
docs: remove legacy identity references (req.user, tronrelic_uid, allowedIdentityStates)

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -22,7 +22,7 @@ There are no `NEXT_PUBLIC_*` vars by design. Production builds inline build-time
 
 ## SESSION_SECRET
 
-`SESSION_SECRET` is the secret `loaders/express.ts` hands to `cookie-parser`, so Express can verify `req.signedCookies`. It no longer signs an identity cookie — the legacy `tronrelic_uid` cookie was removed in the Better Auth cutover, and identity now rides the Better Auth session cookie, which Better Auth signs independently with `BETTER_AUTH_SECRET`. The current analytics cookies (`tronrelic_tid`, `tronrelic_ref`) are unsigned by design. `SESSION_SECRET` is retained as a defensive keep so any future signed cookie is verifiable.
+`SESSION_SECRET` is the secret `loaders/express.ts` hands to `cookie-parser`, so Express can verify `req.signedCookies`. It does not sign an identity cookie — identity rides the Better Auth session cookie, which Better Auth signs independently with `BETTER_AUTH_SECRET`. The analytics cookies (`tronrelic_tid`, `tronrelic_ref`) are unsigned by design. `SESSION_SECRET` is retained as a defensive keep so any future signed cookie is verifiable.
 
 If the variable is unset, production (`NODE_ENV=production` or `ENV=production`) refuses to start, while dev and test fall back to a placeholder and emit `console.warn`. Rotating it only affects signed cookies parsed by `cookie-parser`; it does not touch Better Auth sessions (those rotate with `BETTER_AUTH_SECRET`).
 

--- a/docs/plugins/plugins-api-registration.md
+++ b/docs/plugins/plugins-api-registration.md
@@ -37,11 +37,11 @@ The middleware overlaps with `IUserGroupService.isAdmin(req.userId)` — both co
 
 - `isLoggedIn(req)` — any authenticated account. Login-only gates.
 - `isAdmin(req)` / `isInGroup(req, id)` — role / group-membership gates.
-- `hasPrimaryWallet(req)` — the account has a signature-proven primary wallet. **Use this for wallet-gated routes**, not `isLoggedIn`: a Better Auth account can be email/OAuth/passkey-only with no wallet, so mapping a legacy `req.user.identityState === Verified` gate to `isLoggedIn` would open it to wallet-less callers.
+- `hasPrimaryWallet(req)` — the account has a signature-proven primary wallet. **Use this for wallet-gated routes** rather than `isLoggedIn`: a Better Auth account can be email/OAuth/passkey-only with no wallet, so a wallet-gated route must confirm the wallet, not merely a session.
 
 The user id is `req.authSession.user.id`; the canonical wallet is `req.authSession.primaryWallet`. See [system-auth.md](../system/system-auth.md) for the full model.
 
-> **Note.** The legacy `req.user` (`IUser`) field and the `tronrelic_uid` cookie were removed in the Better Auth cutover. Gate on `req.authSession` and the predicates above — never `req.user`. (`req.userId` survives, but now carries the Better Auth user id that `requireAdmin` sets for audit, not a legacy UUID.)
+> **Note.** Gate on `req.authSession` through the predicates above. `req.userId` carries the Better Auth user id that `requireAdmin` sets for audit logging on admin routes.
 
 ## Minimal Example
 

--- a/docs/plugins/plugins-page-registration-menu.md
+++ b/docs/plugins/plugins-page-registration-menu.md
@@ -40,7 +40,7 @@ export const myBackendPlugin = definePlugin({
 | `parent` | Parent node `_id`, or `null` for top-level |
 | `enabled` | Visibility toggle |
 | `requiresGroups` | OR-of-membership across admin-defined groups |
-| `requiresAdmin` | Visibility predicate via `IUserGroupService.isAdmin` |
+| `requiresAdmin` | Visibility predicate via the viewer's `isAdmin(req)` flag (derived from the Better Auth session) |
 
 `order` convention: `0–9` core nav, `10–99` feature plugins, `100+` admin/system.
 
@@ -66,7 +66,7 @@ await context.menuService.create({
 Two optional fields filter menu visibility per visitor at read time:
 
 - `requiresGroups` — OR-membership across admin-defined groups.
-- `requiresAdmin` — routes through `IUserGroupService.isAdmin`.
+- `requiresAdmin` — matches the viewer's admin flag (`isAdmin(req)`, derived from the Better Auth session).
 
 The menu config's `requiresAdmin` is a *visibility* predicate. It is unrelated to the `requireAdmin` HTTP middleware in [plugins-api-registration.md](./plugins-api-registration.md), which gates routes (Better Auth session or `x-admin-token`).
 

--- a/docs/plugins/plugins-page-registration-menu.md
+++ b/docs/plugins/plugins-page-registration-menu.md
@@ -39,7 +39,6 @@ export const myBackendPlugin = definePlugin({
 | `order` | Sort position; lower = earlier; default 999 |
 | `parent` | Parent node `_id`, or `null` for top-level |
 | `enabled` | Visibility toggle |
-| `allowedIdentityStates` | **Vestigial** — the `UserIdentityState` taxonomy it gated was removed in the Better Auth cutover; gate on `requiresGroups` / `requiresAdmin` instead |
 | `requiresGroups` | OR-of-membership across admin-defined groups |
 | `requiresAdmin` | Visibility predicate via `IUserGroupService.isAdmin` |
 
@@ -70,8 +69,6 @@ Two optional fields filter menu visibility per visitor at read time:
 - `requiresAdmin` — routes through `IUserGroupService.isAdmin`.
 
 The menu config's `requiresAdmin` is a *visibility* predicate. It is unrelated to the `requireAdmin` HTTP middleware in [plugins-api-registration.md](./plugins-api-registration.md), which gates routes (Better Auth session or `x-admin-token`).
-
-> **Note.** `allowedIdentityStates` (the legacy `UserIdentityState` taxonomy) was removed in the Better Auth cutover. Gate menu visibility on `requiresGroups` / `requiresAdmin` (group membership) instead. See [system-auth.md](../system/system-auth.md).
 
 ```typescript
 await context.menuService.create({

--- a/docs/system/modules/modules-creating.md
+++ b/docs/system/modules/modules-creating.md
@@ -92,7 +92,7 @@ If your service implements an `IXxxService` interface, it must be a singleton (s
 
 ### 4. Register in Bootstrap
 
-Add the module to `src/backend/index.ts`. Construct and `init()` it alongside the other module inits in `bootstrapInit()` (after `MenuModule.init()`, in the same block as Logs/Pages/Theme/Scheduler/User/AddressLabels/Tools); call its `run()` from `bootstrapRun()` before `loadPlugins(...)`:
+Add the module to `src/backend/index.ts`. Construct and `init()` it alongside the other module inits in `bootstrapInit()` (after `MenuModule.init()`, in the same block as Logs/Pages/Theme/Scheduler/Identity/Traffic/AddressLabels/Tools); call its `run()` from `bootstrapRun()` before `loadPlugins(...)`:
 
 ```typescript
 import { MyFeatureModule } from './modules/my-feature/index.js';

--- a/docs/system/modules/modules.md
+++ b/docs/system/modules/modules.md
@@ -39,7 +39,7 @@ See [frontend-architecture-modules.md](../../frontend/frontend-architecture-modu
 | Deep integration | Express app, core database | Injected `IPluginContext` only |
 | Frontend UI | Optional | Typically included |
 
-**Module examples:** Pages, Menu, User, Scheduler, Logs, Database.
+**Module examples:** Pages, Menu, Identity, Traffic, Scheduler, Logs, Database.
 
 The deciding factor between module and plugin is no longer "does it provide shared services?" but "can the application function without it?" If the answer is no, it's a module. If yes — even if other components optionally consume its services — it's a plugin. The service registry (`context.services`) makes this possible by enabling plugins to expose shared capabilities at runtime without requiring promotion to a module.
 

--- a/docs/system/system-api-websockets.md
+++ b/docs/system/system-api-websockets.md
@@ -77,7 +77,7 @@ socket.emit('subscribe', {
 socket.emit('unsubscribe', 'plugin-id', 'room-name');
 ```
 
-Format 3 keys are core capabilities (`transactions`, `comments`, `chat`, `markets`, `memos`, `notifications`), not plugin IDs. (The legacy per-user `user` subscription was removed in the Better Auth cutover along with the `tronrelic_uid` cookie it keyed on.)
+Format 3 keys are core capabilities (`transactions`, `comments`, `chat`, `markets`, `memos`, `notifications`), not plugin IDs.
 
 Subscribe failures surface as `subscription:error` with `{ message }`. Standard Socket.IO `connect_error` and `disconnect` events apply; on `disconnect` reason `'io server disconnect'` the client must call `socket.connect()` to reconnect.
 

--- a/docs/system/system-auth.md
+++ b/docs/system/system-auth.md
@@ -6,7 +6,7 @@ Identity and access control run on [Better Auth](https://better-auth.com). A vis
 
 Auth touches every protected route, admin surface, and wallet-gated plugin feature. Reading session cookies or rolling per-feature "is this user allowed" checks by hand produces inconsistent gating, security holes, and code that breaks when the identity backend changes. The system below funnels every check through one resolved session object and one predicate vocabulary, so a route's access rule is one readable call and the backend can evolve without touching call sites.
 
-Better Auth is the sole identity layer. The legacy UUID identity system (`tronrelic_uid` cookie, `req.user`, `UserIdentityState`) was removed in the Phase 6 cutover — it no longer exists, and `req.authSession` is the only identity surface.
+Better Auth is the sole identity layer. `req.authSession` — populated once per request by the `attachAuthSession` middleware — is the only identity surface; read it through the `isLoggedIn` / `isInGroup` / `isAdmin` predicates.
 
 ## How It Works
 

--- a/docs/system/system.md
+++ b/docs/system/system.md
@@ -16,7 +16,7 @@ Solves Next.js build-time env inlining so a single Docker image runs on any doma
 
 ### Backend Modules
 
-Non-toggleable infrastructure (Pages, Menu, User, Migrations) initialized during bootstrap. Two-phase lifecycle — `init()` resolves typed DI dependencies, `run()` mounts routes — fail-fast, no degraded mode. Plugins, by contrast, are optional and runtime-toggleable. See [modules.md](./modules/modules.md), [modules-architecture.md](./modules/modules-architecture.md), [modules-creating.md](./modules/modules-creating.md).
+Non-toggleable infrastructure (Pages, Menu, Identity, Traffic, Migrations) initialized during bootstrap. Two-phase lifecycle — `init()` resolves typed DI dependencies, `run()` mounts routes — fail-fast, no degraded mode. Plugins, by contrast, are optional and runtime-toggleable. See [modules.md](./modules/modules.md), [modules-architecture.md](./modules/modules-architecture.md), [modules-creating.md](./modules/modules-creating.md).
 
 ### Database Access
 

--- a/packages/types/src/auth/IAuthSession.ts
+++ b/packages/types/src/auth/IAuthSession.ts
@@ -8,11 +8,9 @@
  * so this is the narrowed, dependency-free view plugins read through
  * `req.authSession` — without importing Better Auth or any core module.
  *
- * It is the Better Auth successor to the legacy `req.user` surface: where
- * plugins used to gate on `req.user.identityState === Verified`, they now
- * gate on the presence of `req.authSession` (logged in) and its `groups`
- * (admin / membership). Use the {@link isLoggedIn} / {@link isAdmin} /
- * {@link isInGroup} helpers rather than poking at the fields directly.
+ * Gate on the presence of `req.authSession` (logged in) and its `groups`
+ * (admin / membership) through the {@link isLoggedIn} / {@link isAdmin} /
+ * {@link isInGroup} helpers rather than reading the fields directly.
  */
 
 /**

--- a/packages/types/src/auth/authPredicates.ts
+++ b/packages/types/src/auth/authPredicates.ts
@@ -5,8 +5,7 @@
  * depends on Better Auth and lives outside the plugin workspace), so
  * these dependency-free helpers read the pre-resolved
  * {@link IAuthSession} the core middleware already attached to the
- * request. They are the Better Auth replacement for the legacy
- * `req.user.identityState === Verified` checks plugins used to write.
+ * request.
  *
  * Unlike the core facade's async `isLoggedIn(req)` (which resolves the
  * session from cookies), these are synchronous pure reads of
@@ -102,10 +101,8 @@ export function isAdmin<T extends IHasAuthSession>(
  *
  * Better Auth separates "logged in" from "owns a wallet": a visitor can
  * authenticate via email-OTP / OAuth / passkey with no wallet at all.
- * Plugin routes that previously gated on the legacy
- * `req.user.identityState === Verified` — which implied a signature-proven
- * wallet — must migrate to THIS predicate, not {@link isLoggedIn}, or they
- * would open to wallet-less accounts. Every wallet in the Phase-4 store is
+ * Use THIS predicate, not {@link isLoggedIn}, for wallet-gated routes, or
+ * they would open to wallet-less accounts. Every wallet in the store is
  * signature-proven at link time, so a present `primaryWallet` is a proven
  * wallet.
  *

--- a/packages/types/src/auth/index.ts
+++ b/packages/types/src/auth/index.ts
@@ -2,7 +2,7 @@
  * @fileoverview Barrel for the plugin-facing Better Auth authorization
  * surface: the {@link IAuthSession} shape carried on `req.authSession`
  * and the synchronous {@link isLoggedIn} / {@link isAdmin} predicates
- * plugins use in place of the retired `req.user.identityState` checks.
+ * plugins use to gate authenticated routes.
  */
 
 export type { IAuthSession, IAuthSessionUser } from './IAuthSession.js';

--- a/packages/types/src/http/IHttpRequest.ts
+++ b/packages/types/src/http/IHttpRequest.ts
@@ -13,28 +13,30 @@ import type { IAuthSession } from '../auth/IAuthSession.js';
  * - Easier testing with mock request objects
  * - Clear contract for what request data is available
  *
- * ## User Context
+ * ## Auth Context
  *
- * The `userId` and `user` fields are populated by middleware before requests
- * reach plugin routes. Plugins can check `req.user` to determine if a user
- * is authenticated and access their profile data.
+ * The core `attachAuthSession` middleware resolves the Better Auth session
+ * onto `req.authSession` before requests reach plugin routes. Gate with the
+ * synchronous predicates from `@delphian/tronrelic-types` — they read
+ * `req.authSession` and act as type guards.
  *
  * @example
  * ```typescript
+ * import { isLoggedIn, hasPrimaryWallet } from '@delphian/tronrelic-types';
+ *
  * // In a plugin route handler
  * handler: async (req, res) => {
- *     if (!req.user) {
+ *     if (!isLoggedIn(req)) {
  *         return res.status(401).json({ error: 'Authentication required' });
  *     }
  *
- *     // Check if user has linked wallets (registered)
- *     const isRegistered = (req.user.wallets?.length ?? 0) > 0;
- *     if (!isRegistered) {
- *         return res.status(403).json({ error: 'Wallet verification required' });
+ *     // Wallet-gated routes confirm a signature-proven primary wallet
+ *     if (!hasPrimaryWallet(req)) {
+ *         return res.status(403).json({ error: 'A linked wallet is required' });
  *     }
  *
- *     // Proceed with authenticated, registered user
- *     const userId = req.userId;
+ *     // Proceed with the authenticated account
+ *     const userId = req.authSession.user.id;
  * }
  * ```
  */
@@ -189,10 +191,9 @@ export interface IHttpRequest<
      * reach — test stubs, or the middleware's own bypassed paths (it
      * early-returns on `/api/auth/*`). Plugin routes always run after the
      * middleware, so for plugin handlers `authSession` is always set
-     * (`null` or populated), never `undefined`. This is the Better Auth
-     * successor to {@link user}: gate authenticated plugin routes on
-     * `req.authSession` via the `isLoggedIn` / `isAdmin` / `isInGroup`
-     * predicates rather than the legacy `req.user.identityState` reads.
+     * (`null` or populated), never `undefined`. Gate authenticated plugin
+     * routes on `req.authSession` via the `isLoggedIn` / `isAdmin` /
+     * `isInGroup` predicates.
      *
      * @example
      * ```typescript

--- a/src/backend/config/env.ts
+++ b/src/backend/config/env.ts
@@ -21,8 +21,7 @@ const envSchema = z.object({
   METRICS_TOKEN: z.string().optional(),
   /**
    * Secret passed to cookie-parser so Express can verify `req.signedCookies`.
-   * No longer signs an identity cookie — the legacy `tronrelic_uid` cookie was
-   * removed in the Better Auth cutover, and the Better Auth session cookie is
+   * It does not sign an identity cookie — the Better Auth session cookie is
    * signed independently with `BETTER_AUTH_SECRET`.
    *
    * Required in production: cookie-parser falls back to no-op signing if a

--- a/src/backend/modules/identity/api/wallet.controller.ts
+++ b/src/backend/modules/identity/api/wallet.controller.ts
@@ -1,13 +1,10 @@
 /**
  * @fileoverview HTTP interface for the Better Auth-keyed wallet store.
  *
- * Phase 4 of the Better Auth refactor. Unlike the legacy wallet
- * endpoints under `/api/user/:id/wallet/*` — which validate a
- * `tronrelic_uid` cookie against a UUID path param — these routes
- * resolve the caller from the Better Auth session (`req.authSession`,
- * populated by the `attachAuthSession` middleware) and carry no id in
- * the path. Anonymous callers get 401; the account is never named on
- * the wire because it is implied by the session.
+ * These routes resolve the caller from the Better Auth session
+ * (`req.authSession`, populated by the `attachAuthSession` middleware) and
+ * carry no id in the path. Anonymous callers get 401; the account is never
+ * named on the wire because it is implied by the session.
  *
  * The controller is a thin HTTP adapter: it resolves the session user
  * id, validates the request body, delegates to {@link WalletService},

--- a/src/backend/modules/identity/services/auth-facade.ts
+++ b/src/backend/modules/identity/services/auth-facade.ts
@@ -4,8 +4,9 @@
  * codebase.
  *
  * Plugins, modules, controllers, and middleware import the predicate
- * helpers exported here and never reach for `req.user`, Better Auth's
- * client API, or the GroupService directly. The single-surface rule
+ * helpers exported here rather than resolving the session, calling
+ * Better Auth's client API, or querying the GroupService directly. The
+ * single-surface rule
  * lets later phases swap the underlying mechanism — different session
  * backend, role/permission overlays, multi-tier admin — without
  * touching every call site.

--- a/src/backend/modules/menu/README.md
+++ b/src/backend/modules/menu/README.md
@@ -139,13 +139,15 @@ if (menu) {
 
 Menu nodes can be gated on two independent fields, ANDed together. The
 backend filters menu reads at request time using the Better Auth session
-resolved onto `req.authSession`; admin token holders bypass the filter so the
-admin UI can render and edit gated nodes.
+resolved onto `req.authSession`. `GET /api/menu` applies this per-visitor
+filter to every caller; the origin-tagged admin view at `GET /api/menu/manage`
+(behind `requireAdmin`) returns the full tree including disabled and gated
+rows so the admin UI can render and edit them.
 
 | Field | Shape | Semantics |
 |-------|-------|-----------|
 | `requiresGroups` | `string[]?` | Visible if the user is a member of *any* listed group id (OR-of-membership). Group ids reference `module_user_groups` rows managed by the identity module. |
-| `requiresAdmin` | `boolean?` | Visible only when `IUserGroupService.isAdmin(req.userId)` returns true. Routes through the user-groups service registry entry so future seeded admin tiers (e.g. `super-admin`) automatically qualify. |
+| `requiresAdmin` | `boolean?` | Visible only when the viewer's admin flag is true — `isAdmin(req)` derived from the Better Auth session and resolved once per request by `resolveViewer`. |
 
 The filter lives in `MenuService.getTreeForUser(namespace, user?)` and
 `getChildrenForUser(parentId, namespace, user?)`. Both are called by the

--- a/src/backend/modules/menu/README.md
+++ b/src/backend/modules/menu/README.md
@@ -137,20 +137,13 @@ if (menu) {
 
 ## Visibility Gating
 
-Menu nodes can be gated on three independent fields, ANDed together. The
+Menu nodes can be gated on two independent fields, ANDed together. The
 backend filters menu reads at request time using the Better Auth session
 resolved onto `req.authSession`; admin token holders bypass the filter so the
 admin UI can render and edit gated nodes.
 
-> **Note.** The Better Auth cutover removed the legacy `UserIdentityState`
-> taxonomy, so `allowedIdentityStates` is now a vestigial schema field with no
-> live identity state to match — gate on `requiresGroups` / `requiresAdmin`
-> (group membership), which key off `req.authSession`. See
-> [system-auth.md](../../../../docs/system/system-auth.md).
-
 | Field | Shape | Semantics |
 |-------|-------|-----------|
-| `allowedIdentityStates` | `string[]?` | **Vestigial.** The `UserIdentityState` taxonomy it gated on was removed in the Better Auth cutover. Retained in the schema but no longer matches a live session attribute — use `requiresGroups` / `requiresAdmin` instead. |
 | `requiresGroups` | `string[]?` | Visible if the user is a member of *any* listed group id (OR-of-membership). Group ids reference `module_user_groups` rows managed by the identity module. |
 | `requiresAdmin` | `boolean?` | Visible only when `IUserGroupService.isAdmin(req.userId)` returns true. Routes through the user-groups service registry entry so future seeded admin tiers (e.g. `super-admin`) automatically qualify. |
 
@@ -252,7 +245,7 @@ Navigation reads are public — the frontend chrome fetches them without an admi
 | Endpoint | Method | Purpose | Key Fields |
 |----------|--------|---------|------------|
 | `/api/menu/manage` | GET | Origin-tagged tree for the menu admin UI — includes disabled and gated rows | Query: `namespace` (optional, defaults to 'main') |
-| `/api/menu` | POST | Create persisted menu node | Body: `label` (required), `description`, `url`, `icon`, `order`, `parent`, `enabled`, `allowedIdentityStates`, `requiresGroups`, `requiresAdmin` |
+| `/api/menu` | POST | Create persisted menu node | Body: `label` (required), `description`, `url`, `icon`, `order`, `parent`, `enabled`, `requiresGroups`, `requiresAdmin` |
 | `/api/menu/:id` | PATCH | Update menu node | Body: any fields to update |
 | `/api/menu/:id` | DELETE | Delete menu node | Does **not** cascade — children become orphans unless a `before:delete` subscriber handles them |
 | `/api/menu/namespace/:namespace/config` | PUT | Replace namespace configuration | Body: `overflow`, `icons`, `layout`, `styling` |

--- a/src/backend/modules/menu/api/menu.controller.ts
+++ b/src/backend/modules/menu/api/menu.controller.ts
@@ -326,8 +326,8 @@ export class MenuController {
      *
      * Returns the hierarchical menu projected through the cookie-resolved
      * visitor's gating: nodes with `enabled: false` are stripped, and per-node
-     * gating fields (`allowedIdentityStates`, `requiresGroups`, `requiresAdmin`)
-     * narrow the tree to what this visitor may see. Admins receive the same
+     * gating fields (`requiresGroups`, `requiresAdmin`) narrow the tree to
+     * what this visitor may see. Admins receive the same
      * shape as everyone else — the origin-tagged management view lives at
      * `GET /api/menu/manage`. Root nodes are in the `roots` array, each
      * potentially containing nested children; the `all` array provides a
@@ -384,7 +384,7 @@ export class MenuController {
             // Admins do not get a privileged shape here; the admin
             // management surface lives at `GET /api/menu/manage`. Node
             // visibility is controlled exclusively by per-node gating
-            // (`allowedIdentityStates`, `requiresGroups`, `requiresAdmin`).
+            // (`requiresGroups`, `requiresAdmin`).
             const viewer = await resolveViewer(req);
             const filtered = await this.service.getTreeForUser(namespace, viewer);
             res.json({ success: true, tree: publicTreeView(filtered) });

--- a/src/backend/modules/menu/services/menu.service.ts
+++ b/src/backend/modules/menu/services/menu.service.ts
@@ -1271,8 +1271,8 @@ export class MenuService implements IMenuService {
                 return;
             }
 
-            // Per-user gating (allowedIdentityStates / requiresGroups /
-            // requiresAdmin) means there is no single tree shape that fits
+            // Per-user gating (requiresGroups / requiresAdmin) means there
+            // is no single tree shape that fits
             // every connected client. Send a refetch signal instead — each
             // client re-requests `GET /api/menu` with its own cookie and the
             // server returns the filtered view. Identifiers are kept in the

--- a/src/backend/modules/traffic/api/traffic-cookies.ts
+++ b/src/backend/modules/traffic/api/traffic-cookies.ts
@@ -2,11 +2,10 @@
  * @fileoverview Analytics (`tronrelic_tid`) and referral (`tronrelic_ref`)
  * cookie specs and helpers.
  *
- * These cookies decouple behavioral analytics from identity. The legacy
- * `tronrelic_uid` cookie did double duty — identity continuity AND the visitor
- * key for `traffic_events`. The Better Auth cutover removed `tronrelic_uid`
- * (Better Auth owns identity), so analytics keeps its own key that survives
- * that removal: `tronrelic_tid`.
+ * These cookies decouple behavioral analytics from identity. Better Auth
+ * owns identity; analytics keeps its own independent visitor key,
+ * `tronrelic_tid`, so the `traffic_events` store never depends on the
+ * identity layer.
  *
  * **`tronrelic_tid` (traffic id).** A server-minted UUID v4 that keys every
  * `traffic_events` row regardless of auth state. It confers no identity or

--- a/src/backend/modules/traffic/services/traffic.service.ts
+++ b/src/backend/modules/traffic/services/traffic.service.ts
@@ -67,10 +67,9 @@ export interface ITrafficEvent {
     /** Server-side wall clock at write time. */
     timestamp: Date;
     /**
-     * Analytics visitor key. Since Phase 5 of the Better Auth refactor this
-     * is the `tronrelic_tid` UUID (decoupled from identity), not the legacy
-     * `tronrelic_uid`. Still a UUID v4, so the column type is unchanged. The
-     * field name stays `candidate_uid` to avoid retyping a sort-key column.
+     * Analytics visitor key — the `tronrelic_tid` UUID, decoupled from
+     * identity. A UUID v4 stored in the `candidate_uid` column; the field
+     * name stays `candidate_uid` to avoid retyping a sort-key column.
      */
     candidate_uid: string;
     /**

--- a/src/frontend/components/layout/MenuNav/MenuNavSSR.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNavSSR.tsx
@@ -70,9 +70,9 @@ interface IMenuNavSSRProps {
  * to retrieve only relevant navigation items.
  *
  * The component includes error handling and will render an empty navigation if the
- * API request fails (graceful degradation). The visitor's identity cookie is
- * forwarded so the backend's per-user gating filter resolves req.user; missing
- * or invalid cookies degrade to the anonymous-visible subset.
+ * API request fails (graceful degradation). The visitor's Better Auth session
+ * cookie is forwarded so the backend's per-visitor gating filter resolves
+ * `req.authSession`; missing or invalid cookies degrade to the anonymous-visible subset.
  *
  * Menu items are fetched fresh on every request (no caching) to ensure navigation
  * always reflects the current menu structure from the database, and because the

--- a/src/frontend/modules/user/components/SessionProvider.tsx
+++ b/src/frontend/modules/user/components/SessionProvider.tsx
@@ -22,7 +22,7 @@ import type { ISSRSession } from '../lib/session-server';
  *
  * `session` is the merged read: live data from the BA client when
  * present, otherwise the SSR seed for the first render. `isLoggedIn`
- * is the binary identity flag plugin and core code use to gate on
+ * is the binary identity flag that plugin and core code use to gate on
  * authentication.
  */
 export interface IAuthSessionContext {

--- a/src/frontend/modules/user/components/SessionProvider.tsx
+++ b/src/frontend/modules/user/components/SessionProvider.tsx
@@ -22,8 +22,8 @@ import type { ISSRSession } from '../lib/session-server';
  *
  * `session` is the merged read: live data from the BA client when
  * present, otherwise the SSR seed for the first render. `isLoggedIn`
- * is the binary identity flag plugin and core code should use in
- * Phase 3+ in place of the legacy `identityState === Verified` check.
+ * is the binary identity flag plugin and core code use to gate on
+ * authentication.
  */
 export interface IAuthSessionContext {
     /**

--- a/src/shared/types/socket.d.ts
+++ b/src/shared/types/socket.d.ts
@@ -20,8 +20,6 @@ export interface SocketSubscriptions {
         wallet: string;
         channels?: NotificationChannel[];
     };
-    /** Identity room opt-in. UUID is resolved server-side from the cookie. */
-    user?: true;
 }
 export interface TransactionAlertPayload {
     event: 'transaction:large' | 'delegation:new' | 'stake:new';

--- a/src/shared/types/socket.ts
+++ b/src/shared/types/socket.ts
@@ -21,13 +21,6 @@ export interface SocketSubscriptions {
     wallet: string;
     channels?: NotificationChannel[];
   };
-  /**
-   * Identity-scoped subscription. The user's UUID is resolved server-side
-   * from the `tronrelic_uid` cookie at handshake time — clients no longer
-   * (and must not) pass a userId in the payload. Send a sentinel `true`
-   * to opt the socket into its own `user:<uid>` room.
-   */
-  user?: true;
 }
 
 export interface TransactionAlertPayload {
@@ -123,7 +116,6 @@ export interface MenuNodeSerialized {
   parent?: string | null;
   enabled: boolean;
   namespace?: string;
-  allowedIdentityStates?: string[];
   requiresGroups?: string[];
   requiresAdmin?: boolean;
   children?: MenuNodeSerialized[];


### PR DESCRIPTION
Rewrites documentation and code comments to mention and direct toward current Better Auth patterns only, stripping dead-token references left over from the Phase 6 identity cutover.

## Removed

- **`req.user` / `IUser`** — from the `IHttpRequest` doc block and example, the auth-predicate JSDoc, and `IAuthSession` / `auth-facade` / `MenuNavSSR` comments. Callers gate via `req.authSession` and the `isLoggedIn` / `isInGroup` / `isAdmin` / `hasPrimaryWallet` predicates.
- **`tronrelic_uid`** — from `env.ts` (`SESSION_SECRET`), the traffic cookie/service comments, the wallet controller, and docs.
- **`allowedIdentityStates` / `UserIdentityState`** — the vestigial field is removed from the `MenuNodeSerialized` socket DTO and from all menu prose/comments. Menu gating is `requiresGroups` / `requiresAdmin` only.
- **Dead socket `user?: true` subscription field** — no server handler consumed it.

## Intentionally retained

- Migration `003_replace_required_role_with_gating_fields` — its id/description is the historical record that introduced the gating fields.
- The `@delphian/tronrelic-types` 3.0.0 changelog note in `packages/types/src/user/index.ts`.

Type check passes (`tsc --noEmit`). No runtime behavior change — comments, docs, and one unused serialization field only.