### PR TITLE
Add draft IHttpClient contract to types package (tronrelic#289)

### DIFF
--- a/packages/types/src/http/HttpResponseType.ts
+++ b/packages/types/src/http/HttpResponseType.ts
@@ -1,0 +1,8 @@
+/**
+ * DRAFT (tronrelic#289) — supporting type for the proposed outbound HTTP client
+ * contract. See IHttpClient.ts for full status and caveats. Not yet wired into
+ * IPluginContext.http.
+ */
+
+/** Response body interpretation requested from the transport. */
+export type HttpResponseType = 'json' | 'text' | 'stream' | 'arraybuffer';

--- a/packages/types/src/http/IAbortSignalLike.ts
+++ b/packages/types/src/http/IAbortSignalLike.ts
@@ -1,0 +1,22 @@
+/**
+ * DRAFT (tronrelic#289) — minimal structural AbortSignal shape for the proposed
+ * outbound HTTP client contract. See IHttpClient.ts for full status and caveats.
+ *
+ * Defined locally rather than referencing the global `AbortSignal` so the
+ * published contract stays self-contained: a consumer whose tsconfig omits the
+ * `dom` lib and `@types/node` can still consume `IHttpRequestConfig` without a
+ * typecheck failure. A real DOM or Node `AbortSignal` is structurally assignable
+ * to this shape, so callers pass `new AbortController().signal` unchanged.
+ */
+
+/** Minimal structural subset of the standard AbortSignal a real one satisfies. */
+export interface IAbortSignalLike {
+    /** True once abort has been requested. */
+    readonly aborted: boolean;
+    /** Register an abort listener. */
+    addEventListener(type: 'abort', listener: (this: IAbortSignalLike, ev: any) => any, options?: any): void;
+    /** Remove a previously registered abort listener. */
+    removeEventListener(type: 'abort', listener: (this: IAbortSignalLike, ev: any) => any, options?: any): void;
+    /** Abort event handler, or null when none is set. */
+    onabort: ((this: IAbortSignalLike, ev: any) => any) | null;
+}

--- a/packages/types/src/http/IHttpClient.ts
+++ b/packages/types/src/http/IHttpClient.ts
@@ -1,0 +1,80 @@
+/**
+ * DRAFT — outbound HTTP client abstraction for plugins and modules.
+ *
+ * Status: proposed, NOT yet wired into `IPluginContext.http`. This is the
+ * starting-point draft referenced by tronrelic#289. Its purpose is to replace
+ * the leaked axios `AxiosInstance` type on the plugin contract with a
+ * core-owned interface, removing the dual-package type-identity hazard (a
+ * plugin's local axios version differing from core's) and decoupling the
+ * published contract from axios so the implementation can change later.
+ *
+ * DO NOT rely on this shape yet. Per tronrelic#289, an extensive review of
+ * every `context.http` consumer must finalize the request-config/response
+ * surface before `IPluginContext.http` is switched to `IHttpClient`. The
+ * fields below are a provisional union drawn from current consumers
+ * (trp-ai-assistant streaming + abort + family, trp-telegram-bot multipart +
+ * body-size caps, trp-resource-markets generics) and are expected to change.
+ *
+ * Interim convention until the switch lands: type injected http as
+ * `IPluginContext['http']`, not `import type { AxiosInstance } from 'axios'`.
+ */
+
+/** Response body interpretation requested from the transport. */
+export type HttpResponseType = 'json' | 'text' | 'stream' | 'arraybuffer';
+
+/**
+ * Per-request options. Provisional — the union of what current consumers pass
+ * to axios. Kept loose pending the tronrelic#289 review.
+ */
+export interface IHttpRequestConfig {
+    /** Request headers. */
+    headers?: Record<string, string>;
+    /** Query string parameters. */
+    params?: Record<string, string | number | boolean>;
+    /** Per-request timeout in milliseconds. */
+    timeout?: number;
+    /** How to interpret/return the response body. */
+    responseType?: HttpResponseType;
+    /** Cancellation signal; aborting cancels the in-flight request. */
+    signal?: AbortSignal;
+    /** Cap on accepted response size, in bytes. */
+    maxContentLength?: number;
+    /** Cap on sent request body size, in bytes. */
+    maxBodyLength?: number;
+    /** IP family hint (e.g. 4 to force IPv4). */
+    family?: number;
+}
+
+/** Minimal response envelope — only `data` is contractually guaranteed. */
+export interface IHttpResponseEnvelope<T = unknown> {
+    /** Parsed (or stream/text/buffer) response body, per `responseType`. */
+    data: T;
+}
+
+/**
+ * The outbound HTTP surface plugins and modules consume via `context.http`.
+ *
+ * Deliberately narrow: `get` and `post` cover every current consumer. Add
+ * verbs here only when a real consumer needs them, so the contract stays
+ * small and implementation-swappable.
+ */
+export interface IHttpClient {
+    /**
+     * Issue a GET request.
+     *
+     * @param url - Absolute request URL.
+     * @param config - Optional per-request options.
+     * @returns The response envelope.
+     */
+    get<T = unknown>(url: string, config?: IHttpRequestConfig): Promise<IHttpResponseEnvelope<T>>;
+
+    /**
+     * Issue a POST request.
+     *
+     * @param url - Absolute request URL.
+     * @param data - Request body (JSON-serializable object, FormData, etc.).
+     * @param config - Optional per-request options.
+     * @returns The response envelope.
+     */
+    post<T = unknown>(url: string, data?: unknown, config?: IHttpRequestConfig): Promise<IHttpResponseEnvelope<T>>;
+}

--- a/packages/types/src/http/IHttpClient.ts
+++ b/packages/types/src/http/IHttpClient.ts
@@ -11,45 +11,16 @@
  * DO NOT rely on this shape yet. Per tronrelic#289, an extensive review of
  * every `context.http` consumer must finalize the request-config/response
  * surface before `IPluginContext.http` is switched to `IHttpClient`. The
- * fields below are a provisional union drawn from current consumers
- * (trp-ai-assistant streaming + abort + family, trp-telegram-bot multipart +
- * body-size caps, trp-resource-markets generics) and are expected to change.
+ * supporting types (IHttpRequestConfig, IHttpResponseEnvelope, HttpResponseType)
+ * are a provisional union drawn from current consumers (trp-ai-assistant
+ * streaming + abort + family, trp-telegram-bot multipart + body-size caps,
+ * trp-resource-markets generics) and are expected to change.
  *
  * Interim convention until the switch lands: type injected http as
  * `IPluginContext['http']`, not `import type { AxiosInstance } from 'axios'`.
  */
-
-/** Response body interpretation requested from the transport. */
-export type HttpResponseType = 'json' | 'text' | 'stream' | 'arraybuffer';
-
-/**
- * Per-request options. Provisional — the union of what current consumers pass
- * to axios. Kept loose pending the tronrelic#289 review.
- */
-export interface IHttpRequestConfig {
-    /** Request headers. */
-    headers?: Record<string, string>;
-    /** Query string parameters. */
-    params?: Record<string, string | number | boolean>;
-    /** Per-request timeout in milliseconds. */
-    timeout?: number;
-    /** How to interpret/return the response body. */
-    responseType?: HttpResponseType;
-    /** Cancellation signal; aborting cancels the in-flight request. */
-    signal?: AbortSignal;
-    /** Cap on accepted response size, in bytes. */
-    maxContentLength?: number;
-    /** Cap on sent request body size, in bytes. */
-    maxBodyLength?: number;
-    /** IP family hint (e.g. 4 to force IPv4). */
-    family?: number;
-}
-
-/** Minimal response envelope — only `data` is contractually guaranteed. */
-export interface IHttpResponseEnvelope<T = unknown> {
-    /** Parsed (or stream/text/buffer) response body, per `responseType`. */
-    data: T;
-}
+import type { IHttpRequestConfig } from './IHttpRequestConfig.js';
+import type { IHttpResponseEnvelope } from './IHttpResponseEnvelope.js';
 
 /**
  * The outbound HTTP surface plugins and modules consume via `context.http`.

--- a/packages/types/src/http/IHttpRequestConfig.ts
+++ b/packages/types/src/http/IHttpRequestConfig.ts
@@ -1,0 +1,32 @@
+/**
+ * DRAFT (tronrelic#289) — per-request options for the proposed outbound HTTP
+ * client contract. See IHttpClient.ts for full status and caveats. Not yet
+ * wired into IPluginContext.http.
+ */
+import type { HttpResponseType } from './HttpResponseType.js';
+import type { IAbortSignalLike } from './IAbortSignalLike.js';
+
+/**
+ * Per-request options. Provisional — the union of what current consumers pass
+ * to axios (trp-ai-assistant streaming + abort + family, trp-telegram-bot
+ * multipart + body-size caps, trp-resource-markets generics). Kept loose
+ * pending the tronrelic#289 review and expected to change.
+ */
+export interface IHttpRequestConfig {
+    /** Request headers. */
+    headers?: Record<string, string>;
+    /** Query string parameters. */
+    params?: Record<string, string | number | boolean>;
+    /** Per-request timeout in milliseconds. */
+    timeout?: number;
+    /** How to interpret/return the response body. */
+    responseType?: HttpResponseType;
+    /** Cancellation signal; aborting cancels the in-flight request. */
+    signal?: IAbortSignalLike;
+    /** Cap on accepted response size, in bytes. */
+    maxContentLength?: number;
+    /** Cap on sent request body size, in bytes. */
+    maxBodyLength?: number;
+    /** IP family hint (e.g. 4 to force IPv4). */
+    family?: number;
+}

--- a/packages/types/src/http/IHttpResponseEnvelope.ts
+++ b/packages/types/src/http/IHttpResponseEnvelope.ts
@@ -1,0 +1,11 @@
+/**
+ * DRAFT (tronrelic#289) — response envelope for the proposed outbound HTTP
+ * client contract. See IHttpClient.ts for full status and caveats. Not yet
+ * wired into IPluginContext.http.
+ */
+
+/** Minimal response envelope — only `data` is contractually guaranteed. */
+export interface IHttpResponseEnvelope<T = unknown> {
+    /** Parsed (or stream/text/buffer) response body, per `responseType`. */
+    data: T;
+}

--- a/packages/types/src/http/index.ts
+++ b/packages/types/src/http/index.ts
@@ -11,3 +11,6 @@
 export type { IHttpRequest } from './IHttpRequest.js';
 export type { IHttpResponse } from './IHttpResponse.js';
 export type { IHttpNext } from './IHttpNext.js';
+// DRAFT (tronrelic#289) — proposed outbound HTTP client contract, not yet wired
+// into IPluginContext.http. See IHttpClient.ts for status and caveats.
+export type { IHttpClient, IHttpRequestConfig, IHttpResponseEnvelope, HttpResponseType } from './IHttpClient.js';

--- a/packages/types/src/http/index.ts
+++ b/packages/types/src/http/index.ts
@@ -13,4 +13,8 @@ export type { IHttpResponse } from './IHttpResponse.js';
 export type { IHttpNext } from './IHttpNext.js';
 // DRAFT (tronrelic#289) — proposed outbound HTTP client contract, not yet wired
 // into IPluginContext.http. See IHttpClient.ts for status and caveats.
-export type { IHttpClient, IHttpRequestConfig, IHttpResponseEnvelope, HttpResponseType } from './IHttpClient.js';
+export type { IHttpClient } from './IHttpClient.js';
+export type { IHttpRequestConfig } from './IHttpRequestConfig.js';
+export type { IHttpResponseEnvelope } from './IHttpResponseEnvelope.js';
+export type { HttpResponseType } from './HttpResponseType.js';
+export type { IAbortSignalLike } from './IAbortSignalLike.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,6 +5,10 @@ export { definePlugin } from './plugin/index.js';
 export type { ITransaction, ITransactionPersistencePayload, ITransactionCategoryFlags } from './transaction/index.js';
 export { ProcessedTransaction } from './transaction/index.js';
 export type { IHttpRequest, IHttpResponse, IHttpNext } from './http/index.js';
+// DRAFT (tronrelic#289) — proposed core-owned HTTP client contract; additive and
+// unwired. Will replace the leaked axios AxiosInstance on IPluginContext.http
+// after the consumer review tracked in the issue.
+export type { IHttpClient, IHttpRequestConfig, IHttpResponseEnvelope, HttpResponseType } from './http/index.js';
 export type { IAuthSession, IAuthSessionUser, IHasAuthSession } from './auth/index.js';
 export { ADMIN_GROUP_ID, isLoggedIn, isAnonymous, isInGroup, isAdmin, hasPrimaryWallet } from './auth/index.js';
 // ILogger removed - use ISystemLogService instead (exported from './system-log/index.js')

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,7 +8,7 @@ export type { IHttpRequest, IHttpResponse, IHttpNext } from './http/index.js';
 // DRAFT (tronrelic#289) — proposed core-owned HTTP client contract; additive and
 // unwired. Will replace the leaked axios AxiosInstance on IPluginContext.http
 // after the consumer review tracked in the issue.
-export type { IHttpClient, IHttpRequestConfig, IHttpResponseEnvelope, HttpResponseType } from './http/index.js';
+export type { IHttpClient, IHttpRequestConfig, IHttpResponseEnvelope, HttpResponseType, IAbortSignalLike } from './http/index.js';
 export type { IAuthSession, IAuthSessionUser, IHasAuthSession } from './auth/index.js';
 export { ADMIN_GROUP_ID, isLoggedIn, isAnonymous, isInGroup, isAdmin, hasPrimaryWallet } from './auth/index.js';
 // ILogger removed - use ISystemLogService instead (exported from './system-log/index.js')


### PR DESCRIPTION
Introduces a core-owned outbound HTTP client interface (`IHttpClient`) to the published types package as the starting-point draft for tronrelic#289.

## Why

`IPluginContext.http` currently exposes axios's `AxiosInstance` type directly. That leaks a third-party type into the published plugin contract, creating a dual-package type-identity hazard (a plugin's local axios version differing from core's) and coupling the contract to axios so the implementation can't change.

## What

Adds `IHttpClient`, `IHttpRequestConfig`, `IHttpResponseEnvelope`, and `HttpResponseType` under `packages/types/src/http/`, exported through the types barrels. The request-config surface is a provisional union drawn from current `context.http` consumers (trp-ai-assistant streaming/abort/family, trp-telegram-bot multipart/body-size caps, trp-resource-markets generics).

## Scope

Additive and **unwired**. `IPluginContext.http` is unchanged; nothing consumes the new types yet. Per tronrelic#289, an extensive review of every `context.http` consumer must finalize the surface before `context.http` is switched to `IHttpClient`. Marked DRAFT in the file header and both barrel exports.