### PR TITLE
Forward placement instanceConfig to widget components

### DIFF
--- a/packages/types/src/widget/IWidgetComponentProps.ts
+++ b/packages/types/src/widget/IWidgetComponentProps.ts
@@ -69,6 +69,21 @@ export interface IWidgetComponentProps {
      * `{ address: 'TXyz123...' }`. Empty object for static routes.
      */
     params: Record<string, string>;
+
+    /**
+     * Operator-editable per-placement instance configuration for this
+     * widget's placement.
+     *
+     * Mirrors the `instanceConfig` the backend data fetcher received via
+     * {@link IWidgetPlacementContext} (validated against the widget type's
+     * `configSchema` at write time), letting the component branch on the
+     * same operator settings the fetcher saw — e.g. toggling an optional
+     * series or switching display density — without a second round trip.
+     *
+     * Always an object; the renderer substitutes `{}` when the placement
+     * carries no overrides, so reads need no null-guarding.
+     */
+    instanceConfig: Record<string, unknown>;
 }
 
 /**

--- a/packages/types/src/widget/IWidgetData.ts
+++ b/packages/types/src/widget/IWidgetData.ts
@@ -41,4 +41,15 @@ export interface IWidgetData {
      * JSON-serializable object.
      */
     data: unknown;
+
+    /**
+     * Operator-editable per-placement instance configuration, forwarded
+     * verbatim from the resolved placement so the frontend component can
+     * branch on the same config the backend data fetcher received.
+     *
+     * Optional on the wire for backward compatibility; the resolver always
+     * populates it (substituting `{}` when the placement carries no
+     * overrides) and the frontend renderer defaults it to `{}` on read.
+     */
+    instanceConfig?: Record<string, unknown>;
 }

--- a/src/backend/modules/widgets/__tests__/placements.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.test.ts
@@ -565,6 +565,34 @@ describe('PlacementResolver', () => {
         );
     });
 
