### PR TITLE
fix(traffic): correct misleading analytics and add unified overview headline

### DIFF
--- a/src/backend/modules/traffic/README.md
+++ b/src/backend/modules/traffic/README.md
@@ -13,7 +13,7 @@ Owns cookieless behavioral analytics: the ClickHouse `traffic_events` pipeline, 
 | Scheduled job | `gsc:fetch` (daily, `0 3 * * *`) |
 | ClickHouse table | `traffic_events` (migrations 010, 012, 013) |
 | Event types | `bootstrap` (cookieless first touch, incl. bots) · `page` (interactive navigation) |
-| Mongo collection | `module_user_gsc_queries` (GSC keyword cache — physical name preserved) |
+| Mongo collections | `module_user_gsc_queries` (GSC keyword cache — physical name preserved) · `module_user_gsc_daily_totals` (date-only GSC daily totals) |
 | Analytics key | cookieless `tronrelic_tid` (`candidate_uid`), independent of identity |
 | Bootstrap order | Inits/runs **before** `IdentityModule` so its `/api/admin/users/{traffic,analytics}` routers mount ahead of the accounts `/api/admin/users` catch-all |
 
@@ -29,7 +29,7 @@ Physical storage names are unchanged from when this code lived under the user mo
 |------|----------------|
 | `TrafficModule.ts` | Two-phase lifecycle; constructs services, mounts the admin router, registers `gsc:fetch` |
 | `services/traffic.service.ts` | ClickHouse `traffic_events` writes + admin aggregate reads; `buildTrafficEvent`, `ITrafficEvent` |
-| `services/gsc.service.ts` | Google Search Console keyword fetch/store (`module_user_gsc_queries`) |
+| `services/gsc.service.ts` | Google Search Console keyword fetch/store (`module_user_gsc_queries`) plus date-only daily totals (`module_user_gsc_daily_totals`) — GSC drops anonymized queries from keyword rows, so chart totals come from the date-only fetch |
 | `services/bot-classifier.ts` | User-Agent → `BotClass` (powers `traffic_events.bot_class`) |
 | `services/geo.service.ts` | IP → country, referrer parsing, device derivation, `getClientIP`; defines `DeviceCategory` / `ScreenSizeCategory` |
 | `api/traffic.{controller,routes}.ts` | `/api/admin/users/traffic/*` raw-traffic reads **and** `/api/admin/users/analytics/*` dashboard aggregates (ClickHouse-backed), including the per-tid / per-user page-activity reads |
@@ -51,7 +51,7 @@ The `/api/admin/users/traffic/*` reads below are under `requireAdmin` and accept
 | GET | `/api/admin/users/traffic/bot-trend` | Daily counts per `bot_class` (default `sinceHours=168`); NULL folded to `unclassified` |
 | GET | `/api/admin/users/traffic/bot-paths` | Top paths for one `botClass` (validated against the `BotClass` allow-list, 400 on miss) |
 
-The `/api/admin/users/analytics/*` router (also `requireAdmin`) serves the `/system/traffic` dashboard aggregates — daily visitors, anonymous first touches (`new-users`), traffic sources, geo/device breakdowns, engagement, the binary conversion funnel, retention, and the GSC endpoints — all backed by `traffic_events`. GSC reads expose the keyword cache: `gsc/keywords` (aggregated clicks/impressions/CTR/position for a `periodHours` window) and `gsc/keywords-by-day` (daily buckets for trend charts); both are Mongo-backed and return empty until the `gsc:fetch` job has stored data. The frontend consumes everything through `src/frontend/modules/traffic/api/client.ts`.
+The `/api/admin/users/analytics/*` router (also `requireAdmin`) serves the `/system/traffic` dashboard aggregates — the unified `overview-trend` headline (current + equal-length-previous-window KPIs for delta rendering, plus a zero-filled visitors/pageviews series bucketed hourly for windows ≤ 48h and daily otherwise), the `live` counter (distinct visitors in the last 5 minutes), daily visitors, anonymous first touches (`new-users`), traffic sources, geo/device breakdowns, engagement, the binary conversion funnel, retention, and the GSC endpoints — all backed by `traffic_events`. Every windowed analytics read accepts `bots=exclude` to restrict counts to human-classified rows (`bot_class = 'human'` or legacy NULL) — referrers are client-supplied and routinely spoofed by crawlers, so the default include-everything counts overstate real audiences; the dashboard's global filter defaults to humans-only. The `traffic-sources`, `top-landing-pages`, `geo-distribution`, and `device-breakdown` buckets carry `visitors` (distinct tids, the primary measure per analytics convention) alongside the raw event `count`. GSC reads expose the keyword cache: `gsc/keywords` (aggregated clicks/impressions/CTR/position for a `periodHours` window, plus `windowStart`/`windowEnd` carrying the ~3-day-delay-shifted dates actually covered) and `gsc/keywords-by-day` (zero-filled daily buckets for trend charts; per-day totals come from `module_user_gsc_daily_totals` because GSC omits anonymized queries from keyword rows). Both are Mongo-backed and return empty/zero until the `gsc:fetch` job has stored data. The frontend consumes everything through `src/frontend/modules/traffic/api/client.ts`.
 
 Per-page clickstream reads live on the same router: `tid-activity` and `user-activity` summarize `page` events by anonymous tid (`user_id IS NULL`) and registered account (`user_id IS NOT NULL`) respectively, and `page-hits?subject=tid|user&id=` returns one subject's ordered page hits — "every page they hit".
 

--- a/src/backend/modules/traffic/__tests__/gsc.service.test.ts
+++ b/src/backend/modules/traffic/__tests__/gsc.service.test.ts
@@ -1,0 +1,218 @@
+/// <reference types="vitest" />
+
+/**
+ * GscService unit tests.
+ *
+ * Covers the read-side behaviors that keep the /system/traffic SEO tab
+ * honest: the delay-shifted keyword window (and its returned bounds),
+ * zero-filled daily buckets, the true-daily-totals override that corrects
+ * for GSC's anonymized-query undercount, and the totals-collection indexes.
+ * The network fetch path (googleapis) is intentionally untested here —
+ * these tests exercise the Mongo aggregation/lookup logic only.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ICacheService, IDatabaseService, ISystemLogService } from '@/types';
+import { GscService } from '../services/gsc.service.js';
+
+/** Days GSC data lags behind now — mirrors GSC_DATA_DELAY_DAYS in the service. */
+const DELAY_DAYS = 3;
+
+/** Milliseconds per day. */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Minimal logger double — every call is a vi.fn so tests can assert on
+ * warn/info paths without pulling in pino.
+ */
+function createMockLogger(): ISystemLogService {
+    const fns = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        fatal: vi.fn(),
+        trace: vi.fn(),
+        child: vi.fn(() => fns)
+    } as unknown as ISystemLogService;
+    return fns;
+}
+
+/**
+ * In-memory Mongo collection double covering the surface GscService's
+ * read paths touch: createIndex (spied), aggregate().toArray() served
+ * from `aggregateRows`, find().toArray() served from `findRows`, and
+ * bulkWrite (spied).
+ */
+interface IFakeCollection {
+    createIndex: ReturnType<typeof vi.fn>;
+    bulkWrite: ReturnType<typeof vi.fn>;
+    aggregateRows: unknown[];
+    findRows: unknown[];
+    aggregate(pipeline: unknown): { toArray(): Promise<unknown[]> };
+    find(filter: unknown): { toArray(): Promise<unknown[]> };
+}
+
+/**
+ * Build one fake collection double.
+ *
+ * @returns A collection double with staging arrays for reads.
+ */
+function createFakeCollection(): IFakeCollection {
+    const fake: IFakeCollection = {
+        createIndex: vi.fn(async () => 'ok'),
+        bulkWrite: vi.fn(async () => ({})),
+        aggregateRows: [],
+        findRows: [],
+        aggregate() {
+            return { toArray: async () => fake.aggregateRows };
+        },
+        find() {
+            return { toArray: async () => fake.findRows };
+        }
+    };
+    return fake;
+}
+
+/**
+ * Build a fake IDatabaseService routing getCollection() to per-name
+ * collection doubles, plus vi.fn key-value methods.
+ *
+ * @returns The fake database and the two collections GscService uses.
+ */
+function createFakeDatabase(): {
+    database: IDatabaseService;
+    queries: IFakeCollection;
+    totals: IFakeCollection;
+} {
+    const queries = createFakeCollection();
+    const totals = createFakeCollection();
+    const collections: Record<string, IFakeCollection> = {
+        module_user_gsc_queries: queries,
+        module_user_gsc_daily_totals: totals
+    };
+    const database = {
+        getCollection: vi.fn((name: string) => collections[name]),
+        get: vi.fn(async () => null),
+        set: vi.fn(async () => undefined)
+    } as unknown as IDatabaseService;
+    return { database, queries, totals };
+}
+
+/**
+ * Compute the contiguous UTC day keys the service's getKeywordsByDay
+ * window covers, oldest first — mirrors the service's window math.
+ *
+ * @param days - Number of daily buckets.
+ * @returns Day keys in `YYYY-MM-DD`.
+ */
+function expectedDayKeys(days: number): string[] {
+    const now = new Date();
+    const since = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - DELAY_DAYS - days + 1);
+    const keys: string[] = [];
+    for (let i = 0; i < days; i++) {
+        keys.push(new Date(since + i * DAY_MS).toISOString().split('T')[0]);
+    }
+    return keys;
+}
+
+describe('GscService', () => {
+    beforeEach(() => {
+        GscService.resetInstance();
+    });
+
+    /**
+     * Wire a fresh singleton against fake collections.
+     *
+     * @returns The service instance and its staged collections.
+     */
+    function setup(): { service: GscService; queries: IFakeCollection; totals: IFakeCollection } {
+        const { database, queries, totals } = createFakeDatabase();
+        GscService.setDependencies(database, {} as ICacheService, createMockLogger());
+        return { service: GscService.getInstance(), queries, totals };
+    }
+
+    describe('createIndexes()', () => {
+        it('creates the daily-totals dedup and TTL indexes', async () => {
+            const { service, totals } = setup();
+
+            await service.createIndexes();
+
+            expect(totals.createIndex).toHaveBeenCalledWith(
+                { date: 1 },
+                expect.objectContaining({ unique: true, name: 'gsc_totals_dedup' })
+            );
+            expect(totals.createIndex).toHaveBeenCalledWith(
+                { fetchedAt: 1 },
+                expect.objectContaining({ name: 'gsc_totals_ttl' })
+            );
+        });
+    });
+
+    describe('getKeywordsForPeriod()', () => {
+        it('returns the delay-shifted window bounds alongside the keywords', async () => {
+            // The UI labels windows "7d"; without the returned bounds an
+            // operator cannot see that "7d" ends three days ago.
+            const { service } = setup();
+            const periodHours = 168;
+
+            const before = Date.now();
+            const result = await service.getKeywordsForPeriod(periodHours, 10);
+            const after = Date.now();
+
+            const end = new Date(result.windowEnd).getTime();
+            const start = new Date(result.windowStart).getTime();
+            expect(end).toBeGreaterThanOrEqual(before - DELAY_DAYS * DAY_MS);
+            expect(end).toBeLessThanOrEqual(after - DELAY_DAYS * DAY_MS);
+            expect(end - start).toBe(periodHours * 60 * 60 * 1000);
+            expect(result.keywords).toEqual([]);
+        });
+    });
+
+    describe('getKeywordsByDay()', () => {
+        it('zero-fills every day in the window when no data exists', async () => {
+            // A stalled gsc:fetch job must render as an explicit flat line,
+            // not as days silently missing from the chart.
+            const { service } = setup();
+            const days = 5;
+
+            const out = await service.getKeywordsByDay(days);
+
+            expect(out.days).toBe(days);
+            expect(out.buckets.map(b => b.date)).toEqual(expectedDayKeys(days));
+            for (const bucket of out.buckets) {
+                expect(bucket.totalClicks).toBe(0);
+                expect(bucket.totalImpressions).toBe(0);
+                expect(bucket.keywords).toEqual([]);
+            }
+        });
+
+        it('prefers true daily totals over keyword-row sums, with fallback', async () => {
+            // GSC drops anonymized queries from keyword rows, so their sums
+            // undercount; the date-only totals are authoritative when present.
+            const { service, queries, totals } = setup();
+            const days = 3;
+            const [dayA, dayB] = expectedDayKeys(days);
+
+            queries.aggregateRows = [
+                { _id: { date: dayA, query: 'tron energy' }, clicks: 2, impressions: 40, weightedPosition: 120 },
+                { _id: { date: dayB, query: 'tron relic' }, clicks: 1, impressions: 10, weightedPosition: 30 }
+            ];
+            // Totals exist only for dayA — dayB falls back to keyword sums.
+            totals.findRows = [
+                { date: new Date(`${dayA}T00:00:00.000Z`), clicks: 17, impressions: 900, fetchedAt: new Date() }
+            ];
+
+            const out = await service.getKeywordsByDay(days);
+
+            const bucketA = out.buckets.find(b => b.date === dayA);
+            const bucketB = out.buckets.find(b => b.date === dayB);
+            expect(bucketA?.totalClicks).toBe(17);
+            expect(bucketA?.totalImpressions).toBe(900);
+            // Keyword detail rows remain from the query-dimension data.
+            expect(bucketA?.keywords[0]?.keyword).toBe('tron energy');
+            expect(bucketB?.totalClicks).toBe(1);
+            expect(bucketB?.totalImpressions).toBe(10);
+        });
+    });
+});

--- a/src/backend/modules/traffic/__tests__/traffic.service.test.ts
+++ b/src/backend/modules/traffic/__tests__/traffic.service.test.ts
@@ -492,4 +492,185 @@ describe('TrafficService', () => {
             expect(captured.sql).toContain('user_id = {id:String}');
         });
     });
+
+    describe('excludeBots filter', () => {
+        const range = { since: new Date('2026-06-01T00:00:00.000Z') };
+        const HUMAN_FILTER = "(bot_class = 'human' OR bot_class IS NULL)";
+
+        /**
+         * Wire a mock ClickHouse that records every generated SQL string.
+         *
+         * @returns The captured SQL list (joined for substring assertions).
+         */
+        function captureSql(): { sqls: string[] } {
+            const captured = { sqls: [] as string[] };
+            const ch = createMockClickHouse();
+            ch.query = async <T>(sql: string): Promise<T[]> => {
+                captured.sqls.push(sql);
+                return [] as T[];
+            };
+            TrafficService.setDependencies(ch, createMockLogger());
+            return captured;
+        }
+
+        it('getDailyVisitors applies the human filter only when requested', async () => {
+            // Referer headers are spoofable; the filter is what keeps the
+            // visitor chart honest. NULL stays included because legacy
+            // pre-classifier rows cannot be assumed to be bots.
+            const captured = captureSql();
+
+            await TrafficService.getInstance().getDailyVisitors(range, true);
+            expect(captured.sqls.join('\n')).toContain(HUMAN_FILTER);
+
+            captured.sqls.length = 0;
+            await TrafficService.getInstance().getDailyVisitors(range);
+            expect(captured.sqls.join('\n')).not.toContain(HUMAN_FILTER);
+        });
+
+        it('getTrafficSources applies the human filter only when requested', async () => {
+            const captured = captureSql();
+
+            await TrafficService.getInstance().getTrafficSources(range, true);
+            expect(captured.sqls.join('\n')).toContain(HUMAN_FILTER);
+
+            captured.sqls.length = 0;
+            await TrafficService.getInstance().getTrafficSources(range);
+            expect(captured.sqls.join('\n')).not.toContain(HUMAN_FILTER);
+        });
+
+        it('getNewVisitors filters both the tid set and the grouped rows', async () => {
+            // A crawler spoofing a google referrer must neither appear as a
+            // visitor (inner IN set) nor contribute first-touch attribution
+            // (outer grouped rows).
+            const captured = captureSql();
+
+            await TrafficService.getInstance().getNewVisitors(range, 50, 0, true);
+
+            for (const sql of captured.sqls) {
+                const inner = sql.indexOf(HUMAN_FILTER);
+                const outer = sql.lastIndexOf(HUMAN_FILTER);
+                expect(inner).toBeGreaterThan(-1);
+                expect(outer).toBeGreaterThan(inner);
+            }
+        });
+
+        it('getTrafficSourceDetails applies the human filter to the summary read', async () => {
+            const captured = captureSql();
+
+            await TrafficService.getInstance().getTrafficSourceDetails(range, 'google.com', true);
+
+            expect(captured.sqls[0]).toContain(HUMAN_FILTER);
+        });
+    });
+
+    describe('visitors-primary aggregates', () => {
+        it('getTrafficSources counts distinct visitors alongside raw events', async () => {
+            // Raw event counts overstate audiences (one visitor → many rows);
+            // analytics convention leads with unique visitors.
+            const ch = createMockClickHouse();
+            const captured: { sql?: string } = {};
+            ch.query = async <T>(sql: string): Promise<T[]> => {
+                captured.sql = sql;
+                return [{ source: 'google.com', visitors: '17', count: '63' }] as T[];
+            };
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            const out = await TrafficService.getInstance().getTrafficSources({ since: new Date('2026-06-01T00:00:00.000Z') });
+
+            expect(captured.sql).toContain('uniqExact(candidate_uid) AS visitors');
+            expect(captured.sql).toContain('ORDER BY visitors DESC');
+            expect(out).toEqual([{ source: 'google.com', visitors: 17, count: 63 }]);
+        });
+    });
+
+    describe('getOverviewTrend()', () => {
+        it('returns the empty shape when ClickHouse is unavailable', async () => {
+            TrafficService.setDependencies(undefined, createMockLogger());
+            const out = await TrafficService.getInstance().getOverviewTrend({ since: new Date('2026-06-01T00:00:00.000Z') });
+            expect(out.granularity).toBe('day');
+            expect(out.series).toEqual([]);
+            expect(out.current.visitors).toBe(0);
+        });
+
+        it('uses hourly zero-filled buckets for a 24h window', async () => {
+            // A "24 Hours" view bucketed by day is one bar; hourly buckets are
+            // what makes the short window readable. Absent hours must be
+            // explicit zeros so the chart shows quiet, not gaps.
+            const ch = createMockClickHouse();
+            const sqls: string[] = [];
+            ch.query = async <T>(sql: string): Promise<T[]> => {
+                sqls.push(sql);
+                if (sql.includes('GROUP BY bucket')) {
+                    return [{ bucket: '2026-06-01 05:00:00', visitors: '3', pageviews: '7' }] as T[];
+                }
+                return [{ visitors: '10', pageviews: '25', sessions: '0', avgDurationMs: null, bounces: '0' }] as T[];
+            };
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            const out = await TrafficService.getInstance().getOverviewTrend({
+                since: new Date('2026-06-01T00:00:00.000Z'),
+                until: new Date('2026-06-02T00:00:00.000Z')
+            });
+
+            expect(out.granularity).toBe('hour');
+            expect(sqls.some(s => s.includes('toStartOfHour(timestamp)'))).toBe(true);
+            // 00:00 through 24:00 inclusive — 25 hourly buckets, one populated.
+            expect(out.series).toHaveLength(25);
+            expect(out.series.find(p => p.bucket === '2026-06-01T05:00:00.000Z'))
+                .toEqual({ bucket: '2026-06-01T05:00:00.000Z', visitors: 3, pageviews: 7 });
+            expect(out.series.filter(p => p.visitors === 0)).toHaveLength(24);
+            expect(out.current.visitors).toBe(10);
+            // sessions = 0 → bounce rate is 0, not NaN.
+            expect(out.current.bounceRate).toBe(0);
+        });
+
+        it('uses daily buckets beyond 48h and queries an equal-length previous window', async () => {
+            const ch = createMockClickHouse();
+            const calls: Array<{ sql: string; params: Record<string, unknown> }> = [];
+            ch.query = async <T>(sql: string, params?: unknown): Promise<T[]> => {
+                calls.push({ sql, params: params as Record<string, unknown> });
+                if (sql.includes('GROUP BY bucket')) return [] as T[];
+                return [{ visitors: '5', pageviews: '9', sessions: '0', avgDurationMs: null, bounces: '0' }] as T[];
+            };
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            const out = await TrafficService.getInstance().getOverviewTrend({
+                since: new Date('2026-05-03T00:00:00.000Z'),
+                until: new Date('2026-06-02T00:00:00.000Z')
+            });
+
+            expect(out.granularity).toBe('day');
+            expect(calls[2].sql).toContain('toDate(timestamp)');
+            // Promise.all evaluates in order: current KPIs, previous KPIs, series.
+            // The previous window slides back by the full 30-day window length.
+            expect(String(calls[1].params.since)).toContain('2026-04-03');
+            expect(String(calls[1].params.until)).toContain('2026-05-03');
+            // 05-03 through 06-02 inclusive — 31 zero-filled daily buckets.
+            expect(out.series).toHaveLength(31);
+            expect(out.previous.visitors).toBe(5);
+        });
+    });
+
+    describe('getLiveVisitorCount()', () => {
+        it('returns 0 when ClickHouse is unavailable', async () => {
+            TrafficService.setDependencies(undefined, createMockLogger());
+            expect(await TrafficService.getInstance().getLiveVisitorCount()).toBe(0);
+        });
+
+        it('counts distinct visitors over the last five minutes, honoring the bot filter', async () => {
+            const ch = createMockClickHouse();
+            const captured: { sql?: string } = {};
+            ch.query = async <T>(sql: string): Promise<T[]> => {
+                captured.sql = sql;
+                return [{ visitors: '4' }] as T[];
+            };
+            TrafficService.setDependencies(ch, createMockLogger());
+
+            const count = await TrafficService.getInstance().getLiveVisitorCount(true);
+
+            expect(captured.sql).toContain('INTERVAL 5 MINUTE');
+            expect(captured.sql).toContain("(bot_class = 'human' OR bot_class IS NULL)");
+            expect(count).toBe(4);
+        });
+    });
 });

