### PR TITLE
Self-heal SSR runtime-config fallback instead of latching it for container lifetime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,8 +162,14 @@ services:
             - ./.run:/app/.run
             # Mount uploads directory for file persistence
             - ./public/uploads:/app/public/uploads
+        # Gate readiness on /api/config/public actually serving a siteUrl, not
+        # just process liveness. The frontend's depends_on (service_healthy)
+        # waits on this, so "healthy" must mean the runtime-config endpoint is
+        # ready — otherwise the frontend can boot and lazily cache a degraded
+        # fallback. Marked unhealthy never restarts the backend (restart:always
+        # reacts to exit, not health), so this only tightens the startup gate.
         healthcheck:
-            test: ["CMD", "node", "-e", "require('http').get('http://localhost:4000/api/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); });"]
+            test: ["CMD", "node", "-e", "require('http').get('http://localhost:4000/api/config/public', (r) => { let d=''; r.on('data', c => d += c); r.on('end', () => { try { process.exit(r.statusCode === 200 && JSON.parse(d)?.config?.siteUrl ? 0 : 1); } catch { process.exit(1); } }); }).on('error', () => process.exit(1));"]
             interval: 30s
             timeout: 10s
             retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,6 +202,13 @@ services:
             # Backend URL for SSR (reads from .env: http://backend:4000 for Docker, http://localhost:4000 for local)
             - SITE_BACKEND=${SITE_BACKEND}
 
+            # Public site domain used ONLY by the degraded SSR fallback in
+            # serverConfig.ts. Under normal operation siteUrl comes from the
+            # backend /api/config/public response; if the backend is unreachable
+            # during a cold start the fallback emits canonical/OG/sitemap URLs
+            # from this value instead of defaulting to http://localhost:3000.
+            - SITE_URL=${SITE_URL}
+
             # NOTE: NEXT_PUBLIC_* variables removed
             # Runtime config is fetched from backend API and injected via SSR
             # See docs/system/system-runtime-config.md for details

--- a/docs/system/system-runtime-config.md
+++ b/docs/system/system-runtime-config.md
@@ -27,7 +27,7 @@ Backend Database → /api/config/public → SSR Cache → HTML Injection → Cli
 
 ### Frontend SSR (Server-Side)
 
-`getServerConfig()` (`src/frontend/lib/serverConfig.ts`) fetches `/api/config/public` on first SSR request, caches in memory for the container's lifetime (zero overhead after), falls back to env vars if backend unavailable. All server components, `generateMetadata`, `sitemap.ts`, and `layout.tsx` `await getServerConfig()`.
+`getServerConfig()` (`src/frontend/lib/serverConfig.ts`) fetches `/api/config/public` on first SSR request and caches a *successful* response for the container's lifetime (zero overhead after). If the backend is unavailable it serves a degraded fallback pointing at the internal backend URL, but caches that fallback for only ~10s and retries on the next request. The fallback is never latched for the container lifetime — a transient backend blip self-heals instead of poisoning every client with unreachable, mixed-content URLs until a manual restart. All server components, `generateMetadata`, `sitemap.ts`, and `layout.tsx` `await getServerConfig()`.
 
 ### Frontend Client (Browser)
 

--- a/src/frontend/lib/serverConfig.ts
+++ b/src/frontend/lib/serverConfig.ts
@@ -83,36 +83,71 @@ export interface RuntimeConfig {
 }
 
 /**
- * In-memory cache for runtime configuration.
- * Null until first fetch, then cached for container lifetime.
+ * In-memory cache for a *successful* runtime configuration fetch.
+ * Null until the first good fetch, then cached for the container lifetime.
+ * Only live config (isUsingFallback: false) is ever stored here.
  */
 let cachedConfig: RuntimeConfig | null = null;
