### PR TITLE
Add BarChart to frontend plugin context

### DIFF
--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -298,6 +298,35 @@ export interface IChartComponents {
         /** Fixed maximum value for Y-axis (overrides auto-calculated maximum) */
         yAxisMax?: number;
     }>;
+
+    /**
+     * Grouped column (bar) chart for categorical/time-bucketed totals.
+     *
+     * Renders one column per series for each shared category, grouped side by
+     * side, and supports negative values below a zero baseline. The `mode` prop
+     * selects density: `normal` paints axes, legend, and an interactive tooltip;
+     * `widget` strips chrome to bars and baseline for a compact widget-zone fit.
+     */
+    BarChart: ComponentType<{
+        series: Array<{
+            id: string;
+            label: string;
+            data: Array<{ date: string; value: number; metadata?: Record<string, unknown> }>;
+            color?: string;
+        }>;
+        /** Rendering density (default: 'normal') */
+        mode?: 'normal' | 'widget';
+        /** Chart height in pixels (default: 320 normal, 120 widget) */
+        height?: number;
+        yAxisFormatter?: (value: number) => string;
+        xAxisFormatter?: (value: Date) => string;
+        emptyLabel?: string;
+        className?: string;
+        /** Fixed minimum value for Y-axis (overrides auto-calculated minimum) */
+        yAxisMin?: number;
+        /** Fixed maximum value for Y-axis (overrides auto-calculated maximum) */
+        yAxisMax?: number;
+    }>;
 }
 
 /**

--- a/src/frontend/features/charts/components/BarChart/BarChart.module.css
+++ b/src/frontend/features/charts/components/BarChart/BarChart.module.css
@@ -1,0 +1,152 @@
+/**
+ * BarChart Component Styles
+ *
+ * SVG-based grouped column chart with two density modes (normal / widget).
+ * Structural chrome (gridlines, baseline, axis labels, tooltip, legend) is
+ * driven entirely by design tokens; data-driven column fills are applied inline
+ * by the component per the data-visualization token exception.
+ */
+
+/* ========================================
+   Chart Container
+   ======================================== */
+
+.chart {
+    width: 100%;
+    position: relative;
+    margin: 0;
+}
+
+.chart svg {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+/* Widget mode renders edge-to-edge with no surrounding chrome. */
+.chart--widget {
+    line-height: 0;
+}
+
+/* ========================================
+   SVG Chrome (tokenized fills/strokes)
+   ======================================== */
+
+.gridline {
+    stroke: var(--color-border);
+}
+
+.baseline {
+    stroke: var(--color-border-strong);
+    stroke-width: var(--border-width-thin);
+}
+
+.axis_label {
+    fill: var(--color-text-muted);
+    font-size: var(--font-size-caption);
+}
+
+.bar {
+    transition: opacity var(--transition-fast);
+}
+
+.bar--dim {
+    opacity: var(--opacity-35);
+}
+
+/* ========================================
+   Interactive Tooltip (normal mode)
+   ======================================== */
+
+.tooltip {
+    position: absolute;
+    display: inline-flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+    min-width: var(--max-width-xs);
+    max-width: var(--max-width-xs);
+    padding: var(--padding-sm) var(--padding-md);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-accent);
+    border: var(--border-width-thin) solid var(--color-border-strong);
+    box-shadow: var(--shadow-lg);
+    color: var(--color-text);
+    font-size: var(--font-size-body-sm);
+    pointer-events: none;
+    transform: translate(-50%, -110%);
+    z-index: var(--z-index-dropdown);
+}
+
+.tooltip__label {
+    font-weight: var(--font-weight-semibold);
+}
+
+.tooltip__row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--gap-md);
+    color: var(--color-text-muted);
+}
+
+.tooltip__series {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-xs);
+}
+
+.tooltip__swatch {
+    display: inline-block;
+    width: var(--icon-size-xs);
+    height: var(--icon-size-xs);
+    border-radius: var(--radius-xs);
+    flex-shrink: 0;
+}
+
+/* ========================================
+   Legend (normal mode)
+   ======================================== */
+
+.legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-md);
+    margin-top: var(--gap-sm);
+}
+
+.legend__item {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    padding: var(--padding-2xs) var(--padding-sm);
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background-color var(--transition-fast), opacity var(--transition-fast);
+}
+
+.legend__item:hover {
+    background: var(--color-surface-muted);
+}
+
+.legend__item--hidden {
+    opacity: var(--opacity-50);
+}
+
+.legend__item--hidden:hover {
+    opacity: var(--opacity-75);
+}
+
+.legend__dot {
+    display: inline-flex;
+    width: var(--icon-size-xs);
+    height: var(--icon-size-xs);
+    border-radius: var(--radius-full);
+    border: var(--border-width-medium) solid;
+    flex-shrink: 0;
+}
+
+.legend__label {
+    color: var(--color-text-subtle);
+    font-size: var(--font-size-body-sm);
+}

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { cn } from '../../../../lib/cn';
 import styles from './BarChart.module.css';
 
