### PR TITLE
fix(identity): key Better Auth user collection by ObjectId, not hex string

### DIFF
--- a/docs/system/system-auth.md
+++ b/docs/system/system-auth.md
@@ -33,6 +33,10 @@ The core facade is async because it can resolve the session from cookies when no
 
 Group membership (including admin) is owned by `GroupService` (`modules/identity/services/group.service.ts`), which reads/writes the `groups` array on the Better Auth user record. `isAdmin` is membership in the reserved `admin` group.
 
+### User ids are opaque hex strings
+
+A Better Auth user id is a string — the 24-character hex form of the native MongoDB `ObjectId` the adapter stores as `_id` on `module_user_auth_users`. Treat `req.authSession.user.id` as **opaque**: store it verbatim as a foreign key, compare it verbatim, and never cast it to an `ObjectId` or `$lookup` your own collection directly against the user collection's `_id`. The string↔ObjectId conversion is confined to the identity services that own the user collection (`services/user-id.ts`); everyone else resolves account, wallet, and group data through the `'accounts'` / `'wallets'` / `'user-groups'` service contracts, which return the opaque string. Mixing the two representations — storing the id as a string in one place and an ObjectId in another — silently breaks equality matching.
+
 ### `isLoggedIn` is not `hasPrimaryWallet`
 
 Better Auth separates *being signed in* from *owning a wallet*. A visitor can authenticate via email-OTP, OAuth, or a passkey with **no TRON wallet linked at all**. Gate accordingly:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13364,7 +13364,7 @@
     },
     "packages/types": {
       "name": "@delphian/tronrelic-types",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@types/json-schema": "^7.0.15"

--- a/src/backend/api/middleware/__tests__/admin-auth.test.ts
+++ b/src/backend/api/middleware/__tests__/admin-auth.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ObjectId } from 'mongodb';
 import type { ISystemLogService } from '@/types';
 import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
 
@@ -38,6 +39,13 @@ class NullLogger implements ISystemLogService {
 }
 
 const SERVICE_TOKEN = 'test-service-token-1234567890abcdef';
