### PR TITLE
feat(menu): caller-driven MenuNav activation + plugin SubMenu

### DIFF
--- a/docs/plugins/plugins-frontend-context-ui.md
+++ b/docs/plugins/plugins-frontend-context-ui.md
@@ -13,7 +13,7 @@ Layout components carry typed props — `<layout.Stack gap="md">` fails compilat
 ```typescript
 interface IFrontendPluginContext {
     pluginId: string;              // Used internally for namespacing events and API routes
-    layout: ILayoutComponents;     // Page, PageHeader, Stack, Grid, Section
+    layout: ILayoutComponents;     // Page, PageHeader, Stack, Grid, Section, SubMenu
     ui: IUIComponents;             // Card, Badge, Button, IconButton, Switch, Input, Skeleton, ClientTime, Tooltip, IconPickerModal, Table family
     charts: IChartComponents;      // LineChart
     system: ISystemComponents;     // SchedulerMonitor (admin)
@@ -36,6 +36,39 @@ Page structure. Use these for all structural markup.
 | `Stack` | `gap?: 'sm'\|'md'\|'lg'`, `direction?: 'vertical'\|'horizontal'`, `children`, `className?` | Flex container with gap |
 | `Grid` | `gap?: 'sm'\|'md'\|'lg'`, `columns?: 2\|3\|'responsive'`, `children`, `className?` | Grid layout |
 | `Section` | `gap?: 'sm'\|'md'\|'lg'`, `children`, `className?` | Spaced content section |
+| `SubMenu` | `namespace`, `items: ISubMenuItem[]`, `activeUrl?`, `onSelect?: (item) => void`, `ariaLabel?` | In-page tab row backed by the menu service — see below |
+
+### SubMenu — In-Page Tab Navigation
+
+This is the recommended way to build a plugin's internal navigation: the tab row on a single-page admin surface (query / history / tools / settings and the like). The alternative — a hand-rolled `<button>` array with local `activeTab` state — works but is dead-end UI. Backing the row with the menu service instead inherits per-user gating, ordering, live refresh, and runtime extensibility: another plugin can contribute a tab into your row by registering a node. `SubMenu` is the cross-workspace-safe wrapper over the core navigation component; plugins cannot import that component directly, so consume it here.
+
+The flow has three steps. **Register** each tab as a leaf node in the plugin's *own* menu namespace (not `main`) during a backend lifecycle hook, memory-only, setting `requiresAdmin` yourself — the namespace sits outside the System container, so nothing forces the gate for you. **Fetch** that namespace tree SSR-first in the page's `serverDataFetcher` so it arrives as a prop (no loading flash). **Render** the row with `SubMenu`, providing `onSelect` to drive `activeTab` and `activeUrl` to highlight the current tab. Omitting `onSelect` makes the tabs ordinary navigation links instead.
+
+```tsx
+// Backend (plugin init): register tabs in the plugin's own namespace.
+context.menuService.subscribe('ready', async () => {
+    await context.menuService.create({
+        namespace: 'ai-assistant',
+        label: 'Query',
+        url: '/system/plugins/ai-assistant?tab=query',
+        icon: 'Search',
+        order: 0,
+        enabled: true,
+        requiresAdmin: true // caller owns gating outside the System subtree
+    });
+    // ...history, tools, settings
+});
+
+// Frontend (client page): render the SSR-fetched tree as in-page tabs.
+const { layout } = context;
+const [tab, setTab] = useState('query');
+<layout.SubMenu
+    namespace="ai-assistant"
+    items={submenuTree}
+    activeUrl={`/system/plugins/ai-assistant?tab=${tab}`}
+    onSelect={(item) => setTab(tabKeyFromUrl(item.url))}
+/>
+```
 
 ## UI (`context.ui`)
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,6 @@
 export type { Block } from './Block.js';
 export type { IBaseObserver, IBaseBatchObserver, TransactionBatches, IBaseBlockObserver, IBlockData, IBlockchainObserverService, IWebSocketService, IPluginContext, IObserverStats, IPluginWebSocketManager, PluginSubscriptionHandler, PluginUnsubscribeHandler, IPluginWebSocketStats, IAggregatePluginWebSocketStats } from './observer/index.js';
-export type { IPlugin, IPluginManifest, IAdminUIConfig, IApiRouteConfig, HttpMethod, ApiRouteHandler, ApiMiddleware, IMenuItemConfig, IPageConfig, IPluginMetadata, IPluginManagementRequest, IPluginManagementResponse, IPluginInfo, IFrontendPluginContext, IUIComponents, ILayoutComponents, IChartComponents, ISystemComponents, IApiClient, IWebSocketClient, IPluginUserState } from './plugin/index.js';
+export type { IPlugin, IPluginManifest, IAdminUIConfig, IApiRouteConfig, HttpMethod, ApiRouteHandler, ApiMiddleware, IMenuItemConfig, IPageConfig, IPluginMetadata, IPluginManagementRequest, IPluginManagementResponse, IPluginInfo, IFrontendPluginContext, IUIComponents, ILayoutComponents, ISubMenuItem, IChartComponents, ISystemComponents, IApiClient, IWebSocketClient, IPluginUserState } from './plugin/index.js';
 export { definePlugin } from './plugin/index.js';
 export type { ITransaction, ITransactionPersistencePayload, ITransactionCategoryFlags } from './transaction/index.js';
 export { ProcessedTransaction } from './transaction/index.js';

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -330,6 +330,49 @@ export interface IChartComponents {
 }
 
 /**
+ * Serialized menu node consumed by the `SubMenu` layout component.
+ *
+ * Mirrors the wire shape the menu service emits (`GET /api/menu`) after JSON
+ * serialization, so a plugin can pass the namespace tree it fetched via
+ * `serverDataFetcher` straight through without remapping. All ids and the
+ * `parent` reference are opaque strings.
+ */
+export interface ISubMenuItem {
+    /** Stable node id. */
+    _id: string;
+
+    /** Display label for the tab. */
+    label: string;
+
+    /** Tab url; also the active-state key when paired with `activeUrl`. */
+    url?: string;
+
+    /** Optional lucide-react icon name. */
+    icon?: string;
+
+    /** Sort order within the row (ascending). */
+    order: number;
+
+    /** Parent node id, or null for a root-level tab. */
+    parent?: string | null;
+
+    /** Whether the tab renders; disabled tabs are filtered out. */
+    enabled: boolean;
+
+    /** Namespace the node belongs to. */
+    namespace?: string;
+
+    /** Group ids that gate visibility (any-of). */
+    requiresGroups?: string[];
+
+    /** Whether the node is admin-gated. */
+    requiresAdmin?: boolean;
+
+    /** Nested children, when the node is a container. */
+    children?: ISubMenuItem[];
+}
+
+/**
  * Layout component library provided to frontend plugins.
  *
  * Contains structural layout components for building consistent page layouts.
@@ -442,6 +485,41 @@ export interface ILayoutComponents {
         children: React.ReactNode;
         gap?: 'sm' | 'md' | 'lg';
         className?: string;
+    }>;
+
+    /**
+     * In-page submenu (tab row) backed by the menu service.
+     *
+     * The recommended way to build a plugin's internal navigation — the row of
+     * tabs on a single-page admin surface (e.g. query / history / tools /
+     * settings). Register the tabs as leaf nodes in the plugin's own menu
+     * namespace (memory-only, caller-set `requiresAdmin`), fetch that namespace
+     * tree SSR-first via the plugin `serverDataFetcher`, and render it here.
+     * Backing the row with the menu service — instead of a hand-rolled
+     * `<button>` array — inherits per-user gating, ordering, live refresh, and
+     * lets other plugins contribute tabs into the row.
+     *
+     * Provide `onSelect` to drive in-page tab state (clicks suppress
+     * navigation); omit it for ordinary navigation links. Pair `onSelect` with
+     * `activeUrl` to highlight the active tab, since all tabs share one route.
+     *
+     * @example
+     * ```tsx
+     * const [tab, setTab] = useState('query');
+     * <layout.SubMenu
+     *   namespace="ai-assistant"
+     *   items={submenuTree}
+     *   activeUrl={`/system/plugins/ai-assistant?tab=${tab}`}
+     *   onSelect={(item) => setTab(tabKeyFromUrl(item.url))}
+     * />
+     * ```
+     */
+    SubMenu: ComponentType<{
+        namespace: string;
+        items: ISubMenuItem[];
+        activeUrl?: string;
+        onSelect?: (item: ISubMenuItem) => void;
+        ariaLabel?: string;
     }>;
 }
 

--- a/packages/types/src/plugin/index.ts
+++ b/packages/types/src/plugin/index.ts
@@ -20,6 +20,7 @@ export type {
     IFrontendPluginContext,
     IUIComponents,
     ILayoutComponents,
+    ISubMenuItem,
     IChartComponents,
     ISystemComponents,
     IApiClient,

--- a/src/backend/modules/menu/README.md
+++ b/src/backend/modules/menu/README.md
@@ -330,6 +330,55 @@ export const myPluginBackendPlugin = definePlugin({
 
 **Cleanup pattern:** Track menu node IDs during registration, then delete them in the `disable()` hook to remove navigation entries when plugin is disabled.
 
+## Submenu Pattern (Namespaced Tab Rows)
+
+An admin page's submenu — the in-page tab row on surfaces like `/system/traffic` or the AI assistant admin (query / history / tools / settings) — is just a menu. Pages historically hand-roll these as `<button>` arrays with local `activeTab` state, duplicating the same pattern across surfaces. Backing the row with the menu service instead inherits per-user gating, ordering, live `menu:update` refresh, and runtime extensibility: a *different* plugin can contribute a tab into the row by registering a node, which a hand-rolled array cannot offer.
+
+### How It Works
+
+Register each tab as a leaf node in a dedicated namespace (not `main`), memory-only (`persist=false`). Keeping it out of `main` keeps the tabs out of the global nav chrome — only the page's own submenu component reads that namespace. The namespace also sits outside the System container, so the non-bypassable `requiresAdmin` force does **not** apply: the caller owns security and sets `requiresAdmin` per node explicitly (see [The System Container](#the-system-container)).
+
+The frontend renders the row with `MenuNavClient` (`src/frontend/components/layout/MenuNav/`). Two additive, opt-in props govern behavior; both default to undefined, so existing navigation consumers are unchanged:
+
+| Prop | Effect when set |
+|------|-----------------|
+| `onItemSelect(item, event)` | Leaf clicks call this and suppress navigation, letting the page drive `activeTab` (e.g. sync a `?tab=` query param) instead of routing. |
+| `activeUrl` | Highlights the leaf whose `url` matches, bypassing pathname matching — required because the route is identical across tabs. |
+
+The click decision is the caller's: omit `onItemSelect` and a tab navigates like any link; provide it and the tab drives in-page state. Because `onItemSelect` is a function it cannot cross the server boundary — the consumer is the page's own client component (which already holds `activeTab` state and the SSR-fetched namespace tree), rendering `MenuNavClient` directly rather than the server `MenuNavSSR` wrapper.
+
+**Core admin pages** (modules) render `MenuNavClient` directly. **Plugins** cannot import core components across the workspace boundary, so they consume `context.layout.SubMenu` from `IFrontendPluginContext` — a thin wrapper over `MenuNavClient` with a friendlier `onSelect(item)` callback. A plugin registers its tabs in its own namespace via `context.menuService.create(...)`, fetches that namespace tree SSR-first through its `serverDataFetcher`, and renders the row with `context.layout.SubMenu`. See [plugins-frontend-context-ui.md](../../../../docs/plugins/plugins-frontend-context-ui.md#submenu--in-page-tab-navigation).
+
+### Example
+
+```typescript
+// Backend: register the tabs in the page's own namespace during `ready`.
+menuService.subscribe('ready', async () => {
+    await menuService.create({
+        namespace: 'ai-assistant',
+        label: 'Query',
+        url: '/system/plugins/ai-assistant?tab=query',
+        icon: 'Search',
+        order: 0,
+        parent: null,
+        enabled: true,
+        requiresAdmin: true // caller owns gating outside the System subtree
+    });
+    // ...history, tools, settings
+});
+```
+
+```tsx
+// Frontend (page client component): render the row as in-page tabs.
+<MenuNavClient
+    namespace="ai-assistant"
+    items={submenuTree}
+    generatedAt={generatedAt}
+    activeUrl={`/system/plugins/ai-assistant?tab=${activeTab}`}
+    onItemSelect={(item) => setActiveTab(tabKeyFromUrl(item.url))}
+/>
+```
+
 ## Pre-Implementation Checklist
 
 Before implementing menu integration or navigation UI:

--- a/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
@@ -18,6 +18,15 @@
  * pass `namespace="main"` and rely on per-user `requiresAdmin` gating
  * to filter the rendered tree.
  *
+ * By default each leaf renders as a navigating `<Link>` whose active state is
+ * derived from the current pathname. Callers building an in-page submenu — a
+ * tab row backed by its own menu namespace — opt into different behavior with
+ * two additive props: `onItemSelect` intercepts leaf clicks so activation
+ * drives local state (e.g. a `?tab=` query param) instead of route navigation,
+ * and `activeUrl` overrides pathname-based highlighting because the route does
+ * not change between tabs. Both default to undefined, leaving existing
+ * navigation consumers untouched.
+ *
  * @example
  * ```tsx
  * <MenuNavClient
