### PR TITLE
feat(logs): expose read-only AI tools via ai-assistant service watch

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -315,7 +315,7 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     const toolsModule = new ToolsModule();
     const schedulerModule = new SchedulerModule();
 
-    await logsModule.init({ pinoLogger, database: coreDatabase, app });
+    await logsModule.init({ pinoLogger, database: coreDatabase, app, serviceRegistry });
     await pagesModule.init(sharedDeps);
     await widgetsModule.init(sharedDeps);
     await schedulerModule.init({ database: coreDatabase, menuService, app });

--- a/src/backend/modules/logs/LogsModule.ts
+++ b/src/backend/modules/logs/LogsModule.ts
@@ -27,12 +27,13 @@
  */
 
 import type { Express } from 'express';
-import type { IDatabaseService, IModule, IModuleMetadata } from '@/types';
+import type { IDatabaseService, IModule, IModuleMetadata, IServiceRegistry, ServiceWatchDisposer } from '@/types';
 import type pino from 'pino';
 import { logger } from '../../lib/logger.js';
 import { SystemLogService } from './services/system-log.service.js';
 import { SystemLogController } from './api/system-log.controller.js';
 import { createSystemLogRouter } from './api/system-log.router.js';
+import { registerLogAiTools } from './ai-tools.js';
 import type { Router } from 'express';
 
 /**
@@ -63,6 +64,13 @@ export interface ILogsModuleDependencies {
      * The module will attach its admin router using IoC pattern.
      */
     app: Express;
