### PR TITLE
Add shared requireLogin middleware and centralize SSR backend URL resolution

### DIFF
--- a/docs/plugins/plugins-api-registration.md
+++ b/docs/plugins/plugins-api-registration.md
@@ -27,6 +27,8 @@ Every route entry uses the `IApiRouteConfig` contract. Focus on these fields:
 
 Remember: `req.params`, `req.query`, `req.body`, and `req.ip` are plain objects; `res.status()`, `res.json()`, `res.send()`, and `res.setHeader()` mirror familiar Express methods but stay framework-agnostic.
 
+**`requiresAuth` runs the login gate.** The `requireLogin` middleware admits any caller with a live Better Auth session, returns **401** for anonymous requests, and sets `req.userId` to the Better Auth user id. Login is the bar — a wallet-gated route must additionally check `hasPrimaryWallet(req)` inside the handler.
+
 **`requiresAdmin` runs the admin gate.** The `requireAdmin` middleware admits the call when, in order, (a) the Better Auth session is in the `admin` group, or (b) the request carries `ADMIN_API_TOKEN` via `x-admin-token` / `Authorization: Bearer`. The middleware tags the request with `req.adminVia = 'user' | 'service-token'` so handlers and audit logs can attribute the call. See [system-auth.md](../system/system-auth.md) for the authorization model.
 
 The middleware short-circuits failures with **401**, or **503 when `ADMIN_API_TOKEN` is unset and no admin user resolves** — that 503 is the deliberate "admin surface disabled" signal, not a misconfiguration to retry. See [system-auth.md](../system/system-auth.md) for the canonical specification of the admin authorization model.

