### PR TITLE
Clamp BarChart tooltip to chart bounds and add tooltip date+time formatter

### DIFF
--- a/src/frontend/features/charts/components/BarChart/BarChart.module.css
+++ b/src/frontend/features/charts/components/BarChart/BarChart.module.css
@@ -21,6 +21,10 @@
     width: 100%;
     height: auto;
     display: block;
+    /* Browsers clip the root <svg> to its viewBox by default; axis labels are
+       anchored at the margins and would lose their outermost glyphs. Let them
+       paint past the viewBox edge. The figure's margins reserve the room. */
+    overflow: visible;
 }
 
 /* Widget mode renders edge-to-edge with no surrounding chrome. */
@@ -63,8 +67,10 @@
     display: inline-flex;
     flex-direction: column;
     gap: var(--gap-2xs);
-    min-width: var(--max-width-xs);
-    max-width: var(--max-width-xs);
+    width: var(--max-width-xs);
+    /* Never wider than the chart it overlays — on containers narrower than the
+       nominal width the box shrinks so it can be clamped fully into view. */
+    max-width: 100%;
     padding: var(--padding-sm) var(--padding-md);
     border-radius: var(--radius-md);
     background: var(--color-surface-accent);

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -194,7 +194,7 @@ function toDate(value: string) {
  */
 function defaultTooltipDateFormatter(value: Date) {
     const date = value.toLocaleDateString();
-    const time = value.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+    const time = value.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
     return `${date} ${time}`;
 }
 
@@ -544,8 +544,13 @@ export function BarChart({
     // When the chart is too narrow to fit the box plus both gutters, fall back to
     // centering (the box itself caps at the chart width via `max-width: 100%`).
     let tooltipLeftPx = 0;
+    let tooltipTopPx = 0;
     if (tooltip) {
+        // The SVG scales uniformly to its container, so both axes share the
+        // factor chartWidthPx / width. tooltip.x and tooltip.y are viewBox units;
+        // multiply both by chartWidthPx / width to land in on-screen CSS pixels.
         const centerPx = (tooltip.x / width) * tooltip.chartWidthPx;
+        tooltipTopPx = (tooltip.y / width) * tooltip.chartWidthPx;
         const halfWidth = tooltipWidth / 2;
         const minLeft = TOOLTIP_EDGE_GUTTER + halfWidth;
         const maxLeft = tooltip.chartWidthPx - TOOLTIP_EDGE_GUTTER - halfWidth;
@@ -629,7 +634,10 @@ export function BarChart({
                 <div
                     ref={setTooltipNode}
                     className={styles.tooltip}
-                    style={{ left: `${tooltipLeftPx}px`, top: tooltip.y }}
+                    // Hide the single pre-measurement frame: until the effect reads
+                    // the box width, the clamp ignores its half-width and an
+                    // edge-hovered tooltip would briefly overflow before correcting.
+                    style={{ left: `${tooltipLeftPx}px`, top: `${tooltipTopPx}px`, opacity: tooltipWidth === 0 ? 0 : 1 }}
                     role="presentation"
                 >
                     <span className={styles.tooltip__label}>{tooltipDateFormatter(tooltip.date)}</span>

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -54,8 +54,15 @@ interface BarChartProps {
     height?: number;
     /** Custom formatter for Y-axis labels and tooltip values */
     yAxisFormatter?: (value: number) => string;
-    /** Custom formatter for X-axis labels and tooltip dates */
+    /** Custom formatter for X-axis tick labels (kept compact — date only by default) */
     xAxisFormatter?: (value: Date) => string;
+    /**
+     * Custom formatter for the tooltip's date heading. Defaults to date plus
+     * hour and minute, so the hovered bucket's time is visible even when the
+     * compact x-axis only shows the day. Tooltip-only (hover, post-hydration),
+     * so locale-dependent time output is hydration-safe here.
+     */
+    tooltipDateFormatter?: (value: Date) => string;
     /** Additional CSS class names */
     className?: string;
     /** Message to show when no data is available */
@@ -144,7 +151,20 @@ interface TooltipState {
     y: number;
     date: Date;
     items: TooltipDatum[];
+    /**
+     * Displayed (CSS pixel) width of the chart at hover time. Captured from the
+     * SVG's bounding box so the tooltip can be clamped into the chart's on-screen
+     * bounds regardless of how the viewBox is scaled to its container.
+     */
+    chartWidthPx: number;
 }
+
+/**
+ * Gutter, in CSS pixels, kept between the tooltip box and either edge of the
+ * chart when its center is clamped. A small layout constant in the spirit of the
+ * other geometry literals in CHROME — not a themable value.
+ */
+const TOOLTIP_EDGE_GUTTER = 8;
 
 /**
  * Converts a date string to a Date object, handling ISO 8601 timestamps.
@@ -162,6 +182,20 @@ function toDate(value: string) {
         return new Date(value);
     }
     return new Date(time);
+}
+
+/**
+ * Default formatter for the tooltip's date heading: short date plus 24-hour
+ * time. Gives the hovered bucket an hour/minute even when the x-axis label is
+ * date-only, without the caller having to wire a formatter through.
+ *
+ * @param value - The hovered category's Date
+ * @returns A localized "date HH:MM" string
+ */
+function defaultTooltipDateFormatter(value: Date) {
+    const date = value.toLocaleDateString();
+    const time = value.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+    return `${date} ${time}`;
 }
 
 /**
@@ -204,6 +238,7 @@ export function BarChart({
     height: propHeight,
     yAxisFormatter = value => value.toLocaleString(),
     xAxisFormatter = value => value.toLocaleDateString(),
+    tooltipDateFormatter = defaultTooltipDateFormatter,
     className,
     emptyLabel = 'Not enough data to render a chart.',
     yAxisMin: fixedYMin,
@@ -216,7 +251,21 @@ export function BarChart({
     const [container, setContainer] = useState<HTMLElement | null>(null);
     const [containerWidth, setContainerWidth] = useState(chrome.minWidth);
     const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+    const [tooltipNode, setTooltipNode] = useState<HTMLDivElement | null>(null);
+    const [tooltipWidth, setTooltipWidth] = useState(0);
     const [hiddenSeries, setHiddenSeries] = useState<Set<string>>(new Set());
+
+    /**
+     * Measures the rendered tooltip's width so its center can be clamped to keep
+     * the whole box inside the chart. The tooltip mounts only on hover (never
+     * during SSR), so reading its box in an effect is hydration-safe; the width
+     * is stable across hovers, so a single measurement per mount suffices.
+     */
+    useEffect(() => {
+        if (tooltipNode) {
+            setTooltipWidth(tooltipNode.getBoundingClientRect().width);
+        }
+    }, [tooltipNode]);
 
     /**
      * Observes container width changes and updates the chart responsively.
@@ -477,7 +526,7 @@ export function BarChart({
             return;
         }
 
-        setTooltip({ x: nearest.centerX, y: chrome.margin.top, date: nearest.date, items });
+        setTooltip({ x: nearest.centerX, y: chrome.margin.top, date: nearest.date, items, chartWidthPx: bounds.width });
     };
 
     /**
@@ -488,6 +537,22 @@ export function BarChart({
     };
 
     const ariaLabel = `Bar chart: ${series.map(item => item.label).join(', ')}`;
+
+    // Clamp the tooltip's center so the whole box stays within the chart's
+    // on-screen bounds — at the edges it would otherwise overflow by half its
+    // width (~160px), spilling past the chart and, on a wide chart, the screen.
+    // When the chart is too narrow to fit the box plus both gutters, fall back to
+    // centering (the box itself caps at the chart width via `max-width: 100%`).
+    let tooltipLeftPx = 0;
+    if (tooltip) {
+        const centerPx = (tooltip.x / width) * tooltip.chartWidthPx;
+        const halfWidth = tooltipWidth / 2;
+        const minLeft = TOOLTIP_EDGE_GUTTER + halfWidth;
+        const maxLeft = tooltip.chartWidthPx - TOOLTIP_EDGE_GUTTER - halfWidth;
+        tooltipLeftPx = minLeft <= maxLeft
+            ? Math.min(Math.max(centerPx, minLeft), maxLeft)
+            : tooltip.chartWidthPx / 2;
+    }
 
     return (
         <figure ref={setContainer} className={cn(styles.chart, isWidget && styles['chart--widget'], className)}>
@@ -562,11 +627,12 @@ export function BarChart({
 
             {tooltip && (
                 <div
+                    ref={setTooltipNode}
                     className={styles.tooltip}
-                    style={{ left: `${(tooltip.x / width) * 100}%`, top: tooltip.y }}
+                    style={{ left: `${tooltipLeftPx}px`, top: tooltip.y }}
                     role="presentation"
                 >
-                    <span className={styles.tooltip__label}>{xAxisFormatter(tooltip.date)}</span>
+                    <span className={styles.tooltip__label}>{tooltipDateFormatter(tooltip.date)}</span>
                     {tooltip.items.map(item => (
                         <div key={item.id} className={styles.tooltip__row}>
                             <span className={styles.tooltip__series}>


### PR DESCRIPTION
## Summary

Three related BarChart refinements:

- **Tooltip edge-clamping.** The tooltip center is clamped against the chart's measured on-screen width so the whole box stays inside the chart. Previously it was positioned by percentage and overflowed by up to half its width (~160px) at the edges, spilling past the chart and, on wide charts, off-screen. When the chart is too narrow to fit the box plus both gutters, it falls back to centering, and the box itself caps at the chart width via `max-width: 100%`.
- **Unclipped axis labels.** The root `<svg>` now sets `overflow: visible` so margin-anchored axis labels paint past the viewBox edge instead of losing their outermost glyphs. The figure margins already reserve the room.
- **Tooltip date+time heading.** New `tooltipDateFormatter` prop defaults to short date plus 24-hour time, so the hovered bucket shows hour/minute even when the compact x-axis label is date-only. Tooltip-only (hover, post-hydration), so locale-dependent time output is hydration-safe.

Tooltip width is measured once per mount via a ref callback in an effect — the tooltip only mounts on hover, never during SSR, so the measurement is hydration-safe.