### PR TITLE
feat(traffic): per-page clickstream for tid and registered visitors

### DIFF
--- a/src/backend/modules/traffic/README.md
+++ b/src/backend/modules/traffic/README.md
@@ -8,16 +8,17 @@ Owns cookieless behavioral analytics: the ClickHouse `traffic_events` pipeline, 
 |---------|-------|
 | Module id | `traffic` |
 | Module class | `src/backend/modules/traffic/TrafficModule.ts` |
-| Mounted routes | `/api/admin/users/traffic/*`, `/api/admin/users/analytics/*`, `/api/user/bootstrap` |
+| Mounted routes | `/api/admin/users/traffic/*`, `/api/admin/users/analytics/*`, `/api/user/bootstrap`, `/api/user/track` |
 | Scheduled job | `gsc:fetch` (daily, `0 3 * * *`) |
-| ClickHouse table | `traffic_events` (migrations 010, 012) |
+| ClickHouse table | `traffic_events` (migrations 010, 012, 013) |
+| Event types | `bootstrap` (cookieless first touch, incl. bots) · `page` (interactive navigation) |
 | Mongo collection | `module_user_gsc_queries` (GSC keyword cache — physical name preserved) |
 | Analytics key | cookieless `tronrelic_tid` (`candidate_uid`), independent of identity |
 | Bootstrap order | Inits/runs **before** `IdentityModule` so its `/api/admin/users/{traffic,analytics}` routers mount ahead of the accounts `/api/admin/users` catch-all |
 
 ## Why This Module Exists Separately
 
-Analytics keyed off the cookieless `tronrelic_tid` is independent of identity — it survived the Phase 6 removal of the legacy UUID system untouched. The `traffic_events` ClickHouse table captures cookieless and pre-session HTTP traffic (crawlers, unfurlers, probes) without touching identity storage.
+Analytics keyed off the cookieless `tronrelic_tid` is independent of identity — it survived the Phase 6 removal of the legacy UUID system untouched. The `traffic_events` ClickHouse table captures two complementary streams without touching identity storage: server-recorded `bootstrap` first touches (cookieless, so crawlers/unfurlers/probes are included by design) and client-recorded `page` navigations (the interactive clickstream of cookied and registered visitors). One table, differentiated by `event_type` and `user_id`, so a visitor's journey from anonymous first touch through registered browsing stays in one place.
 
 Physical storage names are unchanged from when this code lived under the user module: the GSC collection is still `module_user_gsc_queries`, and the ClickHouse migrations' `id` fields are unchanged. Only their migration `qualifiedId` shifts from `module:user:*` to `module:traffic:*` because the scanner derives it from the directory; both migrations are idempotent (`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`), so re-execution under the new id is a safe no-op.
 
@@ -30,8 +31,8 @@ Physical storage names are unchanged from when this code lived under the user mo
 | `services/gsc.service.ts` | Google Search Console keyword fetch/store (`module_user_gsc_queries`) |
 | `services/bot-classifier.ts` | User-Agent → `BotClass` (powers `traffic_events.bot_class`) |
 | `services/geo.service.ts` | IP → country, referrer parsing, device derivation, `getClientIP`; defines `DeviceCategory` / `ScreenSizeCategory` |
-| `api/traffic.{controller,routes}.ts` | `/api/admin/users/traffic/*` raw-traffic reads **and** `/api/admin/users/analytics/*` dashboard aggregates (ClickHouse-backed) |
-| `api/bootstrap.{controller,routes}.ts` | `POST /api/user/bootstrap` — emits one first-touch `bootstrap` traffic_event (tid-keyed; no identity, no Mongo write) |
+| `api/traffic.{controller,routes}.ts` | `/api/admin/users/traffic/*` raw-traffic reads **and** `/api/admin/users/analytics/*` dashboard aggregates (ClickHouse-backed), including the per-tid / per-user page-activity reads |
+| `api/bootstrap.{controller,routes}.ts` | Public ingestion: `POST /api/user/bootstrap` (first-touch `bootstrap`) and `POST /api/user/track` (navigation `page`) — both tid-keyed, account-attributed when logged in; no identity, no Mongo write |
 | `api/traffic-cookies.ts` | `tronrelic_tid` / `tronrelic_ref` resolve/mint/set helpers |
 | `migrations/010_create_traffic_events_table.ts` | Creates the ClickHouse table (18-month TTL) |
 | `migrations/012_traffic_events_user_referral_columns.ts` | Adds `user_id` + `referral_code` columns |
@@ -47,9 +48,14 @@ The `/api/admin/users/traffic/*` reads below are under `requireAdmin` and accept
 | GET | `/api/admin/users/traffic/top-countries` | Most-active ISO-3166 alpha-2 countries |
 | GET | `/api/admin/users/traffic/bot-other-samples` | Frequent UAs classified `bot_other` (classifier-gap feedback) |
 
-The `/api/admin/users/analytics/*` router (also `requireAdmin`) serves the `/system/users` dashboard aggregates — daily visitors, traffic sources, geo/device breakdowns, engagement, the binary conversion funnel, retention, and the GSC endpoints — all backed by `traffic_events`. The frontend consumes them through `src/frontend/modules/user/api/client.ts`.
+The `/api/admin/users/analytics/*` router (also `requireAdmin`) serves the `/system/users` dashboard aggregates — daily visitors, anonymous first touches (`new-users`), traffic sources, geo/device breakdowns, engagement, the binary conversion funnel, retention, and the GSC endpoints — all backed by `traffic_events`. The frontend consumes them through `src/frontend/modules/user/api/client.ts`.
 
-`POST /api/user/bootstrap` (public) emits one first-touch `bootstrap` row keyed on the inbound `tronrelic_tid`; it mints no identity.
+Per-page clickstream reads live on the same router: `tid-activity` and `user-activity` summarize `page` events by anonymous tid (`user_id IS NULL`) and registered account (`user_id IS NOT NULL`) respectively, and `page-hits?subject=tid|user&id=` returns one subject's ordered page hits — "every page they hit".
+
+Two public ingestion endpoints (no auth) write rows; both resolve the tid from the unsigned `tronrelic_tid` cookie and attribute to the Better Auth account when one is present:
+
+- `POST /api/user/bootstrap` — one first-touch `bootstrap` row. Called server-to-server by the Next.js middleware, so it captures cookieless bots and crawlers; this is the noise that powers the "Anonymous First Touches" table.
+- `POST /api/user/track` — one `page` row per navigation. Called by the client-side route-change beacon (`src/frontend/modules/user/components/PageViewTracker`, via `lib/pageBeacon`), which fires on mount and every soft navigation. Bots that do not run JS never reach it, so the `page` stream is interactive-traffic-only.
 
 When ClickHouse is unavailable every read returns empty with `clickhouseEnabled: false` rather than failing.
 

--- a/src/backend/modules/traffic/TrafficModule.ts
+++ b/src/backend/modules/traffic/TrafficModule.ts
@@ -4,9 +4,10 @@
  * Carved out of the former omnibus user module. Owns the ClickHouse
  * `traffic_events` pipeline (`TrafficService`), Google Search Console keyword
  * integration (`GscService`), the User-Agent bot classifier, geo/IP derivation,
- * the admin traffic dashboard reads, and the slim first-touch analytics
- * bootstrap endpoint. Mounts `/api/admin/users/traffic`, the public
- * `/api/user/bootstrap`, and registers the daily `gsc:fetch` job.
+ * the admin traffic dashboard reads, and the public traffic-event ingestion
+ * endpoints. Mounts `/api/admin/users/{traffic,analytics}`, the public
+ * `/api/user/bootstrap` (first touch) and `/api/user/track` (page navigation),
+ * and registers the daily `gsc:fetch` job.
  *
  * Analytics are keyed off the cookieless `tronrelic_tid`, independent of
  * identity, so this surface survived the Better Auth cutover that removed the
@@ -25,7 +26,7 @@ import { initGeoIP } from './services/geo.service.js';
 import { TrafficController } from './api/traffic.controller.js';
 import { BootstrapController } from './api/bootstrap.controller.js';
 import { createAdminTrafficRouter, createAdminAnalyticsRouter } from './api/traffic.routes.js';
