### PR TITLE
chore: add trp-address-labels types package to root workspace lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,9 @@
         "tsx": "^4.19.1",
         "typescript": "~5.6.2",
         "vitest": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "apps/backend": {
@@ -381,6 +384,10 @@
     },
     "node_modules/@delphian/tronrelic-types": {
       "resolved": "packages/types",
+      "link": true
+    },
+    "node_modules/@delphian/trp-address-labels-types": {
+      "resolved": "src/plugins/trp-address-labels/packages/types",
       "link": true
     },
     "node_modules/@delphian/trp-ai-assistant-types": {
@@ -13647,6 +13654,14 @@
         "socket.io-client": {
           "optional": true
         }
+      }
+    },
+    "src/plugins/trp-address-labels/packages/types": {
+      "name": "@delphian/trp-address-labels-types",
+      "version": "0.1.1",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.3.3"
       }
     },
     "src/plugins/trp-ai-assistant/packages/types": {


### PR DESCRIPTION
The Docker build copies every plugin's nested `packages/*/package.json` before the root `npm ci`, so the root lockfile must contain the workspace entry for `@delphian/trp-address-labels-types` before the plugin can be enabled in tronrelic-ops `plugins.json`.

The types package was published to GitHub Packages as `@delphian/trp-address-labels-types@0.1.1`; the lock entry records the nested workspace member at that version. The `engines` recording on the root entry is mechanical — current npm writes the root `package.json` engines field into the lock on any install.