@@ -128,6 +128,8 @@ interface RenderBar {
  * One tooltip row (one series' value at the hovered category).
  */
 interface TooltipDatum {
+    /** Series id — the stable, unique key for the row (labels may repeat) */
+    id: string;
     label: string;
     value: number;
     color: string;
@@ -211,17 +213,20 @@ export function BarChart({
     const height = propHeight ?? chrome.defaultHeight;
     const isWidget = mode === 'widget';
 
-    const containerRef = useRef<HTMLElement | null>(null);
+    const [container, setContainer] = useState<HTMLElement | null>(null);
     const [containerWidth, setContainerWidth] = useState(chrome.minWidth);
     const [tooltip, setTooltip] = useState<TooltipState | null>(null);
     const [hiddenSeries, setHiddenSeries] = useState<Set<string>>(new Set());
 
     /**
      * Observes container width changes and updates the chart responsively.
-     * Disconnects on unmount to avoid leaks. Skipped entirely in non-DOM/SSR.
+     * Backed by a state ref (`container`) rather than `useRef` so the observer
+     * attaches whenever the figure mounts — including the empty-state-to-loaded
+     * transition, where the figure is absent on the first render. Disconnects on
+     * unmount to avoid leaks. Skipped entirely in non-DOM/SSR.
      */
     useEffect(() => {
-        if (!containerRef.current || typeof ResizeObserver === 'undefined') {
+        if (!container || typeof ResizeObserver === 'undefined') {
             return;
         }
 
@@ -232,13 +237,15 @@ export function BarChart({
             }
         });
 
-        observer.observe(containerRef.current);
+        observer.observe(container);
         return () => observer.disconnect();
-    }, [chrome.minWidth]);
+    }, [container, chrome.minWidth]);
 
     /**
      * Toggles visibility of a series by ID (normal-mode legend interaction).
-     * Hiding a series rescales the Y-axis to the remaining data.
+     * Hiding a series rescales the Y-axis to the remaining data. Refuses to hide
+     * the last visible series so the chart never collapses to the empty state —
+     * which would remove the legend and leave no control to restore the data.
      */
     const toggleSeries = (seriesId: string) => {
         setHiddenSeries(prev => {
@@ -246,11 +253,29 @@ export function BarChart({
             if (next.has(seriesId)) {
                 next.delete(seriesId);
             } else {
+                const visibleCount = series.filter(
+                    item => item.data.length > 0 && !next.has(item.id)
+                ).length;
+                if (visibleCount <= 1) {
+                    return prev;
+                }
                 next.add(seriesId);
             }
             return next;
         });
     };
+
+    /**
+     * Stable fallback colors keyed by series id, derived from each series' index
+     * in the original `series` array. Because the index never depends on which
+     * series are hidden or empty, a series renders the same color in its bars,
+     * tooltip, and legend dot — the three would otherwise desync once an earlier
+     * series is hidden and the filtered indices shift.
+     */
+    const seriesColors = useMemo(
+        () => new Map(series.map((item, index) => [item.id, resolveColor(item.color, index)])),
+        [series]
+    );
 
     /**
      * Computes scales, category layout, and the full list of rendered columns.
@@ -304,9 +329,17 @@ export function BarChart({
         const baselineY = scaleY(zeroInRange ? 0 : minY);
 
         // Categories are the sorted union of all timestamps across visible series.
+        // Drop unparseable dates (NaN) so they cannot poison coordinate math, and
+        // bail to the empty state if nothing valid remains (avoids divide-by-zero).
         const categoryTimes = Array.from(
             new Set(visibleSeries.flatMap(item => item.data.map(point => toDate(point.date).getTime())))
-        ).sort((a, b) => a - b);
+        )
+            .filter(time => !Number.isNaN(time))
+            .sort((a, b) => a - b);
+
+        if (categoryTimes.length === 0) {
+            return null;
+        }
 
         const groupWidth = innerWidth / categoryTimes.length;
         const groupInner = groupWidth * chrome.groupInnerRatio;
@@ -317,11 +350,13 @@ export function BarChart({
         const barInset = seriesCount > 1 ? Math.min(slotWidth * 0.12, 2) : 0;
         const barWidth = Math.max(slotWidth - barInset, chrome.minBarWidth);
 
-        // Fast lookup of each series' value/metadata by category time.
-        const seriesLookup = visibleSeries.map((item, index) => {
+        // Fast lookup of each series' value/metadata by category time. Color is
+        // resolved from the stable per-id map, not the filtered position, so it
+        // stays aligned with the legend when series are hidden.
+        const seriesLookup = visibleSeries.map(item => {
             const byTime = new Map<number, BarDataPoint>();
             item.data.forEach(point => byTime.set(toDate(point.date).getTime(), point));
-            return { item, index, color: resolveColor(item.color, index), byTime };
+            return { item, color: seriesColors.get(item.id) ?? resolveColor(item.color, 0), byTime };
         });
 
         const categories = categoryTimes.map((time, categoryIndex) => {
@@ -385,7 +420,7 @@ export function BarChart({
             zeroInRange,
             seriesLookup
         };
-    }, [series, hiddenSeries, containerWidth, height, chrome, fixedYMin, fixedYMax]);
+    }, [series, hiddenSeries, containerWidth, height, chrome, fixedYMin, fixedYMax, seriesColors]);
 
     if (!chartData) {
         return <div className={cn(styles.chart, className)}>{emptyLabel}</div>;
@@ -397,9 +432,9 @@ export function BarChart({
      * Resolves the hovered category from the pointer X position and builds the
      * tooltip rows for every visible series at that category. Normal mode only.
      *
-     * @param event - React mouse event from the SVG element
+     * @param event - React pointer event from the SVG element (mouse, touch, or pen)
      */
-    const handlePointerMove = (event: React.MouseEvent<SVGSVGElement>) => {
+    const handlePointerMove = (event: React.PointerEvent<SVGSVGElement>) => {
         if (!chrome.interactive || !categories.length) {
             return;
         }
@@ -427,6 +462,7 @@ export function BarChart({
                     return null;
                 }
                 const datum: TooltipDatum = {
+                    id: item.id,
                     label: item.label,
                     value: point.value,
                     color,
@@ -454,13 +490,13 @@ export function BarChart({
     const ariaLabel = `Bar chart: ${series.map(item => item.label).join(', ')}`;
 
     return (
-        <figure ref={containerRef} className={cn(styles.chart, isWidget && styles['chart--widget'], className)}>
+        <figure ref={setContainer} className={cn(styles.chart, isWidget && styles['chart--widget'], className)}>
             <svg
                 viewBox={`0 0 ${width} ${chartHeight}`}
                 role="img"
                 aria-label={ariaLabel}
-                onMouseMove={chrome.interactive ? handlePointerMove : undefined}
-                onMouseLeave={chrome.interactive ? handlePointerLeave : undefined}
+                onPointerMove={chrome.interactive ? handlePointerMove : undefined}
+                onPointerLeave={chrome.interactive ? handlePointerLeave : undefined}
             >
                 {chrome.showAxes && yTicks.map((tick, index) => (
                     <g key={`y-tick-${index}`}>
@@ -532,7 +568,7 @@ export function BarChart({
                 >
                     <span className={styles.tooltip__label}>{xAxisFormatter(tooltip.date)}</span>
                     {tooltip.items.map(item => (
-                        <div key={item.label} className={styles.tooltip__row}>
+                        <div key={item.id} className={styles.tooltip__row}>
                             <span className={styles.tooltip__series}>
                                 <span className={styles.tooltip__swatch} style={{ background: item.color }} />
                                 {item.label}
@@ -545,9 +581,9 @@ export function BarChart({
 
             {chrome.showLegend && (
                 <figcaption className={styles.legend}>
-                    {series.filter(item => item.data.length > 0).map((item, index) => {
+                    {series.filter(item => item.data.length > 0).map(item => {
                         const isHidden = hiddenSeries.has(item.id);
-                        const color = resolveColor(item.color, index);
+                        const color = seriesColors.get(item.id) ?? resolveColor(item.color, 0);
                         return (
                             <button
                                 key={`legend-${item.id}`}

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -1,0 +1,572 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '../../../../lib/cn';
+import styles from './BarChart.module.css';
+
+/**
+ * Individual data point for a bar chart series.
+ */
+interface BarDataPoint {
+    /** ISO date string or timestamp identifying the category bucket */
+    date: string;
+    /** Numeric value to plot (may be negative — bars render below the baseline) */
+    value: number;
+    /** Optional metadata surfaced in the hover tooltip (normal mode only) */
+    metadata?: Record<string, any>;
+}
+
+/**
+ * Bar chart series configuration for grouped (side-by-side) column charts.
+ */
+export interface BarChartSeries {
+    /** Unique identifier for the series */
+    id: string;
+    /** Display label for legend and tooltip */
+    label: string;
+    /** Array of data points; one column per shared category, grouped across series */
+    data: BarDataPoint[];
+    /**
+     * Column color. Accepts any CSS color string, including a token reference
+     * (`var(--chart-color-2)`). Defaults to the `--chart-color-*` palette by index.
+     */
+    color?: string;
+}
+
+/**
+ * Rendering density for the chart.
+ *
+ * - `normal` — full chrome: axes, gridlines, legend, and an interactive tooltip.
+ * - `widget` — very compact: bars and baseline only, no axes/legend/tooltip,
+ *   sized to drop into a small widget zone.
+ */
+type BarChartMode = 'normal' | 'widget';
+
+/**
+ * Properties for the BarChart component.
+ */
+interface BarChartProps {
+    /** Array of data series to plot as grouped columns */
+    series: BarChartSeries[];
+    /** Rendering density (default: 'normal') */
+    mode?: BarChartMode;
+    /** Chart height in pixels (default: 320 in normal mode, 120 in widget mode) */
+    height?: number;
+    /** Custom formatter for Y-axis labels and tooltip values */
+    yAxisFormatter?: (value: number) => string;
+    /** Custom formatter for X-axis labels and tooltip dates */
+    xAxisFormatter?: (value: Date) => string;
+    /** Additional CSS class names */
+    className?: string;
+    /** Message to show when no data is available */
+    emptyLabel?: string;
+    /** Fixed minimum value for Y-axis (overrides auto-calculated minimum) */
+    yAxisMin?: number;
+    /** Fixed maximum value for Y-axis (overrides auto-calculated maximum) */
+    yAxisMax?: number;
+}
+
+/**
+ * Per-mode chrome configuration. Density-driven layout lives here so the render
+ * body stays declarative and the two modes cannot drift apart accidentally.
+ */
+const CHROME: Record<BarChartMode, {
+    margin: { top: number; right: number; bottom: number; left: number };
+    defaultHeight: number;
+    minWidth: number;
+    showAxes: boolean;
+    showLegend: boolean;
+    interactive: boolean;
+    /** Fraction of each category slot occupied by its bar group (rest is gutter) */
+    groupInnerRatio: number;
+    /** Corner radius applied to the top of each column */
+    barRadius: number;
+    /** Floor on rendered bar width so dense datasets stay visible */
+    minBarWidth: number;
+}> = {
+    normal: {
+        margin: { top: 16, right: 20, bottom: 32, left: 56 },
+        defaultHeight: 320,
+        minWidth: 320,
+        showAxes: true,
+        showLegend: true,
+        interactive: true,
+        groupInnerRatio: 0.7,
+        barRadius: 2,
+        minBarWidth: 1
+    },
+    widget: {
+        margin: { top: 3, right: 3, bottom: 3, left: 3 },
+        defaultHeight: 120,
+        minWidth: 80,
+        showAxes: false,
+        showLegend: false,
+        interactive: false,
+        groupInnerRatio: 0.9,
+        barRadius: 0,
+        minBarWidth: 0.5
+    }
+};
+
+/**
+ * A single rendered column, precomputed for both painting and hit-testing.
+ */
+interface RenderBar {
+    seriesId: string;
+    label: string;
+    color: string;
+    categoryTime: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    value: number;
+    metadata?: Record<string, any>;
+}
+
+/**
+ * One tooltip row (one series' value at the hovered category).
+ */
+interface TooltipDatum {
+    label: string;
+    value: number;
+    color: string;
+    metadata?: Record<string, any>;
+}
+
+/**
+ * Complete tooltip state for the hovered category.
+ */
+interface TooltipState {
+    x: number;
+    y: number;
+    date: Date;
+    items: TooltipDatum[];
+}
+
+/**
+ * Converts a date string to a Date object, handling ISO 8601 timestamps.
+ *
+ * Mirrors LineChart's parser so both charts interpret backend UTC timestamps
+ * identically; the resulting Date is displayed in the user's locale by the
+ * xAxisFormatter.
+ *
+ * @param value - ISO date string or timestamp
+ * @returns Parsed Date object
+ */
+function toDate(value: string) {
+    const time = Date.parse(value);
+    if (Number.isNaN(time)) {
+        return new Date(value);
+    }
+    return new Date(time);
+}
+
+/**
+ * Resolves a series' column color, falling back to the themed chart palette.
+ *
+ * The fallback references `--chart-color-*` (a token, not a hardcoded hex) so
+ * series colors stay theme-aware while remaining a deliberate data-viz literal
+ * when the caller supplies one.
+ *
+ * @param color - Caller-supplied color, if any
+ * @param index - Series index used to cycle the palette
+ * @returns A CSS color string suitable for an SVG fill
+ */
+function resolveColor(color: string | undefined, index: number) {
+    return color ?? `var(--chart-color-${(index % 10) + 1})`;
+}
+
+/**
+ * BarChart - Responsive SVG grouped column chart with normal and widget modes.
+ *
+ * Renders one column per series for each shared category (typically a time
+ * bucket), grouped side by side. Supports negative values (columns drop below a
+ * zero baseline), fixed or auto Y-axis bounds, and a ResizeObserver-driven width
+ * so it adapts to any container — full page, card, or compact widget zone.
+ *
+ * Structural chrome (axes, gridlines, baseline, labels) is styled through the
+ * colocated CSS Module using design tokens; only data-driven column fills are
+ * applied inline, per the data-visualization exception to the token rules.
+ *
+ * The `mode` prop selects density: `normal` paints full chrome plus an
+ * interactive tooltip, while `widget` strips everything to bars and baseline for
+ * a sparkline-like footprint.
+ *
+ * @param props - Component properties with series data and configuration
+ * @returns A figure element containing the SVG chart (and legend in normal mode)
+ */
+export function BarChart({
+    series,
+    mode = 'normal',
+    height: propHeight,
+    yAxisFormatter = value => value.toLocaleString(),
+    xAxisFormatter = value => value.toLocaleDateString(),
+    className,
+    emptyLabel = 'Not enough data to render a chart.',
+    yAxisMin: fixedYMin,
+    yAxisMax: fixedYMax
+}: BarChartProps) {
+    const chrome = CHROME[mode];
+    const height = propHeight ?? chrome.defaultHeight;
+    const isWidget = mode === 'widget';
+
+    const containerRef = useRef<HTMLElement | null>(null);
+    const [containerWidth, setContainerWidth] = useState(chrome.minWidth);
+    const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+    const [hiddenSeries, setHiddenSeries] = useState<Set<string>>(new Set());
+
+    /**
+     * Observes container width changes and updates the chart responsively.
+     * Disconnects on unmount to avoid leaks. Skipped entirely in non-DOM/SSR.
+     */
+    useEffect(() => {
+        if (!containerRef.current || typeof ResizeObserver === 'undefined') {
+            return;
+        }
+
+        const observer = new ResizeObserver(entries => {
+            const entry = entries[0];
+            if (entry) {
+                setContainerWidth(Math.max(chrome.minWidth, Math.round(entry.contentRect.width)));
+            }
+        });
+
+        observer.observe(containerRef.current);
+        return () => observer.disconnect();
+    }, [chrome.minWidth]);
+
+    /**
+     * Toggles visibility of a series by ID (normal-mode legend interaction).
+     * Hiding a series rescales the Y-axis to the remaining data.
+     */
+    const toggleSeries = (seriesId: string) => {
+        setHiddenSeries(prev => {
+            const next = new Set(prev);
+            if (next.has(seriesId)) {
+                next.delete(seriesId);
+            } else {
+                next.add(seriesId);
+            }
+            return next;
+        });
+    };
+
+    /**
+     * Computes scales, category layout, and the full list of rendered columns.
+     *
+     * Memoized to avoid recomputing grouped-bar geometry on every hover. Returns
+     * null when there is no visible data, triggering the empty state.
+     */
+    const chartData = useMemo(() => {
+        const visibleSeries = series.filter(item => item.data.length > 0 && !hiddenSeries.has(item.id));
+        if (!visibleSeries.length) {
+            return null;
+        }
+
+        const allValues = visibleSeries.flatMap(item => item.data.map(point => point.value));
+        const dataMin = Math.min(...allValues);
+        const dataMax = Math.max(...allValues);
+
+        // Bars are measured against a zero baseline, so the default domain always
+        // includes 0; callers can still pin either bound explicitly.
+        let minY: number;
+        let maxY: number;
+
+        if (fixedYMin !== undefined) {
+            minY = fixedYMin;
+        } else {
+            minY = Math.min(0, dataMin);
+        }
+
+        if (fixedYMax !== undefined) {
+            maxY = fixedYMax;
+        } else {
+            maxY = Math.max(0, dataMax);
+        }
+
+        // Guard against a zero-height domain (all values equal / all zero).
+        if (minY === maxY) {
+            maxY = minY + 1;
+        }
+
+        const rangeY = maxY - minY || 1;
+
+        const width = Math.max(containerWidth, chrome.minWidth);
+        const innerWidth = width - chrome.margin.left - chrome.margin.right;
+        const innerHeight = height - chrome.margin.top - chrome.margin.bottom;
+
+        const scaleY = (value: number) =>
+            chrome.margin.top + innerHeight - ((value - minY) / rangeY) * innerHeight;
+
+        // The baseline sits at zero when zero is in range, otherwise at the floor.
+        const zeroInRange = minY <= 0 && maxY >= 0;
+        const baselineY = scaleY(zeroInRange ? 0 : minY);
+
+        // Categories are the sorted union of all timestamps across visible series.
+        const categoryTimes = Array.from(
+            new Set(visibleSeries.flatMap(item => item.data.map(point => toDate(point.date).getTime())))
+        ).sort((a, b) => a - b);
+
+        const groupWidth = innerWidth / categoryTimes.length;
+        const groupInner = groupWidth * chrome.groupInnerRatio;
+        const groupPad = (groupWidth - groupInner) / 2;
+        const seriesCount = visibleSeries.length;
+        const slotWidth = groupInner / seriesCount;
+        // Small inset between adjacent bars in a group; none when a group is one bar.
+        const barInset = seriesCount > 1 ? Math.min(slotWidth * 0.12, 2) : 0;
+        const barWidth = Math.max(slotWidth - barInset, chrome.minBarWidth);
+
+        // Fast lookup of each series' value/metadata by category time.
+        const seriesLookup = visibleSeries.map((item, index) => {
+            const byTime = new Map<number, BarDataPoint>();
+            item.data.forEach(point => byTime.set(toDate(point.date).getTime(), point));
+            return { item, index, color: resolveColor(item.color, index), byTime };
+        });
+
+        const categories = categoryTimes.map((time, categoryIndex) => {
+            const groupStart = chrome.margin.left + categoryIndex * groupWidth + groupPad;
+            return { time, date: new Date(time), centerX: groupStart + groupInner / 2 };
+        });
+
+        const bars: RenderBar[] = [];
+        categoryTimes.forEach((time, categoryIndex) => {
+            const groupStart = chrome.margin.left + categoryIndex * groupWidth + groupPad;
+            seriesLookup.forEach(({ item, color, byTime }, seriesIndex) => {
+                const point = byTime.get(time);
+                if (!point) {
+                    return;
+                }
+                const valueY = scaleY(point.value);
+                const top = Math.min(valueY, baselineY);
+                const barHeight = Math.max(Math.abs(valueY - baselineY), chrome.minBarWidth);
+                bars.push({
+                    seriesId: item.id,
+                    label: item.label,
+                    color,
+                    categoryTime: time,
+                    x: groupStart + seriesIndex * slotWidth + barInset / 2,
+                    y: top,
+                    width: barWidth,
+                    height: barHeight,
+                    value: point.value,
+                    metadata: point.metadata
+                });
+            });
+        });
+
+        // Y-axis ticks (normal mode): four evenly spaced, plus an explicit zero
+        // tick when the data crosses the baseline.
+        const yTicks = Array.from({ length: 4 }).map((_, index) => {
+            const value = minY + (rangeY / 3) * index;
+            return { value, y: scaleY(value) };
+        });
+        if (zeroInRange && minY < 0 && maxY > 0) {
+            const hasZeroTick = yTicks.some(tick => Math.abs(tick.value) < 0.0001);
+            if (!hasZeroTick) {
+                yTicks.push({ value: 0, y: scaleY(0) });
+                yTicks.sort((a, b) => b.value - a.value);
+            }
+        }
+
+        // X-axis ticks (normal mode): first, middle, last category.
+        const xTicks = categories.length
+            ? [categories[0], categories[Math.floor((categories.length - 1) / 2)], categories[categories.length - 1]]
+            : [];
+
+        return {
+            width,
+            height,
+            bars,
+            categories,
+            yTicks,
+            xTicks,
+            baselineY,
+            zeroInRange,
+            seriesLookup
+        };
+    }, [series, hiddenSeries, containerWidth, height, chrome, fixedYMin, fixedYMax]);
+
+    if (!chartData) {
+        return <div className={cn(styles.chart, className)}>{emptyLabel}</div>;
+    }
+
+    const { width, height: chartHeight, bars, categories, yTicks, xTicks, baselineY, seriesLookup } = chartData;
+
+    /**
+     * Resolves the hovered category from the pointer X position and builds the
+     * tooltip rows for every visible series at that category. Normal mode only.
+     *
+     * @param event - React mouse event from the SVG element
+     */
+    const handlePointerMove = (event: React.MouseEvent<SVGSVGElement>) => {
+        if (!chrome.interactive || !categories.length) {
+            return;
+        }
+
+        const bounds = event.currentTarget.getBoundingClientRect();
+        // The SVG is scaled to its container; map client px back to viewBox px.
+        const scale = bounds.width / width;
+        const pointerX = (event.clientX - bounds.left) / (scale || 1);
+
+        let nearest = categories[0];
+        let minDistance = Math.abs(categories[0].centerX - pointerX);
+        for (let index = 1; index < categories.length; index += 1) {
+            const candidate = categories[index];
+            const distance = Math.abs(candidate.centerX - pointerX);
+            if (distance < minDistance) {
+                minDistance = distance;
+                nearest = candidate;
+            }
+        }
+
+        const items: TooltipDatum[] = seriesLookup
+            .map(({ item, color, byTime }) => {
+                const point = byTime.get(nearest.time);
+                if (!point) {
+                    return null;
+                }
+                const datum: TooltipDatum = {
+                    label: item.label,
+                    value: point.value,
+                    color,
+                    metadata: point.metadata
+                };
+                return datum;
+            })
+            .filter((item): item is TooltipDatum => Boolean(item));
+
+        if (!items.length) {
+            setTooltip(null);
+            return;
+        }
+
+        setTooltip({ x: nearest.centerX, y: chrome.margin.top, date: nearest.date, items });
+    };
+
+    /**
+     * Clears the tooltip when the pointer leaves the chart.
+     */
+    const handlePointerLeave = () => {
+        setTooltip(null);
+    };
+
+    const ariaLabel = `Bar chart: ${series.map(item => item.label).join(', ')}`;
+
+    return (
+        <figure ref={containerRef} className={cn(styles.chart, isWidget && styles['chart--widget'], className)}>
+            <svg
+                viewBox={`0 0 ${width} ${chartHeight}`}
+                role="img"
+                aria-label={ariaLabel}
+                onMouseMove={chrome.interactive ? handlePointerMove : undefined}
+                onMouseLeave={chrome.interactive ? handlePointerLeave : undefined}
+            >
+                {chrome.showAxes && yTicks.map((tick, index) => (
+                    <g key={`y-tick-${index}`}>
+                        <line
+                            className={styles.gridline}
+                            x1={chrome.margin.left}
+                            x2={width - chrome.margin.right}
+                            y1={tick.y}
+                            y2={tick.y}
+                            strokeDasharray="6 6"
+                        />
+                        <text
+                            className={styles.axis_label}
+                            x={chrome.margin.left - 10}
+                            y={tick.y + 4}
+                            textAnchor="end"
+                        >
+                            {yAxisFormatter(tick.value)}
+                        </text>
+                    </g>
+                ))}
+
+                <line
+                    className={styles.baseline}
+                    x1={chrome.margin.left}
+                    x2={width - chrome.margin.right}
+                    y1={baselineY}
+                    y2={baselineY}
+                />
+
+                {bars.map((bar, index) => {
+                    const dimmed = tooltip ? tooltip.date.getTime() !== bar.categoryTime : false;
+                    return (
+                        <rect
+                            key={`${bar.seriesId}-${bar.categoryTime}-${index}`}
+                            className={cn(styles.bar, dimmed && styles['bar--dim'])}
+                            x={bar.x}
+                            y={bar.y}
+                            width={bar.width}
+                            height={bar.height}
+                            rx={chrome.barRadius}
+                            style={{ fill: bar.color }}
+                        >
+                            {chrome.interactive && (
+                                <title>{`${bar.label}: ${yAxisFormatter(bar.value)}`}</title>
+                            )}
+                        </rect>
+                    );
+                })}
+
+                {chrome.showAxes && xTicks.map((tick, index) => (
+                    <text
+                        key={`x-tick-${index}`}
+                        className={styles.axis_label}
+                        x={tick.centerX}
+                        y={chartHeight - chrome.margin.bottom + 20}
+                        textAnchor={index === 0 ? 'start' : index === xTicks.length - 1 ? 'end' : 'middle'}
+                    >
+                        {xAxisFormatter(tick.date)}
+                    </text>
+                ))}
+            </svg>
+
+            {tooltip && (
+                <div
+                    className={styles.tooltip}
+                    style={{ left: `${(tooltip.x / width) * 100}%`, top: tooltip.y }}
+                    role="presentation"
+                >
+                    <span className={styles.tooltip__label}>{xAxisFormatter(tooltip.date)}</span>
+                    {tooltip.items.map(item => (
+                        <div key={item.label} className={styles.tooltip__row}>
+                            <span className={styles.tooltip__series}>
+                                <span className={styles.tooltip__swatch} style={{ background: item.color }} />
+                                {item.label}
+                            </span>
+                            <span>{yAxisFormatter(item.value)}</span>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {chrome.showLegend && (
+                <figcaption className={styles.legend}>
+                    {series.filter(item => item.data.length > 0).map((item, index) => {
+                        const isHidden = hiddenSeries.has(item.id);
+                        const color = resolveColor(item.color, index);
+                        return (
+                            <button
+                                key={`legend-${item.id}`}
+                                className={cn(styles.legend__item, isHidden && styles['legend__item--hidden'])}
+                                onClick={() => toggleSeries(item.id)}
+                                type="button"
+                                aria-pressed={!isHidden}
+                                title={isHidden ? `Show ${item.label}` : `Hide ${item.label}`}
+                            >
+                                <span
+                                    className={styles.legend__dot}
+                                    style={{ background: isHidden ? 'transparent' : color, borderColor: color }}
+                                />
+                                <span className={styles.legend__label}>{item.label}</span>
+                            </button>
+                        );
+                    })}
+                </figcaption>
+            )}
+        </figure>
+    );
+}

--- a/src/frontend/features/charts/components/BarChart/index.ts
+++ b/src/frontend/features/charts/components/BarChart/index.ts
@@ -1,0 +1,2 @@
+export { BarChart } from './BarChart';
+export type { BarChartSeries } from './BarChart';

--- a/src/frontend/features/charts/index.ts
+++ b/src/frontend/features/charts/index.ts
@@ -6,3 +6,5 @@
 
 // Components
 export { LineChart } from './components/LineChart';
+export { BarChart } from './components/BarChart';
+export type { BarChartSeries } from './components/BarChart';

--- a/src/frontend/lib/frontendPluginContext.tsx
+++ b/src/frontend/lib/frontendPluginContext.tsx
@@ -25,6 +25,7 @@ import { Table, Thead, Tbody, Tr, Th, Td } from '../components/ui/Table';
 import { useModal as useModalHook } from '../components/ui/ModalProvider';
 import { useToast as useToastHook } from '../components/ui/ToastProvider';
 import { LineChart } from '../features/charts/components/LineChart';
+import { BarChart } from '../features/charts/components/BarChart';
 import { SchedulerMonitor } from '../modules/scheduler';
 import { Page, PageHeader, Stack, Grid, Section } from '../components/layout';
 import { useAuthSession } from '../modules/user/components/SessionProvider';
@@ -346,7 +347,8 @@ export function FrontendPluginContextProvider({ children }: { children: React.Re
         };
 
         const charts: IChartComponents = {
-            LineChart
+            LineChart,
+            BarChart
         };
 
         const system: ISystemComponents = {
@@ -442,7 +444,8 @@ export function createPluginContext(pluginId: string): IFrontendPluginContext {
     };
 
     const charts: IChartComponents = {
-        LineChart
+        LineChart,
+        BarChart
     };
 
     const system: ISystemComponents = {


### PR DESCRIPTION
Introduces a grouped column (bar) chart in the charts feature and exposes it to plugins through `IChartComponents`.

## What changed

- New `BarChart` component under `src/frontend/features/charts/components/BarChart/` — grouped columns per series across shared categories, negative-value support below a zero baseline, and two density modes (`normal` paints axes/legend/tooltip; `widget` strips chrome for compact widget-zone fit).
- Exported `BarChart` and `BarChartSeries` from the charts feature barrel.
- Added `BarChart` to the `IChartComponents` type and wired it into both `FrontendPluginContextProvider` and `createPluginContext`, so plugins reach it via `context.charts.BarChart`.

Plugins can now render categorical/time-bucketed totals without importing chart internals across workspace boundaries.