-import { createBootstrapRouter } from './api/bootstrap.routes.js';
+import { createBootstrapRouter, createPageEventRouter } from './api/bootstrap.routes.js';
 import { requireAdmin } from '../../api/middleware/admin-auth.js';
 
 /**
@@ -150,6 +151,13 @@ export class TrafficModule implements IModule<ITrafficModuleDependencies> {
         const bootstrapRouter: Router = createBootstrapRouter(this.bootstrapController);
         this.app.use('/api/user/bootstrap', bootstrapRouter);
         this.logger.info('Bootstrap router mounted at /api/user/bootstrap');
+
+        // Public page-event ingestion — the client-side route-change beacon
+        // posts here on every navigation. Same controller as bootstrap; emits a
+        // `page` row keyed on the tid and attributed to the account when present.
+        const pageEventRouter: Router = createPageEventRouter(this.bootstrapController);
+        this.app.use('/api/user/track', pageEventRouter);
+        this.logger.info('Page-event router mounted at /api/user/track');
 
         // Daily GSC fetch (3 AM). SchedulerService supports late registration.
         if (this.scheduler) {

--- a/src/backend/modules/traffic/__tests__/bootstrap.controller.test.ts
+++ b/src/backend/modules/traffic/__tests__/bootstrap.controller.test.ts
@@ -106,4 +106,34 @@ describe('BootstrapController', () => {
         expect(cookies.find(c => c.name === REF_COOKIE_NAME)?.value).toBe('promo_2026');
         expect(recordEvent.mock.calls[0][0].referral_code).toBe('promo_2026');
     });
+
+    it('emits a page event keyed on the existing tid for the route-change beacon', async () => {
+        const req = buildReq({
+            cookies: { [TID_COOKIE_NAME]: EXISTING_TID },
+            body: { landingPath: '/markets/energy' }
+        } as unknown as Partial<Request>);
+        const { res, json } = buildRes();
+
+        await controller.page(req, res);
+
+        expect(recordEvent).toHaveBeenCalledTimes(1);
+        const event = recordEvent.mock.calls[0][0];
+        expect(event.event_type).toBe('page');
+        expect(event.candidate_uid).toBe(EXISTING_TID);
+        expect(event.path).toBe('/markets/energy');
+        expect(json).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('attributes a page event to the logged-in account', async () => {
+        const req = buildReq({
+            cookies: { [TID_COOKIE_NAME]: EXISTING_TID },
+            body: { landingPath: '/account' },
+            authSession: { user: { id: 'ba_user_42' } }
+        } as unknown as Partial<Request>);
+        const { res } = buildRes();
+
+        await controller.page(req, res);
+
+        expect(recordEvent.mock.calls[0][0].user_id).toBe('ba_user_42');
+    });
 });

--- a/src/backend/modules/traffic/__tests__/traffic.service.test.ts
+++ b/src/backend/modules/traffic/__tests__/traffic.service.test.ts
@@ -287,4 +287,106 @@ describe('TrafficService', () => {
             expect(logger.warn).toHaveBeenCalled();
         });
     });
+
+    describe('getPageActivity()', () => {
+        const range = { since: new Date('2026-04-01T00:00:00.000Z') };
+
+        it('returns an empty page when ClickHouse is unavailable', async () => {
+            TrafficService.setDependencies(undefined, createMockLogger());
+            const out = await TrafficService.getInstance().getPageActivity('tid', range);
+            expect(out).toEqual({ rows: [], total: 0 });
+        });
+
+        it('groups anonymous tid activity on candidate_uid with user_id IS NULL', async () => {
+            const ch = createMockClickHouse();
+            const sqls: string[] = [];
+            ch.query = async <T>(sql: string): Promise<T[]> => {
+                sqls.push(sql);
+                if (sql.includes('AS total')) return [{ total: '3' }] as T[];
+                return [{
+                    id: 'tid-1', firstSeen: '2026-04-30 10:00:00.000', lastSeen: '2026-04-30 10:05:00.000',
+                    pageViews: '4', distinctPaths: '3', firstPath: '/', lastPath: '/markets',
+                    country: 'US', device: 'desktop'
+                }] as T[];
+            };
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            const out = await TrafficService.getInstance().getPageActivity('tid', range, 25, 0);
+
+            const joined = sqls.join('\n');
+            expect(joined).toContain("event_type = 'page'");
+            expect(joined).toContain('user_id IS NULL');
+            expect(joined).toContain('GROUP BY candidate_uid');
+            expect(out.total).toBe(3);
+            expect(out.rows[0]).toMatchObject({ id: 'tid-1', pageViews: 4, distinctPaths: 3, lastPath: '/markets' });
+        });
+
+        it('groups registered activity on user_id with user_id IS NOT NULL', async () => {
+            const ch = createMockClickHouse();
+            const sqls: string[] = [];
+            ch.query = async <T>(sql: string): Promise<T[]> => {
+                sqls.push(sql);
+                if (sql.includes('AS total')) return [{ total: 1 }] as T[];
+                return [] as T[];
+            };
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            await TrafficService.getInstance().getPageActivity('user', range);
+
+            const joined = sqls.join('\n');
+            expect(joined).toContain('user_id IS NOT NULL');
+            expect(joined).toContain('GROUP BY user_id');
+        });
+    });
+
+    describe('getPageHits()', () => {
+        const range = { since: new Date('2026-04-01T00:00:00.000Z') };
+
+        it('returns [] when ClickHouse is unavailable', async () => {
+            TrafficService.setDependencies(undefined, createMockLogger());
+            const out = await TrafficService.getInstance().getPageHits('user', 'ba_42', range);
+            expect(out).toEqual([]);
+        });
+
+        it('rejects a non-UUID tid id without querying ClickHouse', async () => {
+            const ch = createMockClickHouse();
+            let called = false;
+            ch.query = async <T>(): Promise<T[]> => { called = true; return [] as T[]; };
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            const out = await TrafficService.getInstance().getPageHits('tid', 'not-a-uuid', range);
+
+            expect(out).toEqual([]);
+            expect(called).toBe(false);
+        });
+
+        it('matches candidate_uid for a tid subject and maps hits', async () => {
+            const ch = createMockClickHouse();
+            const captured: { sql?: string; params?: Record<string, unknown> } = {};
+            ch.query = async <T>(sql: string, params?: unknown): Promise<T[]> => {
+                captured.sql = sql;
+                captured.params = params as Record<string, unknown>;
+                return [{ timestamp: '2026-04-30 10:05:00.000', path: '/markets', referer: null, device: 'desktop', country: 'US' }] as T[];
+            };
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            const out = await TrafficService.getInstance().getPageHits('tid', '550e8400-e29b-41d4-a716-446655440000', range, 50);
+
+            expect(captured.sql).toContain('candidate_uid = {id:UUID}');
+            expect(captured.sql).toContain("event_type = 'page'");
+            expect(captured.params?.id).toBe('550e8400-e29b-41d4-a716-446655440000');
+            expect(out).toEqual([{ timestamp: '2026-04-30 10:05:00.000', path: '/markets', referer: null, device: 'desktop', country: 'US' }]);
+        });
+
+        it('matches user_id for a user subject', async () => {
+            const ch = createMockClickHouse();
+            const captured: { sql?: string } = {};
+            ch.query = async <T>(sql: string): Promise<T[]> => { captured.sql = sql; return [] as T[]; };
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            await TrafficService.getInstance().getPageHits('user', 'ba_user_42', range);
+
+            expect(captured.sql).toContain('user_id = {id:String}');
+        });
+    });
 });

--- a/src/backend/modules/traffic/api/bootstrap.controller.ts
+++ b/src/backend/modules/traffic/api/bootstrap.controller.ts
@@ -1,23 +1,28 @@
 /**
- * @fileoverview Slim analytics bootstrap controller.
+ * @fileoverview Edge/client traffic-event ingestion controller.
  *
- * `POST /api/user/bootstrap` is the first-touch analytics entry point. The
- * Next.js middleware calls it server-to-server when an inbound page request
- * carries no `tronrelic_tid` cookie, so SSR records a `traffic_events` row on
- * the very first visit; client/direct callers hit it the same way.
+ * Two public, identity-free entry points that both resolve the unsigned
+ * `tronrelic_tid` / `tronrelic_ref` cookies, attribute to the logged-in account
+ * via `req.authSession` when present, and emit one `traffic_events` row:
  *
- * After the Better Auth cutover this endpoint is purely a traffic concern: it
- * reads (and mints) the unsigned `tronrelic_tid` / `tronrelic_ref` cookies,
- * emits one `bootstrap` ClickHouse event, and returns `{ success: true }`. It
- * does NOT mint an identity, touch MongoDB, or read the legacy `users`
- * collection — Better Auth owns identity, and `req.authSession` already carries
- * the logged-in account id when present.
+ * - `POST /api/user/bootstrap` — the first-touch `bootstrap` event. The Next.js
+ *   middleware calls it server-to-server when an inbound page request carries no
+ *   `tronrelic_tid` cookie, so even cookieless bots and unfurlers are captured.
+ * - `POST /api/user/track` — a `page` event. Fired by the client-side
+ *   route-change beacon on every navigation (hard + soft), so it captures the
+ *   full clickstream of cookie-running visitors — anonymous (tid) and registered
+ *   (`user_id`) alike. Bots that do not run JS never reach it, so the `page`
+ *   stream is naturally interactive-traffic-only.
+ *
+ * Neither endpoint mints an identity, touches MongoDB, or reads the legacy
+ * `users` collection — Better Auth owns identity, and `req.authSession` already
+ * carries the logged-in account id when present.
  */
 
 import type { Request, Response } from 'express';
 import { randomUUID } from 'node:crypto';
 import type { ISystemLogService } from '@/types';