+
+/**
+ * Short-lived cache for the degraded fallback config.
+ *
+ * The degraded fallback points the client at the internal backend URL
+ * (e.g. http://backend:4000), which the browser cannot reach. If we latched
+ * it for the container lifetime, a single transient backend blip during a
+ * lazy first fetch would poison every client with mixed-content/unreachable
+ * URLs until someone manually restarted the frontend. Instead we cache the
+ * fallback for only FALLBACK_RETRY_MS and retry on the next request, so the
+ * frontend self-heals within seconds of the backend recovering.
+ */
+let fallbackConfig: RuntimeConfig | null = null;
+
+/**
+ * Timestamp (ms) after which the cached fallback is considered stale and the
+ * backend is retried on the next call to getServerConfig().
+ */
+let fallbackRetryAt = 0;
+
+/**
+ * How long to serve the degraded fallback before retrying the backend. Bounds
+ * backend load during an outage (at most one retry per window) while keeping
+ * recovery fast once the backend is healthy again.
+ */
+const FALLBACK_RETRY_MS = 10_000;
 
 /**
  * Fetches runtime configuration from backend and caches it.
  *
  * Flow:
  * 1. First call: Fetches from backend /api/config/public
- * 2. Subsequent calls: Returns cached value (no fetch)
- * 3. On error: Falls back to environment variables (local dev safety)
+ * 2. After a successful fetch: Returns the cached live config (no fetch)
+ * 3. On error: Serves a degraded fallback, cached only briefly, then retries
  *
  * Fetch timing:
- * - Typically called during first SSR request (when layout.tsx renders)
- * - Happens once per container lifetime (not per request)
- * - Zero overhead after initial fetch
+ * - Typically called during the first SSR request (when layout.tsx renders)
+ * - A successful fetch happens once per container lifetime (zero overhead after)
+ * - While degraded, retries at most once per FALLBACK_RETRY_MS until success
  *
  * Error handling:
  * A missing SITE_BACKEND is a deployment error and throws — it is not
  * caught by the fallback below. If the backend is unreachable or returns
- * an error, falls back to a degraded config (isUsingFallback: true) so
- * SSR keeps rendering while the backend recovers.
+ * an error, serves a degraded config (isUsingFallback: true) so SSR keeps
+ * rendering, but caches it only briefly (FALLBACK_RETRY_MS) and retries the
+ * backend on the next request — the fallback is never latched for the
+ * container lifetime, so the frontend self-heals once the backend recovers.
  *
  * @returns Runtime configuration with siteUrl, apiUrl, and socketUrl
  */
 export async function getServerConfig(): Promise<RuntimeConfig> {
-    // Return cached value if already fetched
+    // Return the live config if we have one (latched for container lifetime).
     if (cachedConfig) {
         return cachedConfig;
+    }
+
+    // Serve the degraded fallback only inside its short retry window. Past it,
+    // fall through and re-attempt the backend so recovery is automatic.
+    if (fallbackConfig && Date.now() < fallbackRetryAt) {
+        return fallbackConfig;
     }
 
     // Resolved outside the try: a missing SITE_BACKEND must surface as a
@@ -136,8 +171,11 @@ export async function getServerConfig(): Promise<RuntimeConfig> {
             throw new Error('Invalid config response format');
         }
 
-        // Cache the config for container lifetime
+        // Cache the live config for container lifetime and clear any prior
+        // degraded fallback so subsequent requests stop serving it.
         cachedConfig = data.config;
+        fallbackConfig = null;
+        fallbackRetryAt = 0;
         console.log('[ServerConfig] Fetched and cached runtime config from backend:', data.config.siteUrl);
 
         return data.config;
@@ -147,7 +185,7 @@ export async function getServerConfig(): Promise<RuntimeConfig> {
 
         const siteUrl = process.env.SITE_URL || 'http://localhost:3000';
 
-        const fallbackConfig: RuntimeConfig = {
+        const degraded: RuntimeConfig = {
             siteUrl: siteUrl.replace(/\/$/, ''),
             apiUrl: `${backendUrl}/api`.replace(/\/$/, ''),
             socketUrl: backendUrl.replace(/\/$/, ''),
@@ -164,10 +202,14 @@ export async function getServerConfig(): Promise<RuntimeConfig> {
             isUsingFallback: true
         };
 
-        // Cache the fallback config (don't retry every request)
-        cachedConfig = fallbackConfig;
+        // Cache the fallback ONLY briefly. Unlike the live config it is never
+        // latched for the container lifetime — once the window elapses the
+        // next request retries the backend, so a transient blip cannot poison
+        // the frontend until a manual restart.
+        fallbackConfig = degraded;
+        fallbackRetryAt = Date.now() + FALLBACK_RETRY_MS;
 
-        return fallbackConfig;
+        return degraded;
     }
 }
 
@@ -181,4 +223,6 @@ export async function getServerConfig(): Promise<RuntimeConfig> {
  */
 export function clearServerConfigCache(): void {
     cachedConfig = null;
+    fallbackConfig = null;
+    fallbackRetryAt = 0;
 }

--- a/src/frontend/lib/serverConfig.ts
+++ b/src/frontend/lib/serverConfig.ts
@@ -116,6 +116,19 @@ let fallbackRetryAt = 0;
 const FALLBACK_RETRY_MS = 10_000;
 
 /**
+ * In-flight fetch shared by concurrent callers to prevent a cache stampede.
+ *
+ * Next.js invokes getServerConfig() once per SSR request. During cold start —
+ * or every FALLBACK_RETRY_MS tick while the backend is down — many requests
+ * arrive before cachedConfig or the fallback window is populated. Without
+ * deduplication each would open its own /api/config/public fetch, stacking N
+ * five-second timeouts and hammering a backend that is already struggling.
+ * Holding the single in-flight promise here collapses that burst into one
+ * fetch; it is cleared in the finally below so the next window can retry.
+ */
+let activeFetchPromise: Promise<RuntimeConfig> | null = null;
+
+/**
  * Fetches runtime configuration from backend and caches it.
  *
  * Flow:
@@ -150,67 +163,83 @@ export async function getServerConfig(): Promise<RuntimeConfig> {
         return fallbackConfig;
     }
 
+    // Join an already in-flight fetch instead of opening a duplicate. This is
+    // what bounds an outage to one retry per FALLBACK_RETRY_MS window even
+    // under concurrent SSR traffic — without it, every request that clears the
+    // two guards above would race its own fetch.
+    if (activeFetchPromise) {
+        return activeFetchPromise;
+    }
+
     // Resolved outside the try: a missing SITE_BACKEND must surface as a
     // deployment error, not degrade into the unreachable-backend fallback.
     // Trailing-slash normalization happens inside getServerSideApiUrl().
     const backendUrl = getServerSideApiUrl();
 
-    try {
-        const response = await fetch(`${backendUrl}/api/config/public`, {
-            cache: 'no-store', // Don't let Next.js cache this (we cache manually)
-            signal: AbortSignal.timeout(5000) // 5 second timeout
-        });
+    activeFetchPromise = (async () => {
+        try {
+            const response = await fetch(`${backendUrl}/api/config/public`, {
+                cache: 'no-store', // Don't let Next.js cache this (we cache manually)
+                signal: AbortSignal.timeout(5000) // 5 second timeout
+            });
 
-        if (!response.ok) {
-            throw new Error(`Config fetch failed: ${response.status}`);
+            if (!response.ok) {
+                throw new Error(`Config fetch failed: ${response.status}`);
+            }
+
+            const data = await response.json();
+
+            if (!data.success || !data.config) {
+                throw new Error('Invalid config response format');
+            }
+
+            // Cache the live config for container lifetime and clear any prior
+            // degraded fallback so subsequent requests stop serving it.
+            cachedConfig = data.config;
+            fallbackConfig = null;
+            fallbackRetryAt = 0;
+            console.log('[ServerConfig] Fetched and cached runtime config from backend:', data.config.siteUrl);
+
+            return data.config;
+        } catch (error) {
+            // Backend unreachable — degrade so SSR keeps rendering.
+            console.warn('[ServerConfig] Failed to fetch runtime config, using fallback:', error);
+
+            const siteUrl = process.env.SITE_URL || 'http://localhost:3000';
+
+            const degraded: RuntimeConfig = {
+                siteUrl: siteUrl.replace(/\/$/, ''),
+                apiUrl: `${backendUrl}/api`.replace(/\/$/, ''),
+                socketUrl: backendUrl.replace(/\/$/, ''),
+                chainParameters: {
+                    totalEnergyLimit: 180_000_000_000,
+                    totalEnergyCurrentLimit: 180_000_000_000,
+                    totalFrozenForEnergy: 19_000_000_000_000_000, // ~19B TRX staked for energy (network average)
+                    energyPerTrx: 9.5, // 180B / 19B TRX (live network ratio)
+                    energyFee: 100,
+                    totalBandwidthLimit: 43_200_000_000,
+                    totalFrozenForBandwidth: 27_000_000_000_000_000, // ~27B TRX staked for bandwidth (network average)
+                    bandwidthPerTrx: 1.6 // 43.2B / 27B TRX (live network ratio)
+                },
+                isUsingFallback: true
+            };
+
+            // Cache the fallback ONLY briefly. Unlike the live config it is never
+            // latched for the container lifetime — once the window elapses the
+            // next request retries the backend, so a transient blip cannot poison
+            // the frontend until a manual restart.
+            fallbackConfig = degraded;
+            fallbackRetryAt = Date.now() + FALLBACK_RETRY_MS;
+
+            return degraded;
+        } finally {
+            // Release the shared promise so the next window (success latches
+            // cachedConfig; failure latches the fallback window) can retry.
+            activeFetchPromise = null;
         }
+    })();
 
-        const data = await response.json();
-
-        if (!data.success || !data.config) {
-            throw new Error('Invalid config response format');
-        }
-
-        // Cache the live config for container lifetime and clear any prior
-        // degraded fallback so subsequent requests stop serving it.
-        cachedConfig = data.config;
-        fallbackConfig = null;
-        fallbackRetryAt = 0;
-        console.log('[ServerConfig] Fetched and cached runtime config from backend:', data.config.siteUrl);
-
-        return data.config;
-    } catch (error) {
-        // Backend unreachable — degrade so SSR keeps rendering.
-        console.warn('[ServerConfig] Failed to fetch runtime config, using fallback:', error);
-
-        const siteUrl = process.env.SITE_URL || 'http://localhost:3000';
-
-        const degraded: RuntimeConfig = {
-            siteUrl: siteUrl.replace(/\/$/, ''),
-            apiUrl: `${backendUrl}/api`.replace(/\/$/, ''),
-            socketUrl: backendUrl.replace(/\/$/, ''),
-            chainParameters: {
-                totalEnergyLimit: 180_000_000_000,
-                totalEnergyCurrentLimit: 180_000_000_000,
-                totalFrozenForEnergy: 19_000_000_000_000_000, // ~19B TRX staked for energy (network average)
-                energyPerTrx: 9.5, // 180B / 19B TRX (live network ratio)
-                energyFee: 100,
-                totalBandwidthLimit: 43_200_000_000,
-                totalFrozenForBandwidth: 27_000_000_000_000_000, // ~27B TRX staked for bandwidth (network average)
-                bandwidthPerTrx: 1.6 // 43.2B / 27B TRX (live network ratio)
-            },
-            isUsingFallback: true
-        };
-
-        // Cache the fallback ONLY briefly. Unlike the live config it is never
-        // latched for the container lifetime — once the window elapses the
-        // next request retries the backend, so a transient blip cannot poison
-        // the frontend until a manual restart.
-        fallbackConfig = degraded;
-        fallbackRetryAt = Date.now() + FALLBACK_RETRY_MS;
-
-        return degraded;
-    }
+    return activeFetchPromise;
 }
 
 /**
@@ -225,4 +254,5 @@ export function clearServerConfigCache(): void {
     cachedConfig = null;
     fallbackConfig = null;
     fallbackRetryAt = 0;
+    activeFetchPromise = null;
 }


### PR DESCRIPTION
## Summary

`getServerConfig()` previously cached the degraded fallback config for the container's lifetime whenever the backend was momentarily unreachable during the lazy first SSR fetch. Because the fallback points the client at the internal backend URL (e.g. `http://backend:4000`), a single transient backend blip would poison every client with unreachable, mixed-content URLs until someone manually restarted the frontend.

This change stores only a *successful* fetch for the container lifetime. The degraded fallback is cached for just `FALLBACK_RETRY_MS` (10s) and the backend is retried on the next request, so the frontend self-heals within seconds of the backend recovering. A successful fetch clears any prior fallback.

It also tightens the backend healthcheck to gate on `/api/config/public` actually returning a `siteUrl` rather than mere process liveness, so the frontend's `depends_on: service_healthy` waits until runtime config is genuinely ready.