--- a/docs/system/system-auth.md
+++ b/docs/system/system-auth.md
@@ -65,7 +65,7 @@ handler: async (req, res) => {
 }
 ```
 
-Admin-gated REST routes should also carry `requiresAdmin: true` so the `requireAdmin` middleware enforces the gate (it admits a Better Auth admin session or the `ADMIN_API_TOKEN` service token). See [plugins-api-registration.md](../plugins/plugins-api-registration.md).
+Login-gated REST routes can carry `requiresAuth: true` so the shared `requireLogin` middleware (`api/middleware/require-login.ts`) enforces the gate — 401 for anonymous callers, `req.userId` set for authenticated ones. Admin-gated routes carry `requiresAdmin: true` so `requireAdmin` enforces the gate (it admits a Better Auth admin session or the `ADMIN_API_TOKEN` service token). Both middlewares are available to core routers and plugin route configs alike. See [plugins-api-registration.md](../plugins/plugins-api-registration.md).
 
 ## Further Reading
 

--- a/packages/types/src/plugin/IApiRouteConfig.ts
+++ b/packages/types/src/plugin/IApiRouteConfig.ts
@@ -140,8 +140,11 @@ export interface IApiRouteConfig {
     /**
      * Requires user authentication to access this route.
      *
-     * When true, the route checks for a valid authentication token before
-     * calling the handler. Unauthenticated requests receive a 401 error.
+     * When true, the platform's `requireLogin` middleware runs before the
+     * handler: any caller with a live Better Auth session passes, anonymous
+     * requests receive a 401 error. Login is the bar — routes that operate
+     * on a wallet must additionally gate with `hasPrimaryWallet` inside the
+     * handler.
      *
      * Default: false (public access)
      */

--- a/src/backend/api/middleware/__tests__/require-login.test.ts
+++ b/src/backend/api/middleware/__tests__/require-login.test.ts
@@ -13,6 +13,10 @@ import {
 } from '../../../modules/identity/services/auth-facade.js';
 import { requireLogin } from '../require-login.js';
 
+/**
+ * No-op ISystemLogService implementation injected into GroupService so
+ * facade session augmentation runs without console noise during tests.
+ */
 class NullLogger implements ISystemLogService {
     info() {} warn() {} error() {} debug() {} trace() {} fatal() {}
     child(): ISystemLogService { return this; }
@@ -31,6 +35,11 @@ class NullLogger implements ISystemLogService {
 // the matching ObjectId.
 const PLAIN_USER = 'd1d1d1d1d1d1d1d1d1d1d1d1';
 
+/**
+ * Build minimal Express req/res/next doubles for exercising the middleware:
+ * the res records `status()`/`json()` calls for assertion, and `called()`
+ * reports whether `next()` ran.
+ */
 function makeReqRes() {
     const req: any = {
         headers: {} as Record<string, string>,

--- a/src/backend/api/middleware/__tests__/require-login.test.ts
+++ b/src/backend/api/middleware/__tests__/require-login.test.ts
@@ -1,0 +1,137 @@
+/// <reference types="vitest" />
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ObjectId } from 'mongodb';
+import type { ISystemLogService } from '@/types';
+import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+
+import { GroupService } from '../../../modules/identity/services/group.service.js';
+import { AUTH_USERS_COLLECTION } from '../../../modules/identity/services/auth-constants.js';
+import {
+    setAuthInstance,
+    resetAuthInstanceForTests
+} from '../../../modules/identity/services/auth-facade.js';
+import { requireLogin } from '../require-login.js';
+
+class NullLogger implements ISystemLogService {
+    info() {} warn() {} error() {} debug() {} trace() {} fatal() {}
+    child(): ISystemLogService { return this; }
+    async initialize() {} async saveLog() {}
+    async getLogs() { return { logs: [], total: 0, page: 1, limit: 50, totalPages: 0, hasNextPage: false, hasPrevPage: false }; }
+    async markAsResolved() {} async markAsUnresolved() { return null; }
+    async cleanup() { return 0; }
+    async getStatistics(): Promise<any> { return { total: 0, byLevel: {}, byService: {}, unresolved: 0 }; }
+    async getLogById() { return null; }
+    async deleteAllLogs() { return 0; }
+    level = 'info';
+}
+
+// Better Auth exposes user ids as the 24-char hex form of the ObjectId
+// `_id`; sessions carry the hex string and the users collection is keyed by
+// the matching ObjectId.
+const PLAIN_USER = 'd1d1d1d1d1d1d1d1d1d1d1d1';
+
+function makeReqRes() {
+    const req: any = {
+        headers: {} as Record<string, string>,
+        userId: undefined as string | undefined
+    };
+
+    let status = 200;
+    let body: any = null;
+    const res: any = {
+        status(code: number) { status = code; return res; },
+        json(data: any) { body = data; return res; },
+        get statusCode() { return status; },
+        get jsonBody() { return body; }
+    };
+
+    let nextCalled = false;
+    const next = () => { nextCalled = true; };
+
+    return { req, res, next, called: () => nextCalled };
+}
+
+/**
+ * Build a stubbed Better Auth instance whose `getSession` returns a fixed
+ * value regardless of input headers.
+ */
+function makeStubAuth(session: { user: { id: string; email: string }; session?: unknown } | null) {
+    return {
+        api: {
+            getSession: vi.fn(async () => session)
+        }
+    } as any;
+}
+
+describe('requireLogin middleware', () => {
+    let mockDb: ReturnType<typeof createMockDatabaseService>;
+
+    /**
+     * Seed a Better Auth user row directly into the auth users collection
+     * so GroupService.getUserGroups resolves the caller's groups during
+     * facade session augmentation.
+     */
+    function seedBaUser(userId: string, groups: string[]): void {
+        mockDb.getCollectionData(AUTH_USERS_COLLECTION).push({
+            _id: new ObjectId(userId),
+            email: `${userId}@example.com`,
+            emailVerified: true,
+            groups
+        });
+    }
+
+    beforeEach(() => {
+        mockDb = createMockDatabaseService();
+        GroupService.resetForTests();
+        GroupService.setDependencies(mockDb, new NullLogger());
+        resetAuthInstanceForTests();
+    });
+
+    afterEach(() => {
+        resetAuthInstanceForTests();
+        GroupService.resetForTests();
+    });
+
+    it('admits any authenticated account and sets req.userId for audit logging', async () => {
+        setAuthInstance(makeStubAuth({
+            user: { id: PLAIN_USER, email: 'p@b.com' },
+            session: { id: 's1', token: 't', expiresAt: new Date().toISOString() }
+        }));
+        seedBaUser(PLAIN_USER, []);
+
+        const { req, res, next, called } = makeReqRes();
+        await requireLogin(req, res, next);
+
+        expect(called()).toBe(true);
+        expect(req.userId).toBe(PLAIN_USER);
+        expect(res.statusCode).toBe(200);
+    });
+
+    it('rejects anonymous callers with 401', async () => {
+        setAuthInstance(makeStubAuth(null));
+
+        const { req, res, next, called } = makeReqRes();
+        await requireLogin(req, res, next);
+
+        expect(called()).toBe(false);
+        expect(res.statusCode).toBe(401);
+        expect(res.jsonBody).toEqual({ success: false, error: 'Authentication required' });
+    });
+
+    it('degrades a failed session resolution to 401, not a thrown error', async () => {
+        // The facade swallows resolution failures and resolves to null, so
+        // a BA/Mongo hiccup on a login-gated route surfaces as 401.
+        setAuthInstance({
+            api: {
+                getSession: vi.fn(async () => { throw new Error('BA down'); })
+            }
+        } as any);
+
+        const { req, res, next, called } = makeReqRes();
+        await requireLogin(req, res, next);
+
+        expect(called()).toBe(false);
+        expect(res.statusCode).toBe(401);
+    });
+});

--- a/src/backend/api/middleware/admin-auth.ts
+++ b/src/backend/api/middleware/admin-auth.ts
@@ -6,30 +6,6 @@ import {
 } from '../../modules/identity/services/auth-facade.js';
 
 /**
- * Augment Express Request with the admin-auth path that approved the call.
- *
- * `'user'` — request was approved via a Better Auth session whose user is a
- *            member of the `admin` group. `req.userId` carries that BA user
- *            id; audit logs should record it.
- * `'service-token'` — request carried a valid `ADMIN_API_TOKEN`. Used by CI
- *            scripts and the bootstrap-first-admin recipe. No human
- *            attribution; audit logs note this fact explicitly.
- */
-declare module 'express-serve-static-core' {
-    interface Request {
-        /** Admin auth path that approved the request, set by `requireAdmin`. */
-        adminVia?: 'user' | 'service-token';
-        /**
-         * Better Auth user id of the authenticated caller, populated by
-         * `requireAdmin` on the session path and by `requireLogin` for
-         * login-gated routes. Declared here so audit-logging handlers can
-         * read it without ad-hoc casts.
-         */
-        userId?: string;
-    }
-}
-
-/**
  * Pull the admin token candidate off a request without enforcing.
  * Accepts the same two transport methods as `requireAdmin`: `x-admin-token`
  * header (preferred) and `Authorization: Bearer {token}`.

--- a/src/backend/api/middleware/admin-auth.ts
+++ b/src/backend/api/middleware/admin-auth.ts
@@ -20,9 +20,10 @@ declare module 'express-serve-static-core' {
         /** Admin auth path that approved the request, set by `requireAdmin`. */
         adminVia?: 'user' | 'service-token';
         /**
-         * Better Auth user id of the admin operator, populated by
-         * `requireAdmin` on the session path. Declared here so audit-logging
-         * admin handlers can read it without ad-hoc casts.
+         * Better Auth user id of the authenticated caller, populated by
+         * `requireAdmin` on the session path and by `requireLogin` for
+         * login-gated routes. Declared here so audit-logging handlers can
+         * read it without ad-hoc casts.
          */
         userId?: string;
     }

--- a/src/backend/api/middleware/require-login.ts
+++ b/src/backend/api/middleware/require-login.ts
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview Login-gating middleware.
+ *
+ * The user-level counterpart to `requireAdmin`: admits any caller with
+ * a live Better Auth session and 401s anonymous requests. Used by core
+ * routers that gate login-only endpoints and pushed automatically onto
+ * plugin routes declaring `requiresAuth: true` (see
+ * `services/plugin-api.service.ts`).
+ *
+ * Login is the bar — any authenticated account passes. Routes that
+ * operate on a wallet must additionally gate with `hasPrimaryWallet`
+ * inside the handler; see `docs/system/system-auth.md`.
+ */
+
+import type { NextFunction, Request, Response } from 'express';
+import { getSessionForRequest } from '../../modules/identity/services/auth-facade.js';
+
+/**
+ * Require the caller to be signed in.
+ *
+ * Resolves the Better Auth session through the auth facade — a pure
+ * cache read when `attachAuthSession` already primed the request, a
+ * cookie resolution otherwise (tests, non-Express call sites). The
+ * facade degrades resolution failures to `null`, so this middleware
+ * never throws: anonymous callers receive 401, authenticated callers
+ * proceed with `req.userId` set to the Better Auth user id for audit
+ * logging.
+ *
+ * @param req - Express request object
+ * @param res - Express response object
+ * @param next - Express next function to pass control to next middleware
+ */
+export async function requireLogin(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const session = await getSessionForRequest(req);
+    if (!session) {
+        res.status(401).json({ success: false, error: 'Authentication required' });
+        return;
+    }
+    req.userId = session.user.id;
+    next();
+}

--- a/src/backend/modules/tools/README.md
+++ b/src/backend/modules/tools/README.md
@@ -42,9 +42,9 @@ The Signature Verifier supports direct URL linking via query parameters: `/tools
 
 ## Security
 