+    it('forwards instanceConfig onto the returned IWidgetData', async () => {
+        (typeRegistry as any).__types.set('plugin:type', buildType('plugin:type', async () => ({ ok: true })));
+        (placementService.findByRoute as ReturnType<typeof vi.fn>).mockResolvedValue([
+            buildPlacement({
+                id: 'p-cfg',
+                typeId: 'plugin:type',
+                instanceConfig: { maxPosts: 3, theme: 'compact' }
+            })
+        ]);
+
+        const result = await resolver.resolveForRoute('/', {});
+
+        expect(result).toHaveLength(1);
+        expect(result[0].instanceConfig).toEqual({ maxPosts: 3, theme: 'compact' });
+    });
+
+    it('defaults the returned instanceConfig to {} when the placement carries none', async () => {
+        (typeRegistry as any).__types.set('plugin:type', buildType('plugin:type', async () => ({ ok: true })));
+        (placementService.findByRoute as ReturnType<typeof vi.fn>).mockResolvedValue([
+            buildPlacement({ id: 'p-empty', typeId: 'plugin:type', instanceConfig: undefined })
+        ]);
+
+        const result = await resolver.resolveForRoute('/', {});
+
+        expect(result).toHaveLength(1);
+        expect(result[0].instanceConfig).toEqual({});
+    });
+
     it('sorts results by zone (alphabetical), then order', async () => {
         // 'main-after' sorts before 'main-before' alphabetically, so
         // the expected ordering joins zone-asc then order-asc within

--- a/src/backend/modules/widgets/placements/placement-resolver.ts
+++ b/src/backend/modules/widgets/placements/placement-resolver.ts
@@ -151,7 +151,11 @@ export class PlacementResolver {
                 pluginId: owner,
                 order: placement.order,
                 title: placement.title,
-                data
+                data,
+                // Forward the same instance config the fetcher received so
+                // the frontend component can branch on it. Mirror the
+                // empty-object default used for the fetcher context above.
+                instanceConfig: placement.instanceConfig ?? {}
             };
         } catch (error) {
             clearTimeout(timerId);

--- a/src/frontend/components/widgets/WidgetWithContext.tsx
+++ b/src/frontend/components/widgets/WidgetWithContext.tsx
@@ -20,6 +20,14 @@ interface WidgetWithContextProps {
     data: unknown;
 
     /**
+     * Operator-editable per-placement instance configuration, forwarded
+     * to the widget component so it can branch on the same config its
+     * backend data fetcher received. Defaults to `{}` when the placement
+     * carries no overrides.
+     */
+    instanceConfig?: Record<string, unknown>;
+
+    /**
      * Plugin ID for creating namespaced context.
      */
     pluginId: string;
@@ -56,6 +64,7 @@ interface WidgetWithContextProps {
 export function WidgetWithContext({
     Component,
     data,
+    instanceConfig,
     pluginId,
     route,
     params
@@ -63,5 +72,13 @@ export function WidgetWithContext({
     // Memoize context creation to avoid recreating on every render
     const context = useMemo(() => createPluginContext(pluginId), [pluginId]);
 
-    return <Component data={data} context={context} route={route} params={params} />;
+    return (
+        <Component
+            data={data}
+            context={context}
+            route={route}
+            params={params}
+            instanceConfig={instanceConfig ?? {}}
+        />
+    );
 }

--- a/src/frontend/components/widgets/WidgetWithContext.tsx
+++ b/src/frontend/components/widgets/WidgetWithContext.tsx
@@ -6,6 +6,16 @@ import type { IWidgetComponentProps } from '@/types';
 import { createPluginContext } from '../../lib/frontendPluginContext';
 
 /**
+ * Stable empty-config reference used as the `instanceConfig` fallback.
+ *
+ * Defined at module scope so the defaulted value keeps a constant
+ * identity across renders. Inlining `{}` would mint a fresh object each
+ * render, breaking `React.memo` and any `useEffect(..., [instanceConfig])`
+ * in widget components that rely on referential equality.
+ */
+const EMPTY_CONFIG: Record<string, unknown> = {};
+
+/**
  * Props for the WidgetWithContext wrapper component.
  */
 interface WidgetWithContextProps {
@@ -78,7 +88,7 @@ export function WidgetWithContext({
             context={context}
             route={route}
             params={params}
-            instanceConfig={instanceConfig ?? {}}
+            instanceConfig={instanceConfig ?? EMPTY_CONFIG}
         />
     );
 }

--- a/src/frontend/components/widgets/WidgetZone.tsx
+++ b/src/frontend/components/widgets/WidgetZone.tsx
@@ -31,6 +31,7 @@ function WidgetRenderer({ widget, route, params }: WidgetRendererProps) {
             <WidgetWithContext
                 Component={Component}
                 data={widget.data}
+                instanceConfig={widget.instanceConfig}
                 pluginId={widget.pluginId}
                 route={route}
                 params={params}

--- a/src/frontend/components/widgets/types.ts
+++ b/src/frontend/components/widgets/types.ts
@@ -37,4 +37,13 @@ export interface WidgetData {
      * JSON-serializable object.
      */
     data: unknown;
+
+    /**
+     * Operator-editable per-placement instance configuration, forwarded
+     * from the resolved placement so the widget component can branch on
+     * the same config its backend data fetcher received.
+     *
+     * Optional on the wire; the renderer defaults it to `{}` on read.
+     */
+    instanceConfig?: Record<string, unknown>;
 }


### PR DESCRIPTION
Mirrors the operator-editable per-placement `instanceConfig` the backend data fetcher already receives through to the rendered widget component, so a component can branch on the same operator settings its fetcher saw without a second round trip.

## What changed

- `PlacementResolver` now forwards `instanceConfig` (defaulting to `{}`) on the resolved `IWidgetData`, mirroring the empty-object default used for the fetcher context.
- `IWidgetData` and the frontend `WidgetData` type gain an optional `instanceConfig` field (optional on the wire for backward compatibility; resolver always populates it).
- `IWidgetComponentProps` gains a non-optional `instanceConfig: Record<string, unknown>` — the renderer substitutes `{}` so component reads need no null-guarding.
- `WidgetZone` / `WidgetWithContext` thread the value from `widget.instanceConfig` to the component, defaulting to `{}`.

Type checks pass for the types package, backend, and frontend.