-import { TrafficService, buildTrafficEvent } from '../services/traffic.service.js';
+import { TrafficService, buildTrafficEvent, type TrafficEventType } from '../services/traffic.service.js';
 import {
     UUID_V4_REGEX,
     resolveTid,
@@ -131,10 +136,7 @@ export class BootstrapController {
     /**
      * POST /api/user/bootstrap
      *
-     * Resolve/mint the traffic id and first-touch referral code, emit one
-     * `bootstrap` ClickHouse event keyed on the tid (attributed to the Better
-     * Auth account when logged in), and return `{ success: true }`. No identity
-     * mint, no MongoDB.
+     * Record the first-touch `bootstrap` event. See {@link record}.
      *
      * @param req - Express request (cookie-parser populated; may carry a
      *   middleware-forwarded body and `?ref=`).
@@ -142,14 +144,45 @@ export class BootstrapController {
      * @returns Resolves once the response has been written.
      */
     async bootstrap(req: Request, res: Response): Promise<void> {
+        return this.record('bootstrap', req, res);
+    }
+
+    /**
+     * POST /api/user/track
+     *
+     * Record a `page` event for the client-side route-change beacon. Same
+     * resolution path as {@link bootstrap} — the only difference is the event
+     * type, so the full clickstream and the first-touch row share one shape and
+     * one attribution rule.
+     *
+     * @param req - Express request carrying the beaconed `landingPath` body.
+     * @param res - Express response.
+     * @returns Resolves once the response has been written.
+     */
+    async page(req: Request, res: Response): Promise<void> {
+        return this.record('page', req, res);
+    }
+
+    /**
+     * Resolve/mint the traffic id and first-touch referral code, emit one
+     * ClickHouse event of `eventType` keyed on the tid (attributed to the Better
+     * Auth account when logged in), and return `{ success: true }`. No identity
+     * mint, no MongoDB.
+     *
+     * @param eventType - `'bootstrap'` (first touch) or `'page'` (navigation).
+     * @param req - Express request.
+     * @param res - Express response.
+     * @returns Resolves once the response has been written.
+     */
+    private async record(eventType: TrafficEventType, req: Request, res: Response): Promise<void> {
         try {
             const { tid, referralCode } = this.resolveTrafficCookies(req, res);
 
             // Fire-and-forget — never blocks the response, never throws into the
             // request path. No-ops silently when ClickHouse is unconfigured.
             this.trafficService.recordEvent(
-                buildTrafficEvent('bootstrap', tid, req, {
-                    ...this.extractBootstrapBody(req),
+                buildTrafficEvent(eventType, tid, req, {
+                    ...this.extractEventInputs(req),
                     userId: req.authSession?.user?.id ?? null,
                     referralCode
                 })
@@ -157,9 +190,9 @@ export class BootstrapController {
 
             res.json({ success: true });
         } catch (error) {
-            this.logger.error({ error }, 'Failed to bootstrap analytics traffic event');
+            this.logger.error({ error, eventType }, 'Failed to record analytics traffic event');
             res.status(500).json({
-                error: 'Failed to bootstrap',
+                error: 'Failed to record',
                 message: error instanceof Error ? error.message : 'Unknown error'
             });
         }
@@ -168,14 +201,14 @@ export class BootstrapController {
     }
 
     /**
-     * Pull `landingPath`, `utm`, and `originalReferrer` from the bootstrap body
+     * Pull `landingPath`, `utm`, and `originalReferrer` from the request body
      * and apply storage caps so a hand-rolled direct caller cannot inflate the
-     * ClickHouse row.
+     * ClickHouse row. Shared by the bootstrap and page-event paths.
      *
      * @param req - Express request carrying the (optionally middleware-forwarded) body.
      * @returns The capped, sanitized event-builder inputs.
      */
-    private extractBootstrapBody(req: Request): {
+    private extractEventInputs(req: Request): {
         landingPath?: string;
         utm?: NonNullable<ReturnType<typeof clampUtm>>;
         originalReferrer?: string | null;

--- a/src/backend/modules/traffic/api/bootstrap.routes.ts
+++ b/src/backend/modules/traffic/api/bootstrap.routes.ts
@@ -1,10 +1,14 @@
 /**
- * @fileoverview Router factory for the slim analytics bootstrap endpoint.
+ * @fileoverview Router factories for the public traffic-event ingestion
+ * endpoints.
  *
- * Mounts `POST /api/user/bootstrap` — the first-touch `traffic_events` entry
- * point called by the Next.js middleware and client/direct callers. No auth:
- * the endpoint mints only the unsigned analytics cookies and emits a ClickHouse
- * row. Rate-limited because each call records an event.
+ * Both mount under `/api/user/*`, take no auth (they mint only the unsigned
+ * analytics cookies and emit a ClickHouse row), and are rate-limited because
+ * each call writes a row:
+ * - `POST /api/user/bootstrap` — first-touch `bootstrap`, called by the Next.js
+ *   middleware and client/direct callers.
+ * - `POST /api/user/track` — `page` navigation, called by the client-side
+ *   route-change beacon.
  */
 
 import { Router } from 'express';
@@ -14,7 +18,7 @@ import { createRateLimiter } from '../../../api/middleware/rate-limit.js';
 /**
  * Create the bootstrap router.
  *
- * @param controller - The bootstrap controller.
+ * @param controller - The traffic ingestion controller.
  * @returns Router exposing `POST /` (mounted at `/api/user/bootstrap`).
  */
 export function createBootstrapRouter(controller: BootstrapController): Router {
@@ -29,6 +33,31 @@ export function createBootstrapRouter(controller: BootstrapController): Router {
     });
 
     router.post('/', bootstrapRateLimiter, controller.bootstrap.bind(controller));
+
+    return router;
+}
+
+/**
+ * Create the page-event router.
+ *
+ * The ceiling is higher than bootstrap's: the route-change beacon fires once
+ * per navigation, and an engaged human can legitimately rack up dozens of
+ * page views per minute. It still caps abuse — a runaway client cannot churn
+ * the table without bound.
+ *
+ * @param controller - The traffic ingestion controller.
+ * @returns Router exposing `POST /` (mounted at `/api/user/track`).
+ */
+export function createPageEventRouter(controller: BootstrapController): Router {
+    const router = Router();
+
+    const pageRateLimiter = createRateLimiter({
+        windowSeconds: 60,
+        maxRequests: 60,
+        keyPrefix: 'traffic:page'
+    });
+
+    router.post('/', pageRateLimiter, controller.page.bind(controller));
 
     return router;
 }

--- a/src/backend/modules/traffic/api/traffic.controller.ts
+++ b/src/backend/modules/traffic/api/traffic.controller.ts
@@ -191,6 +191,63 @@ export class TrafficController {
     }
 
     /**
+     * GET /api/admin/users/analytics/tid-activity?period=&limit=&skip=
+     * Per-tid `page`-event clickstream summary for anonymous visitors. Returns
+     * `{ rows, total }` unwrapped — the client reads it directly.
+     */
+    async getTidActivity(req: Request, res: Response): Promise<void> {
+        const range = resolveAnalyticsRange(req.query);
+        const limit = parsePositiveInt(req.query.limit, 50, MAX_LIMIT);
+        const skip = parseNonNegativeInt(req.query.skip, 0);
+        try {
+            res.json(await this.trafficService.getPageActivity('tid', range, limit, skip));
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to fetch tid activity');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to fetch tid activity' });
+        }
+    }
+
+    /**
+     * GET /api/admin/users/analytics/user-activity?period=&limit=&skip=
+     * Per-account `page`-event clickstream summary for registered visitors.
+     * Returns `{ rows, total }` unwrapped — the client reads it directly.
+     */
+    async getUserActivity(req: Request, res: Response): Promise<void> {
+        const range = resolveAnalyticsRange(req.query);
+        const limit = parsePositiveInt(req.query.limit, 50, MAX_LIMIT);
+        const skip = parseNonNegativeInt(req.query.skip, 0);
+        try {
+            res.json(await this.trafficService.getPageActivity('user', range, limit, skip));
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to fetch user activity');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to fetch user activity' });
+        }
+    }
+
+    /**
+     * GET /api/admin/users/analytics/page-hits?subject=tid|user&id=&period=&limit=
+     * The ordered page-hit clickstream for one subject — every page the tid or
+     * account hit in the window, newest first.
+     */
+    async getPageHits(req: Request, res: Response): Promise<void> {
+        const rawSubject = req.query.subject;
+        const subject = rawSubject === 'user' ? 'user' : rawSubject === 'tid' ? 'tid' : null;
+        const id = typeof req.query.id === 'string' ? req.query.id : '';
+        if (!subject || !id) {
+            res.status(400).json({ error: 'ValidationError', message: "subject ('tid'|'user') and id are required" });
+            return;
+        }
+        const range = resolveAnalyticsRange(req.query);
+        const limit = parsePositiveInt(req.query.limit, MAX_HISTORY_LIMIT, MAX_HISTORY_LIMIT);
+        try {
+            res.json({ data: await this.trafficService.getPageHits(subject, id, range, limit) });
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to fetch page hits');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to fetch page hits' });
+        }
+    }
+
+    /**
      * GET /api/admin/users/analytics/traffic-source-details?source=&period=
      * Drill-down breakdown for one referrer source. Returns the
      * `ITrafficSourceDetails` shape unwrapped — the client reads it directly.

--- a/src/backend/modules/traffic/api/traffic.routes.ts
+++ b/src/backend/modules/traffic/api/traffic.routes.ts
@@ -42,6 +42,9 @@ export function createAdminAnalyticsRouter(controller: TrafficController): Route
     router.get('/daily-visitors', controller.getDailyVisitors.bind(controller));
     router.get('/visitor-origins', controller.getVisitorOrigins.bind(controller));
     router.get('/new-users', controller.getNewUsers.bind(controller));
+    router.get('/tid-activity', controller.getTidActivity.bind(controller));
+    router.get('/user-activity', controller.getUserActivity.bind(controller));
+    router.get('/page-hits', controller.getPageHits.bind(controller));
     router.get('/traffic-sources', controller.getTrafficSources.bind(controller));
     router.get('/traffic-source-details', controller.getTrafficSourceDetails.bind(controller));
     router.get('/top-landing-pages', controller.getTopLandingPages.bind(controller));

--- a/src/backend/modules/traffic/services/traffic.service.ts
+++ b/src/backend/modules/traffic/services/traffic.service.ts
@@ -42,6 +42,7 @@ import type { Request } from 'express';
 import type { IClickHouseService, ISystemLogService } from '@/types';
 import { getClientIP, getCountryFromIP, getDeviceCategory } from './geo.service.js';
 import { classifyUserAgent, type BotClass } from './bot-classifier.js';
+import { UUID_V4_REGEX } from '../api/traffic-cookies.js';
 
 /**
  * Categorical event types written to `traffic_events.event_type`.
@@ -303,6 +304,61 @@ export interface ITrafficSourceDetailsResult {
     searchKeywords: Array<{ keyword: string; count: number }>;
     engagement: { avgSessions: number; avgPageViews: number; avgDuration: number };
     conversion: { walletsConnected: number; walletsVerified: number; conversionRate: number };
+}
+
+/**
+ * One row of a page-activity clickstream summary: a subject (a tid for
+ * anonymous visitors, a Better Auth user id for registered ones) with the
+ * lifetime-in-window counts of its `page` events. Powers the per-tid and
+ * per-user activity tables on the traffic dashboard. `firstPath`/`lastPath`
+ * bound the visit; `distinctPaths` separates a deep explorer from a refresher.
+ */
+export interface IPageActivityRow {
+    /** Subject key — the `candidate_uid` (tid) or `user_id`, depending on the read. */
+    id: string;
+    /** Earliest in-window `page` event for the subject. */
+    firstSeen: string;
+    /** Latest in-window `page` event for the subject. */
+    lastSeen: string;
+    /** Total `page` events in the window. */
+    pageViews: number;
+    /** Distinct paths the subject hit in the window. */
+    distinctPaths: number;
+    /** Path of the earliest in-window `page` event. */
+    firstPath: string | null;
+    /** Path of the latest in-window `page` event. */
+    lastPath: string | null;
+    /** Country of the latest in-window event (ISO-3166 alpha-2), or `null`. */
+    country: string | null;
+    /** Device category of the latest in-window event. */
+    device: string;
+}
+
+/** A page of {@link IPageActivityRow} rows plus the unpaginated subject total. */
+export interface IPageActivityPage {
+    rows: IPageActivityRow[];
+    total: number;
+}
+
+/** Which subject column a page-hit drill-down keys on. */
+export type PageHitSubject = 'tid' | 'user';
+
+/**
+ * One `page` event in a subject's clickstream drill-down. The ordered list of
+ * these is the literal "every page they hit" answer the dashboard renders when
+ * an operator expands a {@link IPageActivityRow}.
+ */
+export interface IPageHit {
+    /** Server-side wall clock the page event was recorded at. */
+    timestamp: string;
+    /** The page path. */
+    path: string;
+    /** HTTP `Referer` at the time, or `null`. */
+    referer: string | null;
+    /** Device category. */
+    device: string;
+    /** Country (ISO-3166 alpha-2), or `null`. */
+    country: string | null;
 }
 
 /**
@@ -1155,6 +1211,126 @@ export class TrafficService {
         } catch (error) {
             this.logger.warn({ error }, 'Failed to read traffic source details');
             return empty;
+        }
+    }
+
+    /**
+     * Per-subject `page`-event clickstream summary over the window, newest
+     * activity first. The subject is the analytics tid (`candidate_uid`) for
+     * anonymous browsing or the Better Auth `user_id` for registered browsing;
+     * the two reads are the same shape so the dashboard renders them through one
+     * table component. Only `page` events count — `bootstrap` first-touch rows
+     * (which include bots) are deliberately excluded so this surface reflects
+     * real interactive navigation, not scanner noise.
+     *
+     * @param subject - `'tid'` groups anonymous page hits by `candidate_uid`
+     *   (rows where `user_id IS NULL`); `'user'` groups by `user_id`
+     *   (`user_id IS NOT NULL`).
+     * @param range - Inclusive date window.
+     * @param limit - Page size.
+     * @param skip - Pagination offset.
+     * @returns A page of activity rows plus the unpaginated subject total.
+     */
+    async getPageActivity(subject: PageHitSubject, range: IAnalyticsDateRange, limit = 50, skip = 0): Promise<IPageActivityPage> {
+        if (!this.clickhouse) return { rows: [], total: 0 };
+        const { clause, params } = this.rangeParams(range);
+        // `subject` is a closed union, never user input, so interpolating the
+        // grouping column and its NULL predicate is injection-safe.
+        const idColumn = subject === 'tid' ? 'candidate_uid' : 'user_id';
+        const subjectFilter = subject === 'tid' ? 'user_id IS NULL' : 'user_id IS NOT NULL';
+        const where = `${clause} AND event_type = 'page' AND ${subjectFilter}`;
+        const rowsSql = `
+            SELECT
+                ${idColumn} AS id,
+                min(timestamp) AS firstSeen,
+                max(timestamp) AS lastSeen,
+                count() AS pageViews,
+                uniqExact(path) AS distinctPaths,
+                argMin(path, timestamp) AS firstPath,
+                argMax(path, timestamp) AS lastPath,
+                argMax(country, timestamp) AS country,
+                argMax(device, timestamp) AS device
+            FROM ${TABLE_NAME}
+            WHERE ${where}
+            GROUP BY ${idColumn}
+            ORDER BY lastSeen DESC
+            LIMIT {limit:UInt32} OFFSET {skip:UInt32}
+        `;
+        const countSql = `
+            SELECT uniqExact(${idColumn}) AS total
+            FROM ${TABLE_NAME}
+            WHERE ${where}
+        `;
+        try {
+            const [rows, countRows] = await Promise.all([
+                this.clickhouse.query<{
+                    id: string; firstSeen: string; lastSeen: string;
+                    pageViews: string | number; distinctPaths: string | number;
+                    firstPath: string | null; lastPath: string | null;
+                    country: string | null; device: string;
+                }>(rowsSql, { ...params, limit, skip }),
+                this.clickhouse.query<{ total: string | number }>(countSql, params)
+            ]);
+            return {
+                rows: rows.map(r => ({
+                    id: r.id,
+                    firstSeen: String(r.firstSeen),
+                    lastSeen: String(r.lastSeen),
+                    pageViews: Number(r.pageViews),
+                    distinctPaths: Number(r.distinctPaths),
+                    firstPath: r.firstPath ?? null,
+                    lastPath: r.lastPath ?? null,
+                    country: r.country ?? null,
+                    device: r.device
+                })),
+                total: Number(countRows[0]?.total ?? 0)
+            };
+        } catch (error) {
+            this.logger.warn({ error, subject }, 'Failed to read page activity');
+            return { rows: [], total: 0 };
+        }
+    }
+
+    /**
+     * The ordered `page`-event clickstream for a single subject — literally
+     * every page the tid or account hit in the window, newest first. Backs the
+     * drill-down an operator opens from a {@link IPageActivityRow}.
+     *
+     * @param subject - `'tid'` matches `candidate_uid` (a UUID); `'user'`
+     *   matches `user_id` (an opaque Better Auth id string).
+     * @param id - The subject key. For `'tid'` it must be a UUID; a malformed
+     *   value yields `[]` rather than a ClickHouse type error.
+     * @param range - Inclusive date window.
+     * @param limit - Max page hits to return.
+     * @returns The subject's page hits, newest first.
+     */
+    async getPageHits(subject: PageHitSubject, id: string, range: IAnalyticsDateRange, limit = 200): Promise<IPageHit[]> {
+        if (!this.clickhouse) return [];
+        if (subject === 'tid' && !UUID_V4_REGEX.test(id)) return [];
+        const { clause, params } = this.rangeParams(range);
+        const subjectExpr = subject === 'tid' ? 'candidate_uid = {id:UUID}' : 'user_id = {id:String}';
+        const sql = `
+            SELECT timestamp, path, referer, device, country
+            FROM ${TABLE_NAME}
+            WHERE ${clause} AND event_type = 'page' AND ${subjectExpr}
+            ORDER BY timestamp DESC
+            LIMIT {limit:UInt32}
+        `;
+        try {
+            const rows = await this.clickhouse.query<{
+                timestamp: string; path: string; referer: string | null;
+                device: string; country: string | null;
+            }>(sql, { ...params, id, limit });
+            return rows.map(r => ({
+                timestamp: String(r.timestamp),
+                path: r.path,
+                referer: r.referer ?? null,
+                device: r.device,
+                country: r.country ?? null
+            }));
+        } catch (error) {
+            this.logger.warn({ error, subject }, 'Failed to read page hits');
+            return [];
         }
     }
 }

--- a/src/frontend/app/(core)/system/users/page.module.scss
+++ b/src/frontend/app/(core)/system/users/page.module.scss
@@ -50,3 +50,10 @@
 .content {
     flex: 1;
 }
+
+/* Traffic tab stacks several capture-pattern dashboards vertically. */
+.traffic_stack {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-lg);
+}