+
+    /**
+     * Shared service registry, watched for the plugin-provided
+     * `ai-assistant` service so the module can register its read-only
+     * log AI tools whenever the assistant is available.
+     */
+    serviceRegistry: IServiceRegistry;
 }
 
 /**
@@ -136,6 +144,14 @@ export class LogsModule implements IModule<ILogsModuleDependencies> {
     private pinoLogger!: pino.Logger;
     private database!: IDatabaseService;
     private app!: Express;
+    private serviceRegistry!: IServiceRegistry;
+
+    /**
+     * Disposer for the ai-assistant service-registry watch created in run().
+     * Modules live for the process lifetime, so this is held for symmetry
+     * with the plugin facade pattern rather than ever being invoked.
+     */
+    private unwatchAiAssistant: ServiceWatchDisposer | null = null;
 
     /**
      * Services created during init() phase.
@@ -174,6 +190,7 @@ export class LogsModule implements IModule<ILogsModuleDependencies> {
         this.pinoLogger = dependencies.pinoLogger;
         this.database = dependencies.database;
         this.app = dependencies.app;
+        this.serviceRegistry = dependencies.serviceRegistry;
 
         // Initialize SystemLogService singleton with Pino logger
         // After this, all logger.info/warn/error calls will save to MongoDB
@@ -229,6 +246,12 @@ export class LogsModule implements IModule<ILogsModuleDependencies> {
             this.logger.error({ error }, 'Failed to register system logs menu item');
             throw new Error(`Failed to register system logs menu item: ${error instanceof Error ? error.message : 'Unknown error'}`);
         }
+
+        // Watch for the ai-assistant plugin service and contribute the
+        // read-only log AI tools whenever it is (re-)enabled. The watch
+        // pattern is required because the assistant is an optional plugin
+        // that loads after modules and can toggle at runtime.
+        this.unwatchAiAssistant = registerLogAiTools(this.serviceRegistry, this.logService, this.logger);
 
         // Router is mounted by system router via: router.use('/logs', createSystemLogRouter())
         this.logger.info('Logs module running (routes available via system router)');

--- a/src/backend/modules/logs/README.md
+++ b/src/backend/modules/logs/README.md
@@ -24,7 +24,8 @@ Every backend service and plugin logs through `SystemLogService.getInstance()`. 
 
 | File | Purpose |
 |------|---------|
-| `LogsModule.ts` | IModule implementation, two-phase lifecycle, menu + route registration |
+| `LogsModule.ts` | IModule implementation, two-phase lifecycle, menu + route registration, ai-assistant watch |
+| `ai-tools.ts` | Read-only AI tool definitions + service-registry watch registration |
 | `services/system-log.service.ts` | Singleton logger + MongoDB storage, sanitization, child loggers, stats |
 | `database/SystemLog.ts` | Mongoose schema, compound indexes, `ISystemLogDocument` interface |
 | `api/system-log.controller.ts` | Express handlers for all 6 endpoints |
@@ -73,6 +74,16 @@ All under `/api/admin/system/logs`, all require `X-Admin-Token` header.
 | PATCH | `/:id/resolve` | Mark as resolved with `resolvedBy` field |
 | PATCH | `/:id/unresolve` | Revert resolution |
 | DELETE | `/` | Bulk delete all logs (destructive) |
+
+## AI Tools
+
+`run()` watches the service registry for the plugin-provided `ai-assistant` service (`IAiAssistantService`) and registers three strictly read-only tools (`providerId: 'logs'`) whenever it appears — the watch pattern covers the assistant loading after modules and toggling at runtime. Handlers call `SystemLogService` directly. The deprecated `resolved` column is excluded from every tool input and output. Registration failures are logged and swallowed; AI tooling never blocks module startup.
+
+| Tool | Backed By | Parameters |
+|------|-----------|------------|
+| `tronrelic-query-system-logs` | `getLogs()` | `levels` (default `["error","warn"]`), `service`, `startTime`/`endTime` (ISO 8601), `page`, `limit` (default 20, cap 50). List-view context truncated at 500 chars |
+| `tronrelic-get-system-log` | `getLogById()` | `id` (required, 24-hex). Full untruncated context |
+| `tronrelic-get-log-statistics` | `getStatistics()` | None. Total + per-level + per-service counts; doubles as `service` value discovery |
 
 ## Service Patterns
 

--- a/src/backend/modules/logs/__tests__/ai-tools.test.ts
+++ b/src/backend/modules/logs/__tests__/ai-tools.test.ts
@@ -1,0 +1,221 @@
+/// <reference types="vitest" />
+
+/**
+ * @file ai-tools.test.ts
+ *
+ * Tests for the logs module's AI tool registrations: parameter
+ * validation, default/capped pagination, list-view context truncation,
+ * and the omission of the deprecated `resolved` fields from every tool
+ * surface.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { registerLogAiTools, AI_TOOL_NAMES } from '../ai-tools.js';
+import { createMockServiceRegistry } from '../../../tests/vitest/mocks/service-registry.js';
+import type { IAiTool } from '@/types';
+
+/**
+ * Minimal logger stub satisfying the registration telemetry calls.
+ */
+function createMockLogger(): any {
+    return {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+        fatal: vi.fn(),
+        child: vi.fn()
+    };
+}
+
+/**
+ * Fake SystemLogService exposing only the read methods the tools use.
+ */
+function createMockLogService() {
+    return {
+        getLogs: vi.fn().mockResolvedValue({
+            logs: [],
+            total: 0,
+            page: 1,
+            limit: 20,
+            totalPages: 0,
+            hasNextPage: false,
+            hasPrevPage: false
+        }),
+        getLogById: vi.fn().mockResolvedValue(null),
+        getStatistics: vi.fn().mockResolvedValue({
+            total: 12,
+            byLevel: { trace: 0, debug: 0, info: 5, warn: 4, error: 3, fatal: 0 },
+            byService: { blockchain: 7, 'plugin:whale-alerts': 5 },
+            unresolved: 3
+        })
+    };
+}
+
+/**
+ * Register the tools against a mock registry and return them by name.
+ */
+function registerAndCapture(logService: any): Record<string, IAiTool> {
+    const registry = createMockServiceRegistry();
+    const captured: Record<string, IAiTool> = {};
+    const ai = {
+        registerTool: vi.fn((tool: IAiTool) => {
+            captured[tool.name] = tool;
+        }),
+        unregisterTool: vi.fn().mockReturnValue(false)
+    };
+    registerLogAiTools(registry, logService, createMockLogger());
+    registry.register('ai-assistant', ai);
+    return captured;
+}
+
+describe('logs AI tools', () => {
+    let logService: ReturnType<typeof createMockLogService>;
+    let tools: Record<string, IAiTool>;
+
+    beforeEach(() => {
+        logService = createMockLogService();
+        tools = registerAndCapture(logService);
+    });
+
+    describe(AI_TOOL_NAMES.queryLogs, () => {
+        it('should default to error and warn levels with default pagination', async () => {
+            await tools[AI_TOOL_NAMES.queryLogs].handler({});
+
+            expect(logService.getLogs).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    levels: ['error', 'warn'],
+                    page: 1,
+                    limit: 20
+                })
+            );
+            // The deprecated resolved filter must never be sent
+            expect(logService.getLogs.mock.calls[0][0]).not.toHaveProperty('resolved');
+        });
+
+        it('should cap limit at the maximum', async () => {
+            await tools[AI_TOOL_NAMES.queryLogs].handler({ limit: 500 });
+
+            expect(logService.getLogs).toHaveBeenCalledWith(
+                expect.objectContaining({ limit: 50 })
+            );
+        });
+
+        it('should reject invalid levels', async () => {
+            await expect(
+                tools[AI_TOOL_NAMES.queryLogs].handler({ levels: ['error', 'bogus'] })
+            ).rejects.toThrow('Invalid levels: bogus');
+        });
+
+        it('should reject malformed date strings', async () => {
+            await expect(
+                tools[AI_TOOL_NAMES.queryLogs].handler({ startTime: 'not-a-date' })
+            ).rejects.toThrow('startTime');
+        });
+
+        it('should pass parsed date bounds to the service', async () => {
+            await tools[AI_TOOL_NAMES.queryLogs].handler({
+                startTime: '2026-06-09T00:00:00Z',
+                endTime: '2026-06-09T12:00:00Z'
+            });
+
+            const query = logService.getLogs.mock.calls[0][0];
+            expect(query.startDate).toEqual(new Date('2026-06-09T00:00:00Z'));
+            expect(query.endDate).toEqual(new Date('2026-06-09T12:00:00Z'));
+        });
+
+        it('should omit resolved fields and truncate long context in list view', async () => {
+            logService.getLogs.mockResolvedValue({
+                logs: [{
+                    _id: 'aaaaaaaaaaaaaaaaaaaaaaaa',
+                    timestamp: new Date('2026-06-09T01:00:00Z'),
+                    level: 'error',
+                    message: 'boom',
+                    service: 'blockchain',
+                    context: { stack: 'x'.repeat(2000) },
+                    resolved: false,
+                    resolvedBy: null
+                }],
+                total: 1, page: 1, limit: 20, totalPages: 1,
+                hasNextPage: false, hasPrevPage: false
+            });
+
+            const result: any = await tools[AI_TOOL_NAMES.queryLogs].handler({});
+            const entry = result.logs[0];
+
+            expect(entry).not.toHaveProperty('resolved');
+            expect(entry).not.toHaveProperty('resolvedBy');
+            expect(typeof entry.context).toBe('string');
+            expect(entry.context).toContain('[truncated');
+            expect(result).not.toHaveProperty('hasPrevPage');
+        });
+    });
+
+    describe(AI_TOOL_NAMES.getLog, () => {
+        it('should reject ids that are not 24-char hex', async () => {
+            await expect(
+                tools[AI_TOOL_NAMES.getLog].handler({ id: 'nope' })
+            ).rejects.toThrow('24-character hex');
+        });
+
+        it('should return the full entry without resolved fields', async () => {
+            logService.getLogById.mockResolvedValue({
+                _id: 'bbbbbbbbbbbbbbbbbbbbbbbb',
+                timestamp: new Date(),
+                level: 'warn',
+                message: 'slow query',
+                service: 'plugin:whale-alerts',
+                context: { detail: 'y'.repeat(2000) },
+                resolved: true,
+                resolvedAt: new Date(),
+                resolvedBy: 'admin'
+            });
+
+            const entry: any = await tools[AI_TOOL_NAMES.getLog].handler({
+                id: 'bbbbbbbbbbbbbbbbbbbbbbbb'
+            });
+
+            expect(entry.id).toBe('bbbbbbbbbbbbbbbbbbbbbbbb');
+            // Full context, no truncation in detail view
+            expect(entry.context.detail).toHaveLength(2000);
+            expect(entry).not.toHaveProperty('resolved');
+            expect(entry).not.toHaveProperty('resolvedAt');
+            expect(entry).not.toHaveProperty('resolvedBy');
+        });
+
+        it('should return null for a missing entry', async () => {
+            const entry = await tools[AI_TOOL_NAMES.getLog].handler({
+                id: 'cccccccccccccccccccccccc'
+            });
+            expect(entry).toBeNull();
+        });
+    });
+
+    describe(AI_TOOL_NAMES.getStatistics, () => {
+        it('should return counts without the unresolved field', async () => {
+            const stats: any = await tools[AI_TOOL_NAMES.getStatistics].handler({});
+
+            expect(stats.total).toBe(12);
+            expect(stats.byLevel.error).toBe(3);
+            expect(stats.byService.blockchain).toBe(7);
+            expect(stats).not.toHaveProperty('unresolved');
+        });
+    });
+
+    describe('registration lifecycle', () => {
+        it('should unregister each tool name before registering', () => {
+            const registry = createMockServiceRegistry();
+            const ai = {
+                registerTool: vi.fn(),
+                unregisterTool: vi.fn().mockReturnValue(true)
+            };
+            registerLogAiTools(registry, logService as any, createMockLogger());
+            registry.register('ai-assistant', ai);
+
+            expect(ai.unregisterTool.mock.calls.map(call => call[0])).toEqual(
+                Object.values(AI_TOOL_NAMES)
+            );
+        });
+    });
+});