--- a/src/backend/modules/traffic/api/traffic.controller.ts
+++ b/src/backend/modules/traffic/api/traffic.controller.ts
@@ -47,6 +47,21 @@ const KNOWN_BOT_CLASSES = new Set([
 ]);
 
 /**
+ * Parse the optional `bots` query param on the visitor-analytics reads.
+ *
+ * `bots=exclude` restricts counts to human-classified rows (legacy NULL
+ * rows kept); anything else — including the param's absence — keeps the
+ * historical include-everything behavior so existing consumers see no
+ * change unless they opt in.
+ *
+ * @param value - Raw `req.query.bots` value.
+ * @returns True when bot rows should be excluded.
+ */
+function parseExcludeBots(value: unknown): boolean {
+    return value === 'exclude';
+}
+
+/**
  * Controller for the traffic-events and analytics admin surfaces.
  */
 export class TrafficController {
@@ -188,13 +203,45 @@ export class TrafficController {
     // ────────────────────────────────────────────────────────────────────────
 
     /**
-     * GET /api/admin/users/analytics/daily-visitors
+     * GET /api/admin/users/analytics/overview-trend?period=&bots=exclude
+     * Unified dashboard headline: current/previous-window KPIs plus the
+     * zero-filled visitors/pageviews series (hourly ≤ 48h, daily otherwise).
+     */
+    async getOverviewTrend(req: Request, res: Response): Promise<void> {
+        const range = resolveAnalyticsRange(req.query);
+        const excludeBots = parseExcludeBots(req.query.bots);
+        try {
+            res.json(await this.trafficService.getOverviewTrend(range, excludeBots));
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to fetch overview trend');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to fetch overview trend' });
+        }
+    }
+
+    /**
+     * GET /api/admin/users/analytics/live?bots=exclude
+     * Distinct visitors active in the last five minutes.
+     */
+    async getLiveVisitors(req: Request, res: Response): Promise<void> {
+        const excludeBots = parseExcludeBots(req.query.bots);
+        try {
+            const visitors = await this.trafficService.getLiveVisitorCount(excludeBots);
+            res.json({ visitors, windowMinutes: 5, clickhouseEnabled: this.trafficService.isEnabled() });
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to fetch live visitors');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to fetch live visitors' });
+        }
+    }
+
+    /**
+     * GET /api/admin/users/analytics/daily-visitors?bots=exclude
      * Distinct analytics visitors (tids) per day.
      */
     async getDailyVisitors(req: Request, res: Response): Promise<void> {
         const range = resolveAnalyticsRange(req.query);
+        const excludeBots = parseExcludeBots(req.query.bots);
         try {
-            res.json({ data: await this.trafficService.getDailyVisitors(range) });
+            res.json({ data: await this.trafficService.getDailyVisitors(range, excludeBots) });
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to fetch daily visitors');
             res.status(500).json({ error: 'InternalError', message: 'Failed to fetch daily visitors' });
@@ -218,13 +265,14 @@ export class TrafficController {
     }
 
     /**
-     * GET /api/admin/users/analytics/traffic-sources
+     * GET /api/admin/users/analytics/traffic-sources?bots=exclude
      * Referrer-domain breakdown.
      */
     async getTrafficSources(req: Request, res: Response): Promise<void> {
         const range = resolveAnalyticsRange(req.query);
+        const excludeBots = parseExcludeBots(req.query.bots);
         try {
-            res.json({ data: await this.trafficService.getTrafficSources(range) });
+            res.json({ data: await this.trafficService.getTrafficSources(range, excludeBots) });
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to fetch traffic sources');
             res.status(500).json({ error: 'InternalError', message: 'Failed to fetch traffic sources' });
@@ -232,7 +280,7 @@ export class TrafficController {
     }
 
     /**
-     * GET /api/admin/users/analytics/new-users?period=&limit=&skip=
+     * GET /api/admin/users/analytics/new-users?period=&limit=&skip=&bots=exclude
      * Visitors whose global first-seen falls within the window, newest first.
      * Returns `{ visitors, total }` unwrapped — the client types this as
      * `{ visitors: IVisitorOrigin[]; total }` and reads it directly.
@@ -241,8 +289,9 @@ export class TrafficController {
         const range = resolveAnalyticsRange(req.query);
         const limit = parsePositiveInt(req.query.limit, 50, MAX_LIMIT);
         const skip = parseNonNegativeInt(req.query.skip, 0);
+        const excludeBots = parseExcludeBots(req.query.bots);
         try {
-            res.json(await this.trafficService.getNewVisitors(range, limit, skip));
+            res.json(await this.trafficService.getNewVisitors(range, limit, skip, excludeBots));
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to fetch new users');
             res.status(500).json({ error: 'InternalError', message: 'Failed to fetch new users' });
@@ -307,7 +356,7 @@ export class TrafficController {
     }
 
     /**
-     * GET /api/admin/users/analytics/traffic-source-details?source=&period=
+     * GET /api/admin/users/analytics/traffic-source-details?source=&period=&bots=exclude
      * Drill-down breakdown for one referrer source. Returns the
      * `ITrafficSourceDetails` shape unwrapped — the client reads it directly.
      */
@@ -318,8 +367,9 @@ export class TrafficController {
             return;
         }
         const range = resolveAnalyticsRange(req.query);
+        const excludeBots = parseExcludeBots(req.query.bots);
         try {
-            res.json(await this.trafficService.getTrafficSourceDetails(range, source));
+            res.json(await this.trafficService.getTrafficSourceDetails(range, source, excludeBots));
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to fetch traffic source details');
             res.status(500).json({ error: 'InternalError', message: 'Failed to fetch traffic source details' });
@@ -327,14 +377,15 @@ export class TrafficController {
     }
 
     /**
-     * GET /api/admin/users/analytics/top-landing-pages?limit=
-     * Top landing paths by event count.
+     * GET /api/admin/users/analytics/top-landing-pages?limit=&bots=exclude
+     * Top landing paths by distinct visitors.
      */
     async getTopLandingPages(req: Request, res: Response): Promise<void> {
         const range = resolveAnalyticsRange(req.query);
         const limit = parsePositiveInt(req.query.limit, 20, MAX_LIMIT);
+        const excludeBots = parseExcludeBots(req.query.bots);
         try {
-            res.json({ data: await this.trafficService.getTopLandingPages(range, limit) });
+            res.json({ data: await this.trafficService.getTopLandingPages(range, limit, excludeBots) });
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to fetch top landing pages');
             res.status(500).json({ error: 'InternalError', message: 'Failed to fetch top landing pages' });
@@ -342,14 +393,15 @@ export class TrafficController {
     }
 
     /**
-     * GET /api/admin/users/analytics/geo-distribution?limit=
+     * GET /api/admin/users/analytics/geo-distribution?limit=&bots=exclude
      * Country distribution (ISO-3166 alpha-2).
      */
     async getGeoDistribution(req: Request, res: Response): Promise<void> {
         const range = resolveAnalyticsRange(req.query);
         const limit = parsePositiveInt(req.query.limit, 30, MAX_LIMIT);
+        const excludeBots = parseExcludeBots(req.query.bots);
         try {
-            res.json({ data: await this.trafficService.getGeoDistribution(range, limit) });
+            res.json({ data: await this.trafficService.getGeoDistribution(range, limit, excludeBots) });
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to fetch geo distribution');
             res.status(500).json({ error: 'InternalError', message: 'Failed to fetch geo distribution' });
@@ -357,13 +409,14 @@ export class TrafficController {
     }
 
     /**
-     * GET /api/admin/users/analytics/device-breakdown
+     * GET /api/admin/users/analytics/device-breakdown?bots=exclude
      * Device-category breakdown.
      */
     async getDeviceBreakdown(req: Request, res: Response): Promise<void> {
         const range = resolveAnalyticsRange(req.query);
+        const excludeBots = parseExcludeBots(req.query.bots);
         try {
-            res.json({ data: await this.trafficService.getDeviceBreakdown(range) });
+            res.json({ data: await this.trafficService.getDeviceBreakdown(range, excludeBots) });
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to fetch device breakdown');
             res.status(500).json({ error: 'InternalError', message: 'Failed to fetch device breakdown' });
@@ -371,13 +424,14 @@ export class TrafficController {
     }
 
     /**
-     * GET /api/admin/users/analytics/retention
+     * GET /api/admin/users/analytics/retention?bots=exclude
      * New-vs-returning visitors per day.
      */
     async getRetention(req: Request, res: Response): Promise<void> {
         const range = resolveAnalyticsRange(req.query);
+        const excludeBots = parseExcludeBots(req.query.bots);
         try {
-            res.json({ data: await this.trafficService.getRetention(range) });
+            res.json({ data: await this.trafficService.getRetention(range, excludeBots) });
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to fetch retention');
             res.status(500).json({ error: 'InternalError', message: 'Failed to fetch retention' });
@@ -385,13 +439,14 @@ export class TrafficController {
     }
 
     /**
-     * GET /api/admin/users/analytics/conversion-funnel
+     * GET /api/admin/users/analytics/conversion-funnel?bots=exclude
      * Binary conversion funnel (distinct tids → tids ever logged in).
      */
     async getConversionFunnel(req: Request, res: Response): Promise<void> {
         const range = resolveAnalyticsRange(req.query);
+        const excludeBots = parseExcludeBots(req.query.bots);
         try {
-            res.json(await this.trafficService.getBinaryConversionFunnel(range));
+            res.json(await this.trafficService.getBinaryConversionFunnel(range, excludeBots));
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to fetch conversion funnel');
             res.status(500).json({ error: 'InternalError', message: 'Failed to fetch conversion funnel' });
@@ -399,14 +454,15 @@ export class TrafficController {
     }
 
     /**
-     * GET /api/admin/users/analytics/campaign-performance?limit=
+     * GET /api/admin/users/analytics/campaign-performance?limit=&bots=exclude
      * UTM-campaign aggregates joined to the binary conversion.
      */
     async getCampaignPerformance(req: Request, res: Response): Promise<void> {
         const range = resolveAnalyticsRange(req.query);
         const limit = parsePositiveInt(req.query.limit, 20, MAX_LIMIT);
+        const excludeBots = parseExcludeBots(req.query.bots);
         try {
-            res.json({ data: await this.trafficService.getCampaignPerformance(range, limit) });
+            res.json({ data: await this.trafficService.getCampaignPerformance(range, limit, excludeBots) });
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to fetch campaign performance');
             res.status(500).json({ error: 'InternalError', message: 'Failed to fetch campaign performance' });
@@ -414,13 +470,14 @@ export class TrafficController {
     }
 
     /**
-     * GET /api/admin/users/analytics/engagement
+     * GET /api/admin/users/analytics/engagement?bots=exclude
      * Average duration, pages/session, bounce rate (session events).
      */
     async getEngagementMetrics(req: Request, res: Response): Promise<void> {
         const range = resolveAnalyticsRange(req.query);
+        const excludeBots = parseExcludeBots(req.query.bots);
         try {
-            res.json(await this.trafficService.getEngagementMetrics(range));
+            res.json(await this.trafficService.getEngagementMetrics(range, excludeBots));
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to fetch engagement metrics');
             res.status(500).json({ error: 'InternalError', message: 'Failed to fetch engagement metrics' });
@@ -521,14 +578,16 @@ export class TrafficController {
      * GET /api/admin/users/analytics/gsc/keywords?periodHours=168&limit=25
      * Aggregated GSC keywords (clicks/impressions/CTR/position) for the
      * window. Pass-through to the daily-fetched keyword cache; returns an
-     * empty array until the `gsc:fetch` job has stored data.
+     * empty array until the `gsc:fetch` job has stored data. The response
+     * carries `windowStart`/`windowEnd` — the delay-shifted dates actually
+     * covered — so the UI can label the period truthfully.
      */
     async getGscKeywords(req: Request, res: Response): Promise<void> {
         const periodHours = parsePositiveInt(req.query.periodHours, 168, MAX_SINCE_HOURS);
         const limit = parsePositiveInt(req.query.limit, 25, MAX_LIMIT);
         try {
-            const keywords = await this.gscService.getKeywordsForPeriod(periodHours, limit);
-            res.json({ periodHours, limit, keywords });
+            const result = await this.gscService.getKeywordsForPeriod(periodHours, limit);
+            res.json({ periodHours, limit, ...result });
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to fetch GSC keywords');
             res.status(500).json({ error: 'InternalError', message: 'Failed to fetch GSC keywords' });

--- a/src/backend/modules/traffic/api/traffic.routes.ts
+++ b/src/backend/modules/traffic/api/traffic.routes.ts
@@ -41,6 +41,8 @@ export function createAdminTrafficRouter(controller: TrafficController): Router 
 export function createAdminAnalyticsRouter(controller: TrafficController): Router {
     const router = Router();
 
+    router.get('/overview-trend', controller.getOverviewTrend.bind(controller));
+    router.get('/live', controller.getLiveVisitors.bind(controller));
     router.get('/daily-visitors', controller.getDailyVisitors.bind(controller));
     router.get('/visitor-origins', controller.getVisitorOrigins.bind(controller));
     router.get('/new-users', controller.getNewUsers.bind(controller));

--- a/src/backend/modules/traffic/services/gsc.service.ts
+++ b/src/backend/modules/traffic/services/gsc.service.ts
@@ -82,6 +82,41 @@ export interface IGscKeyword {
     position: number;
 }
 
+/**
+ * True per-day site totals fetched with the date-only dimension.
+ *
+ * The GSC API silently drops anonymized (low-volume) queries from any
+ * response that includes the `query` dimension, so summing keyword rows
+ * systematically undercounts clicks — on a low-traffic property most days
+ * return zero keyword rows even when GSC's own dashboard shows clicks.
+ * A date-only request is not subject to query anonymization and returns
+ * the property's real daily totals.
+ */
+export interface IGscDailyTotalDocument {
+    /** Calendar day this total represents (UTC midnight). */
+    date: Date;
+    /** Total clicks across all queries, including anonymized ones. */
+    clicks: number;
+    /** Total impressions across all queries, including anonymized ones. */
+    impressions: number;
+    /** When this total was fetched from GSC. */
+    fetchedAt: Date;
+}
+
+/**
+ * Aggregated keywords for a period plus the actual (delay-shifted) window
+ * the aggregation covered, so the UI can show true coverage instead of a
+ * misleading "last 7 days" label.
+ */
+export interface IGscKeywordsPeriodResult {
+    /** Inclusive window start (ISO-8601 UTC). */
+    windowStart: string;
+    /** Inclusive window end (ISO-8601 UTC) — always ~3 days behind now. */
+    windowEnd: string;
+    /** Aggregated keywords sorted by clicks descending. */
+    keywords: IGscKeyword[];
+}
+
 /** Key-value store keys for GSC configuration. */
 const KV_CREDENTIALS = 'gsc:credentials';
 const KV_SITE_URL = 'gsc:siteUrl';
@@ -89,6 +124,12 @@ const KV_LAST_FETCH = 'gsc:lastFetch';
 
 /** Collection name following module_{module-id}_{collection} convention. */
 const COLLECTION_NAME = 'module_user_gsc_queries';
+
+/**
+ * Per-day site totals from the date-only GSC request. Physical name keeps
+ * the `module_user_` prefix for consistency with the keyword collection.
+ */
+const TOTALS_COLLECTION_NAME = 'module_user_gsc_daily_totals';
 
 /** Maximum rows per GSC API request. */
 const GSC_ROW_LIMIT = 5000;
@@ -113,6 +154,7 @@ const GSC_MAX_PAGES = 100;
 export class GscService {
     private static instance: GscService;
     private readonly collection: Collection<IGscQueryDocument>;
+    private readonly totalsCollection: Collection<IGscDailyTotalDocument>;
 
     /**
      * Private constructor enforces singleton pattern. Use setDependencies()
@@ -128,6 +170,7 @@ export class GscService {
         private readonly logger: ISystemLogService
     ) {
         this.collection = database.getCollection<IGscQueryDocument>(COLLECTION_NAME);
+        this.totalsCollection = database.getCollection<IGscDailyTotalDocument>(TOTALS_COLLECTION_NAME);
     }
 
     /**
@@ -188,6 +231,14 @@ export class GscService {
         await this.collection.createIndex(
             { fetchedAt: 1 },
             { expireAfterSeconds: 120 * 24 * 60 * 60, name: 'gsc_ttl' }
+        );
+        await this.totalsCollection.createIndex(
+            { date: 1 },
+            { unique: true, name: 'gsc_totals_dedup' }
+        );
+        await this.totalsCollection.createIndex(
+            { fetchedAt: 1 },
+            { expireAfterSeconds: 120 * 24 * 60 * 60, name: 'gsc_totals_ttl' }
         );
         this.logger.info('GSC query indexes created');
     }
@@ -397,10 +448,72 @@ export class GscService {
             }
         }
 
+        await this.fetchAndStoreDailyTotals(searchConsole, siteUrl, start, end, now);
+
         await this.database.set(KV_LAST_FETCH, now.toISOString());
         this.logger.info({ rowsFetched: totalRows, siteUrl }, 'GSC data fetch complete');
 
         return { rowsFetched: totalRows };
+    }
+
+    /**
+     * Fetch true per-day site totals with a date-only request and upsert
+     * them into the totals collection.
+     *
+     * The keyword fetch above requests the `query` dimension, which makes
+     * GSC silently drop anonymized (low-volume) queries — summing those
+     * rows undercounts clicks, sometimes to zero on quiet days. A request
+     * with only the `date` dimension is exempt from query anonymization,
+     * so these totals match what GSC's own dashboard reports. One row per
+     * day means a single un-paginated request covers any sane window.
+     *
+     * @param searchConsole - Authenticated Search Console client.
+     * @param siteUrl - GSC property URL.
+     * @param start - ISO date string (YYYY-MM-DD), inclusive.
+     * @param end - ISO date string (YYYY-MM-DD), inclusive.
+     * @param fetchedAt - Timestamp stamped onto each upserted row (drives TTL).
+     */
+    private async fetchAndStoreDailyTotals(
+        searchConsole: ReturnType<typeof google.searchconsole>,
+        siteUrl: string,
+        start: string,
+        end: string,
+        fetchedAt: Date
+    ): Promise<void> {
+        const response = await searchConsole.searchanalytics.query({
+            siteUrl,
+            requestBody: {
+                startDate: start,
+                endDate: end,
+                dimensions: ['date'],
+                rowLimit: GSC_ROW_LIMIT
+            }
+        });
+
+        const rows = response.data.rows ?? [];
+        const bulkOps = rows.reduce<Array<{ updateOne: { filter: Record<string, unknown>; update: { $set: IGscDailyTotalDocument }; upsert: true } }>>((ops, row) => {
+            const dateStr = row.keys?.[0];
+            if (!dateStr) {
+                return ops;
+            }
+            const date = new Date(dateStr);
+            if (isNaN(date.getTime())) {
+                return ops;
+            }
+            const doc: IGscDailyTotalDocument = {
+                date,
+                clicks: row.clicks ?? 0,
+                impressions: row.impressions ?? 0,
+                fetchedAt
+            };
+            ops.push({ updateOne: { filter: { date: doc.date }, update: { $set: doc }, upsert: true } });
+            return ops;
+        }, []);
+
+        if (bulkOps.length > 0) {
+            await this.totalsCollection.bulkWrite(bulkOps);
+        }
+        this.logger.info({ days: bulkOps.length, siteUrl }, 'GSC daily totals stored');
     }
 
     /**
@@ -409,6 +522,14 @@ export class GscService {
      * Aggregates stored GSC query rows into daily buckets, each containing
      * the top keywords ranked by clicks. Accounts for the 3-day GSC data
      * delay — the most recent bucket will be offset accordingly.
+     *
+     * Per-day totals come from the date-only totals collection (immune to
+     * GSC's query anonymization) when a totals row exists for the day,
+     * falling back to keyword-row sums for data fetched before the totals
+     * collection existed. Every day in the window is emitted — days with
+     * no data carry zero totals — so a stalled `gsc:fetch` job or a quiet
+     * day renders as an explicit flat line instead of silently vanishing
+     * from the chart.
      *
      * @param days - Number of daily buckets to return (default: 14)
      * @param topN - Maximum keywords per bucket (default: 15)
@@ -427,26 +548,29 @@ export class GscService {
         const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - GSC_DATA_DELAY_DAYS, 23, 59, 59, 999));
         const since = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - GSC_DATA_DELAY_DAYS - days + 1, 0, 0, 0, 0));
 
-        const results = await this.collection.aggregate<{
-            _id: { date: string; query: string };
-            clicks: number;
-            impressions: number;
-            weightedPosition: number;
-        }>([
-            { $match: { date: { $gte: since, $lte: end } } },
-            {
-                $group: {
-                    _id: {
-                        date: { $dateToString: { format: '%Y-%m-%d', date: '$date' } },
-                        query: '$query'
-                    },
-                    clicks: { $sum: '$clicks' },
-                    impressions: { $sum: '$impressions' },
-                    weightedPosition: { $sum: { $multiply: ['$position', '$impressions'] } }
-                }
-            },
-            { $sort: { '_id.date': 1, clicks: -1 } }
-        ]).toArray();
+        const [results, totals] = await Promise.all([
+            this.collection.aggregate<{
+                _id: { date: string; query: string };
+                clicks: number;
+                impressions: number;
+                weightedPosition: number;
+            }>([
+                { $match: { date: { $gte: since, $lte: end } } },
+                {
+                    $group: {
+                        _id: {
+                            date: { $dateToString: { format: '%Y-%m-%d', date: '$date' } },
+                            query: '$query'
+                        },
+                        clicks: { $sum: '$clicks' },
+                        impressions: { $sum: '$impressions' },
+                        weightedPosition: { $sum: { $multiply: ['$position', '$impressions'] } }
+                    }
+                },
+                { $sort: { '_id.date': 1, clicks: -1 } }
+            ]).toArray(),
+            this.totalsCollection.find({ date: { $gte: since, $lte: end } }).toArray()
+        ]);
 
         const dayMap = new Map<string, {
             totalClicks: number;
@@ -454,12 +578,18 @@ export class GscService {
             keywords: Array<{ keyword: string; clicks: number; impressions: number; ctr: number; position: number }>;
         }>();
 
+        // Zero-fill every UTC day in the window so absent days are an
+        // explicit zero, not a hole the chart silently skips.
+        for (let i = 0; i < days; i++) {
+            const day = new Date(since.getTime() + i * 24 * 60 * 60 * 1000);
+            dayMap.set(day.toISOString().split('T')[0], { totalClicks: 0, totalImpressions: 0, keywords: [] });
+        }
+
         for (const row of results) {
-            const date = row._id.date;
-            if (!dayMap.has(date)) {
-                dayMap.set(date, { totalClicks: 0, totalImpressions: 0, keywords: [] });
+            const bucket = dayMap.get(row._id.date);
+            if (!bucket) {
+                continue;
             }
-            const bucket = dayMap.get(date)!;
             bucket.totalClicks += row.clicks;
             bucket.totalImpressions += row.impressions;
             if (bucket.keywords.length < topN) {
@@ -474,6 +604,15 @@ export class GscService {
                         ? Math.round((row.weightedPosition / row.impressions) * 10) / 10
                         : 0
                 });
+            }
+        }
+
+        // True daily totals win over keyword-row sums where available.
+        for (const total of totals) {
+            const bucket = dayMap.get(total.date.toISOString().split('T')[0]);
+            if (bucket) {
+                bucket.totalClicks = total.clicks;
+                bucket.totalImpressions = total.impressions;
             }
         }
 
@@ -496,11 +635,16 @@ export class GscService {
      * impressions, and averaging CTR and position. Results are sorted
      * by clicks descending.
      *
+     * The window is shifted back by the GSC ingestion delay, so "last 7
+     * days" covers the 7 days ending ~3 days ago — the returned
+     * `windowStart`/`windowEnd` carry the actual dates so the UI can show
+     * true coverage instead of an off-by-three-days period label.
+     *
      * @param periodHours - Lookback period in hours
      * @param limit - Maximum keywords to return (default: 10)
-     * @returns Aggregated keyword data sorted by clicks descending
+     * @returns The delay-shifted window and its aggregated keywords
      */
-    async getKeywordsForPeriod(periodHours: number, limit: number = 10): Promise<IGscKeyword[]> {
+    async getKeywordsForPeriod(periodHours: number, limit: number = 10): Promise<IGscKeywordsPeriodResult> {
         // Shift window by the GSC ingestion delay so the period aligns
         // with available data (e.g. "last 7 days" queries the 7 days
         // ending at now - GSC_DATA_DELAY_DAYS, not ending at now).
@@ -527,7 +671,7 @@ export class GscService {
             { $limit: limit }
         ]).toArray();
 
-        return results.map(r => ({
+        const keywords = results.map(r => ({
             keyword: r._id,
             clicks: r.totalClicks,
             impressions: r.totalImpressions,
@@ -538,5 +682,11 @@ export class GscService {
                 ? Math.round((r.weightedPosition / r.totalImpressions) * 10) / 10
                 : 0
         }));
+
+        return {
+            windowStart: since.toISOString(),
+            windowEnd: end.toISOString(),
+            keywords
+        };
     }
 }

--- a/src/backend/modules/traffic/services/traffic.service.ts
+++ b/src/backend/modules/traffic/services/traffic.service.ts
@@ -1077,7 +1077,7 @@ export class TrafficService {
                     SELECT DISTINCT candidate_uid
                     FROM ${TABLE_NAME}
                     WHERE ${clause}${botFilter}
-                )
+                )${botFilter}
                 GROUP BY candidate_uid
             ) AS f USING (candidate_uid)
             GROUP BY day

--- a/src/backend/modules/traffic/services/traffic.service.ts
+++ b/src/backend/modules/traffic/services/traffic.service.ts
@@ -210,27 +210,43 @@ export interface ITrafficVisitorOrigin {
     utmCampaign: string | null;
 }
 
-/** Referrer-domain (or `'direct'`) row count. */
+/**
+ * Referrer-domain (or `'direct'`) bucket. `visitors` (distinct tids) is the
+ * primary measure — the convention every analytics platform leads with —
+ * while `count` keeps the raw event rows for diagnostic context.
+ */
 export interface ITrafficSourceBucket {
     source: string;
+    /** Distinct visitors (tids) — the primary measure. */
+    visitors: number;
+    /** Raw event rows. */
     count: number;
 }
 
-/** Landing-path row count. */
+/** Landing-path bucket: distinct visitors primary, raw event rows secondary. */
 export interface ILandingPageBucket {
     path: string;
+    /** Distinct visitors (tids) — the primary measure. */
+    visitors: number;
+    /** Raw event rows. */
     count: number;
 }
 
-/** Country (ISO-3166 alpha-2) row count. `null` excluded by the query. */
+/** Country (ISO-3166 alpha-2) bucket. `null` excluded by the query. */
 export interface IGeoBucket {
     country: string | null;
+    /** Distinct visitors (tids) — the primary measure. */
+    visitors: number;
+    /** Raw event rows. */
     count: number;
 }
 
-/** Device-category row count. */
+/** Device-category bucket. */
 export interface IDeviceBucket {
     device: string;
+    /** Distinct visitors (tids) — the primary measure. */
+    visitors: number;
+    /** Raw event rows. */
     count: number;
 }
 
@@ -270,6 +286,50 @@ export interface IEngagementMetrics {
     avgDurationMs: number;
     pagesPerSession: number;
     bounceRate: number;
+}
+
+/**
+ * Headline KPIs for one window of the overview trend. `sessions`,
+ * `avgDurationMs`, and `bounceRate` read zero until session-event emission
+ * ships (Phase D) — consumers should treat `sessions === 0` as
+ * "instrumentation not available", not as a measured zero.
+ */
+export interface IOverviewKpis {
+    /** Distinct visitors (tids) in the window. */
+    visitors: number;
+    /** Interactive `page` events in the window. */
+    pageviews: number;
+    /** `session_start` events in the window. */
+    sessions: number;
+    /** Average `session_end` duration in ms. */
+    avgDurationMs: number;
+    /** Bounced sessions / sessions (0-1). */
+    bounceRate: number;
+}
+
+/** One time bucket of the overview trend series. */
+export interface IOverviewTrendPoint {
+    /** Bucket start — ISO-8601 UTC for hour buckets, `YYYY-MM-DD` for days. */
+    bucket: string;
+    /** Distinct visitors (tids) in the bucket. */
+    visitors: number;
+    /** Interactive `page` events in the bucket. */
+    pageviews: number;
+}
+
+/**
+ * The unified dashboard headline: current-window KPIs, the equal-length
+ * previous window for delta rendering, and the zero-filled time series.
+ */
+export interface IOverviewTrend {
+    /** Bucket size — hourly for windows ≤ 48h, daily otherwise. */
+    granularity: 'hour' | 'day';
+    /** KPIs for the requested window. */
+    current: IOverviewKpis;
+    /** KPIs for the equal-length window immediately before it. */
+    previous: IOverviewKpis;
+    /** Zero-filled per-bucket visitors/pageviews, oldest first. */
+    series: IOverviewTrendPoint[];
 }
 
 /**
@@ -386,6 +446,16 @@ export const TRAFFIC_EVENTS_TABLE_NAME = 'traffic_events';
 const TABLE_NAME = TRAFFIC_EVENTS_TABLE_NAME;
 const DEFAULT_AGGREGATE_HOURS = 24;
 const DEFAULT_AGGREGATE_LIMIT = 20;
+
+/**
+ * WHERE fragment selecting human traffic for the `excludeBots` analytics
+ * reads. The `Referer` header is client-supplied and commonly spoofed by
+ * crawlers (google.com referrers on scanner traffic are routine), so
+ * visitor/source counts that ignore `bot_class` overstate real audiences.
+ * NULL rows are kept: they predate the classifier and cannot be assumed
+ * to be bots.
+ */
+const HUMAN_ROWS_FILTER = "(bot_class = 'human' OR bot_class IS NULL)";
 
 /**
  * ClickHouse-backed traffic events store.
@@ -786,15 +856,17 @@ export class TrafficService {
      * Distinct analytics visitors (tids) per calendar day over the window.
      *
      * @param range - Inclusive date window.
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
      * @returns One point per day with the distinct-visitor count, oldest first.
      */
-    async getDailyVisitors(range: IAnalyticsDateRange): Promise<IDailyVisitorPoint[]> {
+    async getDailyVisitors(range: IAnalyticsDateRange, excludeBots = false): Promise<IDailyVisitorPoint[]> {
         if (!this.clickhouse) return [];
         const { clause, params } = this.rangeParams(range);
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
         const sql = `
             SELECT toDate(timestamp) AS day, uniqExact(candidate_uid) AS visitors
             FROM ${TABLE_NAME}
-            WHERE ${clause}
+            WHERE ${clause}${botFilter}
             GROUP BY day
             ORDER BY day ASC
         `;
@@ -857,25 +929,29 @@ export class TrafficService {
 
     /**
      * Referrer-domain breakdown. Null/empty referers collapse to `'direct'`.
+     * Distinct visitors lead; raw event counts ride along.
      *
      * @param range - Inclusive date window.
-     * @returns Source-domain row counts, descending.
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
+     * @returns Source-domain buckets, by visitors descending.
      */
-    async getTrafficSources(range: IAnalyticsDateRange): Promise<ITrafficSourceBucket[]> {
+    async getTrafficSources(range: IAnalyticsDateRange, excludeBots = false): Promise<ITrafficSourceBucket[]> {
         if (!this.clickhouse) return [];
         const { clause, params } = this.rangeParams(range);
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
         const sql = `
             SELECT
                 multiIf(referer IS NULL OR referer = '', 'direct', domain(referer)) AS source,
+                uniqExact(candidate_uid) AS visitors,
                 count() AS count
             FROM ${TABLE_NAME}
-            WHERE ${clause}
+            WHERE ${clause}${botFilter}
             GROUP BY source
-            ORDER BY count DESC
+            ORDER BY visitors DESC, count DESC
         `;
         try {
-            const rows = await this.clickhouse.query<{ source: string; count: string | number }>(sql, params);
-            return rows.map(r => ({ source: r.source, count: Number(r.count) }));
+            const rows = await this.clickhouse.query<{ source: string; visitors: string | number; count: string | number }>(sql, params);
+            return rows.map(r => ({ source: r.source, visitors: Number(r.visitors), count: Number(r.count) }));
         } catch (error) {
             this.logger.warn({ error }, 'Failed to read traffic sources');
             return [];
@@ -883,26 +959,28 @@ export class TrafficService {
     }
 
     /**
-     * Top landing paths by event count.
+     * Top landing paths. Distinct visitors lead; raw event counts ride along.
      *
      * @param range - Inclusive date window.
      * @param limit - Max rows.
-     * @returns Path row counts, descending.
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
+     * @returns Path buckets, by visitors descending.
      */
-    async getTopLandingPages(range: IAnalyticsDateRange, limit = 20): Promise<ILandingPageBucket[]> {
+    async getTopLandingPages(range: IAnalyticsDateRange, limit = 20, excludeBots = false): Promise<ILandingPageBucket[]> {
         if (!this.clickhouse) return [];
         const { clause, params } = this.rangeParams(range);
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
         const sql = `
-            SELECT path AS path, count() AS count
+            SELECT path AS path, uniqExact(candidate_uid) AS visitors, count() AS count
             FROM ${TABLE_NAME}
-            WHERE ${clause} AND path != ''
+            WHERE ${clause}${botFilter} AND path != ''
             GROUP BY path
-            ORDER BY count DESC
+            ORDER BY visitors DESC, count DESC
             LIMIT {limit:UInt32}
         `;
         try {
-            const rows = await this.clickhouse.query<{ path: string; count: string | number }>(sql, { ...params, limit });
-            return rows.map(r => ({ path: r.path, count: Number(r.count) }));
+            const rows = await this.clickhouse.query<{ path: string; visitors: string | number; count: string | number }>(sql, { ...params, limit });
+            return rows.map(r => ({ path: r.path, visitors: Number(r.visitors), count: Number(r.count) }));
         } catch (error) {
             this.logger.warn({ error }, 'Failed to read top landing pages');
             return [];
@@ -911,25 +989,28 @@ export class TrafficService {
 
     /**
      * Geographic distribution (ISO-3166 alpha-2). Null country excluded.
+     * Distinct visitors lead; raw event counts ride along.
      *
      * @param range - Inclusive date window.
      * @param limit - Max rows.
-     * @returns Country row counts, descending.
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
+     * @returns Country buckets, by visitors descending.
      */
-    async getGeoDistribution(range: IAnalyticsDateRange, limit = 30): Promise<IGeoBucket[]> {
+    async getGeoDistribution(range: IAnalyticsDateRange, limit = 30, excludeBots = false): Promise<IGeoBucket[]> {
         if (!this.clickhouse) return [];
         const { clause, params } = this.rangeParams(range);
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
         const sql = `
-            SELECT country, count() AS count
+            SELECT country, uniqExact(candidate_uid) AS visitors, count() AS count
             FROM ${TABLE_NAME}
-            WHERE ${clause} AND country IS NOT NULL
+            WHERE ${clause}${botFilter} AND country IS NOT NULL
             GROUP BY country
-            ORDER BY count DESC
+            ORDER BY visitors DESC, count DESC
             LIMIT {limit:UInt32}
         `;
         try {
-            const rows = await this.clickhouse.query<{ country: string | null; count: string | number }>(sql, { ...params, limit });
-            return rows.map(r => ({ country: r.country, count: Number(r.count) }));
+            const rows = await this.clickhouse.query<{ country: string | null; visitors: string | number; count: string | number }>(sql, { ...params, limit });
+            return rows.map(r => ({ country: r.country, visitors: Number(r.visitors), count: Number(r.count) }));
         } catch (error) {
             this.logger.warn({ error }, 'Failed to read geo distribution');
             return [];
@@ -937,24 +1018,27 @@ export class TrafficService {
     }
 
     /**
-     * Device-category breakdown.
+     * Device-category breakdown. Distinct visitors lead; raw event counts
+     * ride along.
      *
      * @param range - Inclusive date window.
-     * @returns Device row counts, descending.
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
+     * @returns Device buckets, by visitors descending.
      */
-    async getDeviceBreakdown(range: IAnalyticsDateRange): Promise<IDeviceBucket[]> {
+    async getDeviceBreakdown(range: IAnalyticsDateRange, excludeBots = false): Promise<IDeviceBucket[]> {
         if (!this.clickhouse) return [];
         const { clause, params } = this.rangeParams(range);
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
         const sql = `
-            SELECT device, count() AS count
+            SELECT device, uniqExact(candidate_uid) AS visitors, count() AS count
             FROM ${TABLE_NAME}
-            WHERE ${clause}
+            WHERE ${clause}${botFilter}
             GROUP BY device
-            ORDER BY count DESC
+            ORDER BY visitors DESC, count DESC
         `;
         try {
-            const rows = await this.clickhouse.query<{ device: string; count: string | number }>(sql, params);
-            return rows.map(r => ({ device: r.device, count: Number(r.count) }));
+            const rows = await this.clickhouse.query<{ device: string; visitors: string | number; count: string | number }>(sql, params);
+            return rows.map(r => ({ device: r.device, visitors: Number(r.visitors), count: Number(r.count) }));
         } catch (error) {
             this.logger.warn({ error }, 'Failed to read device breakdown');
             return [];
@@ -968,11 +1052,13 @@ export class TrafficService {
      * day activity.
      *
      * @param range - Inclusive date window.
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
      * @returns Per-day new/returning split, oldest first.
      */
-    async getRetention(range: IAnalyticsDateRange): Promise<IRetentionPoint[]> {
+    async getRetention(range: IAnalyticsDateRange, excludeBots = false): Promise<IRetentionPoint[]> {
         if (!this.clickhouse) return [];
         const { clause, params } = this.rangeParams(range);
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
         const sql = `
             SELECT
                 d.day AS day,
@@ -981,7 +1067,7 @@ export class TrafficService {
             FROM (
                 SELECT candidate_uid, toDate(timestamp) AS day
                 FROM ${TABLE_NAME}
-                WHERE ${clause}
+                WHERE ${clause}${botFilter}
                 GROUP BY candidate_uid, day
             ) AS d
             INNER JOIN (
@@ -990,7 +1076,7 @@ export class TrafficService {
                 WHERE candidate_uid IN (
                     SELECT DISTINCT candidate_uid
                     FROM ${TABLE_NAME}
-                    WHERE ${clause}
+                    WHERE ${clause}${botFilter}
                 )
                 GROUP BY candidate_uid
             ) AS f USING (candidate_uid)
@@ -1011,18 +1097,20 @@ export class TrafficService {
      * tids that ever carried a non-null `user_id`.
      *
      * @param range - Inclusive date window.
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
      * @returns Distinct/converted counts and the derived rate.
      */
-    async getBinaryConversionFunnel(range: IAnalyticsDateRange): Promise<IBinaryConversionFunnel> {
+    async getBinaryConversionFunnel(range: IAnalyticsDateRange, excludeBots = false): Promise<IBinaryConversionFunnel> {
         const empty: IBinaryConversionFunnel = { distinctVisitors: 0, converted: 0, conversionRate: 0 };
         if (!this.clickhouse) return empty;
         const { clause, params } = this.rangeParams(range);
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
         const sql = `
             SELECT
                 uniqExact(candidate_uid) AS distinctVisitors,
                 uniqExactIf(candidate_uid, user_id IS NOT NULL) AS converted
             FROM ${TABLE_NAME}
-            WHERE ${clause}
+            WHERE ${clause}${botFilter}
         `;
         try {
             const rows = await this.clickhouse.query<{ distinctVisitors: string | number; converted: string | number }>(sql, params);
@@ -1043,11 +1131,13 @@ export class TrafficService {
      *
      * @param range - Inclusive date window.
      * @param limit - Max campaigns.
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
      * @returns Per-campaign visitors, conversions, and rate, by visitors desc.
      */
-    async getCampaignPerformance(range: IAnalyticsDateRange, limit = 20): Promise<ICampaignPerformanceBucket[]> {
+    async getCampaignPerformance(range: IAnalyticsDateRange, limit = 20, excludeBots = false): Promise<ICampaignPerformanceBucket[]> {
         if (!this.clickhouse) return [];
         const { clause, params } = this.rangeParams(range);
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
         const sql = `
             SELECT
                 coalesce(utm_campaign, '(none)') AS campaign,
@@ -1056,7 +1146,7 @@ export class TrafficService {
                 uniqExact(candidate_uid) AS visitors,
                 uniqExactIf(candidate_uid, user_id IS NOT NULL) AS conversions
             FROM ${TABLE_NAME}
-            WHERE ${clause} AND utm_campaign IS NOT NULL
+            WHERE ${clause}${botFilter} AND utm_campaign IS NOT NULL
             GROUP BY campaign, source, medium
             ORDER BY visitors DESC
             LIMIT {limit:UInt32}
@@ -1091,12 +1181,14 @@ export class TrafficService {
      * emission.
      *
      * @param range - Inclusive date window.
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
      * @returns Aggregate engagement metrics.
      */
-    async getEngagementMetrics(range: IAnalyticsDateRange): Promise<IEngagementMetrics> {
+    async getEngagementMetrics(range: IAnalyticsDateRange, excludeBots = false): Promise<IEngagementMetrics> {
         const empty: IEngagementMetrics = { sessions: 0, avgDurationMs: 0, pagesPerSession: 0, bounceRate: 0 };
         if (!this.clickhouse) return empty;
         const { clause, params } = this.rangeParams(range);
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
         const sql = `
             SELECT
                 countIf(event_type = 'session_start') AS sessions,
@@ -1104,7 +1196,7 @@ export class TrafficService {
                 avgIf(duration_ms, event_type = 'session_end' AND duration_ms IS NOT NULL) AS avgDurationMs,
                 countIf(event_type = 'session_end' AND (duration_ms IS NULL OR duration_ms < 10000)) AS bounces
             FROM ${TABLE_NAME}
-            WHERE ${clause}
+            WHERE ${clause}${botFilter}
         `;
         try {
             const rows = await this.clickhouse.query<{
@@ -1129,6 +1221,154 @@ export class TrafficService {
     }
 
     /**
+     * The unified dashboard headline: KPIs for the window and the
+     * equal-length window before it (for period-over-period deltas), plus a
+     * zero-filled visitors/pageviews time series.
+     *
+     * Buckets are hourly when the window is ≤ 48 hours — a "24 Hours" view
+     * bucketed by day is one bar and carries no information — and daily
+     * otherwise. Days/hours with no rows are emitted as explicit zeros so
+     * gaps read as "no traffic", not as missing chart segments.
+     *
+     * @param range - Inclusive date window.
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
+     * @returns Granularity, current/previous KPIs, and the bucket series.
+     */
+    async getOverviewTrend(range: IAnalyticsDateRange, excludeBots = false): Promise<IOverviewTrend> {
+        const emptyKpis = (): IOverviewKpis => ({ visitors: 0, pageviews: 0, sessions: 0, avgDurationMs: 0, bounceRate: 0 });
+        if (!this.clickhouse) {
+            return { granularity: 'day', current: emptyKpis(), previous: emptyKpis(), series: [] };
+        }
+
+        const HOUR_MS = 60 * 60 * 1000;
+        const DAY_MS = 24 * HOUR_MS;
+        const until = range.until ?? new Date();
+        // Guard against degenerate/inverted ranges so the previous window
+        // and the zero-fill loop stay finite.
+        const windowMs = Math.max(until.getTime() - range.since.getTime(), HOUR_MS);
+        const granularity: 'hour' | 'day' = windowMs <= 48 * HOUR_MS ? 'hour' : 'day';
+
+        const currentRange: IAnalyticsDateRange = { since: range.since, until };
+        const previousRange: IAnalyticsDateRange = {
+            since: new Date(range.since.getTime() - windowMs),
+            until: range.since
+        };
+
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
+
+        /**
+         * Build and run the KPI aggregate for one window.
+         *
+         * @param r - The window to aggregate.
+         * @returns The window's headline KPIs.
+         */
+        const fetchKpis = async (r: IAnalyticsDateRange): Promise<IOverviewKpis> => {
+            const { clause, params } = this.rangeParams(r);
+            const sql = `
+                SELECT
+                    uniqExact(candidate_uid) AS visitors,
+                    countIf(event_type = 'page') AS pageviews,
+                    countIf(event_type = 'session_start') AS sessions,
+                    avgIf(duration_ms, event_type = 'session_end' AND duration_ms IS NOT NULL) AS avgDurationMs,
+                    countIf(event_type = 'session_end' AND (duration_ms IS NULL OR duration_ms < 10000)) AS bounces
+                FROM ${TABLE_NAME}
+                WHERE ${clause}${botFilter}
+            `;
+            const rows = await this.clickhouse!.query<{
+                visitors: string | number; pageviews: string | number; sessions: string | number;
+                avgDurationMs: string | number | null; bounces: string | number;
+            }>(sql, params);
+            const row = rows[0];
+            if (!row) return emptyKpis();
+            const sessions = Number(row.sessions);
+            const bounces = Number(row.bounces);
+            return {
+                visitors: Number(row.visitors),
+                pageviews: Number(row.pageviews),
+                sessions,
+                avgDurationMs: Number(row.avgDurationMs ?? 0),
+                bounceRate: sessions > 0 ? bounces / sessions : 0
+            };
+        };
+
+        const bucketExpr = granularity === 'hour' ? 'toStartOfHour(timestamp)' : 'toDate(timestamp)';
+        const { clause, params } = this.rangeParams(currentRange);
+        const seriesSql = `
+            SELECT
+                ${bucketExpr} AS bucket,
+                uniqExact(candidate_uid) AS visitors,
+                countIf(event_type = 'page') AS pageviews
+            FROM ${TABLE_NAME}
+            WHERE ${clause}${botFilter}
+            GROUP BY bucket
+            ORDER BY bucket ASC
+        `;
+
+        try {
+            const [current, previous, seriesRows] = await Promise.all([
+                fetchKpis(currentRange),
+                fetchKpis(previousRange),
+                this.clickhouse.query<{ bucket: string; visitors: string | number; pageviews: string | number }>(seriesSql, params)
+            ]);
+
+            // Zero-fill every bucket in the window, then overlay the rows.
+            const stepMs = granularity === 'hour' ? HOUR_MS : DAY_MS;
+            const since = range.since;
+            const floorUtc = granularity === 'hour'
+                ? Date.UTC(since.getUTCFullYear(), since.getUTCMonth(), since.getUTCDate(), since.getUTCHours())
+                : Date.UTC(since.getUTCFullYear(), since.getUTCMonth(), since.getUTCDate());
+            const keyFor = (ms: number): string => granularity === 'hour'
+                ? new Date(ms).toISOString()
+                : new Date(ms).toISOString().split('T')[0];
+
+            const buckets = new Map<string, IOverviewTrendPoint>();
+            for (let ms = floorUtc; ms <= until.getTime(); ms += stepMs) {
+                const key = keyFor(ms);
+                buckets.set(key, { bucket: key, visitors: 0, pageviews: 0 });
+            }
+            for (const row of seriesRows) {
+                const key = granularity === 'hour'
+                    ? clickHouseDateToIso(String(row.bucket))
+                    : String(row.bucket);
+                const point = buckets.get(key);
+                if (point) {
+                    point.visitors = Number(row.visitors);
+                    point.pageviews = Number(row.pageviews);
+                }
+            }
+
+            return { granularity, current, previous, series: Array.from(buckets.values()) };
+        } catch (error) {
+            this.logger.warn({ error }, 'Failed to read overview trend');
+            return { granularity, current: emptyKpis(), previous: emptyKpis(), series: [] };
+        }
+    }
+
+    /**
+     * Distinct visitors active in the last five minutes — the "online now"
+     * counter every analytics platform headlines.
+     *
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
+     * @returns The live visitor count (0 when ClickHouse is unavailable).
+     */
+    async getLiveVisitorCount(excludeBots = false): Promise<number> {
+        if (!this.clickhouse) return 0;
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
+        const sql = `
+            SELECT uniqExact(candidate_uid) AS visitors
+            FROM ${TABLE_NAME}
+            WHERE timestamp > now() - INTERVAL 5 MINUTE${botFilter}
+        `;
+        try {
+            const rows = await this.clickhouse.query<{ visitors: string | number }>(sql, {});
+            return Number(rows[0]?.visitors ?? 0);
+        } catch (error) {
+            this.logger.warn({ error }, 'Failed to read live visitor count');
+            return 0;
+        }
+    }
+
+    /**
      * Visitors whose global first-seen (across the full table) falls inside the
      * window — the "new arrivals" of the period — newest first, with first-touch
      * attribution and lifetime activity counts.
@@ -1139,19 +1379,25 @@ export class TrafficService {
      * The inner `IN` filters which tids participate, not which of their rows
      * count, so `min`/`max`/`argMin` still see each tid's full history.
      *
+     * With `excludeBots`, both the participating-tid set and the grouped rows
+     * are restricted to human-classified rows, so crawlers spoofing referrers
+     * neither appear as visitors nor contribute attribution.
+     *
      * @param range - Inclusive date window.
      * @param limit - Page size.
      * @param skip - Pagination offset.
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
      * @returns A page of new-visitor origins plus the unpaginated total.
      */
-    async getNewVisitors(range: IAnalyticsDateRange, limit = 50, skip = 0): Promise<INewVisitorsPage> {
+    async getNewVisitors(range: IAnalyticsDateRange, limit = 50, skip = 0, excludeBots = false): Promise<INewVisitorsPage> {
         if (!this.clickhouse) return { visitors: [], total: 0 };
         const { clause, params } = this.rangeParams(range);
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
         let firstSeenClause = 'firstSeen >= parseDateTimeBestEffort({since:String})';
         if (range.until) {
             firstSeenClause += ' AND firstSeen <= parseDateTimeBestEffort({until:String})';
         }
-        const activeInWindow = `candidate_uid IN (SELECT DISTINCT candidate_uid FROM ${TABLE_NAME} WHERE ${clause})`;
+        const activeInWindow = `candidate_uid IN (SELECT DISTINCT candidate_uid FROM ${TABLE_NAME} WHERE ${clause}${botFilter})`;
         const pageSql = `
             SELECT
                 candidate_uid AS userId,
@@ -1169,7 +1415,7 @@ export class TrafficService {
                 count() AS pageViews,
                 countIf(event_type = 'session_start') AS sessionsCount
             FROM ${TABLE_NAME}
-            WHERE ${activeInWindow}
+            WHERE ${activeInWindow}${botFilter}
             GROUP BY candidate_uid
             HAVING ${firstSeenClause}
             ORDER BY firstSeen DESC
@@ -1179,7 +1425,7 @@ export class TrafficService {
             SELECT count() AS total FROM (
                 SELECT candidate_uid, min(timestamp) AS firstSeen
                 FROM ${TABLE_NAME}
-                WHERE ${activeInWindow}
+                WHERE ${activeInWindow}${botFilter}
                 GROUP BY candidate_uid
                 HAVING ${firstSeenClause}
             )
@@ -1238,10 +1484,11 @@ export class TrafficService {
      *
      * @param range - Inclusive date window.
      * @param source - Referrer domain (e.g. `'duckduckgo.com'`) or `'direct'`.
+     * @param excludeBots - Restrict to human-classified rows (NULL kept).
      * @returns The source breakdown, or an empty shell when the source has no
      *          events in the window.
      */
-    async getTrafficSourceDetails(range: IAnalyticsDateRange, source: string): Promise<ITrafficSourceDetailsResult> {
+    async getTrafficSourceDetails(range: IAnalyticsDateRange, source: string, excludeBots = false): Promise<ITrafficSourceDetailsResult> {
         const empty: ITrafficSourceDetailsResult = {
             source,
             visitors: 0,
@@ -1255,8 +1502,9 @@ export class TrafficService {
         };
         if (!this.clickhouse) return empty;
         const { clause, params } = this.rangeParams(range);
+        const botFilter = excludeBots ? ` AND ${HUMAN_ROWS_FILTER}` : '';
         const sourceExpr = `multiIf(referer IS NULL OR referer = '', 'direct', domain(referer))`;
-        const where = `${clause} AND ${sourceExpr} = {source:String}`;
+        const where = `${clause}${botFilter} AND ${sourceExpr} = {source:String}`;
         const p = { ...params, source };
         const round1 = (n: number): number => Math.round(n * 10) / 10;
         try {

--- a/src/frontend/app/(core)/system/traffic/page.module.scss
+++ b/src/frontend/app/(core)/system/traffic/page.module.scss
@@ -49,6 +49,64 @@
     border-bottom-color: var(--color-primary);
 }
 
+/* Live "online now" counter, pushed to the right edge of the tab row. */
+.live {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-2xs);
+    margin-left: auto;
+    align-self: center;
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-success-text);
+    font-variant-numeric: tabular-nums;
+
+    svg {
+        color: var(--color-success);
+    }
+}
+
+/* Global period + bot-filter bar governing Analytics/Visitors/Pages. */
+.global_controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--gap-md);
+    flex-wrap: wrap;
+}
+
+.bot_toggle {
+    display: flex;
+    gap: 0;
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+}
+
+.bot_btn,
+.bot_btn__active {
+    padding: var(--padding-xs) var(--gap-md);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-medium);
+    border: none;
+    cursor: pointer;
+    transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.bot_btn {
+    color: var(--color-text-muted);
+    background: var(--color-surface);
+}
+
+.bot_btn:hover {
+    color: var(--color-text);
+}
+
+.bot_btn__active {
+    color: var(--color-text);
+    background: var(--gradient-primary);
+}
+
 .content {
     flex: 1;
 }

--- a/src/frontend/app/(core)/system/traffic/page.tsx
+++ b/src/frontend/app/(core)/system/traffic/page.tsx
@@ -20,8 +20,15 @@ import styles from './page.module.scss';
 /** Tab identifiers for the traffic admin page. */
 type TrafficTab = 'analytics' | 'visitors' | 'pages' | 'crawlers' | 'seo' | 'settings';
 
-/** Tabs governed by the global period picker and bot filter. */
+/** Tabs governed by the global period picker. */
 const GOVERNED_TABS: ReadonlySet<TrafficTab> = new Set(['analytics', 'visitors', 'pages']);
+
+/**
+ * Tabs the bot filter actually applies to. Pages is period-governed but
+ * deliberately unfiltered — only JS-running clients emit `page` events, so
+ * the toggle would be an inert control there.
+ */
+const BOT_FILTERED_TABS: ReadonlySet<TrafficTab> = new Set(['analytics', 'visitors']);
 
 /** Polling interval for the live-visitor counter (ms). */
 const LIVE_POLL_MS = 30_000;
@@ -67,14 +74,20 @@ export default function SystemTrafficPage() {
     /**
      * Memoized custom date range built from the date input values.
      * Aligns to localized midnight: start at 00:00:00 of start date,
-     * end at 23:59:59.999 of end date. Undefined unless period is
-     * 'custom' with two valid dates.
+     * end at 23:59:59.999 of end date. Dates are constructed with the
+     * multi-argument constructor (offset-less string parsing is
+     * engine-dependent) and inverted ranges return undefined — the
+     * backend would otherwise silently serve its default window while
+     * the UI displays the custom dates. Undefined unless period is
+     * 'custom' with two valid, ordered dates.
      */
     const customRange = useMemo<ICustomDateRange | undefined>(() => {
         if (period !== 'custom' || !customStart || !customEnd) return undefined;
-        const start = new Date(`${customStart}T00:00:00`);
-        const end = new Date(`${customEnd}T23:59:59.999`);
-        if (isNaN(start.getTime()) || isNaN(end.getTime())) return undefined;
+        const [startY, startM, startD] = customStart.split('-').map(Number);
+        const [endY, endM, endD] = customEnd.split('-').map(Number);
+        const start = new Date(startY, startM - 1, startD, 0, 0, 0, 0);
+        const end = new Date(endY, endM - 1, endD, 23, 59, 59, 999);
+        if (isNaN(start.getTime()) || isNaN(end.getTime()) || start.getTime() > end.getTime()) return undefined;
         return { startDate: start.toISOString(), endDate: end.toISOString() };
     }, [period, customStart, customEnd]);
 
@@ -161,24 +174,26 @@ export default function SystemTrafficPage() {
                         onCustomStartChange={setCustomStart}
                         onCustomEndChange={setCustomEnd}
                     />
-                    <div className={styles.bot_toggle} role="group" aria-label="Bot traffic filter">
-                        <button
-                            type="button"
-                            className={!includeBots ? styles.bot_btn__active : styles.bot_btn}
-                            onClick={() => setIncludeBots(false)}
-                            aria-pressed={!includeBots}
-                        >
-                            Humans only
-                        </button>
-                        <button
-                            type="button"
-                            className={includeBots ? styles.bot_btn__active : styles.bot_btn}
-                            onClick={() => setIncludeBots(true)}
-                            aria-pressed={includeBots}
-                        >
-                            Include bots
-                        </button>
-                    </div>
+                    {BOT_FILTERED_TABS.has(activeTab) && (
+                        <div className={styles.bot_toggle} role="group" aria-label="Bot traffic filter">
+                            <button
+                                type="button"
+                                className={!includeBots ? styles.bot_btn__active : styles.bot_btn}
+                                onClick={() => setIncludeBots(false)}
+                                aria-pressed={!includeBots}
+                            >
+                                Humans only
+                            </button>
+                            <button
+                                type="button"
+                                className={includeBots ? styles.bot_btn__active : styles.bot_btn}
+                                onClick={() => setIncludeBots(true)}
+                                aria-pressed={includeBots}
+                            >
+                                Include bots
+                            </button>
+                        </div>
+                    )}
                 </div>
             )}
 

--- a/src/frontend/app/(core)/system/traffic/page.tsx
+++ b/src/frontend/app/(core)/system/traffic/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { Radio } from 'lucide-react';
 import {
     AnalyticsDashboard,
     VisitorAnalytics,
@@ -8,31 +9,94 @@ import {
     CrawlerDashboard,
     TrafficDashboard,
     GscKeywords,
-    GscSettings
+    GscSettings,
+    PeriodPicker,
+    toDateInputValue
 } from '../../../../modules/traffic';
+import { adminGetLiveVisitors } from '../../../../modules/traffic/api';
+import type { AnalyticsPeriod, ICustomDateRange } from '../../../../modules/traffic/api';
 import styles from './page.module.scss';
 
 /** Tab identifiers for the traffic admin page. */
 type TrafficTab = 'analytics' | 'visitors' | 'pages' | 'crawlers' | 'seo' | 'settings';
+
+/** Tabs governed by the global period picker and bot filter. */
+const GOVERNED_TABS: ReadonlySet<TrafficTab> = new Set(['analytics', 'visitors', 'pages']);
+
+/** Polling interval for the live-visitor counter (ms). */
+const LIVE_POLL_MS = 30_000;
 
 /**
  * System traffic administration page with tabbed interface.
  *
  * Hosts the traffic module's analytics dashboards, carved out of
  * /system/users to mirror the backend identity/traffic split:
- * - Analytics: Aggregate traffic sources, engagement, conversion funnel
- * - Visitors: Daily visitors and anonymous first touches (incl. bots)
+ * - Analytics: KPI strip + unified trend, sources, engagement, funnel
+ * - Visitors: New-visitor first touches (bots filterable)
  * - Pages: Anonymous (tid) and registered (user_id) per-page clickstreams
  * - Crawlers: Bot-class trend, per-bot-class paths, and the bot/geo/path
  *   breakdowns with the bot_other classifier-gap feedback loop
  * - SEO: Google Search Console keywords (clicks/impressions/CTR/position)
  * - Settings: GSC credential configuration
  *
+ * One global period picker + bot filter governs the Analytics, Visitors,
+ * and Pages tabs so an admin never unknowingly compares different windows.
+ * Crawlers keeps its own `sinceHours` windows (capped at 30d server-side)
+ * and SEO its delay-shifted GSC windows. A live "visitors now" counter
+ * (last 5 minutes, polled every 30s) sits beside the tabs.
+ *
  * Follows the simpler button-tab pattern from /system/pages (no ARIA
  * tablist/tab/tabpanel roles to avoid incomplete implementation).
  */
 export default function SystemTrafficPage() {
     const [activeTab, setActiveTab] = useState<TrafficTab>('analytics');
+
+    // Global window + bot filter for the governed tabs.
+    const [period, setPeriod] = useState<AnalyticsPeriod>('30d');
+    const [customStart, setCustomStart] = useState(() => {
+        const d = new Date();
+        d.setDate(d.getDate() - 7);
+        return toDateInputValue(d);
+    });
+    const [customEnd, setCustomEnd] = useState(() => toDateInputValue(new Date()));
+    const [includeBots, setIncludeBots] = useState(false);
+
+    // Live visitors (last 5 minutes), polled while the page is open.
+    const [liveVisitors, setLiveVisitors] = useState<number | null>(null);
+
+    /**
+     * Memoized custom date range built from the date input values.
+     * Aligns to localized midnight: start at 00:00:00 of start date,
+     * end at 23:59:59.999 of end date. Undefined unless period is
+     * 'custom' with two valid dates.
+     */
+    const customRange = useMemo<ICustomDateRange | undefined>(() => {
+        if (period !== 'custom' || !customStart || !customEnd) return undefined;
+        const start = new Date(`${customStart}T00:00:00`);
+        const end = new Date(`${customEnd}T23:59:59.999`);
+        if (isNaN(start.getTime()) || isNaN(end.getTime())) return undefined;
+        return { startDate: start.toISOString(), endDate: end.toISOString() };
+    }, [period, customStart, customEnd]);
+
+    useEffect(() => {
+        let active = true;
+        /**
+         * Refresh the live counter, dropping the result after unmount.
+         */
+        const poll = async (): Promise<void> => {
+            try {
+                const { visitors } = await adminGetLiveVisitors(!includeBots);
+                if (active) setLiveVisitors(visitors);
+            } catch {
+                if (active) setLiveVisitors(null);
+            }
+        };
+        poll();
+        const timer = setInterval(poll, LIVE_POLL_MS);
+        return () => { active = false; clearInterval(timer); };
+    }, [includeBots]);
+
+    const showGlobalControls = GOVERNED_TABS.has(activeTab);
 
     return (
         <div className={styles.container}>
@@ -79,12 +143,55 @@ export default function SystemTrafficPage() {
                 >
                     Settings
                 </button>
+                {liveVisitors !== null && (
+                    <span className={styles.live} title="Distinct visitors in the last 5 minutes">
+                        <Radio size={14} aria-hidden="true" />
+                        {liveVisitors.toLocaleString()} online now
+                    </span>
+                )}
             </div>
 
+            {showGlobalControls && (
+                <div className={styles.global_controls}>
+                    <PeriodPicker
+                        period={period}
+                        onPeriodChange={setPeriod}
+                        customStart={customStart}
+                        customEnd={customEnd}
+                        onCustomStartChange={setCustomStart}
+                        onCustomEndChange={setCustomEnd}
+                    />
+                    <div className={styles.bot_toggle} role="group" aria-label="Bot traffic filter">
+                        <button
+                            type="button"
+                            className={!includeBots ? styles.bot_btn__active : styles.bot_btn}
+                            onClick={() => setIncludeBots(false)}
+                            aria-pressed={!includeBots}
+                        >
+                            Humans only
+                        </button>
+                        <button
+                            type="button"
+                            className={includeBots ? styles.bot_btn__active : styles.bot_btn}
+                            onClick={() => setIncludeBots(true)}
+                            aria-pressed={includeBots}
+                        >
+                            Include bots
+                        </button>
+                    </div>
+                </div>
+            )}
+
             <div className={styles.content}>
-                {activeTab === 'analytics' && <AnalyticsDashboard />}
-                {activeTab === 'visitors' && <VisitorAnalytics />}
-                {activeTab === 'pages' && <PageActivity />}
+                {activeTab === 'analytics' && (
+                    <AnalyticsDashboard period={period} customRange={customRange} includeBots={includeBots} />
+                )}
+                {activeTab === 'visitors' && (
+                    <VisitorAnalytics period={period} customRange={customRange} includeBots={includeBots} />
+                )}
+                {activeTab === 'pages' && (
+                    <PageActivity period={period} customRange={customRange} />
+                )}
                 {activeTab === 'crawlers' && (
                     <div className={styles.crawler_stack}>
                         <CrawlerDashboard />

--- a/src/frontend/modules/traffic/api/client.ts
+++ b/src/frontend/modules/traffic/api/client.ts
@@ -69,15 +69,21 @@ export interface IVisitorOrigin {
 /**
  * Get daily unique visitor counts for charting (admin endpoint).
  * @param days - Number of days to look back (default: 90)
+ * @param options - `excludeBots` restricts counts to human-classified rows
  * @returns Array of daily visitor count data points
  */
-export async function adminGetDailyVisitors(days: number = 90
+export async function adminGetDailyVisitors(days: number = 90,
+    options?: { excludeBots?: boolean }
 ): Promise<IDailyVisitorData[]> {
     // The ClickHouse-backed endpoint takes a date window, not a `days` count;
     // convert. Backend returns { data: [{ day, visitors }] }.
     const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
     const response = await apiClient.get('/admin/users/analytics/daily-visitors', {
-        params: { startDate: since.toISOString(), endDate: new Date().toISOString() }
+        params: {
+            startDate: since.toISOString(),
+            endDate: new Date().toISOString(),
+            ...(options?.excludeBots ? { bots: 'exclude' } : {})
+        }
     });
     const rows = (response.data as { data?: Array<{ day: string; visitors: number }> }).data ?? [];
     return rows.map(r => ({ date: r.day, count: r.visitors }));
@@ -88,16 +94,22 @@ export async function adminGetDailyVisitors(days: number = 90
  * endpoint).
  *
  * A first touch is the earliest `bootstrap` row for a cookieless visitor —
- * server-recorded by the Next.js middleware, so this surface intentionally
- * includes bots, crawlers, and unfurlers as well as humans. Filtered by global
- * first-seen (new arrivals in the window) and sorted most recent first.
- * @param options - Period, pagination options
+ * server-recorded by the Next.js middleware, so this surface includes bots,
+ * crawlers, and unfurlers unless `excludeBots` restricts it to
+ * human-classified rows. Filtered by global first-seen (new arrivals in the
+ * window) and sorted most recent first.
+ * @param options - Period, pagination, and bot-filter options
  * @returns Paginated list of first-touch origins
  */
-export async function adminGetAnonymousFirstTouches(options?: { period?: VisitorPeriod; limit?: number; skip?: number }
+export async function adminGetAnonymousFirstTouches(options?: { period?: VisitorPeriod; customRange?: { startDate: string; endDate: string }; limit?: number; skip?: number; excludeBots?: boolean }
 ): Promise<{ visitors: IVisitorOrigin[]; total: number }> {
+    const { excludeBots, customRange, period, ...rest } = options ?? {};
     const response = await apiClient.get('/admin/users/analytics/new-users', {
-        params: options
+        params: {
+            ...rest,
+            ...(customRange ? customRange : { period }),
+            ...(excludeBots ? { bots: 'exclude' } : {})
+        }
     });
     return response.data as { visitors: IVisitorOrigin[]; total: number };
 }
@@ -143,13 +155,14 @@ export interface IPageHit {
  * @returns Paginated activity rows plus the unpaginated subject total
  */
 export async function adminGetPageActivity(subject: PageActivitySubject,
-    options?: { period?: VisitorPeriod; limit?: number; skip?: number }
+    options?: { period?: VisitorPeriod; customRange?: { startDate: string; endDate: string }; limit?: number; skip?: number }
 ): Promise<{ rows: IPageActivityRow[]; total: number }> {
     const endpoint = subject === 'tid'
         ? '/admin/users/analytics/tid-activity'
         : '/admin/users/analytics/user-activity';
+    const { customRange, period, ...rest } = options ?? {};
     const response = await apiClient.get(endpoint, {
-        params: options
+        params: { ...rest, ...(customRange ? customRange : { period }) }
     });
     return response.data as { rows: IPageActivityRow[]; total: number };
 }
@@ -164,10 +177,11 @@ export async function adminGetPageActivity(subject: PageActivitySubject,
  */
 export async function adminGetPageHits(subject: PageActivitySubject,
     id: string,
-    options?: { period?: VisitorPeriod; limit?: number }
+    options?: { period?: VisitorPeriod; customRange?: { startDate: string; endDate: string }; limit?: number }
 ): Promise<IPageHit[]> {
+    const { customRange, period, ...rest } = options ?? {};
     const response = await apiClient.get('/admin/users/analytics/page-hits', {
-        params: { subject, id, ...options }
+        params: { subject, id, ...rest, ...(customRange ? customRange : { period }) }
     });
     return (response.data as { data?: IPageHit[] }).data ?? [];
 }
@@ -187,11 +201,15 @@ export interface ICustomDateRange {
     endDate: string;
 }
 
-/** Traffic source entry in aggregate breakdown. */
+/** Traffic source entry in aggregate breakdown. Visitors is the primary measure. */
 export interface ITrafficSource {
     source: string;
     category: string;
+    /** Distinct visitors (tids) — the primary measure. */
+    visitors: number;
+    /** Raw event rows. */
     count: number;
+    /** Share of total visitors (0-100, one decimal). */
     percentage: number;
 }
 
@@ -231,17 +249,21 @@ export interface ILandingPage {
     avgPageViews: number;
 }
 
-/** Country entry in geographic distribution. */
+/** Country entry in geographic distribution. Visitors is the primary measure. */
 export interface IGeoEntry {
     country: string;
+    /** Distinct visitors (tids) — the primary measure. */
     count: number;
+    /** Share of total visitors (0-100, one decimal). */
     percentage: number;
 }
 
-/** Device category entry. */
+/** Device category entry. Visitors is the primary measure. */
 export interface IDeviceEntry {
     device: string;
+    /** Distinct visitors (tids) — the primary measure. */
     count: number;
+    /** Share of total visitors (0-100, one decimal). */
     percentage: number;
 }
 
@@ -310,24 +332,31 @@ function categorizeTrafficSource(source: string): string {
 /**
  * Get aggregate traffic source breakdown (admin endpoint).
  * @param period - Lookback period (default: '30d')
- * @returns Traffic sources with counts and percentages
+ * @param customRange - Custom date range overriding the period
+ * @param excludeBots - Restrict to human-classified rows
+ * @returns Traffic sources with visitor counts and percentages
  */
 export async function adminGetTrafficSources(period: AnalyticsPeriod = '30d',
-    customRange?: ICustomDateRange
+    customRange?: ICustomDateRange,
+    excludeBots?: boolean
 ): Promise<{ sources: ITrafficSource[]; total: number }> {
-    const params = customRange ? customRange : { period };
+    const params = {
+        ...(customRange ? customRange : { period }),
+        ...(excludeBots ? { bots: 'exclude' } : {})
+    };
     const response = await apiClient.get('/admin/users/analytics/traffic-sources', {
         params
     });
-    // Backend (TrafficService) returns { data: [{ source, count }] }. Derive
-    // the category badge and percentage client-side.
-    const rows = (response.data as { data?: Array<{ source: string; count: number }> }).data ?? [];
-    const total = rows.reduce((sum, r) => sum + (r.count ?? 0), 0);
+    // Backend returns { data: [{ source, visitors, count }] }. Derive the
+    // category badge and percentage (of visitors) client-side.
+    const rows = (response.data as { data?: Array<{ source: string; visitors: number; count: number }> }).data ?? [];
+    const total = rows.reduce((sum, r) => sum + (r.visitors ?? 0), 0);
     const sources: ITrafficSource[] = rows.map(r => ({
         source: r.source,
         category: categorizeTrafficSource(r.source),
+        visitors: r.visitors,
         count: r.count,
-        percentage: total > 0 ? Math.round((r.count / total) * 1000) / 10 : 0
+        percentage: total > 0 ? Math.round((r.visitors / total) * 1000) / 10 : 0
     }));
     return { sources, total };
 }
@@ -339,13 +368,20 @@ export async function adminGetTrafficSources(period: AnalyticsPeriod = '30d',
  * engagement metrics, and conversion rates for visitors from the given source.
  * @param source - Referrer domain (e.g. 'duckduckgo.com') or 'direct'
  * @param period - Lookback period (default: '30d')
+ * @param customRange - Custom date range overriding the period
+ * @param excludeBots - Restrict to human-classified rows
  * @returns Detailed source breakdown
  */
 export async function adminGetTrafficSourceDetails(source: string,
     period: AnalyticsPeriod = '30d',
-    customRange?: ICustomDateRange
+    customRange?: ICustomDateRange,
+    excludeBots?: boolean
 ): Promise<ITrafficSourceDetails> {
-    const params = customRange ? { source, ...customRange } : { source, period };
+    const params = {
+        source,
+        ...(customRange ? customRange : { period }),
+        ...(excludeBots ? { bots: 'exclude' } : {})
+    };
     const response = await apiClient.get('/admin/users/analytics/traffic-source-details', {
         params
     });
@@ -354,43 +390,50 @@ export async function adminGetTrafficSourceDetails(source: string,
 
 /**
  * Get top landing pages by visitor count (admin endpoint).
- * @param options - Period and limit options
+ * @param options - Period, limit, and bot-filter options
  * @returns Landing pages with engagement metrics
  */
-export async function adminGetTopLandingPages(options?: { period?: AnalyticsPeriod; limit?: number; customRange?: ICustomDateRange }
+export async function adminGetTopLandingPages(options?: { period?: AnalyticsPeriod; limit?: number; customRange?: ICustomDateRange; excludeBots?: boolean }
 ): Promise<{ pages: ILandingPage[]; totalPages: number; totalVisitors: number }> {
-    const { customRange, ...rest } = options ?? {};
-    const params = customRange ? { ...customRange, limit: rest.limit } : rest;
+    const { customRange, excludeBots, ...rest } = options ?? {};
+    const params = {
+        ...(customRange ? { ...customRange, limit: rest.limit } : rest),
+        ...(excludeBots ? { bots: 'exclude' } : {})
+    };
     const response = await apiClient.get('/admin/users/analytics/top-landing-pages', {
         params
     });
-    // Backend returns { data: [{ path, count }] }. Per-page session/view
-    // averages no longer exist (session events land post-Phase-D), so they
-    // surface as 0.
-    const rows = (response.data as { data?: Array<{ path: string; count: number }> }).data ?? [];
-    const pages: ILandingPage[] = rows.map(r => ({ path: r.path, visitors: r.count, avgSessions: 0, avgPageViews: 0 }));
-    return { pages, totalPages: pages.length, totalVisitors: rows.reduce((sum, r) => sum + (r.count ?? 0), 0) };
+    // Backend returns { data: [{ path, visitors, count }] }. Per-page
+    // session/view averages no longer exist (session events land
+    // post-Phase-D), so they surface as 0.
+    const rows = (response.data as { data?: Array<{ path: string; visitors: number; count: number }> }).data ?? [];
+    const pages: ILandingPage[] = rows.map(r => ({ path: r.path, visitors: r.visitors, avgSessions: 0, avgPageViews: 0 }));
+    return { pages, totalPages: pages.length, totalVisitors: rows.reduce((sum, r) => sum + (r.visitors ?? 0), 0) };
 }
 
 /**
  * Get geographic distribution of visitors (admin endpoint).
- * @param options - Period and limit options
- * @returns Country distribution with counts
+ * @param options - Period, limit, and bot-filter options
+ * @returns Country distribution with visitor counts
  */
-export async function adminGetGeoDistribution(options?: { period?: AnalyticsPeriod; limit?: number; customRange?: ICustomDateRange }
+export async function adminGetGeoDistribution(options?: { period?: AnalyticsPeriod; limit?: number; customRange?: ICustomDateRange; excludeBots?: boolean }
 ): Promise<{ countries: IGeoEntry[]; total: number }> {
-    const { customRange, ...rest } = options ?? {};
-    const params = customRange ? { ...customRange, limit: rest.limit } : rest;
+    const { customRange, excludeBots, ...rest } = options ?? {};
+    const params = {
+        ...(customRange ? { ...customRange, limit: rest.limit } : rest),
+        ...(excludeBots ? { bots: 'exclude' } : {})
+    };
     const response = await apiClient.get('/admin/users/analytics/geo-distribution', {
         params
     });
-    // Backend returns { data: [{ country, count }] }; derive percentage.
-    const rows = (response.data as { data?: Array<{ country: string | null; count: number }> }).data ?? [];
-    const total = rows.reduce((sum, r) => sum + (r.count ?? 0), 0);
+    // Backend returns { data: [{ country, visitors, count }] }; visitors is
+    // the primary measure; derive percentage from it.
+    const rows = (response.data as { data?: Array<{ country: string | null; visitors: number; count: number }> }).data ?? [];
+    const total = rows.reduce((sum, r) => sum + (r.visitors ?? 0), 0);
     const countries: IGeoEntry[] = rows.map(r => ({
         country: r.country ?? 'Unknown',
-        count: r.count,
-        percentage: total > 0 ? Math.round((r.count / total) * 1000) / 10 : 0
+        count: r.visitors,
+        percentage: total > 0 ? Math.round((r.visitors / total) * 1000) / 10 : 0
     }));
     return { countries, total };
 }
@@ -398,23 +441,29 @@ export async function adminGetGeoDistribution(options?: { period?: AnalyticsPeri
 /**
  * Get device and screen size breakdown (admin endpoint).
  * @param period - Lookback period (default: '30d')
+ * @param customRange - Custom date range overriding the period
+ * @param excludeBots - Restrict to human-classified rows
  * @returns Device and screen size distributions
  */
 export async function adminGetDeviceBreakdown(period: AnalyticsPeriod = '30d',
-    customRange?: ICustomDateRange
+    customRange?: ICustomDateRange,
+    excludeBots?: boolean
 ): Promise<{ devices: IDeviceEntry[]; screenSizes: IScreenSizeEntry[]; total: number }> {
-    const params = customRange ? customRange : { period };
+    const params = {
+        ...(customRange ? customRange : { period }),
+        ...(excludeBots ? { bots: 'exclude' } : {})
+    };
     const response = await apiClient.get('/admin/users/analytics/device-breakdown', {
         params
     });
-    // Backend returns { data: [{ device, count }] }; screen-size dimension was
-    // dropped in the ClickHouse re-platform.
-    const rows = (response.data as { data?: Array<{ device: string; count: number }> }).data ?? [];
-    const total = rows.reduce((sum, r) => sum + (r.count ?? 0), 0);
+    // Backend returns { data: [{ device, visitors, count }] }; visitors is the
+    // primary measure. Screen-size dimension was dropped in the re-platform.
+    const rows = (response.data as { data?: Array<{ device: string; visitors: number; count: number }> }).data ?? [];
+    const total = rows.reduce((sum, r) => sum + (r.visitors ?? 0), 0);
     const devices: IDeviceEntry[] = rows.map(r => ({
         device: r.device,
-        count: r.count,
-        percentage: total > 0 ? Math.round((r.count / total) * 1000) / 10 : 0
+        count: r.visitors,
+        percentage: total > 0 ? Math.round((r.visitors / total) * 1000) / 10 : 0
     }));
     return { devices, screenSizes: [], total };
 }
@@ -424,10 +473,13 @@ export async function adminGetDeviceBreakdown(period: AnalyticsPeriod = '30d',
  * @param options - Period and limit options
  * @returns Campaign entries with conversion rates
  */
-export async function adminGetCampaignPerformance(options?: { period?: AnalyticsPeriod; limit?: number; customRange?: ICustomDateRange }
+export async function adminGetCampaignPerformance(options?: { period?: AnalyticsPeriod; limit?: number; customRange?: ICustomDateRange; excludeBots?: boolean }
 ): Promise<{ campaigns: ICampaignEntry[]; total: number }> {
-    const { customRange, ...rest } = options ?? {};
-    const params = customRange ? { ...customRange, limit: rest.limit } : rest;
+    const { customRange, excludeBots, ...rest } = options ?? {};
+    const params = {
+        ...(customRange ? { ...customRange, limit: rest.limit } : rest),
+        ...(excludeBots ? { bots: 'exclude' } : {})
+    };
     const response = await apiClient.get('/admin/users/analytics/campaign-performance', {
         params
     });
@@ -455,9 +507,13 @@ export async function adminGetCampaignPerformance(options?: { period?: Analytics
  * @returns Engagement summary (avg duration, pages/session, bounce rate)
  */
 export async function adminGetEngagement(period: AnalyticsPeriod = '30d',
-    customRange?: ICustomDateRange
+    customRange?: ICustomDateRange,
+    excludeBots?: boolean
 ): Promise<IEngagementMetrics> {
-    const params = customRange ? customRange : { period };
+    const params = {
+        ...(customRange ? customRange : { period }),
+        ...(excludeBots ? { bots: 'exclude' } : {})
+    };
     const response = await apiClient.get('/admin/users/analytics/engagement', {
         params
     });
@@ -480,9 +536,13 @@ export async function adminGetEngagement(period: AnalyticsPeriod = '30d',
  * @returns Funnel stages with drop-off percentages
  */
 export async function adminGetConversionFunnel(period: AnalyticsPeriod = '30d',
-    customRange?: ICustomDateRange
+    customRange?: ICustomDateRange,
+    excludeBots?: boolean
 ): Promise<{ stages: IFunnelStage[] }> {
-    const params = customRange ? customRange : { period };
+    const params = {
+        ...(customRange ? customRange : { period }),
+        ...(excludeBots ? { bots: 'exclude' } : {})
+    };
     const response = await apiClient.get('/admin/users/analytics/conversion-funnel', {
         params
     });
@@ -507,9 +567,13 @@ export async function adminGetConversionFunnel(period: AnalyticsPeriod = '30d',
  * @returns Daily new vs returning visitor counts
  */
 export async function adminGetRetention(period: AnalyticsPeriod = '30d',
-    customRange?: ICustomDateRange
+    customRange?: ICustomDateRange,
+    excludeBots?: boolean
 ): Promise<{ data: IRetentionEntry[] }> {
-    const params = customRange ? customRange : { period };
+    const params = {
+        ...(customRange ? customRange : { period }),
+        ...(excludeBots ? { bots: 'exclude' } : {})
+    };
     const response = await apiClient.get('/admin/users/analytics/retention', {
         params
     });
@@ -517,6 +581,72 @@ export async function adminGetRetention(period: AnalyticsPeriod = '30d',
     // the component keys retention rows on `date`.
     const rows = (response.data as { data?: Array<{ day: string; newVisitors: number; returningVisitors: number }> }).data ?? [];
     return { data: rows.map(r => ({ date: r.day, newVisitors: r.newVisitors, returningVisitors: r.returningVisitors })) };
+}
+
+/** Headline KPIs for one window of the overview trend. */
+export interface IOverviewKpis {
+    /** Distinct visitors (tids). */
+    visitors: number;
+    /** Interactive `page` events. */
+    pageviews: number;
+    /** `session_start` events — 0 until session instrumentation ships. */
+    sessions: number;
+    /** Average session duration in ms — 0 until session instrumentation ships. */
+    avgDurationMs: number;
+    /** Bounced sessions / sessions (0-1) — 0 until session instrumentation ships. */
+    bounceRate: number;
+}
+
+/** One time bucket of the overview trend series. */
+export interface IOverviewTrendPoint {
+    /** Bucket start — ISO-8601 UTC for hours, `YYYY-MM-DD` for days. */
+    bucket: string;
+    visitors: number;
+    pageviews: number;
+}
+
+/** Unified dashboard headline: KPIs + previous window + zero-filled series. */
+export interface IOverviewTrend {
+    granularity: 'hour' | 'day';
+    current: IOverviewKpis;
+    previous: IOverviewKpis;
+    series: IOverviewTrendPoint[];
+}
+
+/**
+ * Get the unified overview trend (admin endpoint): current/previous-window
+ * KPIs for delta rendering plus the zero-filled visitors/pageviews series.
+ * @param period - Lookback period (default: '30d')
+ * @param customRange - Custom date range overriding the period
+ * @param excludeBots - Restrict to human-classified rows
+ * @returns Granularity, both KPI windows, and the bucket series
+ */
+export async function adminGetOverviewTrend(period: AnalyticsPeriod = '30d',
+    customRange?: ICustomDateRange,
+    excludeBots?: boolean
+): Promise<IOverviewTrend> {
+    const params = {
+        ...(customRange ? customRange : { period }),
+        ...(excludeBots ? { bots: 'exclude' } : {})
+    };
+    const response = await apiClient.get('/admin/users/analytics/overview-trend', {
+        params
+    });
+    return response.data as IOverviewTrend;
+}
+
+/**
+ * Get the count of visitors active in the last five minutes (admin endpoint).
+ * @param excludeBots - Restrict to human-classified rows
+ * @returns Live visitor count and the window size
+ */
+export async function adminGetLiveVisitors(excludeBots?: boolean
+): Promise<{ visitors: number; windowMinutes: number }> {
+    const response = await apiClient.get('/admin/users/analytics/live', {
+        params: excludeBots ? { bots: 'exclude' } : {}
+    });
+    const d = response.data as { visitors?: number; windowMinutes?: number };
+    return { visitors: d.visitors ?? 0, windowMinutes: d.windowMinutes ?? 5 };
 }
 
 /** Better Auth account overview for the analytics dashboard. */
@@ -614,16 +744,35 @@ export interface IGscDailyKeywords {
 }
 
 /**
+ * Aggregated GSC keywords plus the delay-shifted window actually covered.
+ * GSC data lags ~3 days, so "7d" covers the 7 days ending ~3 days ago —
+ * `windowStart`/`windowEnd` carry the true dates for display.
+ */
+export interface IGscKeywordsResult {
+    /** Inclusive window start (ISO-8601 UTC). */
+    windowStart: string;
+    /** Inclusive window end (ISO-8601 UTC). */
+    windowEnd: string;
+    /** Keywords sorted by clicks descending. */
+    keywords: IGscKeyword[];
+}
+
+/**
  * Get aggregated GSC keywords for a lookback window (admin endpoint).
  * @param options - Window in hours (default 168 = 7d) and row limit
- * @returns Keywords sorted by clicks descending
+ * @returns Keywords sorted by clicks descending plus the covered window
  */
 export async function adminGetGscKeywords(options?: { periodHours?: number; limit?: number }
-): Promise<IGscKeyword[]> {
+): Promise<IGscKeywordsResult> {
     const response = await apiClient.get('/admin/users/analytics/gsc/keywords', {
         params: options
     });
-    return (response.data as { keywords: IGscKeyword[] }).keywords ?? [];
+    const data = response.data as Partial<IGscKeywordsResult>;
+    return {
+        windowStart: data.windowStart ?? '',
+        windowEnd: data.windowEnd ?? '',
+        keywords: data.keywords ?? []
+    };
 }
 
 /**

--- a/src/frontend/modules/traffic/api/index.ts
+++ b/src/frontend/modules/traffic/api/index.ts
@@ -23,6 +23,8 @@ export {
     adminGetConversionFunnel,
     adminGetRetention,
     adminGetAnalyticsOverview,
+    adminGetOverviewTrend,
+    adminGetLiveVisitors,
     // Google Search Console functions
     adminGetGscStatus,
     adminSaveGscCredentials,
@@ -57,8 +59,12 @@ export type {
     IFunnelStage,
     IRetentionEntry,
     IAnalyticsOverview,
+    IOverviewKpis,
+    IOverviewTrendPoint,
+    IOverviewTrend,
     IGscStatus,
     IGscKeyword,
+    IGscKeywordsResult,
     IGscDailyKeywords,
     ITrafficBucket,
     IBotClassDailyPoint

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.module.scss
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.module.scss
@@ -13,51 +13,7 @@
     gap: var(--gap-lg);
 }
 
-.controls {
-    display: flex;
-    align-items: center;
-    gap: var(--input-group-gap);
-    flex-wrap: wrap;
-}
-
-.controls__label {
-    font-size: var(--font-size-body-sm);
-    color: var(--color-text-muted);
-    font-weight: var(--font-weight-medium);
-}
-
-.controls__icon {
-    margin-right: var(--gap-xs);
-    vertical-align: middle;
-}
-
-/* Custom date range picker */
-.date_range {
-    display: flex;
-    align-items: center;
-    gap: var(--gap-sm);
-}
-
-.date_range__separator {
-    font-size: var(--font-size-body-sm);
-    color: var(--color-text-muted);
-}
-
-.date_input {
-    font-size: var(--font-size-body-sm);
-    font-family: inherit;
-    padding: var(--padding-xs) var(--padding-sm);
-    border: var(--border-width-thin) solid var(--color-border);
-    border-radius: var(--radius-md);
-    background: var(--color-surface);
-    color: var(--color-text);
-    color-scheme: dark;
-}
-
-.date_input:focus {
-    outline: var(--border-width-medium) solid var(--color-primary);
-    outline-offset: calc(-1 * var(--border-width-medium));
-}
+/* Period controls moved to the shared PeriodPicker component. */
 
 .section_title {
     font-size: var(--font-size-heading-sm);

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
@@ -6,27 +6,33 @@
  * evaluation, and conversion tracking.
  *
  * Sections:
- * 1. Engagement summary cards (avg duration, pages/session, bounce rate)
- * 2. Conversion funnel (visitors → return → wallet → verified)
+ * 1. Overview headline — KPI strip with period deltas + unified trend chart
+ * 2. Conversion funnel (visitors → logged in)
  * 3. Traffic sources breakdown (direct, organic, social, referral)
- * 4. Top landing pages with engagement metrics
+ * 4. Top landing pages
  * 5. Geographic distribution by country
- * 6. Device and screen size breakdown
+ * 6. Device breakdown
  * 7. UTM campaign performance with conversion rates
  * 8. New vs returning visitor retention chart
+ * 9. Better Auth account overview
+ *
+ * The lookback period, custom range, and bot filter arrive as props from the
+ * page-level global controls so every tab reads the same window. All table
+ * primary numbers are distinct visitors, matching analytics-platform
+ * convention; raw event counts remain available server-side.
  */
 
 'use client';
 
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import {
-    Users, TrendingUp, MousePointerClick,
-    Globe, Smartphone, BarChart3, Target, ChevronDown, ChevronRight, Calendar
+    Users, MousePointerClick,
+    Globe, Smartphone, BarChart3, Target, ChevronDown, ChevronRight
 } from 'lucide-react';
 import { LineChart } from '../../../../../features/charts/components/LineChart';
 import type { ChartSeries } from '../../../../../features/charts/components/LineChart';
-import { Button } from '../../../../../components/ui/Button';
 import { Card } from '../../../../../components/ui/Card';
+import { OverviewTrend } from '../OverviewTrend';
 import {
     adminGetTrafficSources,
     adminGetTrafficSourceDetails,
@@ -34,7 +40,6 @@ import {
     adminGetGeoDistribution,
     adminGetDeviceBreakdown,
     adminGetCampaignPerformance,
-    adminGetEngagement,
     adminGetConversionFunnel,
     adminGetRetention,
     adminGetAnalyticsOverview,
@@ -48,7 +53,6 @@ import type {
     IGeoEntry,
     IDeviceEntry,
     ICampaignEntry,
-    IEngagementMetrics,
     IFunnelStage,
     IRetentionEntry,
     IAnalyticsOverview,
@@ -70,14 +74,6 @@ function resolveCSSColor(varName: string, fallback: string): string {
     const value = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
     return value || fallback;
 }
-
-/** Period option labels for display. */
-const PERIOD_OPTIONS: { value: AnalyticsPeriod; label: string }[] = [
-    { value: '24h', label: '24 Hours' },
-    { value: '7d', label: '7 Days' },
-    { value: '30d', label: '30 Days' },
-    { value: '90d', label: '90 Days' },
-];
 
 /**
  * Format seconds into a human-readable duration string.
@@ -109,40 +105,28 @@ function getCategoryClass(category: string): string {
     }
 }
 
-/**
- * Format a Date as a YYYY-MM-DD string for native date inputs.
- *
- * @param date - Date to format
- * @returns ISO date string without time component
- */
-function toDateInputValue(date: Date): string {
-    const y = date.getFullYear();
-    const m = String(date.getMonth() + 1).padStart(2, '0');
-    const d = String(date.getDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
+interface IAnalyticsDashboardProps {
+    /** Selected lookback period from the page-level controls. */
+    period: AnalyticsPeriod;
+    /** Custom date range when `period === 'custom'`. */
+    customRange?: ICustomDateRange;
+    /** Whether classified bot rows are included. */
+    includeBots: boolean;
 }
 
 /**
  * Aggregate analytics dashboard for admin traffic insights.
  *
- * Fetches data from multiple analytics endpoints and renders engagement
- * metrics, conversion funnel, traffic sources, landing pages, geography,
- * devices, campaigns, and retention data with period filtering.
+ * Fetches data from multiple analytics endpoints and renders the overview
+ * headline, conversion funnel, traffic sources, landing pages, geography,
+ * devices, campaigns, and retention data for the globally selected window.
+ *
+ * @param props - Global period, custom range, and bot-filter selection.
  */
-export function AnalyticsDashboard() {
-    const [period, setPeriod] = useState<AnalyticsPeriod>('24h');
+export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyticsDashboardProps) {
     const [loading, setLoading] = useState(true);
 
-    // Custom date range state — dates as YYYY-MM-DD strings in local time
-    const [customStart, setCustomStart] = useState(() => {
-        const d = new Date();
-        d.setDate(d.getDate() - 7);
-        return toDateInputValue(d);
-    });
-    const [customEnd, setCustomEnd] = useState(() => toDateInputValue(new Date()));
-
     // Data state
-    const [engagement, setEngagement] = useState<IEngagementMetrics | null>(null);
     const [overview, setOverview] = useState<IAnalyticsOverview | null>(null);
     const [funnel, setFunnel] = useState<IFunnelStage[]>([]);
     const [trafficSources, setTrafficSources] = useState<ITrafficSource[]>([]);
@@ -158,19 +142,7 @@ export function AnalyticsDashboard() {
     const [sourceDetails, setSourceDetails] = useState<Record<string, ITrafficSourceDetails>>({});
     const [sourceDetailsLoading, setSourceDetailsLoading] = useState<string | null>(null);
 
-    /**
-     * Memoized custom date range built from the date input values.
-     * Aligns to localized midnight: start at 00:00:00 of start date,
-     * end at 23:59:59.999 of end date. Returns undefined if period is
-     * not 'custom' or either date input is empty/invalid.
-     */
-    const customRange = useMemo<ICustomDateRange | undefined>(() => {
-        if (period !== 'custom' || !customStart || !customEnd) return undefined;
-        const start = new Date(`${customStart}T00:00:00`);
-        const end = new Date(`${customEnd}T23:59:59.999`);
-        if (isNaN(start.getTime()) || isNaN(end.getTime())) return undefined;
-        return { startDate: start.toISOString(), endDate: end.toISOString() };
-    }, [period, customStart, customEnd]);
+    const excludeBots = !includeBots;
 
     /**
      * Toggle drill-down for a traffic source row.
@@ -189,7 +161,7 @@ export function AnalyticsDashboard() {
         if (!sourceDetails[source]) {
             setSourceDetailsLoading(source);
             try {
-                const details = await adminGetTrafficSourceDetails(source, period, customRange);
+                const details = await adminGetTrafficSourceDetails(source, period, customRange, excludeBots);
                 setSourceDetails(prev => ({ ...prev, [source]: details }));
             } catch (error) {
                 console.error('Failed to fetch source details:', error);
@@ -198,7 +170,7 @@ export function AnalyticsDashboard() {
                 setSourceDetailsLoading(prev => prev === source ? null : prev);
             }
         }
-    }, [expandedSource, sourceDetails, period, customRange]);
+    }, [expandedSource, sourceDetails, period, customRange, excludeBots]);
 
     /**
      * Fetch all analytics data for the selected period.
@@ -210,7 +182,6 @@ export function AnalyticsDashboard() {
         setSourceDetails({});
         try {
             const [
-                engagementRes,
                 funnelRes,
                 sourcesRes,
                 pagesRes,
@@ -220,18 +191,16 @@ export function AnalyticsDashboard() {
                 retentionRes,
                 overviewRes,
             ] = await Promise.all([
-                adminGetEngagement(period, customRange),
-                adminGetConversionFunnel(period, customRange),
-                adminGetTrafficSources(period, customRange),
-                adminGetTopLandingPages({ period, limit: 15, customRange }),
-                adminGetGeoDistribution({ period, limit: 20, customRange }),
-                adminGetDeviceBreakdown(period, customRange),
-                adminGetCampaignPerformance({ period, limit: 15, customRange }),
-                adminGetRetention(period, customRange),
+                adminGetConversionFunnel(period, customRange, excludeBots),
+                adminGetTrafficSources(period, customRange, excludeBots),
+                adminGetTopLandingPages({ period, limit: 15, customRange, excludeBots }),
+                adminGetGeoDistribution({ period, limit: 20, customRange, excludeBots }),
+                adminGetDeviceBreakdown(period, customRange, excludeBots),
+                adminGetCampaignPerformance({ period, limit: 15, customRange, excludeBots }),
+                adminGetRetention(period, customRange, excludeBots),
                 adminGetAnalyticsOverview(),
             ]);
 
-            setEngagement(engagementRes);
             setFunnel(funnelRes.stages);
             setTrafficSources(sourcesRes.sources);
             setTrafficTotal(sourcesRes.total);
@@ -246,7 +215,7 @@ export function AnalyticsDashboard() {
         } finally {
             setLoading(false);
         }
-    }, [period, customRange]);
+    }, [period, customRange, excludeBots]);
 
     useEffect(() => {
         fetchAll();
@@ -268,9 +237,9 @@ export function AnalyticsDashboard() {
         }
     ];
 
-    /** Maximum count in traffic sources for bar scaling. */
+    /** Maximum visitors in traffic sources for bar scaling. */
     const maxSourceCount = trafficSources.length > 0
-        ? trafficSources[0].count
+        ? trafficSources[0].visitors
         : 1;
 
     /** Maximum visitors in landing pages for bar scaling. */
@@ -285,122 +254,13 @@ export function AnalyticsDashboard() {
 
     return (
         <div className={styles.dashboard}>
-            {/* Period selector */}
-            <div className={styles.controls}>
-                <span className={styles.controls__label}>Period:</span>
-                {PERIOD_OPTIONS.map(opt => (
-                    <Button
-                        key={opt.value}
-                        variant={period === opt.value ? 'primary' : 'secondary'}
-                        size="sm"
-                        onClick={() => setPeriod(opt.value)}
-                    >
-                        {opt.label}
-                    </Button>
-                ))}
-                <Button
-                    variant={period === 'custom' ? 'primary' : 'secondary'}
-                    size="sm"
-                    onClick={() => setPeriod('custom')}
-                    aria-label="Custom date range"
-                >
-                    <Calendar size={14} className={styles.controls__icon} />
-                    Custom
-                </Button>
-                {period === 'custom' && (
-                    <div className={styles.date_range}>
-                        <input
-                            type="date"
-                            className={styles.date_input}
-                            value={customStart}
-                            max={customEnd}
-                            onChange={(e) => setCustomStart(e.target.value)}
-                            aria-label="Start date"
-                        />
-                        <span className={styles.date_range__separator}>to</span>
-                        <input
-                            type="date"
-                            className={styles.date_input}
-                            value={customEnd}
-                            min={customStart}
-                            max={toDateInputValue(new Date())}
-                            onChange={(e) => setCustomEnd(e.target.value)}
-                            aria-label="End date"
-                        />
-                    </div>
-                )}
-            </div>
+            {/* Overview headline — KPI strip + unified trend (owns its fetch) */}
+            <OverviewTrend period={period} customRange={customRange} includeBots={includeBots} />
 
             {loading ? (
                 <div className={styles.loading}>Loading analytics data...</div>
             ) : (
                 <>
-                    {/* Account Overview (Better Auth) */}
-                    {overview && (
-                        <Card>
-                            <h3 className={styles.section_title}>
-                                <Users size={16} className={styles.section_title__icon} />
-                                Accounts
-                            </h3>
-                            <div className={styles.metrics_grid}>
-                                <div className={styles.metric_card}>
-                                    <div className={styles.metric_card__value}>
-                                        {overview.totalAccounts.toLocaleString()}
-                                    </div>
-                                    <div className={styles.metric_card__label}>Total Accounts</div>
-                                </div>
-                                <div className={styles.metric_card}>
-                                    <div className={styles.metric_card__value}>
-                                        {overview.accountsWithWallets.toLocaleString()}
-                                    </div>
-                                    <div className={styles.metric_card__label}>With Wallet</div>
-                                </div>
-                                <div className={styles.metric_card}>
-                                    <div className={styles.metric_card__value}>
-                                        {Math.round(overview.walletAdoptionRate * 100)}%
-                                    </div>
-                                    <div className={styles.metric_card__label}>Wallet Adoption</div>
-                                </div>
-                            </div>
-                        </Card>
-                    )}
-
-                    {/* Engagement Summary Cards */}
-                    {engagement && (
-                        <Card>
-                            <h3 className={styles.section_title}>
-                                <TrendingUp size={16} className={styles.section_title__icon} />
-                                Engagement Overview
-                            </h3>
-                            <div className={styles.metrics_grid}>
-                                <div className={styles.metric_card}>
-                                    <div className={styles.metric_card__value}>
-                                        {engagement.totalUsers.toLocaleString()}
-                                    </div>
-                                    <div className={styles.metric_card__label}>Active Visitors</div>
-                                </div>
-                                <div className={styles.metric_card}>
-                                    <div className={styles.metric_card__value}>
-                                        {formatDuration(engagement.avgSessionDuration)}
-                                    </div>
-                                    <div className={styles.metric_card__label}>Avg Session Duration</div>
-                                </div>
-                                <div className={styles.metric_card}>
-                                    <div className={styles.metric_card__value}>
-                                        {engagement.avgPagesPerSession}
-                                    </div>
-                                    <div className={styles.metric_card__label}>Pages / Session</div>
-                                </div>
-                                <div className={styles.metric_card}>
-                                    <div className={styles.metric_card__value}>
-                                        {engagement.bounceRate}%
-                                    </div>
-                                    <div className={styles.metric_card__label}>Bounce Rate</div>
-                                </div>
-                            </div>
-                        </Card>
-                    )}
-
                     {/* Conversion Funnel */}
                     {funnel.length > 0 && (
                         <Card>
@@ -488,11 +348,11 @@ export function AnalyticsDashboard() {
                                                                         {s.category}
                                                                     </span>
                                                                 </td>
-                                                                <td className={styles.table__number}>{s.count.toLocaleString()}</td>
+                                                                <td className={styles.table__number}>{s.visitors.toLocaleString()}</td>
                                                                 <td className={styles.table__bar_cell}>
                                                                     <div
                                                                         className={styles.table__bar}
-                                                                        style={{ width: `${(s.count / maxSourceCount) * 100}%` }}
+                                                                        style={{ width: `${(s.visitors / maxSourceCount) * 100}%` }}
                                                                     />
                                                                 </td>
                                                                 <td className={styles.table__number}>{s.percentage}%</td>
@@ -832,6 +692,36 @@ export function AnalyticsDashboard() {
                                 yAxisFormatter={(v) => v.toLocaleString()}
                                 emptyLabel="No retention data for this period"
                             />
+                        </Card>
+                    )}
+
+                    {/* Account Overview (Better Auth) — site-wide, not time-windowed */}
+                    {overview && (
+                        <Card>
+                            <h3 className={styles.section_title}>
+                                <Users size={16} className={styles.section_title__icon} />
+                                Accounts
+                            </h3>
+                            <div className={styles.metrics_grid}>
+                                <div className={styles.metric_card}>
+                                    <div className={styles.metric_card__value}>
+                                        {overview.totalAccounts.toLocaleString()}
+                                    </div>
+                                    <div className={styles.metric_card__label}>Total Accounts</div>
+                                </div>
+                                <div className={styles.metric_card}>
+                                    <div className={styles.metric_card__value}>
+                                        {overview.accountsWithWallets.toLocaleString()}
+                                    </div>
+                                    <div className={styles.metric_card__label}>With Wallet</div>
+                                </div>
+                                <div className={styles.metric_card}>
+                                    <div className={styles.metric_card__value}>
+                                        {Math.round(overview.walletAdoptionRate * 100)}%
+                                    </div>
+                                    <div className={styles.metric_card__label}>Wallet Adoption</div>
+                                </div>
+                            </div>
                         </Card>
                     )}
                 </>

--- a/src/frontend/modules/traffic/components/admin/GscKeywords/GscKeywords.module.scss
+++ b/src/frontend/modules/traffic/components/admin/GscKeywords/GscKeywords.module.scss
@@ -39,6 +39,28 @@
     max-width: var(--max-width-prose);
 }
 
+.picker_stack {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: var(--gap-2xs);
+}
+
+.meta {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+    margin: var(--gap-2xs) 0 0 0;
+}
+
+.meta_warning {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-2xs);
+    font-size: var(--font-size-caption);
+    color: var(--color-warning);
+    margin: var(--gap-2xs) 0 0 0;
+}
+
 .window_picker {
     display: inline-flex;
     background: var(--color-surface-muted);
@@ -154,6 +176,10 @@
     .header {
         flex-direction: column;
         align-items: stretch;
+    }
+
+    .picker_stack {
+        align-items: flex-start;
     }
 
     .grid_two {

--- a/src/frontend/modules/traffic/components/admin/GscKeywords/GscKeywords.tsx
+++ b/src/frontend/modules/traffic/components/admin/GscKeywords/GscKeywords.tsx
@@ -13,18 +13,25 @@
  * - **Top keywords table** — clicks, impressions, CTR, and average position
  *   per query over a selectable window.
  *
+ * Chart totals come from the backend's date-only GSC totals (immune to
+ * query anonymization); the keyword table is limited to non-anonymized
+ * queries by the GSC API itself. The header surfaces the fetch status
+ * (configured / last fetch) so a stalled `gsc:fetch` job is visible, and
+ * the window picker shows the actual delay-shifted dates covered.
+ *
  * Data is delayed ~3 days by GSC's ingestion lag (handled server-side).
  * Mirrors the TrafficDashboard pattern: client-only, session-cookie auth,
  * fetch-on-mount, per-panel loading/error state.
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { Search, TrendingUp } from 'lucide-react';
+import { AlertTriangle, Search, TrendingUp } from 'lucide-react';
 import { LineChart } from '../../../../../features/charts/components/LineChart';
 import type { ChartSeries } from '../../../../../features/charts/components/LineChart';
 import { Card } from '../../../../../components/ui/Card';
-import { adminGetGscKeywords, adminGetGscKeywordsByDay } from '../../../api';
-import type { IGscKeyword, IGscDailyKeywords } from '../../../api';
+import { ClientTime } from '../../../../../components/ui/ClientTime';
+import { adminGetGscKeywords, adminGetGscKeywordsByDay, adminGetGscStatus } from '../../../api';
+import type { IGscKeyword, IGscDailyKeywords, IGscStatus } from '../../../api';
 import styles from './GscKeywords.module.scss';
 
 /** Keyword-table lookback windows. 30d is the backend's hard ceiling. */
@@ -58,12 +65,15 @@ export function GscKeywords() {
     const [periodHours, setPeriodHours] = useState<number>(168);
 
     const [keywords, setKeywords] = useState<IGscKeyword[] | null>(null);
+    const [keywordsWindow, setKeywordsWindow] = useState<{ start: string; end: string } | null>(null);
     const [keywordsError, setKeywordsError] = useState<string | null>(null);
     const [keywordsLoading, setKeywordsLoading] = useState(true);
 
     const [daily, setDaily] = useState<IGscDailyKeywords[] | null>(null);
     const [dailyError, setDailyError] = useState<string | null>(null);
     const [dailyLoading, setDailyLoading] = useState(true);
+
+    const [status, setStatus] = useState<IGscStatus | null>(null);
 
     // Keyword table fetch — re-runs when the window changes.
     useEffect(() => {
@@ -72,7 +82,14 @@ export function GscKeywords() {
         setKeywordsError(null);
 
         adminGetGscKeywords({ periodHours, limit: 25 })
-            .then(data => { if (active) setKeywords(data); })
+            .then(data => {
+                if (active) {
+                    setKeywords(data.keywords);
+                    setKeywordsWindow(data.windowStart && data.windowEnd
+                        ? { start: data.windowStart, end: data.windowEnd }
+                        : null);
+                }
+            })
             .catch(err => { if (active) setKeywordsError(err instanceof Error ? err.message : 'Failed to load'); })
             .finally(() => { if (active) setKeywordsLoading(false); });
 
@@ -87,6 +104,19 @@ export function GscKeywords() {
             .then(data => { if (active) setDaily(data); })
             .catch(err => { if (active) setDailyError(err instanceof Error ? err.message : 'Failed to load'); })
             .finally(() => { if (active) setDailyLoading(false); });
+
+        return () => { active = false; };
+    }, []);
+
+    // Status fetch — surfaces configured/last-fetch so a stalled gsc:fetch
+    // job is distinguishable from genuinely-zero clicks. Best-effort: a
+    // status failure must not block the data panels.
+    useEffect(() => {
+        let active = true;
+
+        adminGetGscStatus()
+            .then(data => { if (active) setStatus(data); })
+            .catch(() => { /* status line simply stays hidden */ });
 
         return () => { active = false; };
     }, []);
@@ -128,21 +158,49 @@ export function GscKeywords() {
                         Google Search Console queries that surfaced this site,
                         refreshed daily by the <code>gsc:fetch</code> job. GSC
                         delays its data ~3 days; windows are shifted to match.
+                        Keyword rows exclude queries Google anonymizes, so the
+                        charts use true daily totals fetched separately.
                         Configure credentials in the Settings tab.
                     </p>
+                    {status && !status.configured && (
+                        <p className={styles.meta_warning}>
+                            <AlertTriangle size={14} aria-hidden="true" />
+                            GSC credentials are not configured — no data is being fetched.
+                        </p>
+                    )}
+                    {status?.configured && !status.lastFetch && (
+                        <p className={styles.meta_warning}>
+                            <AlertTriangle size={14} aria-hidden="true" />
+                            The daily <code>gsc:fetch</code> job has not stored data yet.
+                        </p>
+                    )}
+                    {status?.configured && status.lastFetch && (
+                        <p className={styles.meta}>
+                            Last fetched <ClientTime date={status.lastFetch} format="relative" />.
+                        </p>
+                    )}
                 </div>
-                <div className={styles.window_picker} role="group" aria-label="Lookback window">
-                    {PERIOD_OPTIONS.map(opt => (
-                        <button
-                            key={opt.hours}
-                            type="button"
-                            onClick={() => setPeriodHours(opt.hours)}
-                            className={opt.hours === periodHours ? styles.window_active : styles.window_button}
-                            aria-pressed={opt.hours === periodHours}
-                        >
-                            {opt.label}
-                        </button>
-                    ))}
+                <div className={styles.picker_stack}>
+                    <div className={styles.window_picker} role="group" aria-label="Lookback window">
+                        {PERIOD_OPTIONS.map(opt => (
+                            <button
+                                key={opt.hours}
+                                type="button"
+                                onClick={() => setPeriodHours(opt.hours)}
+                                className={opt.hours === periodHours ? styles.window_active : styles.window_button}
+                                aria-pressed={opt.hours === periodHours}
+                            >
+                                {opt.label}
+                            </button>
+                        ))}
+                    </div>
+                    {keywordsWindow && (
+                        <p className={styles.meta}>
+                            Covers <ClientTime date={keywordsWindow.start} format="date" />
+                            {' – '}
+                            <ClientTime date={keywordsWindow.end} format="date" />
+                        </p>
+                    )}
                 </div>
             </header>
 
@@ -197,9 +255,10 @@ export function GscKeywords() {
                     <p className={styles.panel_loading}>Loading…</p>
                 ) : !keywords || keywords.length === 0 ? (
                     <p className={styles.panel_empty}>
-                        No keyword data in this window. GSC credentials may not
-                        be configured (Settings tab), or the daily fetch has not
-                        run yet.
+                        No keyword data in this window — note GSC windows end
+                        ~3 days ago, and Google omits anonymized low-volume
+                        queries from keyword rows entirely. Check the fetch
+                        status above and the Settings tab.
                     </p>
                 ) : (
                     <table className={styles.table}>

--- a/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.module.scss
+++ b/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.module.scss
@@ -1,0 +1,138 @@
+/**
+ * OverviewTrend styles.
+ *
+ * KPI strip above the unified trend chart. Visitors/Pageviews KPIs are
+ * buttons that switch the chart metric; the active one carries a primary
+ * accent. Container query collapses the strip on narrow widths.
+ */
+
+@use '../../../../../app/breakpoints' as *;
+
+.container {
+    container-type: inline-size;
+    container-name: overview-trend;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+}
+
+.kpi_strip {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: var(--grid-gap-sm);
+}
+
+.kpi,
+.kpi_active,
+.kpi_static {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--gap-2xs);
+    padding: var(--card-padding-xs) var(--padding-sm);
+    border-radius: var(--radius-md);
+    border: var(--border-width-thin) solid var(--color-border);
+    background: var(--color-surface-muted);
+    text-align: left;
+}
+
+.kpi,
+.kpi_active {
+    cursor: pointer;
+    transition: border-color var(--transition-base), background-color var(--transition-base);
+    font-family: inherit;
+}
+
+.kpi:hover {
+    border-color: var(--color-border-strong);
+}
+
+.kpi_active {
+    border-color: var(--color-primary-alpha-38);
+    background: var(--color-primary-alpha-10);
+}
+
+.kpi_label {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-wide);
+}
+
+.kpi_value {
+    font-size: var(--font-size-heading-md);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text);
+    font-variant-numeric: tabular-nums;
+}
+
+.kpi_note {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-subtle);
+}
+
+.delta_good,
+.delta_bad,
+.delta_flat {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-2xs);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-semibold);
+    font-variant-numeric: tabular-nums;
+}
+
+.delta_good {
+    color: var(--color-success);
+}
+
+.delta_bad {
+    color: var(--color-danger);
+}
+
+.delta_flat {
+    color: var(--color-text-subtle);
+}
+
+.footnote {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-subtle);
+    margin: 0;
+}
+
+.loading,
+.error {
+    font-size: var(--font-size-body-sm);
+    margin: 0;
+}
+
+.loading {
+    color: var(--color-text-muted);
+}
+
+.error {
+    color: var(--color-danger);
+}
+
+/* Visually hidden text for screen readers on delta direction. */
+.sr_only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@container overview-trend (max-width: #{$breakpoint-mobile-md}) {
+    .kpi_strip {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .kpi_value {
+        font-size: var(--font-size-heading-sm);
+    }
+}

--- a/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.module.scss
+++ b/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.module.scss
@@ -14,6 +14,12 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-md);
+    transition: opacity var(--transition-base);
+}
+
+/* Stale-while-revalidate refetch cue — previous data stays visible, dimmed. */
+.container_fetching {
+    opacity: var(--opacity-60);
 }
 
 .kpi_strip {

--- a/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
+++ b/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
@@ -1,0 +1,223 @@
+/**
+ * OverviewTrend Component
+ *
+ * The unified dashboard headline every analytics platform leads with: a KPI
+ * strip (Unique Visitors, Pageviews, Views / Visit, Bounce Rate, Visit
+ * Duration) with period-over-period deltas, above a single large time-series
+ * whose metric switches when a clickable KPI is selected.
+ *
+ * Buckets are hourly for windows ≤ 48h and daily otherwise (decided
+ * server-side), zero-filled so quiet periods read as flat lines rather than
+ * missing segments. Bounce Rate and Visit Duration depend on session events
+ * that are not yet emitted (Phase D) — until then they render as "—" with an
+ * annotation instead of false zeros.
+ */
+
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { ArrowDownRight, ArrowUpRight, Minus } from 'lucide-react';
+import { LineChart } from '../../../../../features/charts/components/LineChart';
+import type { ChartSeries } from '../../../../../features/charts/components/LineChart';
+import { Card } from '../../../../../components/ui/Card';
+import { adminGetOverviewTrend } from '../../../api';
+import type { AnalyticsPeriod, ICustomDateRange, IOverviewTrend } from '../../../api';
+import styles from './OverviewTrend.module.scss';
+
+/** Chart-switchable metrics. */
+type TrendMetric = 'visitors' | 'pageviews';
+
+/**
+ * Resolve a CSS variable to its computed value with an SSR-safe fallback.
+ *
+ * @param varName - CSS variable name (e.g. '--color-primary')
+ * @param fallback - Hex fallback when document is unavailable
+ * @returns Resolved color string
+ */
+function resolveCSSColor(varName: string, fallback: string): string {
+    if (typeof document === 'undefined') return fallback;
+    const value = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
+    return value || fallback;
+}
+
+/**
+ * Format milliseconds into a compact human duration ("45s", "2m 30s").
+ *
+ * @param ms - Duration in milliseconds
+ * @returns Formatted duration string
+ */
+function formatDurationMs(ms: number): string {
+    const seconds = Math.round(ms / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+    const hours = Math.floor(minutes / 60);
+    const remaining = minutes % 60;
+    return remaining > 0 ? `${hours}h ${remaining}m` : `${hours}h`;
+}
+
+/**
+ * Percentage change of `current` vs `previous`. A zero previous window with
+ * current activity reads as +100% rather than infinity.
+ *
+ * @param current - Current-window value
+ * @param previous - Previous-window value
+ * @returns Signed percentage change, or null when both windows are zero
+ */
+function percentChange(current: number, previous: number): number | null {
+    if (previous === 0 && current === 0) return null;
+    if (previous === 0) return 100;
+    return ((current - previous) / previous) * 100;
+}
+
+interface IDeltaProps {
+    /** Signed percentage change, or null for no movement to report. */
+    change: number | null;
+    /** Invert color semantics (down = good), e.g. bounce rate. */
+    invert?: boolean;
+}
+
+/**
+ * Render a period-over-period delta with directional arrow and tone.
+ *
+ * @param props - The percentage change and color semantics.
+ * @returns The delta indicator, or a flat dash when there is no movement.
+ */
+function Delta({ change, invert = false }: IDeltaProps) {
+    if (change === null) {
+        return <span className={styles.delta_flat}><Minus size={14} aria-hidden="true" /></span>;
+    }
+    const rounded = Math.round(change);
+    if (rounded === 0) {
+        return <span className={styles.delta_flat}><Minus size={14} aria-hidden="true" /> 0%</span>;
+    }
+    const up = rounded > 0;
+    const good = invert ? !up : up;
+    return (
+        <span className={good ? styles.delta_good : styles.delta_bad}>
+            {up
+                ? <ArrowUpRight size={14} aria-hidden="true" />
+                : <ArrowDownRight size={14} aria-hidden="true" />}
+            {Math.abs(rounded)}%
+            <span className={styles.sr_only}>{up ? 'increase' : 'decrease'} vs previous period</span>
+        </span>
+    );
+}
+
+interface IOverviewTrendProps {
+    /** Selected lookback period. */
+    period: AnalyticsPeriod;
+    /** Custom date range when `period === 'custom'`. */
+    customRange?: ICustomDateRange;
+    /** Whether classified bot rows are included. */
+    includeBots: boolean;
+}
+
+/**
+ * KPI strip + unified trend chart for the Analytics tab.
+ *
+ * @param props - Global period/bot-filter selection from the page controls.
+ * @returns The rendered overview headline.
+ */
+export function OverviewTrend({ period, customRange, includeBots }: IOverviewTrendProps) {
+    const [trend, setTrend] = useState<IOverviewTrend | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [metric, setMetric] = useState<TrendMetric>('visitors');
+
+    useEffect(() => {
+        let active = true;
+        adminGetOverviewTrend(period, customRange, !includeBots)
+            .then(data => { if (active) { setTrend(data); setError(null); } })
+            .catch(err => { if (active) setError(err instanceof Error ? err.message : 'Failed to load'); })
+            .finally(() => { /* trend stays stale-visible during refetch */ });
+        return () => { active = false; };
+    }, [period, customRange, includeBots]);
+
+    const series: ChartSeries[] = useMemo(() => {
+        if (!trend || trend.series.length === 0) return [];
+        return [{
+            id: metric,
+            label: metric === 'visitors' ? 'Unique Visitors' : 'Pageviews',
+            color: metric === 'visitors'
+                ? resolveCSSColor('--color-primary', '#4b8cff')
+                : resolveCSSColor('--color-success', '#57d48c'),
+            fill: true,
+            data: trend.series.map(p => ({ date: p.bucket, value: p[metric] }))
+        }];
+    }, [trend, metric]);
+
+    if (error) {
+        return <Card padding="md"><p className={styles.error}>{error}</p></Card>;
+    }
+    if (!trend) {
+        return <Card padding="md"><p className={styles.loading}>Loading overview…</p></Card>;
+    }
+
+    const { current, previous } = trend;
+    const sessionsAvailable = current.sessions > 0 || previous.sessions > 0;
+    const viewsPerVisit = current.visitors > 0 ? current.pageviews / current.visitors : 0;
+    const prevViewsPerVisit = previous.visitors > 0 ? previous.pageviews / previous.visitors : 0;
+    const numberFormatter = new Intl.NumberFormat();
+
+    return (
+        <Card padding="md" className={styles.container}>
+            <div className={styles.kpi_strip} role="group" aria-label="Headline metrics">
+                <button
+                    type="button"
+                    className={metric === 'visitors' ? styles.kpi_active : styles.kpi}
+                    onClick={() => setMetric('visitors')}
+                    aria-pressed={metric === 'visitors'}
+                >
+                    <span className={styles.kpi_label}>Unique Visitors</span>
+                    <span className={styles.kpi_value}>{numberFormatter.format(current.visitors)}</span>
+                    <Delta change={percentChange(current.visitors, previous.visitors)} />
+                </button>
+                <button
+                    type="button"
+                    className={metric === 'pageviews' ? styles.kpi_active : styles.kpi}
+                    onClick={() => setMetric('pageviews')}
+                    aria-pressed={metric === 'pageviews'}
+                >
+                    <span className={styles.kpi_label}>Pageviews</span>
+                    <span className={styles.kpi_value}>{numberFormatter.format(current.pageviews)}</span>
+                    <Delta change={percentChange(current.pageviews, previous.pageviews)} />
+                </button>
+                <div className={styles.kpi_static}>
+                    <span className={styles.kpi_label}>Views / Visit</span>
+                    <span className={styles.kpi_value}>{viewsPerVisit.toFixed(1)}</span>
+                    <Delta change={percentChange(viewsPerVisit, prevViewsPerVisit)} />
+                </div>
+                <div className={styles.kpi_static}>
+                    <span className={styles.kpi_label}>Bounce Rate</span>
+                    <span className={styles.kpi_value}>
+                        {sessionsAvailable ? `${Math.round(current.bounceRate * 100)}%` : '—'}
+                    </span>
+                    {sessionsAvailable
+                        ? <Delta change={percentChange(current.bounceRate, previous.bounceRate)} invert />
+                        : <span className={styles.kpi_note}>awaiting sessions</span>}
+                </div>
+                <div className={styles.kpi_static}>
+                    <span className={styles.kpi_label}>Visit Duration</span>
+                    <span className={styles.kpi_value}>
+                        {sessionsAvailable ? formatDurationMs(current.avgDurationMs) : '—'}
+                    </span>
+                    {sessionsAvailable
+                        ? <Delta change={percentChange(current.avgDurationMs, previous.avgDurationMs)} />
+                        : <span className={styles.kpi_note}>awaiting sessions</span>}
+                </div>
+            </div>
+
+            <LineChart
+                series={series}
+                height={280}
+                yAxisMin={0}
+                yAxisFormatter={(v) => numberFormatter.format(Math.round(v))}
+                emptyLabel="No traffic recorded in this period."
+            />
+            <p className={styles.footnote}>
+                {trend.granularity === 'hour' ? 'Hourly' : 'Daily'} buckets · deltas compare the
+                equal-length previous period{!sessionsAvailable && ' · bounce rate and visit duration await session instrumentation'}.
+            </p>
+        </Card>
+    );
+}

--- a/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
+++ b/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
@@ -123,13 +123,17 @@ export function OverviewTrend({ period, customRange, includeBots }: IOverviewTre
     const [trend, setTrend] = useState<IOverviewTrend | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [metric, setMetric] = useState<TrendMetric>('visitors');
+    // Stale-while-revalidate: previous data stays visible during a window
+    // change, dimmed via this flag so the refresh is perceptible.
+    const [isFetching, setIsFetching] = useState(true);
 
     useEffect(() => {
         let active = true;
+        setIsFetching(true);
         adminGetOverviewTrend(period, customRange, !includeBots)
             .then(data => { if (active) { setTrend(data); setError(null); } })
             .catch(err => { if (active) setError(err instanceof Error ? err.message : 'Failed to load'); })
-            .finally(() => { /* trend stays stale-visible during refetch */ });
+            .finally(() => { if (active) setIsFetching(false); });
         return () => { active = false; };
     }, [period, customRange, includeBots]);
 
@@ -160,7 +164,7 @@ export function OverviewTrend({ period, customRange, includeBots }: IOverviewTre
     const numberFormatter = new Intl.NumberFormat();
 
     return (
-        <Card padding="md" className={styles.container}>
+        <Card padding="md" className={isFetching ? `${styles.container} ${styles.container_fetching}` : styles.container} aria-busy={isFetching}>
             <div className={styles.kpi_strip} role="group" aria-label="Headline metrics">
                 <button
                     type="button"

--- a/src/frontend/modules/traffic/components/admin/OverviewTrend/index.ts
+++ b/src/frontend/modules/traffic/components/admin/OverviewTrend/index.ts
@@ -1,0 +1,1 @@
+export { OverviewTrend } from './OverviewTrend';

--- a/src/frontend/modules/traffic/components/admin/PageActivity/PageActivity.module.scss
+++ b/src/frontend/modules/traffic/components/admin/PageActivity/PageActivity.module.scss
@@ -41,40 +41,6 @@
     margin: 0;
 }
 
-.toggle_group {
-    display: flex;
-    gap: 0;
-    border: var(--border-width-thin) solid var(--color-border);
-    border-radius: var(--radius-md);
-    overflow: hidden;
-}
-
-.toggle_btn {
-    padding: var(--padding-xs) var(--gap-md);
-    font-size: var(--font-size-caption);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-text-muted);
-    background: var(--color-surface);
-    border: none;
-    cursor: pointer;
-    transition: background var(--transition-fast), color var(--transition-fast);
-}
-
-.toggle_btn:hover:not(.toggle_btn__active) {
-    background: var(--color-surface-muted);
-}
-
-.toggle_btn__active {
-    background: var(--color-primary);
-    color: var(--button-primary-color);
-}
-
-.toggle_btn:focus-visible {
-    outline: var(--focus-outline-width) solid var(--color-focus);
-    outline-offset: var(--focus-outline-offset);
-    box-shadow: var(--focus-shadow);
-}
-
 .table_wrapper {
     overflow-x: auto;
 }

--- a/src/frontend/modules/traffic/components/admin/PageActivity/PageActivity.tsx
+++ b/src/frontend/modules/traffic/components/admin/PageActivity/PageActivity.tsx
@@ -22,21 +22,13 @@
 
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { Button } from '../../../../../components/ui/Button';
 import { adminGetPageActivity, adminGetPageHits } from '../../../api';
-import type { IPageActivityRow, IPageHit, PageActivitySubject, VisitorPeriod } from '../../../api';
+import type { AnalyticsPeriod, ICustomDateRange, IPageActivityRow, IPageHit, PageActivitySubject, VisitorPeriod } from '../../../api';
 import { getDeviceIcon } from '../../../lib/deviceIcon';
 import styles from './PageActivity.module.scss';
-
-/** Period option labels for display. */
-const PERIOD_LABELS: Record<VisitorPeriod, string> = {
-    '24h': '24 Hours',
-    '7d': '7 Days',
-    '30d': '30 Days',
-    '90d': '90 Days'
-};
 
 /** Rows per activity-table page. */
 const PAGE_LIMIT = 25;
@@ -44,10 +36,19 @@ const PAGE_LIMIT = 25;
 /** Max page hits fetched for a drill-down. */
 const HITS_LIMIT = 200;
 
+/**
+ * The resolved lookback window passed to the API client: either a preset
+ * period or a custom date range, derived from the page-level controls.
+ */
+interface IActivityWindow {
+    period?: VisitorPeriod;
+    customRange?: ICustomDateRange;
+}
+
 interface IPageHitsRowProps {
     subject: PageActivitySubject;
     id: string;
-    period: VisitorPeriod;
+    window: IActivityWindow;
 }
 
 /**
@@ -59,7 +60,7 @@ interface IPageHitsRowProps {
  * @param props - The subject to fetch hits for and the active window.
  * @returns A table row spanning the parent's columns with the page-hit list.
  */
-function PageHitsRow({ subject, id, period }: IPageHitsRowProps) {
+function PageHitsRow({ subject, id, window }: IPageHitsRowProps) {
     const [hits, setHits] = useState<IPageHit[]>([]);
     const [loading, setLoading] = useState(true);
 
@@ -72,7 +73,7 @@ function PageHitsRow({ subject, id, period }: IPageHitsRowProps) {
         const fetchHits = async (): Promise<void> => {
             setLoading(true);
             try {
-                const result = await adminGetPageHits(subject, id, { period, limit: HITS_LIMIT });
+                const result = await adminGetPageHits(subject, id, { ...window, limit: HITS_LIMIT });
                 if (active) {
                     setHits(result);
                 }
@@ -89,7 +90,7 @@ function PageHitsRow({ subject, id, period }: IPageHitsRowProps) {
         };
         fetchHits();
         return () => { active = false; };
-    }, [subject, id, period]);
+    }, [subject, id, window]);
 
     return (
         <tr className={styles.detail_row}>
@@ -133,16 +134,17 @@ interface IPageActivityTableProps {
     description: string;
     /** Column header for the subject id (e.g. "Traffic ID" / "Account"). */
     subjectHeading: string;
+    /** Resolved lookback window from the page-level controls. */
+    window: IActivityWindow;
 }
 
 /**
  * One subject's page-activity table with a per-row clickstream drill-down.
  *
- * @param props - Table configuration.
+ * @param props - Table configuration and the global window.
  * @returns The rendered activity section.
  */
-function PageActivityTable({ subject, title, description, subjectHeading }: IPageActivityTableProps) {
-    const [period, setPeriod] = useState<VisitorPeriod>('24h');
+function PageActivityTable({ subject, title, description, subjectHeading, window }: IPageActivityTableProps) {
     const [rows, setRows] = useState<IPageActivityRow[]>([]);
     const [total, setTotal] = useState(0);
     const [loading, setLoading] = useState(true);
@@ -150,17 +152,23 @@ function PageActivityTable({ subject, title, description, subjectHeading }: IPag
 
     const [expandedId, setExpandedId] = useState<string | null>(null);
 
+    // Window changes invalidate the page cursor and any open drill-down.
+    useEffect(() => {
+        setPage(1);
+        setExpandedId(null);
+    }, [window]);
+
     useEffect(() => {
         let active = true;
         /**
-         * Fetch the activity page, dropping the result if a newer period/page
+         * Fetch the activity page, dropping the result if a newer window/page
          * selection (or unmount) superseded this request before it resolved.
          */
         const fetchRows = async (): Promise<void> => {
             setLoading(true);
             try {
                 const result = await adminGetPageActivity(subject, {
-                    period,
+                    ...window,
                     limit: PAGE_LIMIT,
                     skip: (page - 1) * PAGE_LIMIT
                 });
@@ -182,20 +190,9 @@ function PageActivityTable({ subject, title, description, subjectHeading }: IPag
         };
         fetchRows();
         return () => { active = false; };
-    }, [subject, period, page]);
+    }, [subject, window, page]);
 
     const totalPages = total > 0 ? Math.ceil(total / PAGE_LIMIT) : 1;
-
-    /**
-     * Change the lookback period and reset pagination + any open drill-down.
-     *
-     * @param next - The selected period.
-     */
-    const handlePeriodChange = (next: VisitorPeriod): void => {
-        setPeriod(next);
-        setPage(1);
-        setExpandedId(null);
-    };
 
     /**
      * Toggle a row's page-hit drill-down open or closed. The expanded row owns
@@ -212,18 +209,6 @@ function PageActivityTable({ subject, title, description, subjectHeading }: IPag
         <div className={styles.section}>
             <div className={styles.section_header}>
                 <h2 className={styles.section_title}>{title}</h2>
-                <div className={styles.toggle_group} role="group" aria-label={`${title} time period`}>
-                    {(Object.keys(PERIOD_LABELS) as VisitorPeriod[]).map(option => (
-                        <button
-                            key={option}
-                            className={`${styles.toggle_btn} ${period === option ? styles.toggle_btn__active : ''}`}
-                            onClick={() => handlePeriodChange(option)}
-                            aria-pressed={period === option}
-                        >
-                            {PERIOD_LABELS[option]}
-                        </button>
-                    ))}
-                </div>
             </div>
             <p className="text-muted">{description}</p>
 
@@ -273,7 +258,7 @@ function PageActivityTable({ subject, title, description, subjectHeading }: IPag
                                             </td>
                                         </tr>
                                         {expandedId === row.id && (
-                                            <PageHitsRow subject={subject} id={row.id} period={period} />
+                                            <PageHitsRow subject={subject} id={row.id} window={window} />
                                         )}
                                     </React.Fragment>
                                 ))}
@@ -308,12 +293,31 @@ function PageActivityTable({ subject, title, description, subjectHeading }: IPag
     );
 }
 
+interface IPageActivityProps {
+    /** Selected lookback period from the page-level controls. */
+    period: AnalyticsPeriod;
+    /** Custom date range when `period === 'custom'`. */
+    customRange?: ICustomDateRange;
+}
+
 /**
- * PageActivity renders the anonymous-tid and registered-user clickstream tables.
+ * PageActivity renders the anonymous-tid and registered-user clickstream
+ * tables, both governed by the page-level lookback window. Only interactive
+ * `page` events feed these tables, so the bot filter does not apply —
+ * non-JS crawlers never emit them.
  *
+ * @param props - Global period and custom range selection.
  * @returns The rendered page-activity sections.
  */
-export function PageActivity() {
+export function PageActivity({ period, customRange }: IPageActivityProps) {
+    // Memoized: the parent re-renders on live-counter polls, and a fresh
+    // window identity would re-fire every table's fetch effect.
+    const window = useMemo<IActivityWindow>(() => (
+        period === 'custom'
+            ? { customRange }
+            : { period: period as VisitorPeriod }
+    ), [period, customRange]);
+
     return (
         <div className={styles.container}>
             <PageActivityTable
@@ -321,12 +325,14 @@ export function PageActivity() {
                 title="Anonymous Visitor Activity"
                 subjectHeading="Traffic ID"
                 description="Per-page navigation for cookied anonymous visitors, keyed on the traffic id. Expand a row to see every page they hit."
+                window={window}
             />
             <PageActivityTable
                 subject="user"
                 title="Registered User Activity"
                 subjectHeading="Account"
                 description="Per-page navigation for signed-in accounts, keyed on the Better Auth user id. Expand a row to see every page they hit."
+                window={window}
             />
         </div>
     );

--- a/src/frontend/modules/traffic/components/admin/PeriodPicker/PeriodPicker.module.scss
+++ b/src/frontend/modules/traffic/components/admin/PeriodPicker/PeriodPicker.module.scss
@@ -1,0 +1,46 @@
+/**
+ * PeriodPicker styles.
+ *
+ * Preset-period buttons plus the custom date-range inputs. Visual
+ * treatment mirrors the former AnalyticsDashboard controls so the picker
+ * reads identically now that it is hoisted to the page level.
+ */
+
+.controls {
+    display: flex;
+    align-items: center;
+    gap: var(--input-group-gap);
+    flex-wrap: wrap;
+}
+
+.controls__icon {
+    margin-right: var(--gap-xs);
+    vertical-align: middle;
+}
+
+.date_range {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+}
+
+.date_range__separator {
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+}
+
+.date_input {
+    font-size: var(--font-size-body-sm);
+    font-family: inherit;
+    padding: var(--padding-xs) var(--padding-sm);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    color-scheme: dark;
+}
+
+.date_input:focus-visible {
+    outline: var(--border-width-medium) solid var(--color-primary);
+    outline-offset: calc(-1 * var(--border-width-medium));
+}

--- a/src/frontend/modules/traffic/components/admin/PeriodPicker/PeriodPicker.tsx
+++ b/src/frontend/modules/traffic/components/admin/PeriodPicker/PeriodPicker.tsx
@@ -98,7 +98,10 @@ export function PeriodPicker({
                         className={styles.date_input}
                         value={customStart}
                         max={customEnd}
-                        onChange={(e) => onCustomStartChange(e.target.value)}
+                        // Ignore empty clears — Custom mode must always carry a
+                        // real range, or the backend silently serves its default
+                        // window while the UI still claims custom dates.
+                        onChange={(e) => { if (e.target.value) onCustomStartChange(e.target.value); }}
                         aria-label="Start date"
                     />
                     <span className={styles.date_range__separator}>to</span>
@@ -108,7 +111,7 @@ export function PeriodPicker({
                         value={customEnd}
                         min={customStart}
                         max={toDateInputValue(new Date())}
-                        onChange={(e) => onCustomEndChange(e.target.value)}
+                        onChange={(e) => { if (e.target.value) onCustomEndChange(e.target.value); }}
                         aria-label="End date"
                     />
                 </div>

--- a/src/frontend/modules/traffic/components/admin/PeriodPicker/PeriodPicker.tsx
+++ b/src/frontend/modules/traffic/components/admin/PeriodPicker/PeriodPicker.tsx
@@ -1,0 +1,118 @@
+/**
+ * PeriodPicker Component
+ *
+ * Shared lookback-window control for the `/system/traffic` dashboards:
+ * preset period buttons (24h / 7d / 30d / 90d) plus a custom date range.
+ * Extracted from the AnalyticsDashboard so one global picker can govern
+ * every tab instead of each section carrying its own — the per-section
+ * pickers let admins unknowingly compare a 24h table against a 30d chart.
+ *
+ * Fully controlled: the parent owns the period and custom-date state and
+ * derives the actual query range.
+ */
+
+'use client';
+
+import React from 'react';
+import { Calendar } from 'lucide-react';
+import { Button } from '../../../../../components/ui/Button';
+import type { AnalyticsPeriod } from '../../../api';
+import styles from './PeriodPicker.module.scss';
+
+/** Preset period options shown as buttons. */
+const PERIOD_OPTIONS: { value: AnalyticsPeriod; label: string }[] = [
+    { value: '24h', label: '24 Hours' },
+    { value: '7d', label: '7 Days' },
+    { value: '30d', label: '30 Days' },
+    { value: '90d', label: '90 Days' }
+];
+
+/**
+ * Format a Date as a YYYY-MM-DD string for native date inputs.
+ *
+ * @param date - Date to format
+ * @returns ISO date string without time component
+ */
+export function toDateInputValue(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+}
+
+interface IPeriodPickerProps {
+    /** Currently selected period. */
+    period: AnalyticsPeriod;
+    /** Change handler for preset/custom selection. */
+    onPeriodChange(period: AnalyticsPeriod): void;
+    /** Custom range start, YYYY-MM-DD local. */
+    customStart: string;
+    /** Custom range end, YYYY-MM-DD local. */
+    customEnd: string;
+    /** Change handler for the custom start date. */
+    onCustomStartChange(value: string): void;
+    /** Change handler for the custom end date. */
+    onCustomEndChange(value: string): void;
+}
+
+/**
+ * Render the preset-period buttons and, when "Custom" is active, the
+ * native date-range inputs.
+ *
+ * @param props - Controlled picker state and change handlers.
+ * @returns The period picker control group.
+ */
+export function PeriodPicker({
+    period,
+    onPeriodChange,
+    customStart,
+    customEnd,
+    onCustomStartChange,
+    onCustomEndChange
+}: IPeriodPickerProps) {
+    return (
+        <div className={styles.controls} role="group" aria-label="Lookback period">
+            {PERIOD_OPTIONS.map(opt => (
+                <Button
+                    key={opt.value}
+                    variant={period === opt.value ? 'primary' : 'secondary'}
+                    size="sm"
+                    onClick={() => onPeriodChange(opt.value)}
+                >
+                    {opt.label}
+                </Button>
+            ))}
+            <Button
+                variant={period === 'custom' ? 'primary' : 'secondary'}
+                size="sm"
+                onClick={() => onPeriodChange('custom')}
+                aria-label="Custom date range"
+            >
+                <Calendar size={14} className={styles.controls__icon} />
+                Custom
+            </Button>
+            {period === 'custom' && (
+                <div className={styles.date_range}>
+                    <input
+                        type="date"
+                        className={styles.date_input}
+                        value={customStart}
+                        max={customEnd}
+                        onChange={(e) => onCustomStartChange(e.target.value)}
+                        aria-label="Start date"
+                    />
+                    <span className={styles.date_range__separator}>to</span>
+                    <input
+                        type="date"
+                        className={styles.date_input}
+                        value={customEnd}
+                        min={customStart}
+                        max={toDateInputValue(new Date())}
+                        onChange={(e) => onCustomEndChange(e.target.value)}
+                        aria-label="End date"
+                    />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/frontend/modules/traffic/components/admin/PeriodPicker/index.ts
+++ b/src/frontend/modules/traffic/components/admin/PeriodPicker/index.ts
@@ -1,0 +1,1 @@
+export { PeriodPicker, toDateInputValue } from './PeriodPicker';

--- a/src/frontend/modules/traffic/components/admin/VisitorAnalytics/VisitorAnalytics.module.scss
+++ b/src/frontend/modules/traffic/components/admin/VisitorAnalytics/VisitorAnalytics.module.scss
@@ -1,8 +1,9 @@
 /**
  * VisitorAnalytics Styles
  *
- * Admin analytics dashboard showing daily visitor chart and traffic origins table.
- * Uses container queries for responsive behavior.
+ * New-visitor first-touch table for the admin dashboard. The daily-visitor
+ * chart and local filter controls moved to the page-level OverviewTrend and
+ * global controls. Uses container queries for responsive behavior.
  */
 
 @use '../../../../../app/breakpoints' as *;
@@ -38,44 +39,6 @@
     font-weight: var(--font-weight-semibold);
     color: var(--color-text);
     margin: 0;
-}
-
-.toggle_group {
-    display: flex;
-    gap: 0;
-    border: var(--border-width-thin) solid var(--color-border);
-    border-radius: var(--radius-md);
-    overflow: hidden;
-}
-
-.toggle_btn {
-    padding: var(--padding-xs) var(--gap-md);
-    font-size: var(--font-size-caption);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-text-muted);
-    background: var(--color-surface);
-    border: none;
-    cursor: pointer;
-    transition: background var(--transition-fast), color var(--transition-fast);
-}
-
-.toggle_btn:hover:not(.toggle_btn__active) {
-    background: var(--color-surface-muted);
-}
-
-.toggle_btn__active {
-    background: var(--color-primary);
-    color: var(--button-primary-color);
-}
-
-.toggle_btn:focus-visible {
-    outline: var(--focus-outline-width) solid var(--color-focus);
-    outline-offset: var(--focus-outline-offset);
-    box-shadow: var(--focus-shadow);
-}
-
-.chart_wrapper {
-    min-height: 320px;
 }
 
 /* Traffic origins table */

--- a/src/frontend/modules/traffic/components/admin/VisitorAnalytics/VisitorAnalytics.tsx
+++ b/src/frontend/modules/traffic/components/admin/VisitorAnalytics/VisitorAnalytics.tsx
@@ -1,46 +1,33 @@
 /**
  * VisitorAnalytics Component
  *
- * Admin analytics displaying daily visitor trends and the anonymous
- * first-touches table.
+ * Admin table of new visitors (anonymous first touches): the earliest
+ * cookieless `bootstrap` row for each visitor whose first-ever contact falls
+ * in the window, newest first. Recorded server-side by the Next.js
+ * middleware, so it captures bots, crawlers, and unfurlers alongside humans;
+ * the page-level bot filter (humans-only by default) governs which appear.
  *
- * Renders two sections:
- * 1. Daily visitors chart with 30d/90d toggle
- * 2. Anonymous first touches table — the earliest cookieless `bootstrap` row
- *    for each visitor in the window, newest first. Recorded server-side by the
- *    Next.js middleware, so it deliberately includes bots, crawlers, and
- *    unfurlers alongside humans; that first-touch noise is itself the signal.
- *    Per-page clickstream for cookied (tid) and registered (user_id) visitors
- *    lives in the sibling PageActivity sections.
+ * The daily-visitors chart that previously lived here was superseded by the
+ * unified OverviewTrend headline on the Analytics tab — platforms show one
+ * chart, not two competing ones. The lookback window, custom range, and bot
+ * filter arrive as props from the page-level global controls.
+ *
+ * Per-page clickstream for cookied (tid) and registered (user_id) visitors
+ * lives in the sibling PageActivity sections.
  */
 
 'use client';
 
-import React, { useEffect, useState, useCallback } from 'react';
-import { LineChart } from '../../../../../features/charts/components/LineChart';
-import type { ChartSeries } from '../../../../../features/charts/components/LineChart';
+import React, { useEffect, useState } from 'react';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { Button } from '../../../../../components/ui/Button';
-import {
-    adminGetDailyVisitors,
-    adminGetAnonymousFirstTouches
-} from '../../../api';
-import type { IDailyVisitorData, IVisitorOrigin, VisitorPeriod } from '../../../api';
+import { adminGetAnonymousFirstTouches } from '../../../api';
+import type { AnalyticsPeriod, ICustomDateRange, IVisitorOrigin, VisitorPeriod } from '../../../api';
 import { getDeviceIcon } from '../../../lib/deviceIcon';
 import styles from './VisitorAnalytics.module.scss';
 
-/**
- * Resolve a CSS variable to its computed hex value.
- *
- * @param varName - CSS variable name
- * @param fallback - Hex fallback for SSR
- * @returns Resolved hex color string
- */
-function resolveCSSColor(varName: string, fallback: string): string {
-    if (typeof document === 'undefined') return fallback;
-    const value = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
-    return value || fallback;
-}
+/** Rows per table page. */
+const PAGE_LIMIT = 25;
 
 /**
  * Format UTM parameters into a readable summary string.
@@ -58,68 +45,49 @@ function formatUtm(utm: IVisitorOrigin['utm']): string | null {
     return parts.length > 0 ? parts.join(' / ') : null;
 }
 
-/** Available chart range options. */
-type ChartRange = '30d' | '90d';
-
-/** Period option labels for display. */
-const PERIOD_LABELS: Record<VisitorPeriod, string> = {
-    '24h': '24 Hours',
-    '7d': '7 Days',
-    '30d': '30 Days',
-    '90d': '90 Days'
-};
+interface IVisitorAnalyticsProps {
+    /** Selected lookback period from the page-level controls. */
+    period: AnalyticsPeriod;
+    /** Custom date range when `period === 'custom'`. */
+    customRange?: ICustomDateRange;
+    /** Whether classified bot rows are included. */
+    includeBots: boolean;
+}
 
 /**
- * VisitorAnalytics displays aggregate visitor analytics for the admin dashboard.
+ * New-visitor first-touch table for the admin dashboard, showing
+ * first-touch acquisition data (original referrer, landing page, country,
+ * device, UTM) for SEO and marketing analysis.
  *
- * Includes a daily visitor trend chart (30d/90d) and an anonymous first-touches
- * table showing first-touch acquisition data (original referrer, landing page,
- * country, device, UTM) for SEO and marketing analysis.
+ * @param props - Global period, custom range, and bot-filter selection.
  */
-export function VisitorAnalytics() {
-    const [chartRange, setChartRange] = useState<ChartRange>('30d');
-    const [chartData, setChartData] = useState<IDailyVisitorData[]>([]);
-    const [chartLoading, setChartLoading] = useState(true);
-
-    const [firstTouchesPeriod, setFirstTouchesPeriod] = useState<VisitorPeriod>('24h');
+export function VisitorAnalytics({ period, customRange, includeBots }: IVisitorAnalyticsProps) {
     const [firstTouches, setFirstTouches] = useState<IVisitorOrigin[]>([]);
     const [firstTouchesTotal, setFirstTouchesTotal] = useState(0);
     const [firstTouchesLoading, setFirstTouchesLoading] = useState(true);
     const [firstTouchesPage, setFirstTouchesPage] = useState(1);
-    const firstTouchesLimit = 25;
 
-    /**
-     * Fetch daily visitor chart data using typed API client.
-     */
-    const fetchChartData = useCallback(async () => {
-        setChartLoading(true);
-        try {
-            const days = chartRange === '30d' ? 30 : 90;
-            const data = await adminGetDailyVisitors(days);
-            setChartData(data);
-        } catch (error) {
-            console.error('Failed to fetch daily visitors:', error);
-            setChartData([]);
-        } finally {
-            setChartLoading(false);
-        }
-    }, [chartRange]);
-
-    useEffect(() => { fetchChartData(); }, [fetchChartData]);
+    // Window or filter changes invalidate the page cursor.
+    useEffect(() => {
+        setFirstTouchesPage(1);
+    }, [period, customRange, includeBots]);
 
     useEffect(() => {
         let active = true;
         /**
          * Fetch the first-touches page, dropping the result if a newer
-         * period/page selection (or unmount) superseded it before resolving.
+         * window/page selection (or unmount) superseded it before resolving.
          */
         const fetchFirstTouches = async (): Promise<void> => {
             setFirstTouchesLoading(true);
             try {
                 const result = await adminGetAnonymousFirstTouches({
-                    period: firstTouchesPeriod,
-                    limit: firstTouchesLimit,
-                    skip: (firstTouchesPage - 1) * firstTouchesLimit
+                    ...(period === 'custom'
+                        ? { customRange }
+                        : { period: period as VisitorPeriod }),
+                    limit: PAGE_LIMIT,
+                    skip: (firstTouchesPage - 1) * PAGE_LIMIT,
+                    excludeBots: !includeBots
                 });
                 if (active) {
                     setFirstTouches(result.visitors ?? []);
@@ -139,108 +107,28 @@ export function VisitorAnalytics() {
         };
         fetchFirstTouches();
         return () => { active = false; };
-    }, [firstTouchesPeriod, firstTouchesPage]);
+    }, [period, customRange, includeBots, firstTouchesPage]);
 
-    /**
-     * Build chart series from daily visitor data.
-     */
-    const chartSeries: ChartSeries[] = chartData.length > 0
-        ? [{
-            id: 'daily-visitors',
-            label: 'Unique Visitors',
-            data: chartData.map(d => ({
-                date: d.date,
-                value: d.count
-            })),
-            color: resolveCSSColor('--color-primary', '#4b8cff'),
-            fill: true
-        }]
-        : [];
-
-    const chartDays = chartRange === '30d' ? 30 : 90;
-    const minDate = new Date();
-    minDate.setDate(minDate.getDate() - chartDays);
-    minDate.setHours(0, 0, 0, 0);
-
-    const totalFirstTouchesPages = firstTouchesTotal > 0 ? Math.ceil(firstTouchesTotal / firstTouchesLimit) : 1;
-
-    /**
-     * Handle period change and reset pagination for first touches.
-     *
-     * @param period - The new period to filter by
-     */
-    const handleFirstTouchesPeriodChange = (period: VisitorPeriod): void => {
-        setFirstTouchesPeriod(period);
-        setFirstTouchesPage(1);
-    };
+    const totalFirstTouchesPages = firstTouchesTotal > 0 ? Math.ceil(firstTouchesTotal / PAGE_LIMIT) : 1;
 
     return (
         <div className={styles.container}>
-            {/* Daily Visitors Chart */}
             <div className={styles.section}>
                 <div className={styles.section_header}>
-                    <h2 className={styles.section_title}>Daily Visitors</h2>
-                    <div className={styles.toggle_group} role="group" aria-label="Chart range">
-                        <button
-                            className={`${styles.toggle_btn} ${chartRange === '30d' ? styles.toggle_btn__active : ''}`}
-                            onClick={() => setChartRange('30d')}
-                            aria-pressed={chartRange === '30d'}
-                        >
-                            30 Days
-                        </button>
-                        <button
-                            className={`${styles.toggle_btn} ${chartRange === '90d' ? styles.toggle_btn__active : ''}`}
-                            onClick={() => setChartRange('90d')}
-                            aria-pressed={chartRange === '90d'}
-                        >
-                            90 Days
-                        </button>
-                    </div>
-                </div>
-                <div className={styles.chart_wrapper}>
-                    {chartLoading ? (
-                        <div className={styles.loading}>Loading chart data...</div>
-                    ) : (
-                        <LineChart
-                            series={chartSeries}
-                            height={320}
-                            minDate={minDate}
-                            maxDate={new Date()}
-                            yAxisMin={0}
-                            yAxisFormatter={val => Math.round(val).toLocaleString()}
-                            emptyLabel="No visitor data available for this period."
-                        />
-                    )}
-                </div>
-            </div>
-
-            {/* Anonymous First Touches Table */}
-            <div className={styles.section}>
-                <div className={styles.section_header}>
-                    <h2 className={styles.section_title}>Anonymous First Touches</h2>
-                    <div className={styles.toggle_group} role="group" aria-label="Anonymous first touches time period">
-                        {(Object.keys(PERIOD_LABELS) as VisitorPeriod[]).map(period => (
-                            <button
-                                key={period}
-                                className={`${styles.toggle_btn} ${firstTouchesPeriod === period ? styles.toggle_btn__active : ''}`}
-                                onClick={() => handleFirstTouchesPeriodChange(period)}
-                                aria-pressed={firstTouchesPeriod === period}
-                            >
-                                {PERIOD_LABELS[period]}
-                            </button>
-                        ))}
-                    </div>
+                    <h2 className={styles.section_title}>New Visitors</h2>
                 </div>
                 <p className="text-muted">
-                    The first cookieless hit per visitor — server-recorded, so bots and crawlers
-                    are included by design. Per-page activity for cookied and registered visitors
-                    is in the sections below.
+                    The first cookieless hit per visitor, server-recorded.{' '}
+                    {includeBots
+                        ? 'Bots, crawlers, and unfurlers are included; referrers are client-supplied and often spoofed by crawlers.'
+                        : 'Showing human-classified visitors only — switch the page filter to "Include bots" to see crawler and unfurler first touches.'}
+                    {' '}Per-page activity for cookied and registered visitors is on the Pages tab.
                 </p>
 
                 {firstTouchesLoading ? (
                     <div className={styles.loading}>Loading first touches...</div>
                 ) : firstTouches.length === 0 ? (
-                    <div className={styles.empty}>No anonymous first touches found in this period.</div>
+                    <div className={styles.empty}>No new visitors found in this period.</div>
                 ) : (
                     <>
                         <div className={styles.table_wrapper}>
@@ -300,7 +188,7 @@ export function VisitorAnalytics() {
                                 Previous
                             </Button>
                             <span className={styles.page_info}>
-                                Page {firstTouchesPage} of {totalFirstTouchesPages} ({firstTouchesTotal.toLocaleString()} first touches)
+                                Page {firstTouchesPage} of {totalFirstTouchesPages} ({firstTouchesTotal.toLocaleString()} new visitors)
                             </span>
                             <Button
                                 onClick={() => setFirstTouchesPage(firstTouchesPage + 1)}

--- a/src/frontend/modules/traffic/components/admin/index.ts
+++ b/src/frontend/modules/traffic/components/admin/index.ts
@@ -13,3 +13,5 @@ export { GscSettings } from './GscSettings';
 export { GscKeywords } from './GscKeywords';
 export { TrafficDashboard } from './TrafficDashboard';
 export { CrawlerDashboard } from './CrawlerDashboard';
+export { OverviewTrend } from './OverviewTrend';
+export { PeriodPicker, toDateInputValue } from './PeriodPicker';

--- a/src/frontend/modules/traffic/components/index.ts
+++ b/src/frontend/modules/traffic/components/index.ts
@@ -11,5 +11,8 @@ export {
     GscSettings,
     GscKeywords,
     TrafficDashboard,
-    CrawlerDashboard
+    CrawlerDashboard,
+    OverviewTrend,
+    PeriodPicker,
+    toDateInputValue
 } from './admin';

--- a/src/frontend/modules/traffic/index.ts
+++ b/src/frontend/modules/traffic/index.ts
@@ -29,6 +29,8 @@ export { GscSettings } from './components';
 export { GscKeywords } from './components';
 export { TrafficDashboard } from './components';
 export { CrawlerDashboard } from './components';
+export { OverviewTrend } from './components';
+export { PeriodPicker, toDateInputValue } from './components';
 
 // =============================================================================
 // API client


### PR DESCRIPTION
## Summary

Fixes the data-accuracy bugs found in the /system/traffic dashboards and brings the presentation in line with analytics-platform conventions (GA4/Plausible/Fathom).

**GSC accuracy.** The SEO tab undercounted clicks because GSC silently drops anonymized queries from any response carrying the `query` dimension. The `gsc:fetch` job now also fetches date-only daily totals (exempt from anonymization) into `module_user_gsc_daily_totals`, and the trend charts use those. Daily buckets are zero-filled, the keyword window returns its true delay-shifted `windowStart`/`windowEnd`, and the SEO tab surfaces fetch status (configured / last fetch) so a stalled job is distinguishable from zero clicks.

**Bot-aware visitor counts.** Referrers are client-supplied and routinely spoofed by crawlers, so raw counts overstated real audiences. Every windowed analytics read now accepts `bots=exclude` (filters to `bot_class = 'human'` or legacy NULL), governed by a page-level Humans only / Include bots toggle defaulting to humans-only. Source/landing/geo/device buckets lead with distinct visitors (`uniqExact(candidate_uid)`) instead of raw event rows.

**Unified overview headline.** New `overview-trend` endpoint returns current + equal-length previous-window KPIs and a zero-filled visitors/pageviews series (hourly buckets ≤48h, daily beyond). The Analytics tab opens with a KPI strip (Unique Visitors, Pageviews, Views/Visit, Bounce Rate, Visit Duration) carrying period-over-period deltas and a metric-switchable trend chart; bounce/duration render as unavailable until session events ship instead of false zeros. A global period picker (24h/7d/30d/90d/custom) governs the Analytics, Visitors, and Pages tabs, and a live online-now counter (5-minute window, 30s poll) sits beside the tabs. The mislabeled "Active Visitors" card (showed session count) and the redundant Visitors-tab chart are removed.

## Testing

- 111 traffic-module vitest tests pass (10 new: GSC window/zero-fill/totals, bot filter SQL, overview-trend granularity + previous window, live counter)
- `typecheck:backend` and `typecheck:frontend` clean