--- a/src/frontend/app/(core)/system/users/page.tsx
+++ b/src/frontend/app/(core)/system/users/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useSystemAuth } from '../../../../features/system';
-import { UsersMonitor, AnalyticsDashboard, GscSettings, GroupsManager, TrafficDashboard } from '../../../../modules/user';
+import { UsersMonitor, AnalyticsDashboard, GscSettings, GroupsManager, TrafficDashboard, VisitorAnalytics, PageActivity } from '../../../../modules/user';
 import styles from './page.module.scss';
 
 /** Tab identifiers for the users admin page. */
@@ -12,8 +12,11 @@ type UsersTab = 'users' | 'analytics' | 'traffic' | 'groups' | 'settings';
  * System users administration page with tabbed interface.
  *
  * Tabs consolidate user-related admin functionality:
- * - Users: Per-user identity management, wallet links, activity
+ * - Users: Better Auth account directory and group management
  * - Analytics: Aggregate traffic sources, engagement, conversion funnel
+ * - Traffic: Capture patterns — anonymous first touches (incl. bots), daily
+ *   visitors, anonymous (tid) and registered (user_id) per-page clickstreams,
+ *   and bot/geo/path breakdowns
  * - Groups: Admin-defined user groups consumed by plugins for permission gating
  * - Settings: GSC integration and other admin settings
  *
