### PR TITLE
Fix traffic analytics first-seen timestamps rendering as 'just now'

### DIFF
--- a/src/backend/modules/traffic/__tests__/traffic.service.test.ts
+++ b/src/backend/modules/traffic/__tests__/traffic.service.test.ts
@@ -379,7 +379,9 @@ describe('TrafficService', () => {
             expect(captured.sql).toContain('candidate_uid = {id:UUID}');
             expect(captured.sql).toContain("event_type = 'page'");
             expect(captured.params?.id).toBe('550e8400-e29b-41d4-a716-446655440000');
-            expect(out).toEqual([{ timestamp: '2026-04-30 10:05:00.000', path: '/markets', referer: null, device: 'desktop', country: 'US' }]);
+            // The suffix-less ClickHouse timestamp is normalized to ISO-8601 UTC so
+            // the frontend's `new Date(...)` parses it as UTC, not local time.
+            expect(out).toEqual([{ timestamp: '2026-04-30T10:05:00.000Z', path: '/markets', referer: null, device: 'desktop', country: 'US' }]);
         });
 
         it('matches user_id for a user subject', async () => {

--- a/src/backend/modules/traffic/__tests__/traffic.service.test.ts
+++ b/src/backend/modules/traffic/__tests__/traffic.service.test.ts
@@ -319,6 +319,10 @@ describe('TrafficService', () => {
             expect(joined).toContain('GROUP BY candidate_uid');
             expect(out.total).toBe(3);
             expect(out.rows[0]).toMatchObject({ id: 'tid-1', pageViews: 4, distinctPaths: 3, lastPath: '/markets' });
+            // ClickHouse's native suffix-less DateTime is normalized to ISO-8601 UTC
+            // so the frontend's `new Date(...)` parses it as UTC, not local time.
+            expect(out.rows[0].firstSeen).toBe('2026-04-30T10:00:00.000Z');
+            expect(out.rows[0].lastSeen).toBe('2026-04-30T10:05:00.000Z');
         });
 
         it('groups registered activity on user_id with user_id IS NOT NULL', async () => {

--- a/src/backend/modules/traffic/services/traffic.service.ts
+++ b/src/backend/modules/traffic/services/traffic.service.ts
@@ -723,7 +723,7 @@ export class TrafficService {
             }>(sql, { ...params, limit, skip });
             return rows.map(r => ({
                 candidateUid: r.candidateUid,
-                firstSeen: String(r.firstSeen),
+                firstSeen: clickHouseDateToIso(String(r.firstSeen)),
                 path: r.path,
                 referer: r.referer,
                 utmSource: r.utmSource,
@@ -1081,8 +1081,8 @@ export class TrafficService {
                 const hasUtm = Boolean(r.utmSource || r.utmMedium || r.utmCampaign || r.utmTerm || r.utmContent);
                 return {
                     userId: r.userId,
-                    firstSeen: String(r.firstSeen),
-                    lastSeen: String(r.lastSeen),
+                    firstSeen: clickHouseDateToIso(String(r.firstSeen)),
+                    lastSeen: clickHouseDateToIso(String(r.lastSeen)),
                     country: r.country ?? null,
                     referrerDomain: r.referrerDomain ?? null,
                     landingPage: r.landingPage ?? null,
@@ -1274,8 +1274,8 @@ export class TrafficService {
             return {
                 rows: rows.map(r => ({
                     id: r.id,
-                    firstSeen: String(r.firstSeen),
-                    lastSeen: String(r.lastSeen),
+                    firstSeen: clickHouseDateToIso(String(r.firstSeen)),
+                    lastSeen: clickHouseDateToIso(String(r.lastSeen)),
                     pageViews: Number(r.pageViews),
                     distinctPaths: Number(r.distinctPaths),
                     firstPath: r.firstPath ?? null,
@@ -1534,6 +1534,24 @@ function parseClickHouseDateTime64Utc(value: string): Date {
         Number(second),
         Number(milliseconds.padEnd(3, '0'))
     ));
+}
+
+/**
+ * Convert a ClickHouse native `DateTime64(3)` string to an ISO-8601 UTC string.
+ *
+ * Aggregate reads (`min`/`max`/`argMin` over `timestamp`) return the column's
+ * native `YYYY-MM-DD HH:MM:SS.mmm` form with no zone suffix. The frontend's
+ * `new Date(value)` parses that space-separated, suffix-less form as *local*
+ * time, shifting every value by the viewer's UTC offset and skewing relative
+ * ages — west-of-UTC offsets push recent rows into the future, which renders
+ * as "just now" indefinitely. Emitting ISO-8601 with the `Z` suffix keeps the
+ * wire value unambiguously UTC so the client parses it correctly.
+ *
+ * @param value - ClickHouse native DateTime64 string.
+ * @returns ISO-8601 UTC string (with `Z` suffix).
+ */
+function clickHouseDateToIso(value: string): string {
+    return parseClickHouseDateTime64Utc(value).toISOString();
 }
 
 /**

--- a/src/backend/modules/traffic/services/traffic.service.ts
+++ b/src/backend/modules/traffic/services/traffic.service.ts
@@ -1322,7 +1322,7 @@ export class TrafficService {
                 device: string; country: string | null;
             }>(sql, { ...params, id, limit });
             return rows.map(r => ({
-                timestamp: String(r.timestamp),
+                timestamp: clickHouseDateToIso(String(r.timestamp)),
                 path: r.path,
                 referer: r.referer ?? null,
                 device: r.device,
@@ -1551,7 +1551,8 @@ function parseClickHouseDateTime64Utc(value: string): Date {
  * @returns ISO-8601 UTC string (with `Z` suffix).
  */
 function clickHouseDateToIso(value: string): string {
-    return parseClickHouseDateTime64Utc(value).toISOString();
+    const date = parseClickHouseDateTime64Utc(value);
+    return Number.isNaN(date.getTime()) ? value : date.toISOString();
 }
 
 /**


### PR DESCRIPTION
## Problem

On `/system/users`, every **Anonymous First Touches** "First Seen" entry was stuck on "just now" regardless of the row's actual age.

## Root cause

ClickHouse aggregate reads (`min`/`max` over `timestamp`) return the column's native `DateTime64(3)` form — `YYYY-MM-DD HH:MM:SS.mmm`, UTC but with **no zone suffix**. The three aggregate readers in `traffic.service.ts` forwarded that string raw via `String(r.firstSeen)`. On the client, `ClientTime` does `new Date(value)`, and a space-separated suffix-less datetime is parsed as **local** time, not UTC. For any operator west of UTC the parsed instant lands the offset's worth of hours in the future, so `now - date` goes negative and `formatRelative` hits its `diffMins < 1` → "just now" branch. Within the default 24h window nearly every row falls inside that offset.

The codebase already had the correct parser (`parseClickHouseDateTime64Utc`), but only `deserializeEvent` used it — the aggregate paths were missed.

## Fix

Added a `clickHouseDateToIso` helper that reparses as UTC and emits ISO-8601 with the `Z` suffix, applied at all five aggregate `firstSeen`/`lastSeen` return sites across `getVisitorOrigins`, `getNewVisitors`, and `getPageActivity`. This also corrects the same latent bug in the registered/anonymous page-activity tables.

Type check passes; 24 traffic-service tests pass, including a new regression assertion that the native form is normalized to `Z`-suffixed ISO.