@@ -31,6 +40,7 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import { createPortal } from 'react-dom';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -76,6 +86,26 @@ interface IMenuNavClientProps {
      * Defaults to "{namespace} navigation".
      */
     ariaLabel?: string;
+
+    /**
+     * Optional activation handler for leaf items. When provided, clicking a
+     * leaf link calls this callback and suppresses navigation (the handler
+     * receives the already-default-prevented event), letting a caller drive
+     * in-page tab state — for example syncing a `?tab=` query param — instead
+     * of routing. Omitted (the default) preserves ordinary `<Link>`
+     * navigation, so existing consumers are unaffected. Container (parent)
+     * nodes are unaffected; only leaf links honor this.
+     */
+    onItemSelect?: (item: MenuNodeSerialized, event: ReactMouseEvent<HTMLAnchorElement>) => void;
+
+    /**
+     * Optional active-item override. When set, the leaf whose `url` equals this
+     * value is highlighted instead of deriving active state from the current
+     * pathname. Pair it with `onItemSelect` for in-page tab submenus where the
+     * route is identical across tabs. Omitted (the default) keeps
+     * pathname-based highlighting for navigation consumers.
+     */
+    activeUrl?: string;
 }
 
 /**
@@ -97,8 +127,10 @@ interface IMenuNavClientProps {
  * @param props.items - Menu items from server
  * @param props.generatedAt - SSR snapshot timestamp seeded onto Redux
  * @param props.ariaLabel - Optional accessible label
+ * @param props.onItemSelect - Optional leaf activation handler; suppresses navigation when set
+ * @param props.activeUrl - Optional active-item override keyed by url; bypasses pathname matching
  */