-### Rate Limiting
+### Rate Limiting and Authentication
 
-All endpoints are unauthenticated and rate-limited at 30 requests per 60-second window per IP address, using the same Redis-backed `createRateLimiter` infrastructure as other public routes.
+Endpoints are rate-limited at 30 requests per 60-second window per IP address, using the same Redis-backed `createRateLimiter` infrastructure as other public routes. All tools are unauthenticated except the approval checker, which is gated by the shared `requireLogin` middleware (`api/middleware/require-login.ts`) and has its own tighter limiter (10 requests per 60 seconds).
 
 ### Async Error Handling
 

--- a/src/backend/modules/tools/api/tools.router.ts
+++ b/src/backend/modules/tools/api/tools.router.ts
@@ -8,30 +8,10 @@
  */
 
 import { Router } from 'express';
-import type { Request, Response, NextFunction } from 'express';
 import { asyncHandler } from '../../../api/middleware/async-handler.js';
 import { createRateLimiter } from '../../../api/middleware/rate-limit.js';
-import { getSessionForRequest } from '../../../modules/identity/services/auth-facade.js';
+import { requireLogin } from '../../../api/middleware/require-login.js';
 import type { ToolsController } from './tools.controller.js';
-
-/**
- * Require the caller to be signed in.
- *
- * Resolves the Better Auth session and returns 401 for anonymous callers;
- * any authenticated account passes. The approval checker only reads public
- * on-chain data for an address the caller types in, so a linked wallet is not
- * a prerequisite — login is the bar, matching the frontend `isLoggedIn` gate
- * in `ApprovalChecker`. `getSessionForRequest` resolves to null rather than
- * throwing, so this middleware never rejects.
- */
-async function requireLogin(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const session = await getSessionForRequest(req);
-    if (!session) {
-        res.status(401).json({ error: 'Authentication required', message: 'Sign in to use this tool' });
-        return;
-    }
-    next();
-}
 
 /**
  * Create the tools router with all public endpoints.
@@ -62,6 +42,9 @@ export function createToolsRouter(controller: ToolsController): Router {
     router.post('/stake/from-trx', rateLimiter, asyncHandler(controller.estimateStakeFromTrx));
     router.post('/stake/from-energy', rateLimiter, asyncHandler(controller.estimateStakeFromEnergy));
     router.post('/signature/verify', rateLimiter, asyncHandler(controller.verifySignature));
+    // The approval checker only reads public on-chain data for an address the
+    // caller types in, so a linked wallet is not a prerequisite — login is the
+    // bar, matching the frontend `isLoggedIn` gate in `ApprovalChecker`.
     router.post('/approval/check', requireLogin, approvalRateLimiter, asyncHandler(controller.checkApprovals));
     router.post('/timestamp/convert', rateLimiter, asyncHandler(controller.convertTimestamp));
 

--- a/src/backend/modules/tools/api/tools.router.ts
+++ b/src/backend/modules/tools/api/tools.router.ts
@@ -45,7 +45,9 @@ export function createToolsRouter(controller: ToolsController): Router {
     // The approval checker only reads public on-chain data for an address the
     // caller types in, so a linked wallet is not a prerequisite — login is the
     // bar, matching the frontend `isLoggedIn` gate in `ApprovalChecker`.
-    router.post('/approval/check', requireLogin, approvalRateLimiter, asyncHandler(controller.checkApprovals));
+    // Rate limit before the login gate so anonymous spam is throttled before
+    // it reaches Better Auth session resolution.
+    router.post('/approval/check', approvalRateLimiter, requireLogin, asyncHandler(controller.checkApprovals));
     router.post('/timestamp/convert', rateLimiter, asyncHandler(controller.convertTimestamp));
 
     return router;

--- a/src/backend/services/plugin-api.service.ts
+++ b/src/backend/services/plugin-api.service.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response, type NextFunction, type RequestHan
 import type { IPlugin, IApiRouteConfig, IHttpRequest, IHttpResponse, IHttpNext, ApiRouteHandler, ApiMiddleware } from '@/types';
 import { logger } from '../lib/logger.js';
 import { requireAdmin } from '../api/middleware/admin-auth.js';
+import { requireLogin } from '../api/middleware/require-login.js';
 
 /**
  * Adapt Express Request to framework-agnostic IHttpRequest.
@@ -234,8 +235,8 @@ export class PluginApiService {
             middlewareChain.push(requireAdmin);
             logger.debug({ pluginId, path }, 'Admin auth middleware applied to route');
         } else if (requiresAuth) {
-            // TODO: Implement authentication middleware
-            // middlewareChain.push(authMiddleware);
+            middlewareChain.push(requireLogin);
+            logger.debug({ pluginId, path }, 'Login auth middleware applied to route');
         }
 
         // Adapt plugin handler to Express RequestHandler

--- a/src/backend/types/express.d.ts
+++ b/src/backend/types/express.d.ts
@@ -20,5 +20,24 @@ declare module 'express-serve-static-core' {
      * {@link isInGroup} predicates from the auth facade instead.
      */
     authSession?: IAugmentedSession | null;