--- a/src/backend/modules/logs/__tests__/logs-module.test.ts
+++ b/src/backend/modules/logs/__tests__/logs-module.test.ts
@@ -2,9 +2,12 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { LogsModule } from '../LogsModule.js';
+import { AI_TOOL_NAMES } from '../ai-tools.js';
 import { MAIN_SYSTEM_CONTAINER_ID } from '../../menu/index.js';
 import type { Express } from 'express';
+import type { IServiceRegistry } from '@/types';
 import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+import { createMockServiceRegistry } from '../../../tests/vitest/mocks/service-registry.js';
 
 /**
  * Mock Pino logger for testing.
@@ -82,6 +85,7 @@ describe('LogsModule', () => {
     let mockPino: MockPinoLogger;
     let mockDatabase: ReturnType<typeof createMockDatabaseService>;
     let mockApp: Partial<Express>;
+    let mockServiceRegistry: IServiceRegistry;
 
     beforeEach(() => {
         vi.clearAllMocks();
@@ -91,6 +95,7 @@ describe('LogsModule', () => {
         mockPino = new MockPinoLogger();
         mockDatabase = createMockDatabaseService();
         mockApp = createMockApp();
+        mockServiceRegistry = createMockServiceRegistry();
     });
 
     describe('Metadata', () => {
@@ -118,7 +123,8 @@ describe('LogsModule', () => {
             await module.init({
                 pinoLogger: mockPino as any,
                 database: mockDatabase as any,
-                app: mockApp as any
+                app: mockApp as any,
+                serviceRegistry: mockServiceRegistry
             });
 
             // Verify module initialized successfully (no errors thrown)
@@ -134,7 +140,8 @@ describe('LogsModule', () => {
             await module.init({
                 pinoLogger: mockPino as any,
                 database: mockDatabase as any,
-                app: mockApp as any
+                app: mockApp as any,
+                serviceRegistry: mockServiceRegistry
             });
 
             // Verify module can provide log service after init
@@ -178,7 +185,8 @@ describe('LogsModule', () => {
             await module.init({
                 pinoLogger: mockPino as any,
                 database: mockDatabase as any,
-                app: mockApp as any
+                app: mockApp as any,
+                serviceRegistry: mockServiceRegistry
             });
 
             await module.run();
@@ -209,12 +217,98 @@ describe('LogsModule', () => {
             await module.init({
                 pinoLogger: mockPino as any,
                 database: mockDatabase as any,
-                app: mockApp as any
+                app: mockApp as any,
+                serviceRegistry: mockServiceRegistry
             });
 
             await expect(module.run()).rejects.toThrow(
                 'Failed to register system logs menu item'
             );
+        });
+    });
+
+    describe('AI tool registration', () => {
+        /**
+         * Build a fake ai-assistant service with spied tool methods.
+         */
+        function createMockAiAssistant() {
+            return {
+                registerTool: vi.fn(),
+                unregisterTool: vi.fn().mockReturnValue(false)
+            };
+        }
+
+        /**
+         * Test: tools register when ai-assistant appears after run().
+         *
+         * Verifies the watch pattern handles the normal boot order where
+         * the ai-assistant plugin loads after modules.
+         */
+        it('should register log tools when ai-assistant becomes available', async () => {
+            await module.init({
+                pinoLogger: mockPino as any,
+                database: mockDatabase as any,
+                app: mockApp as any,
+                serviceRegistry: mockServiceRegistry
+            });
+            await module.run();
+
+            const ai = createMockAiAssistant();
+            mockServiceRegistry.register('ai-assistant', ai);
+
+            const registeredNames = ai.registerTool.mock.calls.map(call => call[0].name);
+            expect(registeredNames).toEqual([
+                AI_TOOL_NAMES.queryLogs,
+                AI_TOOL_NAMES.getLog,
+                AI_TOOL_NAMES.getStatistics
+            ]);
+            for (const call of ai.registerTool.mock.calls) {
+                expect(call[1]).toBe('logs');
+            }
+        });
+
+        /**
+         * Test: tools register when ai-assistant is already present.
+         *
+         * Verifies the synchronous-onAvailable semantics of watch() cover
+         * the case where the service registered before run().
+         */
+        it('should register log tools when ai-assistant is already registered', async () => {
+            const ai = createMockAiAssistant();
+            mockServiceRegistry.register('ai-assistant', ai);
+
+            await module.init({
+                pinoLogger: mockPino as any,
+                database: mockDatabase as any,
+                app: mockApp as any,
+                serviceRegistry: mockServiceRegistry
+            });
+            await module.run();
+
+            expect(ai.registerTool).toHaveBeenCalledTimes(3);
+        });
+
+        /**
+         * Test: run() survives a failing ai-assistant registration.
+         *
+         * Verifies that AI tooling stays optional — a throwing registerTool
+         * must not take the logs module (and thus the application) down.
+         */
+        it('should not throw when tool registration fails', async () => {
+            const ai = createMockAiAssistant();
+            ai.registerTool.mockImplementation(() => {
+                throw new Error('duplicate tool');
+            });
+            mockServiceRegistry.register('ai-assistant', ai);
+
+            await module.init({
+                pinoLogger: mockPino as any,
+                database: mockDatabase as any,
+                app: mockApp as any,
+                serviceRegistry: mockServiceRegistry
+            });
+
+            await expect(module.run()).resolves.not.toThrow();
         });
     });
 
