### PR TITLE
feat(types): add IAiConversationMessage for multi-turn AI queries

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delphian/tronrelic-types",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "description": "Core type definitions for the TronRelic platform",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/types/src/ai-tools/IAiConversationMessage.ts
+++ b/packages/types/src/ai-tools/IAiConversationMessage.ts
@@ -1,0 +1,24 @@
+/**
+ * @file IAiConversationMessage.ts
+ *
+ * A single prior turn in a multi-turn AI conversation. Consumers that want
+ * interactive chat (rather than one-shot queries) pass an ordered array of
+ * these as {@link IAiQueryOptions.messages}; the AI Assistant seeds Claude's
+ * Messages request with them ahead of the new prompt.
+ */
+
+/**
+ * One completed turn of conversation history.
+ *
+ * Content is plain text — the resolved transcript of an earlier user prompt
+ * or assistant reply. Tool-use and extended-thinking blocks are intentionally
+ * not modeled here: replaying them across turns requires echoing Anthropic's
+ * opaque block signatures, so prior turns carry only their visible text.
+ */
+export interface IAiConversationMessage {
+    /** Who authored this turn. */
+    role: 'user' | 'assistant';
+
+    /** The turn's plain-text content. */
+    content: string;
+}

--- a/packages/types/src/ai-tools/IAiQueryOptions.ts
+++ b/packages/types/src/ai-tools/IAiQueryOptions.ts
@@ -7,6 +7,7 @@
  */
 
 import type { IAiTool } from './IAiTool.js';
+import type { IAiConversationMessage } from './IAiConversationMessage.js';
 
 /**
  * Options for a non-streaming AI query submitted through
@@ -33,6 +34,26 @@ import type { IAiTool } from './IAiTool.js';
 export interface IAiQueryOptions {
     /** The user's natural language prompt. Required. */
     prompt: string;
+
+    /**
+     * Prior conversation turns for multi-turn (chat) queries. When present,
+     * the AI Assistant seeds Claude's Messages request with these turns
+     * before appending `prompt` as the newest user turn — giving the model
+     * the full thread for context. Omit for one-shot queries (the default);
+     * the result is identical to passing an empty array.
+     *
+     * Turns are sent verbatim and are NOT template-expanded — only `prompt`
+     * and the system prompt resolve `{%variable%}` patterns, so a transcript
+     * stays a literal record of what was already said.
+     */
+    messages?: IAiConversationMessage[];
+
+    /**
+     * Optional conversation grouping id. Persisted on the query history
+     * record so every turn of one chat shares an id and can be grouped in
+     * the history view. Omit for one-shot queries.
+     */
+    conversationId?: string;
 
     /** Override the system prompt. Falls back to configured default. */
     systemPrompt?: string;

--- a/packages/types/src/ai-tools/index.ts
+++ b/packages/types/src/ai-tools/index.ts
@@ -11,6 +11,7 @@
 
 export type { IAiTool, IAiToolInputSchema } from './IAiTool.js';
 export { AI_TOOL_NAME_PATTERN } from './IAiTool.js';
+export type { IAiConversationMessage } from './IAiConversationMessage.js';
 export type { IAiAssistantService } from './IAiAssistantService.js';
 export type { IAiQueryOptions } from './IAiQueryOptions.js';
 export type { IAiQueryResult } from './IAiQueryResult.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -48,7 +48,7 @@ export type { IUserGroup, ICreateUserGroupInput, IUpdateUserGroupInput, IUserGro
 export type { ITronGridService, ITronGridAccountResponse, ITronGridAccountPermission } from './tron-grid/index.js';
 export type { IBlockStats, IBlock, IBlockchainService, ITransactionTimeseriesPoint } from './blockchain/index.js';
 export type { IToolsService, IAddressConversionResult, IAddressValidationResult } from './tools/index.js';
-export type { IAiTool, IAiToolInputSchema, IAiAssistantService, IAiQueryOptions, IAiQueryResult, IModelInfo } from './ai-tools/index.js';
+export type { IAiTool, IAiToolInputSchema, IAiConversationMessage, IAiAssistantService, IAiQueryOptions, IAiQueryResult, IModelInfo } from './ai-tools/index.js';
 export { AI_TOOL_NAME_PATTERN } from './ai-tools/index.js';
 export type {
     HookDescriptor,


### PR DESCRIPTION
## Summary

Adds multi-turn conversation support to the AI Assistant type contract in `@delphian/tronrelic-types`.

- New `IAiConversationMessage` interface — one completed conversation turn (`role` + plain-text `content`). Tool-use and extended-thinking blocks are intentionally not modeled; prior turns carry only their visible text.
- `IAiQueryOptions` gains two optional fields:
  - `messages?: IAiConversationMessage[]` — prior turns that seed Claude's Messages request ahead of the new `prompt`. Sent verbatim (no `{%variable%}` template expansion). Omitting is identical to an empty array.
  - `conversationId?: string` — grouping id persisted on query history so all turns of one chat share an id.
- Re-exported from the package root `index.ts`; version bumped to `3.1.0`.

Additive and backward-compatible — one-shot queries are unchanged. `tsc --noEmit` passes.