@@ -67,7 +70,13 @@ export default function SystemUsersPage() {
             <div className={styles.content}>
                 {activeTab === 'users' && <UsersMonitor token={token} />}
                 {activeTab === 'analytics' && <AnalyticsDashboard token={token} />}
-                {activeTab === 'traffic' && <TrafficDashboard token={token} />}
+                {activeTab === 'traffic' && (
+                    <div className={styles.traffic_stack}>
+                        <VisitorAnalytics token={token} />
+                        <PageActivity token={token} />
+                        <TrafficDashboard token={token} />
+                    </div>
+                )}
                 {activeTab === 'groups' && <GroupsManager token={token} />}
                 {activeTab === 'settings' && <GscSettings token={token} />}
             </div>

--- a/src/frontend/app/providers.tsx
+++ b/src/frontend/app/providers.tsx
@@ -10,6 +10,7 @@ import { PluginLoader } from '../components/plugins/PluginLoader';
 import { FrontendPluginContextProvider } from '../lib/frontendPluginContext';
 // Direct imports avoid pulling component CSS via barrel exports
 import { SessionProvider } from '../modules/user/components/SessionProvider';
+import { PageViewTracker } from '../modules/user/components/PageViewTracker';
 import type { ISSRSession } from '../modules/user/lib/session-server';
 
 // Re-export the SSR session shape for layout.tsx
@@ -40,6 +41,7 @@ export function Providers({ children, ssrSession }: ProvidersProps) {
                         <SocketBridge />
                         <SessionProvider initialSession={ssrSession ?? null}>
                             <PluginLoader />
+                            <PageViewTracker />
                             {children}
                         </SessionProvider>
                     </FrontendPluginContextProvider>

--- a/src/frontend/modules/user/api/client.ts
+++ b/src/frontend/modules/user/api/client.ts
@@ -88,15 +88,19 @@ export async function adminGetDailyVisitors(
 }
 
 /**
- * Get new users first seen within the specified period (admin endpoint).
+ * Get anonymous first touches first seen within the specified period (admin
+ * endpoint).
  *
- * Filters by firstSeen (new arrivals) and sorts most recent first.
+ * A first touch is the earliest `bootstrap` row for a cookieless visitor —
+ * server-recorded by the Next.js middleware, so this surface intentionally
+ * includes bots, crawlers, and unfurlers as well as humans. Filtered by global
+ * first-seen (new arrivals in the window) and sorted most recent first.
  *
  * @param token - Admin API token
  * @param options - Period, pagination options
- * @returns Paginated list of new user origins
+ * @returns Paginated list of first-touch origins
  */
-export async function adminGetNewUsers(
+export async function adminGetAnonymousFirstTouches(
     token: string,
     options?: { period?: VisitorPeriod; limit?: number; skip?: number }
 ): Promise<{ visitors: IVisitorOrigin[]; total: number }> {
@@ -105,6 +109,86 @@ export async function adminGetNewUsers(
         params: options
     });
     return response.data as { visitors: IVisitorOrigin[]; total: number };
+}
+
+/** Which subject a page-activity clickstream read keys on. */
+export type PageActivitySubject = 'tid' | 'user';
+
+/**
+ * One row of a page-activity clickstream summary — a subject (an anonymous tid
+ * or a registered account) with its `page`-event counts over the window. Only
+ * interactive `page` events count; first-touch `bootstrap` rows are excluded,
+ * so bots do not appear here.
+ */
+export interface IPageActivityRow {
+    /** Subject key — the analytics tid (UUID) or the Better Auth user id. */
+    id: string;
+    firstSeen: string;
+    lastSeen: string;
+    pageViews: number;
+    distinctPaths: number;
+    firstPath: string | null;
+    lastPath: string | null;
+    country: string | null;
+    device: string;
+}
+
+/** One page hit in a subject's clickstream drill-down. */
+export interface IPageHit {
+    timestamp: string;
+    path: string;
+    referer: string | null;
+    device: string;
+    country: string | null;
+}
+
+/**
+ * Get the per-subject page-activity clickstream summary (admin endpoint).
+ *
+ * `'tid'` returns anonymous visitors keyed on the cookieless traffic id;
+ * `'user'` returns registered accounts keyed on the Better Auth user id.
+ *
+ * @param token - Admin API token
+ * @param subject - `'tid'` (anonymous) or `'user'` (registered)
+ * @param options - Period, pagination options
+ * @returns Paginated activity rows plus the unpaginated subject total
+ */
+export async function adminGetPageActivity(
+    token: string,
+    subject: PageActivitySubject,
+    options?: { period?: VisitorPeriod; limit?: number; skip?: number }
+): Promise<{ rows: IPageActivityRow[]; total: number }> {
+    const endpoint = subject === 'tid'
+        ? '/admin/users/analytics/tid-activity'
+        : '/admin/users/analytics/user-activity';
+    const response = await apiClient.get(endpoint, {
+        headers: { [adminHeaderKey]: token },
+        params: options
+    });
+    return response.data as { rows: IPageActivityRow[]; total: number };
+}
+
+/**
+ * Get the ordered page-hit clickstream for one subject (admin endpoint) —
+ * every page the tid or account hit in the window, newest first.
+ *
+ * @param token - Admin API token
+ * @param subject - `'tid'` (anonymous) or `'user'` (registered)
+ * @param id - The subject key (a UUID for `'tid'`, the user id for `'user'`)
+ * @param options - Period, limit options
+ * @returns The subject's page hits
+ */
+export async function adminGetPageHits(
+    token: string,
+    subject: PageActivitySubject,
+    id: string,
+    options?: { period?: VisitorPeriod; limit?: number }
+): Promise<IPageHit[]> {
+    const response = await apiClient.get('/admin/users/analytics/page-hits', {
+        headers: { [adminHeaderKey]: token },
+        params: { subject, id, ...options }
+    });
+    return (response.data as { data?: IPageHit[] }).data ?? [];
 }
 
 // ============================================================================

--- a/src/frontend/modules/user/api/index.ts
+++ b/src/frontend/modules/user/api/index.ts
@@ -9,7 +9,9 @@
 export {
     // Visitor analytics
     adminGetDailyVisitors,
-    adminGetNewUsers,
+    adminGetAnonymousFirstTouches,
+    adminGetPageActivity,
+    adminGetPageHits,
     // Aggregate analytics functions
     adminGetTrafficSources,
     adminGetTrafficSourceDetails,
@@ -33,6 +35,9 @@ export type {
     IVisitorOrigin,
     IUtmParams,
     VisitorPeriod,
+    PageActivitySubject,
+    IPageActivityRow,
+    IPageHit,
     // Aggregate analytics types
     AnalyticsPeriod,
     ICustomDateRange,

--- a/src/frontend/modules/user/components/PageViewTracker/PageViewTracker.tsx
+++ b/src/frontend/modules/user/components/PageViewTracker/PageViewTracker.tsx
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Page-view tracker.
+ *
+ * Mounted once near the root (in `providers.tsx`), it watches the App Router
+ * pathname and fires a page-view beacon on the initial mount and on every
+ * navigation — capturing both hard loads and client-side soft navigations. It
+ * renders nothing, so there is no SSR/hydration surface.
+ *
+ * Bots that do not run JavaScript never mount this, so the `page` event stream
+ * it feeds is naturally interactive-traffic-only; the cookieless first-touch
+ * (`bootstrap`) stream still captures them server-side via the middleware.
+ */
+
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+import { sendPageView } from '../../lib/pageBeacon';
+
+/**
+ * Emits a page-view beacon whenever the pathname changes (and on first mount).
+ *
+ * @returns Always `null` — this component renders no DOM.
+ */
+export function PageViewTracker(): null {
+    const pathname = usePathname();
+    // Guard against firing twice for the same path: React StrictMode double-runs
+    // effects in dev, and an unrelated re-render must not re-beacon.
+    const lastPath = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!pathname || lastPath.current === pathname) {
+            return;
+        }
+        lastPath.current = pathname;
+        sendPageView(pathname);
+    }, [pathname]);
+
+    return null;
+}

--- a/src/frontend/modules/user/components/PageViewTracker/index.ts
+++ b/src/frontend/modules/user/components/PageViewTracker/index.ts
@@ -1,0 +1,1 @@
+export { PageViewTracker } from './PageViewTracker';

--- a/src/frontend/modules/user/components/admin/PageActivity/PageActivity.module.scss
+++ b/src/frontend/modules/user/components/admin/PageActivity/PageActivity.module.scss
@@ -1,0 +1,223 @@
+/**
+ * PageActivity Styles
+ *
+ * Per-subject page-activity clickstream tables (anonymous tid + registered
+ * user) with an expandable per-row page-hit list. Mirrors the VisitorAnalytics
+ * table treatment; uses container queries for responsive behavior.
+ */
+
+@use '../../../../../app/breakpoints' as *;
+
+.container {
+    container-type: inline-size;
+    container-name: page-activity;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-lg);
+}
+
+.section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+    background: var(--color-surface-muted);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--card-padding-sm);
+}
+
+.section_header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--input-group-gap);
+    flex-wrap: wrap;
+}
+
+.section_title {
+    font-size: var(--font-size-heading-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text);
+    margin: 0;
+}
+
+.toggle_group {
+    display: flex;
+    gap: 0;
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+}
+
+.toggle_btn {
+    padding: var(--padding-xs) var(--gap-md);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-muted);
+    background: var(--color-surface);
+    border: none;
+    cursor: pointer;
+    transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.toggle_btn:hover:not(.toggle_btn__active) {
+    background: var(--color-surface-muted);
+}
+
+.toggle_btn__active {
+    background: var(--color-primary);
+    color: var(--button-primary-color);
+}
+
+.toggle_btn:focus-visible {
+    outline: var(--focus-outline-width) solid var(--color-focus);
+    outline-offset: var(--focus-outline-offset);
+    box-shadow: var(--focus-shadow);
+}
+
+.table_wrapper {
+    overflow-x: auto;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--font-size-body-sm);
+}
+
+.table th {
+    text-align: left;
+    padding: var(--padding-xs) var(--input-group-gap);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-wide);
+    border-bottom: var(--border-width-thin) solid var(--color-border);
+    white-space: nowrap;
+}
+
+.table td {
+    padding: var(--padding-xs) var(--input-group-gap);
+    color: var(--color-text);
+    border-bottom: var(--border-width-thin) solid var(--color-border);
+    vertical-align: middle;
+}
+
+.table tr:hover td {
+    background: var(--color-surface-elevated);
+}
+
+.id_cell {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+    max-width: var(--max-width-xs);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.path_cell {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+    max-width: var(--max-width-xs);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.device_cell {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-subtle);
+}
+
+.muted {
+    color: var(--color-text-subtle);
+}
+
+/* Expanded per-row page-hit clickstream */
+.detail_row td {
+    background: var(--color-surface);
+    padding: var(--card-padding-sm);
+}
+
+.hits {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+}
+
+.hit {
+    display: flex;
+    align-items: baseline;
+    gap: var(--gap-sm);
+    font-size: var(--font-size-caption);
+}
+
+.hit_time {
+    color: var(--color-text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.hit_path {
+    font-family: var(--font-mono);
+    color: var(--color-text);
+    word-break: break-all;
+}
+
+.hit_referer {
+    color: var(--color-text-subtle);
+    max-width: var(--max-width-sm);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: var(--gap-md);
+    padding-top: var(--input-group-gap);
+}
+
+.page_info {
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+}
+
+.loading,
+.empty {
+    padding: var(--card-padding-md);
+    text-align: center;
+    color: var(--color-text-muted);
+}
+
+/* Container query responsive overrides */
+@container page-activity (max-width: #{$breakpoint-mobile-lg}) {
+    .section_header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .hit {
+        flex-direction: column;
+        gap: var(--gap-2xs);
+    }
+}
+
+@container page-activity (max-width: #{$breakpoint-mobile-md}) {
+    .container {
+        gap: var(--gap-md);
+    }
+
+    .section {
+        padding: var(--input-group-gap);
+    }
+}

--- a/src/frontend/modules/user/components/admin/PageActivity/PageActivity.tsx
+++ b/src/frontend/modules/user/components/admin/PageActivity/PageActivity.tsx
@@ -1,0 +1,285 @@
+/**
+ * PageActivity Component
+ *
+ * Per-page clickstream summaries for the two cookie-running audiences, rendered
+ * as sibling tables on the Traffic tab:
+ *
+ * 1. Anonymous Visitor Activity — `page` events keyed on the cookieless traffic
+ *    id (`tid`), for visitors who are not signed in.
+ * 2. Registered User Activity — `page` events keyed on the Better Auth user id.
+ *
+ * Each row summarizes a subject's navigation in the window (page views, distinct
+ * pages, first/last seen, last path) and expands to its full ordered page-hit
+ * list — "every page they hit". Only interactive `page` events feed this; the
+ * cookieless first-touch (`bootstrap`) stream, which includes bots, lives in the
+ * VisitorAnalytics "Anonymous First Touches" table.
+ *
+ * Client-only admin tool: `/system/users` is admin-gated and the token comes
+ * from `SystemAuthContext` at runtime, so the SSR + Live Updates pattern does
+ * not apply — the loading states here are the user-triggered fetch/pagination
+ * case the pattern explicitly permits. Mirrors UsersMonitor / TrafficDashboard.
+ */
+
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { ClientTime } from '../../../../../components/ui/ClientTime';
+import { Button } from '../../../../../components/ui/Button';
+import { adminGetPageActivity, adminGetPageHits } from '../../../api';
+import type { IPageActivityRow, IPageHit, PageActivitySubject, VisitorPeriod } from '../../../api';
+import { getDeviceIcon } from '../../../lib/deviceIcon';
+import styles from './PageActivity.module.scss';
+
+/** Period option labels for display. */
+const PERIOD_LABELS: Record<VisitorPeriod, string> = {
+    '24h': '24 Hours',
+    '7d': '7 Days',
+    '30d': '30 Days',
+    '90d': '90 Days'
+};
+
+/** Rows per activity-table page. */
+const PAGE_LIMIT = 25;
+
+/** Max page hits fetched for a drill-down. */
+const HITS_LIMIT = 200;
+
+interface TableProps {
+    token: string;
+    subject: PageActivitySubject;
+    title: string;
+    description: string;
+    /** Column header for the subject id (e.g. "Traffic ID" / "Account"). */
+    subjectHeading: string;
+}
+
+/**
+ * One subject's page-activity table with a per-row clickstream drill-down.
+ *
+ * @param props - Table configuration.
+ * @returns The rendered activity section.
+ */
+function PageActivityTable({ token, subject, title, description, subjectHeading }: TableProps) {
+    const [period, setPeriod] = useState<VisitorPeriod>('24h');
+    const [rows, setRows] = useState<IPageActivityRow[]>([]);
+    const [total, setTotal] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [page, setPage] = useState(1);
+
+    const [expandedId, setExpandedId] = useState<string | null>(null);
+    const [hits, setHits] = useState<IPageHit[]>([]);
+    const [hitsLoading, setHitsLoading] = useState(false);
+
+    const fetchRows = useCallback(async () => {
+        setLoading(true);
+        try {
+            const result = await adminGetPageActivity(token, subject, {
+                period,
+                limit: PAGE_LIMIT,
+                skip: (page - 1) * PAGE_LIMIT
+            });
+            setRows(result.rows ?? []);
+            setTotal(result.total ?? 0);
+        } catch (error) {
+            console.error('Failed to fetch page activity:', error);
+            setRows([]);
+            setTotal(0);
+        } finally {
+            setLoading(false);
+        }
+    }, [token, subject, period, page]);
+
+    useEffect(() => { fetchRows(); }, [fetchRows]);
+
+    const totalPages = total > 0 ? Math.ceil(total / PAGE_LIMIT) : 1;
+
+    /**
+     * Change the lookback period and reset pagination + any open drill-down.
+     *
+     * @param next - The selected period.
+     */
+    const handlePeriodChange = (next: VisitorPeriod): void => {
+        setPeriod(next);
+        setPage(1);
+        setExpandedId(null);
+    };
+
+    /**
+     * Toggle a row's page-hit drill-down, fetching the clickstream on open.
+     *
+     * @param id - The subject id of the row to expand or collapse.
+     */
+    const toggleExpand = useCallback(async (id: string): Promise<void> => {
+        if (expandedId === id) {
+            setExpandedId(null);
+            return;
+        }
+        setExpandedId(id);
+        setHits([]);
+        setHitsLoading(true);
+        try {
+            const result = await adminGetPageHits(token, subject, id, { period, limit: HITS_LIMIT });
+            setHits(result);
+        } catch (error) {
+            console.error('Failed to fetch page hits:', error);
+            setHits([]);
+        } finally {
+            setHitsLoading(false);
+        }
+    }, [expandedId, token, subject, period]);
+
+    return (
+        <div className={styles.section}>
+            <div className={styles.section_header}>
+                <h2 className={styles.section_title}>{title}</h2>
+                <div className={styles.toggle_group} role="group" aria-label={`${title} time period`}>
+                    {(Object.keys(PERIOD_LABELS) as VisitorPeriod[]).map(option => (
+                        <button
+                            key={option}
+                            className={`${styles.toggle_btn} ${period === option ? styles.toggle_btn__active : ''}`}
+                            onClick={() => handlePeriodChange(option)}
+                            aria-pressed={period === option}
+                        >
+                            {PERIOD_LABELS[option]}
+                        </button>
+                    ))}
+                </div>
+            </div>
+            <p className="text-muted">{description}</p>
+
+            {loading ? (
+                <div className={styles.loading}>Loading activity…</div>
+            ) : rows.length === 0 ? (
+                <div className={styles.empty}>No page activity found in this period.</div>
+            ) : (
+                <>
+                    <div className={styles.table_wrapper}>
+                        <table className={styles.table}>
+                            <thead>
+                                <tr>
+                                    <th>{subjectHeading}</th>
+                                    <th>First Seen</th>
+                                    <th>Last Seen</th>
+                                    <th>Page Views</th>
+                                    <th>Distinct Pages</th>
+                                    <th>Last Path</th>
+                                    <th>Device</th>
+                                    <th><span className="text-muted">Pages</span></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {rows.map(row => (
+                                    <React.Fragment key={row.id}>
+                                        <tr>
+                                            <td className={styles.id_cell} title={row.id}>{row.id}</td>
+                                            <td><ClientTime date={row.firstSeen} format="relative" /></td>
+                                            <td><ClientTime date={row.lastSeen} format="relative" /></td>
+                                            <td>{row.pageViews.toLocaleString()}</td>
+                                            <td>{row.distinctPaths.toLocaleString()}</td>
+                                            <td className={styles.path_cell} title={row.lastPath ?? undefined}>
+                                                {row.lastPath || <span className={styles.muted}>—</span>}
+                                            </td>
+                                            <td className={styles.device_cell}>{getDeviceIcon(row.device)}</td>
+                                            <td>
+                                                <Button
+                                                    size="xs"
+                                                    variant="ghost"
+                                                    onClick={() => toggleExpand(row.id)}
+                                                    aria-expanded={expandedId === row.id}
+                                                    aria-label={`${expandedId === row.id ? 'Hide' : 'View'} pages for ${row.id}`}
+                                                >
+                                                    {expandedId === row.id ? 'Hide' : 'View'}
+                                                </Button>
+                                            </td>
+                                        </tr>
+                                        {expandedId === row.id && (
+                                            <tr className={styles.detail_row}>
+                                                <td colSpan={8}>
+                                                    {hitsLoading ? (
+                                                        <div className={styles.loading}>Loading pages…</div>
+                                                    ) : hits.length === 0 ? (
+                                                        <div className={styles.empty}>No page hits in this window.</div>
+                                                    ) : (
+                                                        <ol className={styles.hits}>
+                                                            {hits.map((hit, index) => (
+                                                                <li key={`${hit.timestamp}_${index}`} className={styles.hit}>
+                                                                    <span className={styles.hit_time}>
+                                                                        <ClientTime date={hit.timestamp} format="datetime" />
+                                                                    </span>
+                                                                    <code className={styles.hit_path}>{hit.path}</code>
+                                                                    {hit.referer && (
+                                                                        <span className={styles.hit_referer} title={hit.referer}>
+                                                                            ← {hit.referer}
+                                                                        </span>
+                                                                    )}
+                                                                </li>
+                                                            ))}
+                                                        </ol>
+                                                    )}
+                                                </td>
+                                            </tr>
+                                        )}
+                                    </React.Fragment>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div className={styles.pagination}>
+                        <Button
+                            onClick={() => setPage(page - 1)}
+                            disabled={page <= 1}
+                            size="sm"
+                            variant="ghost"
+                        >
+                            Previous
+                        </Button>
+                        <span className={styles.page_info}>
+                            Page {page} of {totalPages} ({total.toLocaleString()} {total === 1 ? 'visitor' : 'visitors'})
+                        </span>
+                        <Button
+                            onClick={() => setPage(page + 1)}
+                            disabled={page >= totalPages}
+                            size="sm"
+                            variant="ghost"
+                        >
+                            Next
+                        </Button>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+interface Props {
+    token: string;
+}
+
+/**
+ * PageActivity renders the anonymous-tid and registered-user clickstream tables.
+ *
+ * @param props - Component props.
+ * @param props.token - Admin authentication token for API requests.
+ * @returns The rendered page-activity sections.
+ */
+export function PageActivity({ token }: Props) {
+    return (
+        <div className={styles.container}>
+            <PageActivityTable
+                token={token}
+                subject="tid"
+                title="Anonymous Visitor Activity"
+                subjectHeading="Traffic ID"
+                description="Per-page navigation for cookied anonymous visitors, keyed on the traffic id. Expand a row to see every page they hit."
+            />
+            <PageActivityTable
+                token={token}
+                subject="user"
+                title="Registered User Activity"
+                subjectHeading="Account"
+                description="Per-page navigation for signed-in accounts, keyed on the Better Auth user id. Expand a row to see every page they hit."
+            />
+        </div>
+    );
+}

--- a/src/frontend/modules/user/components/admin/PageActivity/PageActivity.tsx
+++ b/src/frontend/modules/user/components/admin/PageActivity/PageActivity.tsx
@@ -44,7 +44,91 @@ const PAGE_LIMIT = 25;
 /** Max page hits fetched for a drill-down. */
 const HITS_LIMIT = 200;
 
-interface TableProps {
+interface IPageHitsRowProps {
+    token: string;
+    subject: PageActivitySubject;
+    id: string;
+    period: VisitorPeriod;
+}
+
+/**
+ * Expanded clickstream row for a single subject. Self-contained so each open
+ * drill-down owns its fetch — mounting on expand and unmounting on collapse —
+ * which eliminates the shared-state race where a late response from a
+ * previously-open row could render under the currently-open one.
+ *
+ * @param props - The subject to fetch hits for and the active window.
+ * @returns A table row spanning the parent's columns with the page-hit list.
+ */
+function PageHitsRow({ token, subject, id, period }: IPageHitsRowProps) {
+    const [hits, setHits] = useState<IPageHit[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let active = true;
+        /**
+         * Fetch this subject's page hits, dropping the result if the row has
+         * unmounted (collapsed or the table re-fetched) before it resolved.
+         */
+        const fetchHits = async (): Promise<void> => {
+            setLoading(true);
+            try {
+                const result = await adminGetPageHits(token, subject, id, { period, limit: HITS_LIMIT });
+                if (active) {
+                    setHits(result);
+                }
+            } catch (error) {
+                console.error('Failed to fetch page hits:', error);
+                if (active) {
+                    setHits([]);
+                }
+            } finally {
+                if (active) {
+                    setLoading(false);
+                }
+            }
+        };
+        fetchHits();
+        return () => { active = false; };
+    }, [token, subject, id, period]);
+
+    return (
+        <tr className={styles.detail_row}>
+            <td colSpan={8}>
+                {loading ? (
+                    <div className={styles.loading}>Loading pages…</div>
+                ) : hits.length === 0 ? (
+                    <div className={styles.empty}>No page hits in this window.</div>
+                ) : (
+                    <>
+                        <ol className={styles.hits}>
+                            {hits.map((hit, index) => (
+                                <li key={`${hit.timestamp}_${index}`} className={styles.hit}>
+                                    <span className={styles.hit_time}>
+                                        <ClientTime date={hit.timestamp} format="datetime" />
+                                    </span>
+                                    <code className={styles.hit_path}>{hit.path}</code>
+                                    {hit.referer && (
+                                        <span className={styles.hit_referer} title={hit.referer}>
+                                            ← {hit.referer}
+                                        </span>
+                                    )}
+                                </li>
+                            ))}
+                        </ol>
+                        {hits.length >= HITS_LIMIT && (
+                            <p className="text-muted">
+                                Showing the newest {HITS_LIMIT} page hits — more exist in this window.
+                            </p>
+                        )}
+                    </>
+                )}
+            </td>
+        </tr>
+    );
+}
+
+interface IPageActivityTableProps {
     token: string;
     subject: PageActivitySubject;
     title: string;
@@ -59,7 +143,7 @@ interface TableProps {
  * @param props - Table configuration.
  * @returns The rendered activity section.
  */
-function PageActivityTable({ token, subject, title, description, subjectHeading }: TableProps) {
+function PageActivityTable({ token, subject, title, description, subjectHeading }: IPageActivityTableProps) {
     const [period, setPeriod] = useState<VisitorPeriod>('24h');
     const [rows, setRows] = useState<IPageActivityRow[]>([]);
     const [total, setTotal] = useState(0);
@@ -67,29 +151,40 @@ function PageActivityTable({ token, subject, title, description, subjectHeading 
     const [page, setPage] = useState(1);
 
     const [expandedId, setExpandedId] = useState<string | null>(null);
-    const [hits, setHits] = useState<IPageHit[]>([]);
-    const [hitsLoading, setHitsLoading] = useState(false);
 
-    const fetchRows = useCallback(async () => {
-        setLoading(true);
-        try {
-            const result = await adminGetPageActivity(token, subject, {
-                period,
-                limit: PAGE_LIMIT,
-                skip: (page - 1) * PAGE_LIMIT
-            });
-            setRows(result.rows ?? []);
-            setTotal(result.total ?? 0);
-        } catch (error) {
-            console.error('Failed to fetch page activity:', error);
-            setRows([]);
-            setTotal(0);
-        } finally {
-            setLoading(false);
-        }
+    useEffect(() => {
+        let active = true;
+        /**
+         * Fetch the activity page, dropping the result if a newer period/page
+         * selection (or unmount) superseded this request before it resolved.
+         */
+        const fetchRows = async (): Promise<void> => {
+            setLoading(true);
+            try {
+                const result = await adminGetPageActivity(token, subject, {
+                    period,
+                    limit: PAGE_LIMIT,
+                    skip: (page - 1) * PAGE_LIMIT
+                });
+                if (active) {
+                    setRows(result.rows ?? []);
+                    setTotal(result.total ?? 0);
+                }
+            } catch (error) {
+                console.error('Failed to fetch page activity:', error);
+                if (active) {
+                    setRows([]);
+                    setTotal(0);
+                }
+            } finally {
+                if (active) {
+                    setLoading(false);
+                }
+            }
+        };
+        fetchRows();
+        return () => { active = false; };
     }, [token, subject, period, page]);
-
-    useEffect(() => { fetchRows(); }, [fetchRows]);
 
     const totalPages = total > 0 ? Math.ceil(total / PAGE_LIMIT) : 1;
 
@@ -105,28 +200,15 @@ function PageActivityTable({ token, subject, title, description, subjectHeading 
     };
 
     /**
-     * Toggle a row's page-hit drill-down, fetching the clickstream on open.
+     * Toggle a row's page-hit drill-down open or closed. The expanded row owns
+     * its own fetch (see {@link PageHitsRow}), so this only flips which row is
+     * open — there is no shared hit state to race.
      *
      * @param id - The subject id of the row to expand or collapse.
      */
-    const toggleExpand = useCallback(async (id: string): Promise<void> => {
-        if (expandedId === id) {
-            setExpandedId(null);
-            return;
-        }
-        setExpandedId(id);
-        setHits([]);
-        setHitsLoading(true);
-        try {
-            const result = await adminGetPageHits(token, subject, id, { period, limit: HITS_LIMIT });
-            setHits(result);
-        } catch (error) {
-            console.error('Failed to fetch page hits:', error);
-            setHits([]);
-        } finally {
-            setHitsLoading(false);
-        }
-    }, [expandedId, token, subject, period]);
+    const toggleExpand = useCallback((id: string): void => {
+        setExpandedId(prev => (prev === id ? null : id));
+    }, []);
 
     return (
         <div className={styles.section}>
@@ -193,31 +275,7 @@ function PageActivityTable({ token, subject, title, description, subjectHeading 
                                             </td>
                                         </tr>
                                         {expandedId === row.id && (
-                                            <tr className={styles.detail_row}>
-                                                <td colSpan={8}>
-                                                    {hitsLoading ? (
-                                                        <div className={styles.loading}>Loading pages…</div>
-                                                    ) : hits.length === 0 ? (
-                                                        <div className={styles.empty}>No page hits in this window.</div>
-                                                    ) : (
-                                                        <ol className={styles.hits}>
-                                                            {hits.map((hit, index) => (
-                                                                <li key={`${hit.timestamp}_${index}`} className={styles.hit}>
-                                                                    <span className={styles.hit_time}>
-                                                                        <ClientTime date={hit.timestamp} format="datetime" />
-                                                                    </span>
-                                                                    <code className={styles.hit_path}>{hit.path}</code>
-                                                                    {hit.referer && (
-                                                                        <span className={styles.hit_referer} title={hit.referer}>
-                                                                            ← {hit.referer}
-                                                                        </span>
-                                                                    )}
-                                                                </li>
-                                                            ))}
-                                                        </ol>
-                                                    )}
-                                                </td>
-                                            </tr>
+                                            <PageHitsRow token={token} subject={subject} id={row.id} period={period} />
                                         )}
                                     </React.Fragment>
                                 ))}
@@ -252,7 +310,7 @@ function PageActivityTable({ token, subject, title, description, subjectHeading 
     );
 }
 
-interface Props {
+interface IPageActivityProps {
     token: string;
 }
 
@@ -263,7 +321,7 @@ interface Props {
  * @param props.token - Admin authentication token for API requests.
  * @returns The rendered page-activity sections.
  */
-export function PageActivity({ token }: Props) {
+export function PageActivity({ token }: IPageActivityProps) {
     return (
         <div className={styles.container}>
             <PageActivityTable

--- a/src/frontend/modules/user/components/admin/PageActivity/index.ts
+++ b/src/frontend/modules/user/components/admin/PageActivity/index.ts
@@ -1,0 +1,1 @@
+export { PageActivity } from './PageActivity';

--- a/src/frontend/modules/user/components/admin/UsersMonitor/UsersMonitor.tsx
+++ b/src/frontend/modules/user/components/admin/UsersMonitor/UsersMonitor.tsx
@@ -8,7 +8,6 @@ import { Badge } from '../../../../../components/ui/Badge';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { useModal } from '../../../../../components/ui/ModalProvider';
 import { useToast } from '../../../../../components/ui/ToastProvider';
-import { VisitorAnalytics } from '../VisitorAnalytics';
 import { UserGroupsForm } from './UserGroupsForm';
 import styles from './UsersMonitor.module.scss';
 
@@ -50,8 +49,9 @@ interface Props {
  * membership, and opens the group-membership editor per account.
  *
  * Account-count and wallet-adoption overviews live in the Analytics tab
- * (`AnalyticsDashboard`); this view embeds `VisitorAnalytics` for the
- * new-arrivals panel and otherwise focuses on the account list.
+ * (`AnalyticsDashboard`); first-touch and per-page traffic analytics moved to
+ * the Traffic tab (`VisitorAnalytics` / `PageActivity`). This view focuses on
+ * the account list.
  *
  * Client-only admin tool: `/system/users` is admin-gated and the token comes
  * from `SystemAuthContext` at runtime, so the SSR + Live Updates pattern does
@@ -184,8 +184,6 @@ export function UsersMonitor({ token }: Props) {
                     Better Auth accounts — search by email or name and manage group membership
                 </p>
             </header>
-
-            <VisitorAnalytics token={token} />
 
             <div className={styles.controls}>
                 <div className={styles.search_box}>

--- a/src/frontend/modules/user/components/admin/VisitorAnalytics/VisitorAnalytics.tsx
+++ b/src/frontend/modules/user/components/admin/VisitorAnalytics/VisitorAnalytics.tsx
@@ -1,27 +1,32 @@
 /**
  * VisitorAnalytics Component
  *
- * Admin analytics dashboard displaying daily visitor trends and a new
- * users table.
+ * Admin analytics displaying daily visitor trends and the anonymous
+ * first-touches table.
  *
  * Renders two sections:
  * 1. Daily visitors chart with 30d/90d toggle
- * 2. New users table showing recently arrived users sorted by first seen date
+ * 2. Anonymous first touches table — the earliest cookieless `bootstrap` row
+ *    for each visitor in the window, newest first. Recorded server-side by the
+ *    Next.js middleware, so it deliberately includes bots, crawlers, and
+ *    unfurlers alongside humans; that first-touch noise is itself the signal.
+ *    Per-page clickstream for cookied (tid) and registered (user_id) visitors
+ *    lives in the sibling PageActivity sections.
  */
 
 'use client';
 
 import React, { useEffect, useState, useCallback } from 'react';
-import { Smartphone, Tablet, Monitor, HelpCircle } from 'lucide-react';
 import { LineChart } from '../../../../../features/charts/components/LineChart';
 import type { ChartSeries } from '../../../../../features/charts/components/LineChart';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { Button } from '../../../../../components/ui/Button';
 import {
     adminGetDailyVisitors,
-    adminGetNewUsers
+    adminGetAnonymousFirstTouches
 } from '../../../api';
 import type { IDailyVisitorData, IVisitorOrigin, VisitorPeriod } from '../../../api';
+import { getDeviceIcon } from '../../../lib/deviceIcon';
 import styles from './VisitorAnalytics.module.scss';
 
 /**
@@ -35,24 +40,6 @@ function resolveCSSColor(varName: string, fallback: string): string {
     if (typeof document === 'undefined') return fallback;
     const value = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
     return value || fallback;
-}
-
-/** Device icon size for inline table display. */
-const DEVICE_ICON_SIZE = 14;
-
-/**
- * Get device icon for display in the visitors table.
- *
- * @param device - Device category string
- * @returns JSX element for the device icon
- */
-function getDeviceIcon(device: string): JSX.Element {
-    switch (device) {
-        case 'mobile': return <Smartphone size={DEVICE_ICON_SIZE} aria-label="Mobile device" />;
-        case 'tablet': return <Tablet size={DEVICE_ICON_SIZE} aria-label="Tablet device" />;
-        case 'desktop': return <Monitor size={DEVICE_ICON_SIZE} aria-label="Desktop device" />;
-        default: return <HelpCircle size={DEVICE_ICON_SIZE} aria-label="Unknown device" />;
-    }
 }
 
 /**
@@ -89,8 +76,8 @@ interface Props {
 /**
  * VisitorAnalytics displays aggregate visitor analytics for the admin dashboard.
  *
- * Includes a daily visitor trend chart (30d/90d) and a new users table
- * showing first-session acquisition data (original referrer, landing page,
+ * Includes a daily visitor trend chart (30d/90d) and an anonymous first-touches
+ * table showing first-touch acquisition data (original referrer, landing page,
  * country, device, UTM) for SEO and marketing analysis.
  *
  * @param props - Component props
@@ -101,12 +88,12 @@ export function VisitorAnalytics({ token }: Props) {
     const [chartData, setChartData] = useState<IDailyVisitorData[]>([]);
     const [chartLoading, setChartLoading] = useState(true);
 
-    const [newUsersPeriod, setNewUsersPeriod] = useState<VisitorPeriod>('24h');
-    const [newUsers, setNewUsers] = useState<IVisitorOrigin[]>([]);
-    const [newUsersTotal, setNewUsersTotal] = useState(0);
-    const [newUsersLoading, setNewUsersLoading] = useState(true);
-    const [newUsersPage, setNewUsersPage] = useState(1);
-    const newUsersLimit = 25;
+    const [firstTouchesPeriod, setFirstTouchesPeriod] = useState<VisitorPeriod>('24h');
+    const [firstTouches, setFirstTouches] = useState<IVisitorOrigin[]>([]);
+    const [firstTouchesTotal, setFirstTouchesTotal] = useState(0);
+    const [firstTouchesLoading, setFirstTouchesLoading] = useState(true);
+    const [firstTouchesPage, setFirstTouchesPage] = useState(1);
+    const firstTouchesLimit = 25;
 
     /**
      * Fetch daily visitor chart data using typed API client.
@@ -126,29 +113,29 @@ export function VisitorAnalytics({ token }: Props) {
     }, [token, chartRange]);
 
     /**
-     * Fetch new users using typed API client.
+     * Fetch anonymous first touches using typed API client.
      */
-    const fetchNewUsers = useCallback(async () => {
-        setNewUsersLoading(true);
+    const fetchFirstTouches = useCallback(async () => {
+        setFirstTouchesLoading(true);
         try {
-            const result = await adminGetNewUsers(token, {
-                period: newUsersPeriod,
-                limit: newUsersLimit,
-                skip: (newUsersPage - 1) * newUsersLimit
+            const result = await adminGetAnonymousFirstTouches(token, {
+                period: firstTouchesPeriod,
+                limit: firstTouchesLimit,
+                skip: (firstTouchesPage - 1) * firstTouchesLimit
             });
-            setNewUsers(result.visitors ?? []);
-            setNewUsersTotal(result.total ?? 0);
+            setFirstTouches(result.visitors ?? []);
+            setFirstTouchesTotal(result.total ?? 0);
         } catch (error) {
-            console.error('Failed to fetch new users:', error);
-            setNewUsers([]);
-            setNewUsersTotal(0);
+            console.error('Failed to fetch anonymous first touches:', error);
+            setFirstTouches([]);
+            setFirstTouchesTotal(0);
         } finally {
-            setNewUsersLoading(false);
+            setFirstTouchesLoading(false);
         }
-    }, [token, newUsersPeriod, newUsersPage]);
+    }, [token, firstTouchesPeriod, firstTouchesPage]);
 
     useEffect(() => { fetchChartData(); }, [fetchChartData]);
-    useEffect(() => { fetchNewUsers(); }, [fetchNewUsers]);
+    useEffect(() => { fetchFirstTouches(); }, [fetchFirstTouches]);
 
     /**
      * Build chart series from daily visitor data.
@@ -171,16 +158,16 @@ export function VisitorAnalytics({ token }: Props) {
     minDate.setDate(minDate.getDate() - chartDays);
     minDate.setHours(0, 0, 0, 0);
 
-    const totalNewUsersPages = newUsersTotal > 0 ? Math.ceil(newUsersTotal / newUsersLimit) : 1;
+    const totalFirstTouchesPages = firstTouchesTotal > 0 ? Math.ceil(firstTouchesTotal / firstTouchesLimit) : 1;
 
     /**
-     * Handle period change and reset pagination for new users.
+     * Handle period change and reset pagination for first touches.
      *
      * @param period - The new period to filter by
      */
-    const handleNewUsersPeriodChange = (period: VisitorPeriod): void => {
-        setNewUsersPeriod(period);
-        setNewUsersPage(1);
+    const handleFirstTouchesPeriodChange = (period: VisitorPeriod): void => {
+        setFirstTouchesPeriod(period);
+        setFirstTouchesPage(1);
     };
 
     return (
@@ -223,28 +210,33 @@ export function VisitorAnalytics({ token }: Props) {
                 </div>
             </div>
 
-            {/* New Users Table */}
+            {/* Anonymous First Touches Table */}
             <div className={styles.section}>
                 <div className={styles.section_header}>
-                    <h2 className={styles.section_title}>New Users</h2>
-                    <div className={styles.toggle_group} role="group" aria-label="New users time period">
+                    <h2 className={styles.section_title}>Anonymous First Touches</h2>
+                    <div className={styles.toggle_group} role="group" aria-label="Anonymous first touches time period">
                         {(Object.keys(PERIOD_LABELS) as VisitorPeriod[]).map(period => (
                             <button
                                 key={period}
-                                className={`${styles.toggle_btn} ${newUsersPeriod === period ? styles.toggle_btn__active : ''}`}
-                                onClick={() => handleNewUsersPeriodChange(period)}
-                                aria-pressed={newUsersPeriod === period}
+                                className={`${styles.toggle_btn} ${firstTouchesPeriod === period ? styles.toggle_btn__active : ''}`}
+                                onClick={() => handleFirstTouchesPeriodChange(period)}
+                                aria-pressed={firstTouchesPeriod === period}
                             >
                                 {PERIOD_LABELS[period]}
                             </button>
                         ))}
                     </div>
                 </div>
+                <p className="text-muted">
+                    The first cookieless hit per visitor — server-recorded, so bots and crawlers
+                    are included by design. Per-page activity for cookied and registered visitors
+                    is in the sections below.
+                </p>
 
-                {newUsersLoading ? (
-                    <div className={styles.loading}>Loading new users...</div>
-                ) : newUsers.length === 0 ? (
-                    <div className={styles.empty}>No new users found in this period.</div>
+                {firstTouchesLoading ? (
+                    <div className={styles.loading}>Loading first touches...</div>
+                ) : firstTouches.length === 0 ? (
+                    <div className={styles.empty}>No anonymous first touches found in this period.</div>
                 ) : (
                     <>
                         <div className={styles.table_wrapper}>
@@ -262,31 +254,31 @@ export function VisitorAnalytics({ token }: Props) {
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {newUsers.map(user => {
-                                        const utmDisplay = formatUtm(user.utm);
+                                    {firstTouches.map(touch => {
+                                        const utmDisplay = formatUtm(touch.utm);
 
                                         return (
-                                            <tr key={user.userId}>
+                                            <tr key={touch.userId}>
                                                 <td>
-                                                    <ClientTime date={user.firstSeen} format="relative" />
+                                                    <ClientTime date={touch.firstSeen} format="relative" />
                                                 </td>
                                                 <td className={styles.country_cell}>
-                                                    {user.country || <span className={styles.muted}>—</span>}
+                                                    {touch.country || <span className={styles.muted}>—</span>}
                                                 </td>
-                                                <td className={styles.referrer_cell} title={user.referrerDomain ?? undefined}>
-                                                    {user.referrerDomain || <span className={styles.muted}>direct</span>}
+                                                <td className={styles.referrer_cell} title={touch.referrerDomain ?? undefined}>
+                                                    {touch.referrerDomain || <span className={styles.muted}>direct</span>}
                                                 </td>
-                                                <td className={styles.landing_cell} title={user.landingPage ?? undefined}>
-                                                    {user.landingPage || <span className={styles.muted}>—</span>}
+                                                <td className={styles.landing_cell} title={touch.landingPage ?? undefined}>
+                                                    {touch.landingPage || <span className={styles.muted}>—</span>}
                                                 </td>
                                                 <td className={styles.utm_cell} title={utmDisplay ?? undefined}>
                                                     {utmDisplay || <span className={styles.muted}>—</span>}
                                                 </td>
                                                 <td className={styles.device_cell}>
-                                                    {getDeviceIcon(user.device)}
+                                                    {getDeviceIcon(touch.device)}
                                                 </td>
-                                                <td>{user.pageViews.toLocaleString()}</td>
-                                                <td>{user.sessionsCount.toLocaleString()}</td>
+                                                <td>{touch.pageViews.toLocaleString()}</td>
+                                                <td>{touch.sessionsCount.toLocaleString()}</td>
                                             </tr>
                                         );
                                     })}
@@ -296,19 +288,19 @@ export function VisitorAnalytics({ token }: Props) {
 
                         <div className={styles.pagination}>
                             <Button
-                                onClick={() => setNewUsersPage(newUsersPage - 1)}
-                                disabled={newUsersPage <= 1}
+                                onClick={() => setFirstTouchesPage(firstTouchesPage - 1)}
+                                disabled={firstTouchesPage <= 1}
                                 size="sm"
                                 variant="ghost"
                             >
                                 Previous
                             </Button>
                             <span className={styles.page_info}>
-                                Page {newUsersPage} of {totalNewUsersPages} ({newUsersTotal.toLocaleString()} new users)
+                                Page {firstTouchesPage} of {totalFirstTouchesPages} ({firstTouchesTotal.toLocaleString()} first touches)
                             </span>
                             <Button
-                                onClick={() => setNewUsersPage(newUsersPage + 1)}
-                                disabled={newUsersPage >= totalNewUsersPages}
+                                onClick={() => setFirstTouchesPage(firstTouchesPage + 1)}
+                                disabled={firstTouchesPage >= totalFirstTouchesPages}
                                 size="sm"
                                 variant="ghost"
                             >

--- a/src/frontend/modules/user/components/admin/VisitorAnalytics/VisitorAnalytics.tsx
+++ b/src/frontend/modules/user/components/admin/VisitorAnalytics/VisitorAnalytics.tsx
@@ -112,30 +112,41 @@ export function VisitorAnalytics({ token }: Props) {
         }
     }, [token, chartRange]);
 
-    /**
-     * Fetch anonymous first touches using typed API client.
-     */
-    const fetchFirstTouches = useCallback(async () => {
-        setFirstTouchesLoading(true);
-        try {
-            const result = await adminGetAnonymousFirstTouches(token, {
-                period: firstTouchesPeriod,
-                limit: firstTouchesLimit,
-                skip: (firstTouchesPage - 1) * firstTouchesLimit
-            });
-            setFirstTouches(result.visitors ?? []);
-            setFirstTouchesTotal(result.total ?? 0);
-        } catch (error) {
-            console.error('Failed to fetch anonymous first touches:', error);
-            setFirstTouches([]);
-            setFirstTouchesTotal(0);
-        } finally {
-            setFirstTouchesLoading(false);
-        }
-    }, [token, firstTouchesPeriod, firstTouchesPage]);
-
     useEffect(() => { fetchChartData(); }, [fetchChartData]);
-    useEffect(() => { fetchFirstTouches(); }, [fetchFirstTouches]);
+
+    useEffect(() => {
+        let active = true;
+        /**
+         * Fetch the first-touches page, dropping the result if a newer
+         * period/page selection (or unmount) superseded it before resolving.
+         */
+        const fetchFirstTouches = async (): Promise<void> => {
+            setFirstTouchesLoading(true);
+            try {
+                const result = await adminGetAnonymousFirstTouches(token, {
+                    period: firstTouchesPeriod,
+                    limit: firstTouchesLimit,
+                    skip: (firstTouchesPage - 1) * firstTouchesLimit
+                });
+                if (active) {
+                    setFirstTouches(result.visitors ?? []);
+                    setFirstTouchesTotal(result.total ?? 0);
+                }
+            } catch (error) {
+                console.error('Failed to fetch anonymous first touches:', error);
+                if (active) {
+                    setFirstTouches([]);
+                    setFirstTouchesTotal(0);
+                }
+            } finally {
+                if (active) {
+                    setFirstTouchesLoading(false);
+                }
+            }
+        };
+        fetchFirstTouches();
+        return () => { active = false; };
+    }, [token, firstTouchesPeriod, firstTouchesPage]);
 
     /**
      * Build chart series from daily visitor data.

--- a/src/frontend/modules/user/components/admin/index.ts
+++ b/src/frontend/modules/user/components/admin/index.ts
@@ -7,6 +7,7 @@
 
 export { UsersMonitor } from './UsersMonitor';
 export { VisitorAnalytics } from './VisitorAnalytics';
+export { PageActivity } from './PageActivity';
 export { AnalyticsDashboard } from './AnalyticsDashboard';
 export { GscSettings } from './GscSettings';
 export { GroupsManager } from './GroupsManager';

--- a/src/frontend/modules/user/components/index.ts
+++ b/src/frontend/modules/user/components/index.ts
@@ -17,6 +17,7 @@ export type { IProfileMenuProps } from './ProfileMenu';
 // Admin components
 export { UsersMonitor } from './admin';
 export { VisitorAnalytics } from './admin';
+export { PageActivity } from './admin';
 export { AnalyticsDashboard } from './admin';
 export { GscSettings } from './admin';
 export { GroupsManager } from './admin';

--- a/src/frontend/modules/user/index.ts
+++ b/src/frontend/modules/user/index.ts
@@ -36,6 +36,7 @@ export type { IProfileMenuProps } from './components';
 
 export { UsersMonitor } from './components';
 export { VisitorAnalytics } from './components';
+export { PageActivity } from './components';
 export { AnalyticsDashboard } from './components';
 export { GscSettings } from './components';
 export { GroupsManager } from './components';

--- a/src/frontend/modules/user/lib/deviceIcon.tsx
+++ b/src/frontend/modules/user/lib/deviceIcon.tsx
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Shared device-category icon helper for the analytics tables.
+ *
+ * Extracted so the first-touches table and the page-activity tables render the
+ * same glyph for a given device category without duplicating the switch.
+ */
+
+import { Smartphone, Tablet, Monitor, HelpCircle } from 'lucide-react';
+
+/** Default inline icon size for analytics table cells. */
+const DEFAULT_DEVICE_ICON_SIZE = 14;
+
+/**
+ * Map a device-category string to its Lucide icon.
+ *
+ * @param device - Device category (`'mobile'` | `'tablet'` | `'desktop'` | other).
+ * @param size - Icon pixel size.
+ * @returns The icon element.
+ */
+export function getDeviceIcon(device: string, size: number = DEFAULT_DEVICE_ICON_SIZE): JSX.Element {
+    switch (device) {
+        case 'mobile': return <Smartphone size={size} aria-label="Mobile device" />;
+        case 'tablet': return <Tablet size={size} aria-label="Tablet device" />;
+        case 'desktop': return <Monitor size={size} aria-label="Desktop device" />;
+        default: return <HelpCircle size={size} aria-label="Unknown device" />;
+    }
+}

--- a/src/frontend/modules/user/lib/pageBeacon.ts
+++ b/src/frontend/modules/user/lib/pageBeacon.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Client-side page-view beacon.
+ *
+ * Fires a fire-and-forget `page` traffic event to `POST /api/user/track` on
+ * every navigation. Prefers `navigator.sendBeacon` (which survives page unload)
+ * and falls back to a `keepalive` fetch.
+ *
+ * The analytics tid cookie is `httpOnly`, so it is deliberately never read here.
+ * The request is same-origin, so the browser attaches the cookie automatically
+ * and the backend resolves the tid from it (and the account from the Better Auth
+ * session) — the client only needs to report the path it landed on. Soft (App
+ * Router) navigations never round-trip the server, so this client beacon is the
+ * only way to capture them; hard loads are covered too because the tracker fires
+ * on mount.
+ */
+
+import { getRuntimeConfig } from '../../../lib/runtimeConfig';
+
+/**
+ * Send one page-view beacon for the given path. Best-effort: any failure is
+ * swallowed so analytics never interferes with navigation.
+ *
+ * @param path - The path the visitor navigated to (query string is dropped
+ *   server-side; pass the bare pathname).
+ * @returns Nothing — the call is fire-and-forget.
+ */
+export function sendPageView(path: string): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        const url = `${getRuntimeConfig().apiUrl}/user/track`;
+        const body = JSON.stringify({
+            landingPath: path,
+            originalReferrer: typeof document !== 'undefined' ? document.referrer || null : null
+        });
+
+        // sendBeacon survives an unload that would abort a normal fetch. The
+        // Blob carries the JSON content type so the backend body parser reads it.
+        if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+            const blob = new Blob([body], { type: 'application/json' });
+            if (navigator.sendBeacon(url, blob)) {
+                return;
+            }
+        }
+
+        // Fallback for browsers without sendBeacon (or a queue rejection).
+        void fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body,
+            credentials: 'include',
+            keepalive: true
+        }).catch(() => {
+            /* analytics is best-effort — never surface a navigation error */
+        });
+    } catch {
+        /* never throw into the navigation path */
+    }
+
+    return;
+}


### PR DESCRIPTION
## What

Extends the traffic module from cookieless first-touch capture to a full per-page clickstream for both anonymous (tid) and registered (user_id) visitors, and reorganizes the `/system/users` dashboard around the capture patterns.

## Capture
- New `page` event written via a shared `BootstrapController.record(eventType)` and a `page()` handler behind the public, rate-limited `POST /api/user/track` route.
- Client-side route-change beacon (`PageViewTracker` mounted in `providers.tsx` + `lib/pageBeacon`) fires on mount and every soft navigation. Bots that don't run JS never reach it, so the `page` stream is interactive-traffic-only; `bootstrap` continues to capture cookieless first touches (including bots).
- No migration — `traffic_events` already has every column `page` needs (`event_type` is `LowCardinality(String)`).

## Reads
- `TrafficService.getPageActivity(subject)` summarizes `page` events per tid (`user_id IS NULL`) or per account (`user_id IS NOT NULL`); `getPageHits` returns one subject's ordered clickstream.
- Exposed at `/api/admin/users/analytics/{tid-activity,user-activity,page-hits}`.

## Dashboard
- "New Users" renamed to **Anonymous First Touches** and moved (with Daily Visitors) out of the Users tab into the **Traffic** tab.
- New `PageActivity` component: anonymous-tid and registered-user activity tables, each row expandable to its full page-hit list.
- Users tab now focuses on the account directory.

## Verification
- `tsc --noEmit` clean (backend + frontend); 90 traffic-module tests pass, including new coverage for the `page` write path and both clickstream reads.
- Not yet runtime-verified against a live ClickHouse/browser — the new SQL is unit-tested at the query-string level only (same posture as the existing `new-users` read).