@@ -229,7 +323,8 @@ describe('LogsModule', () => {
             await module.init({
                 pinoLogger: mockPino as any,
                 database: mockDatabase as any,
-                app: mockApp as any
+                app: mockApp as any,
+                serviceRegistry: mockServiceRegistry
             });
 
             const router = module.createRouter();
@@ -249,7 +344,8 @@ describe('LogsModule', () => {
             await module.init({
                 pinoLogger: mockPino as any,
                 database: mockDatabase as any,
-                app: mockApp as any
+                app: mockApp as any,
+                serviceRegistry: mockServiceRegistry
             });
 
             // Verify service accessible after init

--- a/src/backend/modules/logs/ai-tools.ts
+++ b/src/backend/modules/logs/ai-tools.ts
@@ -1,0 +1,281 @@
+/**
+ * @file ai-tools.ts
+ *
+ * AI tool registrations for the logs module. Exposes three strictly
+ * read-only tools backed by SystemLogService — query-system-logs,
+ * get-system-log, and get-log-statistics — so the AI assistant can
+ * inspect system health and investigate errors.
+ *
+ * Tools are registered against the ai-assistant service via the
+ * service-registry watch pattern: the AI assistant is a plugin that
+ * loads after modules and may be disabled or re-enabled at runtime, so
+ * the module subscribes to its presence rather than resolving it once.
+ * When ai-assistant unregisters, its tool registry forgets these tools;
+ * each onAvailable re-registers them.
+ *
+ * The legacy `resolved` column is intentionally absent from every tool
+ * surface — it is unused and scheduled for removal.
+ */
+
+import type {
+    IAiAssistantService,
+    IAiTool,
+    IServiceRegistry,
+    ISystemLogService,
+    LogLevel,
+    ServiceWatchDisposer
+} from '@/types';
+import type { SystemLogService } from './services/system-log.service.js';
+
+/** Provider id passed to `registerTool` so the admin UI groups tools under this module. */
+const PROVIDER_ID = 'logs';
+
+/** Tool name constants. `tronrelic-` prefix matches platform-default tools. */
+export const AI_TOOL_NAMES = {
+    queryLogs: 'tronrelic-query-system-logs',
+    getLog: 'tronrelic-get-system-log',
+    getStatistics: 'tronrelic-get-log-statistics'
+} as const;
+
+/** Valid severity levels accepted by the query tool's `levels` parameter. */
+const VALID_LEVELS: readonly LogLevel[] = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
+
+/** Default page size for the query tool — full entries are verbose, keep the context lean. */
+const DEFAULT_QUERY_LIMIT = 20;
+
+/** Hard cap on page size to protect the model's context window. */
+const MAX_QUERY_LIMIT = 50;
+
+/** Maximum serialized length of a log entry's context in list view. */
+const LIST_CONTEXT_MAX_CHARS = 500;
+
+/**
+ * Parse an optional ISO 8601 string into a Date, throwing a descriptive
+ * error the model can correct from when the value is malformed.
+ *
+ * @param value - Raw tool input value for a date parameter.
+ * @param name - Parameter name used in the error message.
+ * @returns Parsed Date, or undefined when the value was omitted.
+ */
+function parseIsoDate(value: unknown, name: string): Date | undefined {
+    let result: Date | undefined;
+    if (value !== undefined && value !== null) {
+        const date = new Date(String(value));
+        if (Number.isNaN(date.getTime())) {
+            throw new Error(`Parameter "${name}" must be a valid ISO 8601 date string, got: ${String(value)}`);
+        }
+        result = date;
+    }
+    return result;
+}
+
+/**
+ * Project a raw log document into the shape returned to the model,
+ * omitting the deprecated `resolved` fields and optionally truncating
+ * the context payload for list views.
+ *
+ * @param log - Raw `system_logs` document (lean object).
+ * @param truncateContext - When true, serialized context is capped at
+ *                          {@link LIST_CONTEXT_MAX_CHARS} characters.
+ * @returns Plain object safe to JSON-stringify into the tool result.
+ */
+function projectLogEntry(log: any, truncateContext: boolean): Record<string, unknown> {
+    let context: unknown = log.context ?? null;
+    if (truncateContext && context !== null) {
+        const serialized = JSON.stringify(context);
+        if (serialized.length > LIST_CONTEXT_MAX_CHARS) {
+            context = `${serialized.slice(0, LIST_CONTEXT_MAX_CHARS)}… [truncated — use ${AI_TOOL_NAMES.getLog} with id ${String(log._id)} for the full entry]`;
+        }
+    }
+    return {
+        id: String(log._id),
+        timestamp: log.timestamp,
+        level: log.level,
+        message: log.message,
+        service: log.service,
+        context
+    };
+}
+
+/**
+ * Build the three read-only log tools bound to the given service.
+ *
+ * @param logService - The SystemLogService singleton the handlers read through.
+ * @returns Array of tool definitions ready for `registerTool`.
+ */
+function buildTools(logService: SystemLogService): IAiTool[] {
+    const queryTool: IAiTool = {
+        name: AI_TOOL_NAMES.queryLogs,
+        description:
+            'Query the TronRelic system logs with filtering and pagination. ' +
+            'Use this to investigate errors, warnings, or activity from a specific service or time window — ' +
+            'e.g. "what errors happened in the last hour?" or "show warnings from plugin:whale-alerts". ' +
+            'Returns a page of log entries (id, timestamp, level, message, service, context) plus pagination metadata. ' +
+            'Long context payloads are truncated in this list view — call ' + AI_TOOL_NAMES.getLog + ' with an entry id for the full record. ' +
+            'Defaults to error and warn levels only; pass `levels` explicitly to widen. ' +
+            'Service names can be discovered via ' + AI_TOOL_NAMES.getStatistics + '. This tool is read-only.',
+        inputSchema: {
+            type: 'object',
+            description: 'Optional filters and pagination for the log query',
+            properties: {
+                levels: {
+                    type: 'array',
+                    items: { type: 'string', enum: [...VALID_LEVELS] },
+                    description: 'Severity levels to include. Defaults to ["error","warn"] when omitted.'
+                },
+                service: {
+                    type: 'string',
+                    description: 'Filter to one service or plugin id (e.g. "blockchain", "plugin:whale-alerts"). Omit for all services.'
+                },
+                startTime: {
+                    type: 'string',
+                    description: 'ISO 8601 timestamp; only logs at or after this time are returned. Omit for no lower bound.'
+                },
+                endTime: {
+                    type: 'string',
+                    description: 'ISO 8601 timestamp; only logs at or before this time are returned. Omit for no upper bound.'
+                },
+                page: {
+                    type: 'integer',
+                    minimum: 1,
+                    description: 'Page number, 1-indexed. Defaults to 1.'
+                },
+                limit: {
+                    type: 'integer',
+                    minimum: 1,
+                    maximum: MAX_QUERY_LIMIT,
+                    description: `Entries per page. Defaults to ${DEFAULT_QUERY_LIMIT}, capped at ${MAX_QUERY_LIMIT}.`
+                }
+            },
+            required: [],
+            additionalProperties: false
+        },
+        handler: async (input) => {
+            let levels: LogLevel[] = ['error', 'warn'];
+            if (Array.isArray(input.levels) && input.levels.length > 0) {
+                const invalid = input.levels.filter(level => !VALID_LEVELS.includes(level as LogLevel));
+                if (invalid.length > 0) {
+                    throw new Error(`Invalid levels: ${invalid.join(', ')}. Valid levels: ${VALID_LEVELS.join(', ')}`);
+                }
+                levels = input.levels as LogLevel[];
+            }
+
+            const limit = Math.min(
+                Math.max(1, Number(input.limit) || DEFAULT_QUERY_LIMIT),
+                MAX_QUERY_LIMIT
+            );
+            const page = Math.max(1, Number(input.page) || 1);
+
+            const result = await logService.getLogs({
+                levels,
+                service: typeof input.service === 'string' && input.service.length > 0 ? input.service : undefined,
+                startDate: parseIsoDate(input.startTime, 'startTime'),
+                endDate: parseIsoDate(input.endTime, 'endTime'),
+                page,
+                limit
+            });
+
+            return {
+                logs: result.logs.map(log => projectLogEntry(log, true)),
+                total: result.total,
+                page: result.page,
+                limit: result.limit,
+                totalPages: result.totalPages,
+                hasNextPage: result.hasNextPage
+            };
+        }
+    };
+
+    const getTool: IAiTool = {
+        name: AI_TOOL_NAMES.getLog,
+        description:
+            'Fetch one TronRelic system log entry by its id, returning the complete record including the ' +
+            'full context payload (error stacks, request details, plugin metadata) without truncation. ' +
+            'Use this after ' + AI_TOOL_NAMES.queryLogs + ' surfaces an entry worth drilling into. ' +
+            'Returns null when no entry exists for the id. This tool is read-only.',
+        inputSchema: {
+            type: 'object',
+            description: 'Identifier of the log entry to fetch',
+            properties: {
+                id: {
+                    type: 'string',
+                    description: 'The 24-character hex id of the log entry, as returned by ' + AI_TOOL_NAMES.queryLogs + '.'
+                }
+            },
+            required: ['id'],
+            additionalProperties: false
+        },
+        handler: async (input) => {
+            const id = String(input.id ?? '');
+            if (!/^[a-f0-9]{24}$/i.test(id)) {
+                throw new Error(`Parameter "id" must be a 24-character hex log id, got: ${id}`);
+            }
+            const log = await logService.getLogById(id);
+            return log ? projectLogEntry(log, false) : null;
+        }
+    };
+
+    const statsTool: IAiTool = {
+        name: AI_TOOL_NAMES.getStatistics,
+        description:
+            'Get aggregate statistics over the TronRelic system logs: total entry count, counts per severity ' +
+            'level (trace through fatal), and counts per service/plugin. ' +
+            'Use this first when asked about overall system health, and to discover valid `service` values for ' +
+            AI_TOOL_NAMES.queryLogs + '. Counts are cached for up to 30 seconds. ' +
+            'Takes no parameters. This tool is read-only.',
+        inputSchema: {
+            type: 'object',
+            description: 'No parameters',
+            properties: {},
+            required: [],
+            additionalProperties: false
+        },
+        handler: async () => {
+            const stats = await logService.getStatistics();
+            return {
+                total: stats.total,
+                byLevel: stats.byLevel,
+                byService: stats.byService
+            };
+        }
+    };
+
+    return [queryTool, getTool, statsTool];
+}
+
+/**
+ * Watch the service registry for the ai-assistant service and register
+ * the log tools whenever it becomes available.
+ *
+ * Each tool is unregistered before registration so re-availability
+ * (plugin disable/enable cycles, hot reload) never trips the
+ * duplicate-name guard in `registerTool`. Registration failures are
+ * logged and swallowed — AI tooling is optional capability and must
+ * never take the logs module down.
+ *
+ * @param serviceRegistry - Shared service registry to watch.
+ * @param logService - SystemLogService singleton backing the tool handlers.
+ * @param logger - Module-scoped logger for registration telemetry.
+ * @returns Disposer that removes the watch subscription.
+ */
+export function registerLogAiTools(
+    serviceRegistry: IServiceRegistry,
+    logService: SystemLogService,
+    logger: ISystemLogService
+): ServiceWatchDisposer {
+    const tools = buildTools(logService);
+
+    return serviceRegistry.watch<IAiAssistantService>('ai-assistant', {
+        onAvailable: (ai) => {
+            try {
+                for (const tool of tools) {
+                    ai.unregisterTool(tool.name);
+                    ai.registerTool(tool, PROVIDER_ID);
+                }
+                logger.info({ tools: tools.map(tool => tool.name) }, 'Registered log AI tools with ai-assistant');
+            } catch (error) {
+                logger.error({ error }, 'Failed to register log AI tools with ai-assistant');
+            }
+        }
+    });
+}


### PR DESCRIPTION
## Summary

The logs module now contributes three strictly read-only AI tools to the `ai-assistant` plugin via the service-registry watch pattern, registered under `providerId: 'logs'` whenever the assistant is available (including disable/re-enable cycles).

- `tronrelic-query-system-logs` — backed by `getLogs()`; levels (default error/warn), service, ISO time range, pagination (default 20, cap 50), list-view context truncated at 500 chars
- `tronrelic-get-system-log` — backed by `getLogById()`; full untruncated record by 24-hex id
- `tronrelic-get-log-statistics` — backed by `getStatistics()`; total, per-level, and per-service counts (also serves as service-name discovery)

The deprecated `resolved` column is excluded from every tool input and output. Registration failures are logged and swallowed so optional AI tooling never blocks the fail-fast module lifecycle. `ILogsModuleDependencies` gains a required `serviceRegistry`, wired in bootstrap.

Tests: new `ai-tools.test.ts` (handler validation, limit cap, truncation, resolved omission, unregister-before-register) plus new lifecycle cases in `logs-module.test.ts`. Module README documents the tool contract.