-export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMenuNavClientProps) {
+export function MenuNavClient({ namespace, items, generatedAt, ariaLabel, onItemSelect, activeUrl }: IMenuNavClientProps) {
     const pathname = usePathname();
     const dispatch = useAppDispatch();
     const menuConfig = useMenuConfig(namespace);
@@ -272,9 +304,15 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
      * that overflowed into the "More" menu.
      */
     const renderLinkItem = (item: MenuNodeSerialized, isNested = false): JSX.Element => {
-        const isActive = item.url === '/'
-            ? pathname === '/'
-            : pathname.startsWith(item.url!);
+        // When the caller supplies `activeUrl` (in-page tab mode) the active
+        // item is the one whose url matches it exactly — the route does not
+        // change between tabs, so pathname matching cannot tell them apart.
+        // Without it, fall back to pathname matching for navigation links.
+        const isActive = activeUrl !== undefined
+            ? item.url === activeUrl
+            : item.url === '/'
+                ? pathname === '/'
+                : pathname.startsWith(item.url!);
 
         // Nested rows (inside category dropdowns) are vertical-list items
         // where icon-top and label-hiding both degrade readability. Force
@@ -309,7 +347,17 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel }: IMen
                 role={isNested ? 'menuitem' : undefined}
                 aria-current={isActive ? 'page' : undefined}
                 aria-label={rowShowLabels ? undefined : item.label}
-                onClick={() => {
+                onClick={(event) => {
+                    // Opt-in activation: when the caller provides onItemSelect,
+                    // the item drives in-page state (e.g. a `?tab=` submenu)
+                    // instead of navigating. Preventing default keeps the
+                    // <Link> href intact for SSR and no-JS visitors while
+                    // suppressing client-side navigation. Omitting the handler
+                    // preserves ordinary link navigation for existing consumers.
+                    if (onItemSelect) {
+                        event.preventDefault();
+                        onItemSelect(item, event);
+                    }
                     if (isNested) {
                         closeDropdown();
                         // Trigger PriorityNav's click-outside handler to close "More" dropdown

--- a/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
+++ b/src/frontend/components/layout/MenuNav/MenuNavClient.tsx
@@ -312,7 +312,7 @@ export function MenuNavClient({ namespace, items, generatedAt, ariaLabel, onItem
             ? item.url === activeUrl
             : item.url === '/'
                 ? pathname === '/'
-                : pathname.startsWith(item.url!);
+                : !!item.url && pathname.startsWith(item.url);
 
         // Nested rows (inside category dropdowns) are vertical-list items
         // where icon-top and label-hiding both degrade readability. Force

--- a/src/frontend/components/layout/MenuNav/SubMenu.tsx
+++ b/src/frontend/components/layout/MenuNav/SubMenu.tsx
@@ -1,0 +1,85 @@
+/**
+ * @fileoverview SubMenu — plugin-facing wrapper over MenuNavClient.
+ *
+ * Exposes the menu-service-backed navigation row to plugins as an in-page tab
+ * strip. Plugins cannot import core components across the workspace boundary,
+ * so this thin wrapper is published on `IFrontendPluginContext.layout` (see
+ * `lib/frontendPluginContext.tsx`) and consumed as `context.layout.SubMenu`.
+ *
+ * It delegates all rendering to `MenuNavClient` — inheriting Priority+ overflow,
+ * per-namespace config, gating-filtered items, and live `menu:update` refresh —
+ * and only adapts the surface for the submenu use case: a friendlier
+ * `onSelect(item)` callback (mapped to MenuNavClient's `onItemSelect`) and a
+ * defaulted `generatedAt` so callers pass just the namespace, items, and active
+ * url. When `onSelect` is omitted the row behaves as ordinary navigation links.
+ *
+ * The consumer is a client component (a plugin page already holds `activeTab`
+ * state and receives its namespace tree via the plugin `serverDataFetcher`), so
+ * there is no server/client function-boundary concern — the SSR-first data
+ * arrives as a prop and this renders it immediately, no loading flash.
+ *
+ * @module components/layout/MenuNav/SubMenu
+ */
+'use client';
+
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import type { MenuNodeSerialized } from '@/shared';
+import { MenuNavClient } from './MenuNavClient';
+
+/**
+ * Props for the SubMenu wrapper.
+ */
+export interface ISubMenuProps {
+    /** Menu namespace whose tree backs this submenu (e.g. the plugin id). */
+    namespace: string;
+
+    /** Serialized menu nodes for the namespace, fetched SSR-first by the caller. */
+    items: MenuNodeSerialized[];
+
+    /**
+     * Url of the active tab. Highlights the matching leaf instead of deriving
+     * active state from the route, since tabs share one route.
+     */
+    activeUrl?: string;
+
+    /**
+     * Activation callback. When provided, leaf clicks call this and suppress
+     * navigation, letting the page drive in-page tab state. Omitted leaves the
+     * row as ordinary navigation links.
+     */
+    onSelect?: (item: MenuNodeSerialized) => void;
+
+    /** Optional accessible label for the nav element. */
+    ariaLabel?: string;
+
+    /**
+     * SSR snapshot timestamp seeded onto Redux. Optional for submenus — the
+     * value is metadata only, so it defaults to an empty string when the caller
+     * has no meaningful timestamp.
+     */
+    generatedAt?: string;
+}
+
+/**
+ * Render a menu-service-backed in-page submenu (tab row) for a plugin.
+ *
+ * Delegates to MenuNavClient, mapping the friendlier `onSelect(item)` callback
+ * onto MenuNavClient's `onItemSelect(item, event)` and defaulting `generatedAt`.
+ *
+ * @param props - SubMenu props
+ * @returns The rendered submenu navigation row
+ */
+export function SubMenu({ namespace, items, activeUrl, onSelect, ariaLabel, generatedAt = '' }: ISubMenuProps): JSX.Element {
+    return (
+        <MenuNavClient
+            namespace={namespace}
+            items={items}
+            generatedAt={generatedAt}
+            ariaLabel={ariaLabel}
+            activeUrl={activeUrl}
+            onItemSelect={onSelect
+                ? (item: MenuNodeSerialized, _event: ReactMouseEvent<HTMLAnchorElement>) => onSelect(item)
+                : undefined}
+        />
+    );
+}

--- a/src/frontend/components/layout/MenuNav/SubMenu.tsx
+++ b/src/frontend/components/layout/MenuNav/SubMenu.tsx
@@ -22,8 +22,7 @@
  */
 'use client';
 
-import type { MouseEvent as ReactMouseEvent } from 'react';
-import type { MenuNodeSerialized } from '@/shared';
+import type { ISubMenuItem } from '@/types';
 import { MenuNavClient } from './MenuNavClient';
 
 /**
@@ -34,7 +33,7 @@ export interface ISubMenuProps {
     namespace: string;
 
     /** Serialized menu nodes for the namespace, fetched SSR-first by the caller. */
-    items: MenuNodeSerialized[];
+    items: ISubMenuItem[];
 
     /**
      * Url of the active tab. Highlights the matching leaf instead of deriving
@@ -47,7 +46,7 @@ export interface ISubMenuProps {
      * navigation, letting the page drive in-page tab state. Omitted leaves the
      * row as ordinary navigation links.
      */
-    onSelect?: (item: MenuNodeSerialized) => void;
+    onSelect?: (item: ISubMenuItem) => void;
 
     /** Optional accessible label for the nav element. */
     ariaLabel?: string;
@@ -77,9 +76,7 @@ export function SubMenu({ namespace, items, activeUrl, onSelect, ariaLabel, gene
             generatedAt={generatedAt}
             ariaLabel={ariaLabel}
             activeUrl={activeUrl}
-            onItemSelect={onSelect
-                ? (item: MenuNodeSerialized, _event: ReactMouseEvent<HTMLAnchorElement>) => onSelect(item)
-                : undefined}
+            onItemSelect={onSelect ? (item) => onSelect(item) : undefined}
         />
     );
 }

--- a/src/frontend/lib/frontendPluginContext.tsx
+++ b/src/frontend/lib/frontendPluginContext.tsx
@@ -28,6 +28,11 @@ import { LineChart } from '../features/charts/components/LineChart';
 import { BarChart } from '../features/charts/components/BarChart';
 import { SchedulerMonitor } from '../modules/scheduler';
 import { Page, PageHeader, Stack, Grid, Section } from '../components/layout';
+// Imported by direct path, not the layout barrel: the barrel is kept
+// client-safe and excludes MenuNav (MenuNavSSR pulls next/headers). SubMenu
+// wraps only the client-safe MenuNavClient, so importing the file directly
+// keeps server-only code out of this client bundle.
+import { SubMenu } from '../components/layout/MenuNav/SubMenu';
 import { useAuthSession } from '../modules/user/components/SessionProvider';
 import { getSocket } from './socketClient';
 import { getRuntimeConfig } from './runtimeConfig';
@@ -343,7 +348,8 @@ export function FrontendPluginContextProvider({ children }: { children: React.Re
             PageHeader,
             Stack,
             Grid,
-            Section
+            Section,
+            SubMenu
         };
 
         const charts: IChartComponents = {
@@ -440,7 +446,8 @@ export function createPluginContext(pluginId: string): IFrontendPluginContext {
         PageHeader,
         Stack,
         Grid,
-        Section
+        Section,
+        SubMenu
     };
 
     const charts: IChartComponents = {


### PR DESCRIPTION
## Summary

Makes the menu service usable as the backing store for in-page submenus (tab rows), so admin pages and plugins can stop hand-rolling `<button>` arrays and inherit per-user gating, ordering, live refresh, and cross-plugin extensibility.

### MenuNav (additive, non-breaking)
`MenuNavClient` gains two opt-in props:
- `onItemSelect(item, event)` — leaf clicks call this and suppress navigation, letting a caller drive in-page tab state (e.g. sync a `?tab=` query param).
- `activeUrl` — highlights the leaf matching this url instead of deriving active state from the pathname (tabs share one route).

Both default to `undefined`; existing navigation consumers render and behave exactly as before.

### Plugin SubMenu wrapper
Plugins cannot import core components across the workspace boundary, so a thin `SubMenu` wrapper over `MenuNavClient` is published on `IFrontendPluginContext.layout` (mirroring how `SchedulerMonitor` is exposed under `system`), with a serializable `ISubMenuItem` type. A plugin registers its tabs in its own menu namespace, fetches that tree SSR-first via `serverDataFetcher`, and renders `context.layout.SubMenu`.

### Service
No change required — `create()` already accepts any namespace and stores `requiresAdmin` verbatim; the System-container auto-gate only applies within that subtree, so a separate-namespace submenu leaves gating entirely to the caller.

### Docs
- Menu module README: Submenu Pattern section (core vs plugin paths).
- `plugins-frontend-context-ui.md`: `SubMenu` as the recommended pattern for plugin internal menus, with register → SSR-fetch → render flow.

## Verification
Types package builds clean; frontend `tsc` clean excluding pre-existing gitignored `.next/` stale artifacts (unrelated `address-labels` page).