+    /**
+     * Admin auth path that approved the request, set by `requireAdmin`
+     * (`api/middleware/admin-auth.ts`).
+     *
+     * - `'user'` — approved via a Better Auth session whose user is a
+     *   member of the `admin` group. `req.userId` carries that BA user
+     *   id; audit logs should record it.
+     * - `'service-token'` — request carried a valid `ADMIN_API_TOKEN`.
+     *   Used by CI scripts and the bootstrap-first-admin recipe. No human
+     *   attribution; audit logs note this fact explicitly.
+     */
+    adminVia?: 'user' | 'service-token';
+    /**
+     * Better Auth user id of the authenticated caller, populated by
+     * `requireAdmin` on the session path and by `requireLogin` for
+     * login-gated routes. Declared here so audit-logging handlers can
+     * read it without ad-hoc casts.
+     */
+    userId?: string;
   }
 }

--- a/src/frontend/lib/api-url.ts
+++ b/src/frontend/lib/api-url.ts
@@ -52,7 +52,7 @@
  * code (getServerSideProps, API routes, etc.). Client components should use
  * getClientSideApiUrl() instead.
  *
- * @returns {string} The base API URL without /api suffix (e.g., http://backend:4000)
+ * @returns {string} The base API URL without /api suffix or trailing slash (e.g., http://backend:4000)
  *
  * @example
  * ```typescript
@@ -71,7 +71,9 @@ export function getServerSideApiUrl(): string {
     if (!process.env.SITE_BACKEND) {
         throw new Error('SITE_BACKEND environment variable is required for server-side API requests');
     }
-    return process.env.SITE_BACKEND;
+    // Strip any trailing slash so `${url}/api/...` interpolation at call
+    // sites can never produce `//api/...` paths.
+    return process.env.SITE_BACKEND.replace(/\/$/, '');
 }
 
 /**

--- a/src/frontend/lib/serverConfig.ts
+++ b/src/frontend/lib/serverConfig.ts
@@ -36,6 +36,8 @@
  * - The legacy lib/config.ts module was removed; this and lib/runtimeConfig.ts are the only config sources
  */
 
+import { getServerSideApiUrl } from './api-url';
+
 /**
  * TRON blockchain chain parameters for frontend calculations.
  * Subset of IChainParameters containing only the parameters object.
@@ -87,22 +89,6 @@ export interface RuntimeConfig {
 let cachedConfig: RuntimeConfig | null = null;
 
 /**
- * Resolves the backend URL for SSR-to-backend communication.
- *
- * Requires SITE_BACKEND environment variable:
- * - Docker: http://backend:4000 (container-to-container communication)
- * - Local npm: http://localhost:4000 (direct localhost connection)
- *
- * @returns Backend URL for SSR fetch calls (e.g., "http://backend:4000")
- */
-function getBackendUrl(): string {
-    if (!process.env.SITE_BACKEND) {
-        throw new Error('SITE_BACKEND environment variable is required for server-side rendering');
-    }
-    return process.env.SITE_BACKEND.replace(/\/$/, '');
-}
-
-/**
  * Fetches runtime configuration from backend and caches it.
  *
  * Flow:
@@ -116,9 +102,10 @@ function getBackendUrl(): string {
  * - Zero overhead after initial fetch
  *
  * Error handling:
- * If backend is unavailable or returns an error, falls back to environment variables.
- * This ensures local development works even if backend isn't running yet,
- * and provides graceful degradation in production if the backend config endpoint fails.
+ * A missing SITE_BACKEND is a deployment error and throws — it is not
+ * caught by the fallback below. If the backend is unreachable or returns
+ * an error, falls back to a degraded config (isUsingFallback: true) so
+ * SSR keeps rendering while the backend recovers.
  *
  * @returns Runtime configuration with siteUrl, apiUrl, and socketUrl
  */
@@ -128,8 +115,11 @@ export async function getServerConfig(): Promise<RuntimeConfig> {
         return cachedConfig;
     }
 
+    // Resolved outside the try: a missing SITE_BACKEND must surface as a
+    // deployment error, not degrade into the unreachable-backend fallback.
+    const backendUrl = getServerSideApiUrl().replace(/\/$/, '');
+
     try {
-        const backendUrl = getBackendUrl();
         const response = await fetch(`${backendUrl}/api/config/public`, {
             cache: 'no-store', // Don't let Next.js cache this (we cache manually)
             signal: AbortSignal.timeout(5000) // 5 second timeout
@@ -151,11 +141,9 @@ export async function getServerConfig(): Promise<RuntimeConfig> {
 
         return data.config;
     } catch (error) {
-        // Fallback to localhost defaults (local dev safety)
-        console.warn('[ServerConfig] Failed to fetch runtime config, using localhost fallback:', error);
+        // Backend unreachable — degrade so SSR keeps rendering.
+        console.warn('[ServerConfig] Failed to fetch runtime config, using fallback:', error);
 
-        // Use SITE_BACKEND if available, otherwise default to localhost
-        const backendUrl = process.env.SITE_BACKEND || 'http://localhost:4000';
         const siteUrl = process.env.SITE_URL || 'http://localhost:3000';
 
         const fallbackConfig: RuntimeConfig = {

--- a/src/frontend/lib/serverConfig.ts
+++ b/src/frontend/lib/serverConfig.ts
@@ -117,7 +117,8 @@ export async function getServerConfig(): Promise<RuntimeConfig> {
 
     // Resolved outside the try: a missing SITE_BACKEND must surface as a
     // deployment error, not degrade into the unreachable-backend fallback.
-    const backendUrl = getServerSideApiUrl().replace(/\/$/, '');
+    // Trailing-slash normalization happens inside getServerSideApiUrl().
+    const backendUrl = getServerSideApiUrl();
 
     try {
         const response = await fetch(`${backendUrl}/api/config/public`, {

--- a/src/frontend/middleware.ts
+++ b/src/frontend/middleware.ts
@@ -12,6 +12,7 @@
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { getServerSideApiUrl } from './lib/api-url';
 
 /** Cookie name for preserved external referrer */
 export const ORIGINAL_REFERRER_COOKIE = '_original_ref';
@@ -193,7 +194,9 @@ async function emitBootstrapEvent(
     tid: string,
     referralCode: string | null
 ): Promise<void> {
-    const backendUrl = process.env.SITE_BACKEND || 'http://localhost:4000';
+    // Resolved outside the try: a missing SITE_BACKEND is a deployment
+    // error that must surface, while the fetch below stays best-effort.
+    const backendUrl = getServerSideApiUrl();
     try {
         await fetch(`${backendUrl}/api/user/bootstrap`, {
             method: 'POST',

--- a/src/frontend/modules/user/lib/session-server.ts
+++ b/src/frontend/modules/user/lib/session-server.ts
@@ -14,6 +14,7 @@
  */
 
 import { headers } from 'next/headers';
+import { getServerSideApiUrl } from '../../../lib/api-url';
 
 /**
  * Minimal SSR-safe shape of the Better Auth session response.
@@ -53,14 +54,17 @@ export interface ISSRSession {
  * Forwards every inbound cookie to the backend's `/api/auth/get-session`
  * endpoint so the BA session cookie reaches the auth pipeline. Returns
  * `null` when no session is active, the backend is unreachable, or the
- * response is malformed — every failure mode collapses to "render
- * signed-out" rather than throwing, which keeps SSR resilient.
+ * response is malformed — runtime failure modes collapse to "render
+ * signed-out" rather than throwing, which keeps SSR resilient. A missing
+ * `SITE_BACKEND` is a deployment error, not a runtime failure, and throws.
  *
  * @returns Resolved session for the inbound request, or null.
  */
 export async function getServerSession(): Promise<ISSRSession | null> {
+    // Resolved outside the try: a missing SITE_BACKEND must surface
+    // rather than collapse to signed-out.
+    const backendUrl = getServerSideApiUrl();
     try {
-        const backendUrl = process.env.SITE_BACKEND || 'http://localhost:4000';
         const reqHeaders = await headers();
         const cookieHeader = reqHeaders.get('cookie');
 


### PR DESCRIPTION
## Summary

- Extract the tools router's inline login gate into a shared `api/middleware/require-login.ts` and wire it into `PluginApiService`, so plugin routes declaring `requiresAuth: true` are enforced (replacing the long-standing TODO). The middleware sets `req.userId` for audit logging; the `IApiRouteConfig.requiresAuth` JSDoc and auth docs now describe the actual contract (login is the bar; wallet-gated routes additionally check `hasPrimaryWallet`).
- Centralize SSR backend URL resolution through `getServerSideApiUrl()` in `serverConfig.ts`, `middleware.ts`, and `session-server.ts`, so a missing `SITE_BACKEND` surfaces as a deployment error instead of silently falling back to localhost; the unreachable-backend fallback path remains for graceful degradation.
- Add unit tests for the new middleware.