+
+// Better Auth exposes user ids as the 24-char hex form of the ObjectId
+// `_id`; sessions carry the hex string and the users collection is keyed by
+// the matching ObjectId.
+const ADMIN_USER_1 = '1a1a1a1a1a1a1a1a1a1a1a1a';
+const ADMIN_USER_3 = '3a3a3a3a3a3a3a3a3a3a3a3a';
+const PLAIN_USER = 'd1d1d1d1d1d1d1d1d1d1d1d1';
 
 function makeReqRes(opts: { headerToken?: string; bearer?: string } = {}) {
     const req: any = {
@@ -85,7 +93,7 @@ describe('requireAdmin middleware', () => {
      */
     function seedBaUser(userId: string, groups: string[]): void {
         mockDb.getCollectionData(AUTH_USERS_COLLECTION).push({
-            _id: userId,
+            _id: new ObjectId(userId),
             email: `${userId}@example.com`,
             emailVerified: true,
             groups
@@ -109,27 +117,27 @@ describe('requireAdmin middleware', () => {
     describe('Better Auth session path', () => {
         it('approves a BA admin session and tags adminVia="user" with the BA user id', async () => {
             setAuthInstance(makeStubAuth({
-                user: { id: 'ba_admin_1', email: 'a@b.com' },
+                user: { id: ADMIN_USER_1, email: 'a@b.com' },
                 session: { id: 's1', token: 't', expiresAt: new Date().toISOString() }
             }));
-            seedBaUser('ba_admin_1', ['admin']);
+            seedBaUser(ADMIN_USER_1, ['admin']);
 
             const { req, res, next, called } = makeReqRes();
             await requireAdmin(req, res, next);
 
             expect(called()).toBe(true);
             expect(req.adminVia).toBe('user');
-            expect(req.userId).toBe('ba_admin_1');
+            expect(req.userId).toBe(ADMIN_USER_1);
         });
 
         it('rejects a non-admin BA session — there is no legacy fallback', async () => {
             // Service token set so the failed session path lands on 401, not 503.
             process.env.ADMIN_API_TOKEN = SERVICE_TOKEN;
             setAuthInstance(makeStubAuth({
-                user: { id: 'ba_plain', email: 'p@b.com' },
+                user: { id: PLAIN_USER, email: 'p@b.com' },
                 session: { id: 's2', token: 't', expiresAt: new Date().toISOString() }
             }));
-            seedBaUser('ba_plain', ['vip']);
+            seedBaUser(PLAIN_USER, ['vip']);
 
             const { req, res, next, called } = makeReqRes();
             await requireAdmin(req, res, next);
@@ -207,17 +215,17 @@ describe('requireAdmin middleware', () => {
         it('admits the BA admin session even when a service token is also present', async () => {
             process.env.ADMIN_API_TOKEN = SERVICE_TOKEN;
             setAuthInstance(makeStubAuth({
-                user: { id: 'ba_admin_3', email: 'a@b.com' },
+                user: { id: ADMIN_USER_3, email: 'a@b.com' },
                 session: { id: 's3', token: 't', expiresAt: new Date().toISOString() }
             }));
-            seedBaUser('ba_admin_3', ['admin']);
+            seedBaUser(ADMIN_USER_3, ['admin']);
 
             const { req, res, next, called } = makeReqRes({ headerToken: SERVICE_TOKEN });
             await requireAdmin(req, res, next);
 
             expect(called()).toBe(true);
             expect(req.adminVia).toBe('user');
-            expect(req.userId).toBe('ba_admin_3');
+            expect(req.userId).toBe(ADMIN_USER_3);
         });
     });
 });

--- a/src/backend/api/middleware/__tests__/auth-session.test.ts
+++ b/src/backend/api/middleware/__tests__/auth-session.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ObjectId } from 'mongodb';
 import type { Request, Response, NextFunction } from 'express';
 import type { ISystemLogService } from '@/types';
 import { attachAuthSession } from '../auth-session.js';
@@ -21,6 +22,11 @@ import {
 import { GroupService } from '../../../modules/identity/services/group.service.js';
 import { AUTH_USERS_COLLECTION } from '../../../modules/identity/services/auth-constants.js';
 import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+
+// Better Auth exposes the user id as the 24-char hex form of the ObjectId
+// `_id`; the session carries the hex string and the users collection is
+// keyed by the matching ObjectId.
+const USER_ABC = 'abcabcabcabcabcabcabcabc';
 
 class StubLogger implements ISystemLogService {
     public level: string = 'info';
@@ -103,12 +109,12 @@ describe('attachAuthSession middleware', () => {
     it('sets req.authSession to the augmented session for logged-in callers', async () => {
         setAuthInstance(makeStubAuth({
             session: {
-                user: { id: 'user_abc', email: 'a@b.com' },
+                user: { id: USER_ABC, email: 'a@b.com' },
                 session: { id: 'sess_1', token: 't', expiresAt: new Date().toISOString() }
             }
         }));
         mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({
-            _id: 'user_abc',
+            _id: new ObjectId(USER_ABC),
             email: 'a@b.com',
             emailVerified: true,
             groups: ['admin', 'vip']
@@ -122,7 +128,7 @@ describe('attachAuthSession middleware', () => {
 
         const populated = req as Request & { authSession?: { user: { id: string }; groups: string[] } | null };
         expect(populated.authSession).not.toBeNull();
-        expect(populated.authSession?.user.id).toBe('user_abc');
+        expect(populated.authSession?.user.id).toBe(USER_ABC);
         expect(populated.authSession?.groups).toEqual(expect.arrayContaining(['admin', 'vip']));
         expect(next).toHaveBeenCalledOnce();
     });

--- a/src/backend/modules/identity/README.md
+++ b/src/backend/modules/identity/README.md
@@ -19,6 +19,8 @@ Owns Better Auth and everything keyed by the Better Auth user id: the auth insta
 
 Better Auth is the sole identity layer — the legacy UUID identity system was removed in the Phase 6 cutover. Keeping BA-keyed concerns in their own module enforces a single-responsibility boundary: **no code outside this module reads `module_user_auth_users` directly** — not even via `IDatabaseService`. The only sanctioned path is `services.get<IAccountDirectoryService>('accounts')`. Wallet and group data follow the same rule through `'wallets'` and `'user-groups'`.
 
+**User id type.** Better Auth's `mongodbAdapter` stores the user `_id` as a native MongoDB `ObjectId` and exposes it as its 24-character hex string (`user.id`). That hex string is the canonical, *opaque* user id everywhere outside this module: store it verbatim, compare it verbatim, never cast it to an `ObjectId`, and never `$lookup` against the user collection's `_id`. The string↔ObjectId conversion lives only in `services/user-id.ts`, used by the services that own the BA collection (`GroupService`, `WalletService`, `AccountDirectoryService`).
+
 ## Source Map
 
 | Path | Responsibility |
@@ -27,6 +29,7 @@ Better Auth is the sole identity layer — the legacy UUID identity system was r
 | `auth.ts` | Better Auth factory (`createAuth`), `Auth` type; takes a raw Mongo `Db` (documented `IDatabaseService` exception) |
 | `services/auth-facade.ts` | Session resolution + `isLoggedIn`/`isAdmin`/`isInGroup` predicates over `req.authSession`; `setAuthInstance` |
 | `services/auth-constants.ts` | Physical BA collection names (`AUTH_USERS_COLLECTION`, `AUTH_COLLECTIONS`) |
+| `services/user-id.ts` | `toUserKey` / `userIdFromKey` — BA user-id hex ↔ `_id` ObjectId conversion at the collection boundary; the opaque-hex-string contract |
 | `services/group.service.ts` | Membership primitive over the BA `groups` field; `ADMIN_GROUP_ID` |
 | `services/user-group.service.ts` | Group-definition registry + the `'user-groups'` contract; composes `GroupService` |
 | `services/wallet.service.ts` | BA-keyed wallet store (`module_user_wallets`); the `'wallets'` contract |

--- a/src/backend/modules/identity/__tests__/auth-facade.test.ts
+++ b/src/backend/modules/identity/__tests__/auth-facade.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ObjectId } from 'mongodb';
 import type { Request } from 'express';
 import type { ISystemLogService } from '@/types';
 import {
@@ -58,6 +59,12 @@ class StubLogger implements ISystemLogService {
 function makeRequest(headers: Record<string, string> = {}): Request {
     return { headers } as unknown as Request;
 }
+
+// Better Auth exposes user ids as the 24-char hex form of the ObjectId
+// `_id`; sessions carry the hex string and the users collection is keyed by
+// the matching ObjectId.
+const USER_ABC = 'abcabcabcabcabcabcabcabc';
+const USER_PLAIN = 'abcdef012345abcdef012345';
 
 /**
  * Build a stubbed Better Auth instance that returns a fixed session
@@ -114,14 +121,14 @@ describe('auth facade', () => {
         });
 
         it('returns true / false respectively when a session resolves', async () => {
-            setAuthInstance(makeStubAuth({ user: { id: 'user_abc', email: 'a@b.com' } }));
+            setAuthInstance(makeStubAuth({ user: { id: USER_ABC, email: 'a@b.com' } }));
             const req = makeRequest();
             expect(await isLoggedIn(req)).toBe(true);
             expect(await isAnonymous(req)).toBe(false);
         });
 
         it('caches the resolved session on the request object', async () => {
-            const auth = makeStubAuth({ user: { id: 'user_abc', email: 'a@b.com' } });
+            const auth = makeStubAuth({ user: { id: USER_ABC, email: 'a@b.com' } });
             setAuthInstance(auth);
             const req = makeRequest();
             await isLoggedIn(req);
@@ -141,9 +148,9 @@ describe('auth facade', () => {
         });
 
         it('returns true for a logged-in user with the requested group', async () => {
-            setAuthInstance(makeStubAuth({ user: { id: 'user_abc', email: 'a@b.com' } }));
+            setAuthInstance(makeStubAuth({ user: { id: USER_ABC, email: 'a@b.com' } }));
             mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({
-                _id: 'user_abc',
+                _id: new ObjectId(USER_ABC),
                 email: 'a@b.com',
                 emailVerified: true,
                 groups: ['admin', 'vip']
@@ -155,9 +162,9 @@ describe('auth facade', () => {
         });
 
         it('routes isAdmin through the ADMIN_GROUP_ID constant', async () => {
-            setAuthInstance(makeStubAuth({ user: { id: 'user_abc', email: 'a@b.com' } }));
+            setAuthInstance(makeStubAuth({ user: { id: USER_ABC, email: 'a@b.com' } }));
             mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({
-                _id: 'user_abc',
+                _id: new ObjectId(USER_ABC),
                 email: 'a@b.com',
                 emailVerified: true,
                 groups: [ADMIN_GROUP_ID]
@@ -167,9 +174,9 @@ describe('auth facade', () => {
         });
 
         it('returns false for a logged-in user not in the group', async () => {
-            setAuthInstance(makeStubAuth({ user: { id: 'user_plain', email: 'p@b.com' } }));
+            setAuthInstance(makeStubAuth({ user: { id: USER_PLAIN, email: 'p@b.com' } }));
             mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({
-                _id: 'user_plain',
+                _id: new ObjectId(USER_PLAIN),
                 email: 'p@b.com',
                 emailVerified: true,
                 groups: ['vip']

--- a/src/backend/modules/identity/__tests__/group.service.test.ts
+++ b/src/backend/modules/identity/__tests__/group.service.test.ts
@@ -3,19 +3,32 @@
 /**
  * @fileoverview Phase 1 sanity tests for {@link GroupService}.
  *
- * Covers the singleton contract and the read methods (which the
- * in-memory mock supports). Mutation tests are deferred to integration
- * coverage because the shared `createMockDatabaseService` mock does not
- * implement `$addToSet` / `$pull` semantics; spying on the underlying
- * collection handle here is sufficient to verify that the right MongoDB
- * operator is issued.
+ * Covers the singleton contract, the read methods (which the in-memory
+ * mock supports), and the user-id boundary: Better Auth stores the user
+ * `_id` as a native `ObjectId` and exposes it as a hex string, so every
+ * method converts the incoming hex id to an `ObjectId` before querying.
+ * The seeds therefore store `_id: new ObjectId(hex)` and the mutation
+ * spies assert the filter is keyed by that ObjectId — a regression to a
+ * raw-string filter would never match the stored `_id`. Malformed ids
+ * short-circuit to a no-match read / no-op write without touching Mongo.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ObjectId } from 'mongodb';
 import type { ISystemLogService } from '@/types';
 import { GroupService, ADMIN_GROUP_ID } from '../services/group.service.js';
 import { AUTH_USERS_COLLECTION } from '../services/auth-constants.js';
 import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+
+/** Valid 24-character hex Better Auth user ids used across the suite. */
+const USER_ABC = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+const USER_ADMIN = 'bbbbbbbbbbbbbbbbbbbbbbbb';
+const USER_PLAIN = 'cccccccccccccccccccccccc';
+const USER_NO_GROUPS = 'dddddddddddddddddddddddd';
+const USER_MISSING = 'eeeeeeeeeeeeeeeeeeeeeeee';
+
+/** Not a 24-hex string — {@link toUserKey} rejects it. */
+const MALFORMED_ID = 'not-a-valid-object-id';
 
 /**
  * Minimal stub logger — GroupService only emits debug-level breadcrumbs.
@@ -46,8 +59,14 @@ class StubLogger implements ISystemLogService {
 /**
  * Seed a BA-shaped user row directly into the mock's users collection.
  *
+ * Stores `_id` as an `ObjectId` — exactly as Better Auth's adapter does —
+ * so the service's hex-to-ObjectId conversion is exercised on reads.
  * Bypasses {@link GroupService.addMember} because the mock doesn't
- * implement `$addToSet`; reads can still exercise the documents.
+ * implement `$addToSet`.
+ *
+ * @param db - Mock database service.
+ * @param id - 24-character hex user id.
+ * @param groups - Group ids to seed onto the row.
  */
 function seedAuthUser(
     db: ReturnType<typeof createMockDatabaseService>,
@@ -55,7 +74,7 @@ function seedAuthUser(
     groups: string[] = []
 ): void {
     db.getCollectionData(AUTH_USERS_COLLECTION).push({
-        _id: id,
+        _id: new ObjectId(id),
         email: `${id}@example.com`,
         emailVerified: true,
         groups
@@ -99,87 +118,121 @@ describe('GroupService', () => {
 
     describe('getUserGroups', () => {
         it('returns the stored groups array for a known user', async () => {
-            seedAuthUser(mockDatabase, 'user_abc', ['admin', 'vip']);
-            const groups = await service.getUserGroups('user_abc');
+            seedAuthUser(mockDatabase, USER_ABC, ['admin', 'vip']);
+            const groups = await service.getUserGroups(USER_ABC);
             expect(groups).toEqual(expect.arrayContaining(['admin', 'vip']));
         });
 
         it('returns an empty array for an unknown user', async () => {
-            const groups = await service.getUserGroups('user_missing');
+            const groups = await service.getUserGroups(USER_MISSING);
             expect(groups).toEqual([]);
         });
 
         it('returns an empty array when the user has no groups field', async () => {
             mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({
-                _id: 'user_no_groups',
+                _id: new ObjectId(USER_NO_GROUPS),
                 email: 'x@example.com'
             });
-            const groups = await service.getUserGroups('user_no_groups');
+            const groups = await service.getUserGroups(USER_NO_GROUPS);
             expect(groups).toEqual([]);
         });
     });
 
     describe('isMember', () => {
         it('returns true when the user is in the requested group', async () => {
-            seedAuthUser(mockDatabase, 'user_admin', ['admin', 'vip']);
-            const result = await service.isMember('user_admin', 'admin');
+            seedAuthUser(mockDatabase, USER_ADMIN, ['admin', 'vip']);
+            const result = await service.isMember(USER_ADMIN, 'admin');
             expect(result).toBe(true);
         });
 
         it('returns false when the user is not in the requested group', async () => {
-            seedAuthUser(mockDatabase, 'user_plain', ['vip']);
-            const result = await service.isMember('user_plain', 'admin');
+            seedAuthUser(mockDatabase, USER_PLAIN, ['vip']);
+            const result = await service.isMember(USER_PLAIN, 'admin');
             expect(result).toBe(false);
         });
 
         it('returns false for a missing user', async () => {
-            const result = await service.isMember('user_missing', 'admin');
+            const result = await service.isMember(USER_MISSING, 'admin');
             expect(result).toBe(false);
         });
     });
 
     describe('isAdmin', () => {
         it('delegates to isMember with the reserved admin group id', async () => {
-            seedAuthUser(mockDatabase, 'user_admin', ['admin']);
+            seedAuthUser(mockDatabase, USER_ADMIN, ['admin']);
             const spy = vi.spyOn(service, 'isMember');
-            await service.isAdmin('user_admin');
-            expect(spy).toHaveBeenCalledWith('user_admin', ADMIN_GROUP_ID);
+            await service.isAdmin(USER_ADMIN);
+            expect(spy).toHaveBeenCalledWith(USER_ADMIN, ADMIN_GROUP_ID);
         });
     });
 
     describe('addMember', () => {
-        it('issues an $addToSet update against the users collection', async () => {
+        it('issues an $addToSet update keyed by the ObjectId form of the user id', async () => {
             const collection = mockDatabase.getCollection(AUTH_USERS_COLLECTION);
             const spy = vi.spyOn(collection, 'updateOne');
-            await service.addMember('user_abc', 'admin');
-            expect(spy).toHaveBeenCalledWith(
-                { _id: 'user_abc' },
-                { $addToSet: { groups: 'admin' } }
-            );
+            await service.addMember(USER_ABC, 'admin');
+            expect(spy).toHaveBeenCalledTimes(1);
+            const [filter, update] = spy.mock.calls[0];
+            expect((filter._id as ObjectId).toHexString()).toBe(USER_ABC);
+            expect(update).toEqual({ $addToSet: { groups: 'admin' } });
         });
     });
 
     describe('removeMember', () => {
-        it('issues a $pull update against the users collection', async () => {
+        it('issues a $pull update keyed by the ObjectId form of the user id', async () => {
             const collection = mockDatabase.getCollection(AUTH_USERS_COLLECTION);
             const spy = vi.spyOn(collection, 'updateOne');
-            await service.removeMember('user_abc', 'admin');
-            expect(spy).toHaveBeenCalledWith(
-                { _id: 'user_abc' },
-                { $pull: { groups: 'admin' } }
-            );
+            await service.removeMember(USER_ABC, 'admin');
+            expect(spy).toHaveBeenCalledTimes(1);
+            const [filter, update] = spy.mock.calls[0];
+            expect((filter._id as ObjectId).toHexString()).toBe(USER_ABC);
+            expect(update).toEqual({ $pull: { groups: 'admin' } });
         });
     });
 
     describe('setUserGroups', () => {
-        it('replaces the groups array with $set and deduplicates input', async () => {
+        it('replaces the groups array with $set, deduplicates, and keys by ObjectId', async () => {
             const collection = mockDatabase.getCollection(AUTH_USERS_COLLECTION);
             const spy = vi.spyOn(collection, 'updateOne');
-            await service.setUserGroups('user_abc', ['admin', 'vip', 'admin']);
-            expect(spy).toHaveBeenCalledWith(
-                { _id: 'user_abc' },
-                { $set: { groups: ['admin', 'vip'] } }
-            );
+            await service.setUserGroups(USER_ABC, ['admin', 'vip', 'admin']);
+            expect(spy).toHaveBeenCalledTimes(1);
+            const [filter, update] = spy.mock.calls[0];
+            expect((filter._id as ObjectId).toHexString()).toBe(USER_ABC);
+            expect(update).toEqual({ $set: { groups: ['admin', 'vip'] } });
+        });
+    });
+
+    describe('getMembers', () => {
+        it('returns member ids as hex strings, not ObjectIds', async () => {
+            seedAuthUser(mockDatabase, USER_ABC, ['admin']);
+            seedAuthUser(mockDatabase, USER_ADMIN, ['admin']);
+            const { userIds, total } = await service.getMembers('admin');
+            expect(total).toBe(2);
+            expect(userIds).toEqual(expect.arrayContaining([USER_ABC, USER_ADMIN]));
+            expect(userIds.every((id) => typeof id === 'string')).toBe(true);
+        });
+    });
+
+    describe('malformed user id', () => {
+        it('getUserGroups returns [] and never queries the collection', async () => {
+            const collection = mockDatabase.getCollection(AUTH_USERS_COLLECTION);
+            const spy = vi.spyOn(collection, 'findOne');
+            const groups = await service.getUserGroups(MALFORMED_ID);
+            expect(groups).toEqual([]);
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        it('isMember returns false for a malformed id', async () => {
+            const result = await service.isMember(MALFORMED_ID, 'admin');
+            expect(result).toBe(false);
+        });
+
+        it('addMember returns false and issues no write for a malformed id', async () => {
+            const collection = mockDatabase.getCollection(AUTH_USERS_COLLECTION);
+            const spy = vi.spyOn(collection, 'updateOne');
+            const result = await service.addMember(MALFORMED_ID, 'admin');
+            expect(result).toBe(false);
+            expect(spy).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/backend/modules/identity/__tests__/user-group.service.test.ts
+++ b/src/backend/modules/identity/__tests__/user-group.service.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import { ObjectId } from 'mongodb';
 import type { ISystemLogService } from '@/types';
 import { UserGroupService } from '../services/user-group.service.js';
 import { GroupService } from '../services/group.service.js';
@@ -56,19 +57,32 @@ function seedGroup(
 }
 
 /**
+ * Valid 24-character hex Better Auth user ids. Better Auth stores the user
+ * `_id` as a native ObjectId and exposes it as this hex string, so seeded
+ * users must use hex ids and seed `_id` as an ObjectId. Group *slugs*
+ * (`vip`, `admin`, …) are not user ids and stay arbitrary strings.
+ */
+const USER_1 = '111111111111111111111111';
+const ALICE = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+const BOB = 'bbbbbbbbbbbbbbbbbbbbbbbb';
+const CAROL = 'cccccccccccccccccccccccc';
+const ADMIN_USER = 'dddddddddddddddddddddddd';
+const NORMAL_USER = 'eeeeeeeeeeeeeeeeeeeeeeee';
+
+/**
  * Helper: seed a Better Auth user document directly into the
- * `module_user_auth_users` collection. Membership now lives on the BA
- * user's `groups` additional field (keyed by `_id`), so seeding here is
+ * `module_user_auth_users` collection. Membership lives on the BA user's
+ * `groups` additional field, keyed by the ObjectId `_id`, so seeding here is
  * how we establish membership state — the shared mock does not apply
  * `$addToSet`/`$pull`, so write paths are validated via matched/throw
- * contracts rather than array mutation.
+ * contracts rather than array mutation. `id` must be a 24-char hex string.
  */
 function seedUser(
     db: ReturnType<typeof createMockDatabaseService>,
     id: string,
     groups: string[] = []
 ): void {
-    db.getCollectionData(AUTH_USERS_COLLECTION).push({ _id: id, groups });
+    db.getCollectionData(AUTH_USERS_COLLECTION).push({ _id: new ObjectId(id), groups });
 }
 
 describe('UserGroupService', () => {
@@ -202,7 +216,7 @@ describe('UserGroupService', () => {
     // the read-side contract plus the definition-validation/throw paths.
 
     describe('membership reads', () => {
-        const userId = 'user-1';
+        const userId = USER_1;
 
         beforeEach(() => {
             seedUser(mockDatabase, userId, ['vip']);
@@ -228,7 +242,7 @@ describe('UserGroupService', () => {
     });
 
     describe('membership write validation', () => {
-        const userId = 'user-1';
+        const userId = USER_1;
 
         beforeEach(() => {
             seedUser(mockDatabase, userId);
@@ -251,7 +265,7 @@ describe('UserGroupService', () => {
     // -------- setUserGroups --------
 
     describe('setUserGroups', () => {
-        const userId = 'user-1';
+        const userId = USER_1;
 
         beforeEach(() => {
             seedUser(mockDatabase, userId, ['vip']);
@@ -282,14 +296,14 @@ describe('UserGroupService', () => {
             expect(result).toEqual(['vip', 'whales']);
             // Confirm the persisted BA user document reflects the new array.
             // GroupService uses a top-level $set, which the mock supports.
-            const doc = mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).find(u => u._id === userId);
+            const doc = mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).find(u => u._id?.toString() === userId);
             expect(doc?.groups).toEqual(['vip', 'whales']);
         });
 
         it('accepts an empty array to clear all memberships', async () => {
             const result = await service.setUserGroups(userId, []);
             expect(result).toEqual([]);
-            const doc = mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).find(u => u._id === userId);
+            const doc = mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).find(u => u._id?.toString() === userId);
             expect(doc?.groups).toEqual([]);
         });
     });
@@ -299,9 +313,9 @@ describe('UserGroupService', () => {
     describe('getMembers', () => {
         beforeEach(() => {
             seedGroup(mockDatabase, { id: 'vip', name: 'VIP' });
-            seedUser(mockDatabase, 'alice', ['vip']);
-            seedUser(mockDatabase, 'bob', ['vip']);
-            seedUser(mockDatabase, 'carol', []);
+            seedUser(mockDatabase, ALICE, ['vip']);
+            seedUser(mockDatabase, BOB, ['vip']);
+            seedUser(mockDatabase, CAROL, []);
         });
 
         it('throws on unknown group so admin UIs can distinguish "no members" from "wrong slug"', async () => {
@@ -310,7 +324,7 @@ describe('UserGroupService', () => {
 
         it('returns the user ids that belong to the group with total count', async () => {
             const result = await service.getMembers('vip');
-            expect(new Set(result.userIds)).toEqual(new Set(['alice', 'bob']));
+            expect(new Set(result.userIds)).toEqual(new Set([ALICE, BOB]));
             expect(result.total).toBe(2);
         });
 
@@ -325,8 +339,8 @@ describe('UserGroupService', () => {
     // -------- isAdmin --------
 
     describe('isAdmin', () => {
-        const adminUser = 'admin-user';
-        const normalUser = 'normal-user';
+        const adminUser = ADMIN_USER;
+        const normalUser = NORMAL_USER;
 
         beforeEach(() => {
             seedUser(mockDatabase, adminUser, ['admin']);

--- a/src/backend/modules/identity/__tests__/user-id.test.ts
+++ b/src/backend/modules/identity/__tests__/user-id.test.ts
@@ -1,0 +1,50 @@
+/// <reference types="vitest" />
+
+/**
+ * @fileoverview Unit tests for the Better Auth user-id boundary helpers.
+ *
+ * The contract under test: a Better Auth user id is the 24-character hex
+ * form of the ObjectId `_id` stored on `module_user_auth_users`.
+ * {@link toUserKey} converts the hex string to that ObjectId (null on
+ * anything malformed, so callers no-match rather than throw), and
+ * {@link userIdFromKey} converts it back so an ObjectId never leaves an
+ * identity surface.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { toUserKey, userIdFromKey } from '../services/user-id.js';
+
+describe('user-id helpers', () => {
+    describe('toUserKey', () => {
+        it('converts a 24-char hex id to the matching ObjectId', () => {
+            const hex = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+            const key = toUserKey(hex);
+            expect(key).toBeInstanceOf(ObjectId);
+            expect(key?.toHexString()).toBe(hex);
+        });
+
+        it('round-trips an ObjectId through hex and back', () => {
+            const original = new ObjectId();
+            const key = toUserKey(original.toHexString());
+            expect(key?.equals(original)).toBe(true);
+        });
+
+        it.each([
+            ['empty string', ''],
+            ['too short', 'abc'],
+            ['non-hex characters', 'zzzzzzzzzzzzzzzzzzzzzzzz'],
+            ['legacy-style id', 'user_abc'],
+            ['25 hex chars', 'aaaaaaaaaaaaaaaaaaaaaaaaa']
+        ])('returns null for a malformed id (%s)', (_label, value) => {
+            expect(toUserKey(value)).toBeNull();
+        });
+    });
+
+    describe('userIdFromKey', () => {
+        it('returns the 24-char hex form of an ObjectId', () => {
+            const id = new ObjectId();
+            expect(userIdFromKey(id)).toBe(id.toHexString());
+        });
+    });
+});

--- a/src/backend/modules/identity/__tests__/wallet.service.test.ts
+++ b/src/backend/modules/identity/__tests__/wallet.service.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ObjectId } from 'mongodb';
 import type { ICacheService, ISystemLogService } from '@/types';
 import { WalletService, WALLETS_COLLECTION } from '../services/wallet.service.js';
 import { WalletChallengeService } from '../services/wallet-challenge.service.js';
@@ -95,8 +96,10 @@ class StubLogger implements ISystemLogService {
     async getStats(): Promise<any> { return { total: 0, byLevel: {}, resolved: 0, unresolved: 0 }; }
 }
 
-const USER_A = 'user_aaa';
-const USER_B = 'user_bbb';
+// Better Auth exposes user ids as the 24-char hex form of the ObjectId
+// `_id`; the denormalized primaryWallet write keys by that ObjectId.
+const USER_A = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+const USER_B = 'bbbbbbbbbbbbbbbbbbbbbbbb';
 const WALLET_1 = 'TWallet1111111111111111111111111111';
 const WALLET_2 = 'TWallet2222222222222222222222222222';
 
@@ -115,11 +118,15 @@ describe('WalletService', () => {
         return { address, message: challenge.message, signature: 'sig', nonce: challenge.nonce };
     }
 
-    /** Read the denormalized primaryWallet from the seeded BA user row. */
+    /**
+     * Read the denormalized primaryWallet from the seeded BA user row.
+     * The seeded `_id` is an ObjectId (as BA stores it), so compare on its
+     * hex form against the caller's hex user id.
+     */
     function authPrimary(userId: string): string | null | undefined {
         const row = mockDatabase
             .getCollectionData(AUTH_USERS_COLLECTION)
-            .find((d: any) => d._id === userId);
+            .find((d: any) => d._id?.toString() === userId);
         return row ? row.primaryWallet : undefined;
     }
 
@@ -127,8 +134,9 @@ describe('WalletService', () => {
         mockDatabase = createMockDatabaseService();
         cache = new MockCacheService();
         // Seed BA user rows so the denormalized primaryWallet write lands.
-        mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({ _id: USER_A, primaryWallet: null });
-        mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({ _id: USER_B, primaryWallet: null });
+        // `_id` is an ObjectId, matching Better Auth's storage shape.
+        mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({ _id: new ObjectId(USER_A), primaryWallet: null });
+        mockDatabase.getCollectionData(AUTH_USERS_COLLECTION).push({ _id: new ObjectId(USER_B), primaryWallet: null });
         WalletService.resetForTests();
         WalletService.setDependencies(mockDatabase, cache, new StubLogger(), {} as any);
         service = WalletService.getInstance();

--- a/src/backend/modules/identity/services/account-directory.service.ts
+++ b/src/backend/modules/identity/services/account-directory.service.ts
@@ -12,7 +12,7 @@
  * state configured once at bootstrap.
  */
 
-import type { Collection } from 'mongodb';
+import type { Collection, ObjectId } from 'mongodb';
 import type {
     IAccountDirectoryService,
     IAccountSummary,
@@ -22,6 +22,7 @@ import type {
     ISystemLogService
 } from '@/types';
 import { AUTH_USERS_COLLECTION } from './auth-constants.js';
+import { toUserKey, userIdFromKey } from './user-id.js';
 
 /** Default page size for {@link AccountDirectoryService.listAccounts}. */
 const DEFAULT_LIMIT = 50;
@@ -32,11 +33,14 @@ const MAX_LIMIT = 200;
 /**
  * Subset of the Better Auth user row this service reads.
  *
- * Better Auth's adapter maps the logical `id` to MongoDB `_id` (a string), and
- * the `groups` / `primaryWallet` additional fields are declared in `auth.ts`.
+ * BA's adapter stores the user `_id` as a native `ObjectId` and exposes it as
+ * the hex `user.id`; reads convert the incoming hex id to an `ObjectId` via
+ * {@link toUserKey}, and {@link userIdFromKey} converts it back on the way out
+ * so the public summary's `id` stays an opaque string. The `groups` /
+ * `primaryWallet` additional fields are declared in `auth.ts`.
  */
 interface IAuthUserDocument {
-    _id: string;
+    _id: ObjectId;
     email: string;
     name?: string | null;
     emailVerified?: boolean;
@@ -116,8 +120,13 @@ export class AccountDirectoryService implements IAccountDirectoryService {
      * @returns The summary, or null when no such account exists.
      */
     public async getAccount(baUserId: string): Promise<IAccountSummary | null> {
-        const doc = await this.authUsers.findOne({ _id: baUserId });
-        return doc ? AccountDirectoryService.toSummary(doc) : null;
+        const key = toUserKey(baUserId);
+        let summary: IAccountSummary | null = null;
+        if (key) {
+            const doc = await this.authUsers.findOne({ _id: key });
+            summary = doc ? AccountDirectoryService.toSummary(doc) : null;
+        }
+        return summary;
     }
 
     /**
@@ -175,7 +184,7 @@ export class AccountDirectoryService implements IAccountDirectoryService {
      */
     private static toSummary(doc: IAuthUserDocument): IAccountSummary {
         return {
-            id: doc._id,
+            id: userIdFromKey(doc._id),
             email: doc.email,
             name: doc.name ?? null,
             emailVerified: doc.emailVerified ?? false,

--- a/src/backend/modules/identity/services/group.service.ts
+++ b/src/backend/modules/identity/services/group.service.ts
@@ -12,17 +12,20 @@
  * (`setDependencies()` / `getInstance()`) because membership state is
  * shared application-wide and configured exactly once at bootstrap.
  *
- * **Storage shape.** Better Auth's `mongodbAdapter` maps the logical
- * `id` field on the User model to MongoDB's `_id` (transparently
- * transforming on read and write), so every query in this service
- * filters by `{ _id: userId }`. The `groups` field is the BA
- * additional field declared in `auth.ts`; nothing else in the codebase
- * writes to it.
+ * **Storage shape.** Better Auth's `mongodbAdapter` lets MongoDB
+ * generate the user `_id` as a native `ObjectId` and exposes it to the
+ * app as its 24-character hex string (`user.id`). Every query in this
+ * service therefore converts the incoming hex `userId` to an `ObjectId`
+ * via {@link toUserKey} before filtering by `{ _id }` — a raw string
+ * would never match the ObjectId-typed `_id`. The `groups` field is the
+ * BA additional field declared in `auth.ts`; nothing else in the
+ * codebase writes to it. See `user-id.ts` for the id-type contract.
  */
 
-import type { Collection } from 'mongodb';
+import type { Collection, ObjectId } from 'mongodb';
 import type { IDatabaseService, ISystemLogService } from '@/types';
 import { AUTH_USERS_COLLECTION } from './auth-constants.js';
+import { toUserKey, userIdFromKey } from './user-id.js';
 
 /**
  * Group id reserved for administrators.
@@ -41,12 +44,12 @@ export const ADMIN_GROUP_ID = 'admin';
  */
 interface IAuthUserDoc {
     /**
-     * Better Auth's user id, stored as MongoDB `_id` (string, not
-     * ObjectId). The adapter remaps `id` ↔ `_id` transparently when
-     * BA itself queries, so the `_id` we see here is the same value
-     * BA returns as `user.id` from its session API.
+     * Better Auth's user id, stored as MongoDB's native `ObjectId`.
+     * Better Auth exposes it to the app as its 24-character hex string
+     * (`user.id`); this service converts that string to an `ObjectId`
+     * via {@link toUserKey} for every `_id` query. See `user-id.ts`.
      */
-    _id: string;
+    _id: ObjectId;
 
     /**
      * Group ids the user is a member of. Empty array or missing both
@@ -166,12 +169,15 @@ export class GroupService {
      *          $addToSet writes. Order is not guaranteed.
      */
     public async getUserGroups(userId: string): Promise<string[]> {
-        const collection = this.getCollection();
-        const doc = await collection.findOne(
-            { _id: userId },
-            { projection: { groups: 1 } }
-        );
-        const groups = doc?.groups ?? [];
+        const key = toUserKey(userId);
+        let groups: string[] = [];
+        if (key) {
+            const doc = await this.getCollection().findOne(
+                { _id: key },
+                { projection: { groups: 1 } }
+            );
+            groups = doc?.groups ?? [];
+        }
         return groups;
     }
 
@@ -184,12 +190,16 @@ export class GroupService {
      *          `groups` array, `false` otherwise (including missing user).
      */
     public async isMember(userId: string, groupId: string): Promise<boolean> {
-        const collection = this.getCollection();
-        const count = await collection.countDocuments(
-            { _id: userId, groups: groupId },
-            { limit: 1 }
-        );
-        return count > 0;
+        const key = toUserKey(userId);
+        let member = false;
+        if (key) {
+            const count = await this.getCollection().countDocuments(
+                { _id: key, groups: groupId },
+                { limit: 1 }
+            );
+            member = count > 0;
+        }
+        return member;
     }
 
     /**
@@ -221,12 +231,16 @@ export class GroupService {
      *          MongoDB would otherwise return invisibly).
      */
     public async addMember(userId: string, groupId: string): Promise<boolean> {
-        const collection = this.getCollection();
-        const result = await collection.updateOne(
-            { _id: userId },
-            { $addToSet: { groups: groupId } }
-        );
-        return result.matchedCount > 0;
+        const key = toUserKey(userId);
+        let matched = false;
+        if (key) {
+            const result = await this.getCollection().updateOne(
+                { _id: key },
+                { $addToSet: { groups: groupId } }
+            );
+            matched = result.matchedCount > 0;
+        }
+        return matched;
     }
 
     /**
@@ -240,12 +254,16 @@ export class GroupService {
      *          `false` when no user matched the id.
      */
     public async removeMember(userId: string, groupId: string): Promise<boolean> {
-        const collection = this.getCollection();
-        const result = await collection.updateOne(
-            { _id: userId },
-            { $pull: { groups: groupId } }
-        );
-        return result.matchedCount > 0;
+        const key = toUserKey(userId);
+        let matched = false;
+        if (key) {
+            const result = await this.getCollection().updateOne(
+                { _id: key },
+                { $pull: { groups: groupId } }
+            );
+            matched = result.matchedCount > 0;
+        }
+        return matched;
     }
 
     /**
@@ -262,13 +280,17 @@ export class GroupService {
      *          `false` when no user matched the id.
      */
     public async setUserGroups(userId: string, groupIds: string[]): Promise<boolean> {
-        const collection = this.getCollection();
-        const unique = Array.from(new Set(groupIds));
-        const result = await collection.updateOne(
-            { _id: userId },
-            { $set: { groups: unique } }
-        );
-        return result.matchedCount > 0;
+        const key = toUserKey(userId);
+        let matched = false;
+        if (key) {
+            const unique = Array.from(new Set(groupIds));
+            const result = await this.getCollection().updateOne(
+                { _id: key },
+                { $set: { groups: unique } }
+            );
+            matched = result.matchedCount > 0;
+        }
+        return matched;
     }
 
     /**
@@ -300,7 +322,7 @@ export class GroupService {
                 .toArray(),
             collection.countDocuments(filter)
         ]);
-        return { userIds: docs.map((d) => d._id), total };
+        return { userIds: docs.map((d) => userIdFromKey(d._id)), total };
     }
 
     /**

--- a/src/backend/modules/identity/services/user-id.ts
+++ b/src/backend/modules/identity/services/user-id.ts
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Conversion between the Better Auth user id and the MongoDB
+ * `_id` stored on `module_user_auth_users`.
+ *
+ * **The contract this module enforces.** Better Auth's `mongodbAdapter` lets
+ * MongoDB generate each user document's `_id` as a native `ObjectId` and
+ * exposes it to application code as that ObjectId's 24-character hex string
+ * (`session.user.id`, `req.authSession.user.id`). The rest of the codebase
+ * treats that hex string as the canonical, *opaque* user id: it is stored
+ * verbatim as a foreign key in module/plugin collections, compared verbatim,
+ * and never cast to an `ObjectId` by consumers. The single place the string
+ * must become an `ObjectId` is here — the boundary where identity services
+ * read or write the Better Auth user collection by `_id`. Confining the
+ * conversion to one module keeps every other surface (and every plugin)
+ * ignorant of the storage type, and means a future change to Better Auth's id
+ * strategy touches exactly this file.
+ *
+ * Code outside the identity module must not import these helpers to hand-roll
+ * Better Auth collection access. It consumes account, wallet, and group data
+ * through the registered `'accounts'` / `'wallets'` / `'user-groups'` service
+ * contracts, which return the opaque hex string.
+ */
+
+import { ObjectId } from 'mongodb';
+
+/** A Better Auth user id is the 24-character hex form of its ObjectId `_id`. */
+const USER_ID_HEX = /^[0-9a-fA-F]{24}$/;
+
+/**
+ * Convert a Better Auth user id (hex string) to the `ObjectId` stored as
+ * `_id` on `module_user_auth_users`.
+ *
+ * Returns `null` for any value that is not a 24-character hex string, so
+ * callers treat a malformed id as "no such user" — a no-match read or a
+ * no-op write — rather than throwing. This mirrors the auth facade's
+ * graceful-degradation contract: a bad id never escalates to a 500.
+ *
+ * @param userId - Better Auth user id as exposed on the resolved session.
+ * @returns The matching `ObjectId`, or `null` when `userId` is malformed.
+ */
+export function toUserKey(userId: string): ObjectId | null {
+    const key = USER_ID_HEX.test(userId) ? new ObjectId(userId) : null;
+    return key;
+}
+
+/**
+ * Convert the stored `_id` `ObjectId` back to the canonical hex-string user
+ * id the rest of the application consumes.
+ *
+ * Identity services call this on every id value leaving their surface so an
+ * `ObjectId` never crosses the module boundary — callers always receive the
+ * same opaque string they passed in.
+ *
+ * @param id - The `_id` ObjectId from a `module_user_auth_users` document.
+ * @returns The 24-character hex user id.
+ */
+export function userIdFromKey(id: ObjectId): string {
+    const userId = id.toHexString();
+    return userId;
+}

--- a/src/backend/modules/identity/services/user-id.ts
+++ b/src/backend/modules/identity/services/user-id.ts
@@ -39,7 +39,7 @@ const USER_ID_HEX = /^[0-9a-fA-F]{24}$/;
  * @returns The matching `ObjectId`, or `null` when `userId` is malformed.
  */
 export function toUserKey(userId: string): ObjectId | null {
-    const key = USER_ID_HEX.test(userId) ? new ObjectId(userId) : null;
+    const key = typeof userId === 'string' && USER_ID_HEX.test(userId) ? new ObjectId(userId) : null;
     return key;
 }
 

--- a/src/backend/modules/identity/services/wallet.service.ts
+++ b/src/backend/modules/identity/services/wallet.service.ts
@@ -44,6 +44,7 @@ import { WalletChallengeService } from './wallet-challenge.service.js';
 import type { WalletChallengeAction, IWalletChallenge } from './wallet-challenge.service.js';
 import type { IWalletDocument, ILinkedWallet } from '../database/IWalletDocument.js';
 import { AUTH_USERS_COLLECTION } from './auth-constants.js';
+import { toUserKey } from './user-id.js';
 
 /**
  * Physical collection name for the Better Auth-keyed wallet store.
@@ -83,12 +84,14 @@ export interface IWalletMutationInput {
 /**
  * Shape of the Better Auth user row this service denormalizes onto.
  *
- * Restricted to the field written here — BA owns the full schema. The
- * adapter maps the logical `id` to MongoDB `_id`, so writes filter by
- * `{ _id: userId }` (same boundary {@link GroupService} uses).
+ * Restricted to the field written here — BA owns the full schema. BA's
+ * adapter stores the user `_id` as a native `ObjectId` and exposes it as
+ * the hex `user.id`, so the denormalized write converts the incoming
+ * `userId` to an `ObjectId` via {@link toUserKey} before filtering by
+ * `{ _id }` (same boundary {@link GroupService} uses). See `user-id.ts`.
  */
 interface IAuthUserPrimaryWallet {
-    _id: string;
+    _id: ObjectId;
     primaryWallet?: string | null;
 }
 
@@ -496,7 +499,12 @@ export class WalletService implements IWalletService {
      * @param address - Primary address, or `null` to clear.
      */
     private async setAuthPrimary(userId: string, address: string | null): Promise<void> {
-        await this.authUsers.updateOne({ _id: userId }, { $set: { primaryWallet: address } });
+        const key = toUserKey(userId);
+        if (key) {
+            await this.authUsers.updateOne({ _id: key }, { $set: { primaryWallet: address } });
+        } else {
+            this.logger.warn({ userId }, 'setAuthPrimary skipped: malformed Better Auth user id');
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Better Auth's `mongodbAdapter` stores the user `_id` as a native MongoDB ObjectId and exposes it as a 24-character hex string (`session.user.id`). The identity services queried `module_user_auth_users` with the raw hex **string**, which never matches the ObjectId `_id` — silently breaking every group/admin lookup (**admin-by-session was non-functional in production**), the `primaryWallet` denormalization (`hasPrimaryWallet` always false), and account-directory reads. String-keyed test mocks masked the regression.

## Fix

- New `services/user-id.ts` — `toUserKey` (hex → `ObjectId | null`, null on malformed) and `userIdFromKey` (→ hex): the single conversion boundary.
- `GroupService`, `WalletService`, and `AccountDirectoryService` convert at every `_id` query; `getMembers` / `toSummary` convert back so an `ObjectId` never leaves an identity surface.
- Corrected the false "`_id` is a string" docstrings on all three services.
- Documented the opaque-hex-string contract in the identity README and `system-auth.md`.
- Updated identity + middleware tests to seed ObjectId `_id`s with 24-hex ids; added `user-id.test.ts`.

`tsc --noEmit` clean; 114 identity/middleware tests + 14 menu gating tests pass.

## Note

Includes a one-line `package-lock.json` sync (`@delphian/tronrelic-types` 2.1.0 → 3.0.0) that corrects a pre-existing lock drift against the already-committed `packages/types/package.json` — required for `npm ci` in the Docker build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
