### PR TITLE
feat(widgets): operator-settable titleUrl to link widget headings

### DIFF
--- a/docs/plugins/plugins-widget-zones-registration.md
+++ b/docs/plugins/plugins-widget-zones-registration.md
@@ -8,7 +8,7 @@ Getting registration wrong fails in operator-visible ways: the widget never appe
 
 ## What You Register
 
-A plugin registers a **widget type** — an id, label, a `defaultDataFetcher`, and default placement parameters (zone, routes, order, optional title). The platform stores the type descriptor in an in-memory type registry and upserts a `source: 'plugin'` row into `module_widgets_placements` keyed by `(typeId, pluginId)`. From that point forward the placement is operator-owned: `zoneId`, `routes`, `order`, `title`, `instanceConfig`, and `enabled` are all overridable through `/system/widgets`. The plugin's stated defaults are cached so an operator can revert via restore-defaults.
+A plugin registers a **widget type** — an id, label, a `defaultDataFetcher`, and default placement parameters (zone, routes, order, optional title). The platform stores the type descriptor in an in-memory type registry and upserts a `source: 'plugin'` row into `module_widgets_placements` keyed by `(typeId, pluginId)`. From that point forward the placement is operator-owned: `zoneId`, `routes`, `order`, `title`, `titleUrl`, `instanceConfig`, and `enabled` are all overridable through `/system/widgets`. The plugin's stated defaults are cached so an operator can revert via restore-defaults.
 
 A plugin may *additionally* register **zones** if it wants to expose new injection points other plugins (or operators) can target. Zones are runtime-only — they live for the plugin's enabled lifetime and disappear on disable. Most plugins consume zones rather than declare them.
 
@@ -82,7 +82,7 @@ widgets.registerType({
 
 ## Operator Overrides
 
-Once a plugin-source row exists, the operator can edit it from `/system/widgets`. Editable fields are `zoneId`, `routes`, `order`, `title`, `instanceConfig`, and `enabled`. The plugin's original `registerWidget(input, ownerId)` arguments are cached in process so the operator can revert via the restore-defaults action — which resets everything except the row's id and `createdAt`. Operators can also create entirely new placements of the same widget type pointing at different zones or routes; those new rows are `source: 'operator'` and can be deleted outright.
+Once a plugin-source row exists, the operator can edit it from `/system/widgets`. Editable fields are `zoneId`, `routes`, `order`, `title`, `titleUrl`, `instanceConfig`, and `enabled`. The plugin's original `registerWidget(input, ownerId)` arguments are cached in process so the operator can revert via the restore-defaults action — which resets everything except the row's id and `createdAt`. Operators can also create entirely new placements of the same widget type pointing at different zones or routes; those new rows are `source: 'operator'` and can be deleted outright.
 
 Treat the values in `IRegisterWidgetInput` as *defaults*, not invariants. Anything an operator might reasonably want to retarget — zone, route filter, order, instance config — belongs in those defaults rather than hardcoded in the data fetcher.
 

--- a/docs/system/system-api-widgets.md
+++ b/docs/system/system-api-widgets.md
@@ -60,6 +60,7 @@ The placements controller refuses input on any of:
 - `routes` entry that doesn't start with `/`, contains whitespace, or carries a glob marker outside the trailing segment.
 - `order` outside `[0, 10000]`, non-integer, or non-finite.
 - `title` empty after trim, or longer than 80 characters. Pass `title: null` on PATCH to clear an existing override (`$unset`).
+- `titleUrl` not a root-relative internal path (must start with a single `/`; protocol-relative, absolute, or scheme URLs are rejected), or longer than 512 characters. Pass `titleUrl: null` on PATCH to clear the heading link (`$unset`).
 - `instanceConfig` not a plain object.
 
 ## Route Pattern Grammar

--- a/packages/types/src/widget-placements/IPlacementService.ts
+++ b/packages/types/src/widget-placements/IPlacementService.ts
@@ -41,12 +41,17 @@ export interface IPlacementListFilter {
  * Omitting `title` from the patch leaves the existing value unchanged.
  * `title: ''` is rejected at the controller boundary so blank cannot
  * sneak in through clients that drop empty strings.
+ *
+ * `titleUrl` follows the same three-state convention as `title`:
+ * a string sets the heading link, `null` clears it (`$unset`), and
+ * omission leaves it unchanged.
  */
 export interface IPlacementPatch {
     zoneId?: string;
     routes?: string[];
     order?: number;
     title?: string | null;
+    titleUrl?: string | null;
     instanceConfig?: Record<string, unknown>;
     enabled?: boolean;
 }

--- a/packages/types/src/widget-placements/IWidgetPlacement.ts
+++ b/packages/types/src/widget-placements/IWidgetPlacement.ts
@@ -49,6 +49,15 @@ export interface IWidgetPlacement {
     /** Optional heading rendered above the widget. */
     readonly title?: string;
     /**
+     * Optional root-relative URL that turns the rendered heading into a
+     * link. Operator-only state — plugins never seed it. Only honoured
+     * when {@link title} is also set, since the host chrome links the
+     * title text. Validated at the admin boundary to a single-leading-
+     * slash internal path (e.g. `/markets`); absolute or off-site URLs
+     * are rejected.
+     */
+    readonly titleUrl?: string;
+    /**
      * Per-instance configuration the widget type's data fetcher /
      * component may consume. Validated against the type's
      * `configSchema` if provided (admin UI concern, forthcoming).
@@ -76,6 +85,8 @@ export interface IPlacementInput {
     routes: string[];
     order?: number;
     title?: string;
+    /** Optional root-relative link target for the heading. See {@link IWidgetPlacement.titleUrl}. */
+    titleUrl?: string;
     instanceConfig?: Record<string, unknown>;
     enabled?: boolean;
 }

--- a/packages/types/src/widget/IWidgetData.ts
+++ b/packages/types/src/widget/IWidgetData.ts
@@ -34,6 +34,14 @@ export interface IWidgetData {
     title?: string;
 
     /**
+     * Optional root-relative URL that turns the rendered title into a
+     * link. Carried verbatim from the resolved placement; only takes
+     * effect when `title` is also present, since the host chrome links
+     * the title text.
+     */
+    titleUrl?: string;
+
+    /**
      * Pre-fetched data for SSR rendering.
      *
      * This is the result of calling the widget's fetchData() function.

--- a/src/backend/modules/widgets/README.md
+++ b/src/backend/modules/widgets/README.md
@@ -71,7 +71,7 @@ All endpoints require admin auth (cookie path: verified wallet + admin group; se
 | GET | `/api/admin/system/widgets/placements` | — | `{ success, placements: IWidgetPlacement[] }` | Query: `zoneId?`, `pluginId?`, `source?` (`plugin`\|`operator`), `enabledOnly?` |
 | GET | `/api/admin/system/widgets/placements/:id` | — | `{ success, placement }` or 404 | |
 | POST | `/api/admin/system/widgets/placements` | `IPlacementInput` | `{ success, placement }` 201 | Always `source: 'operator'`; rejects unknown `typeId`/`zoneId` |
-| PATCH | `/api/admin/system/widgets/placements/:id` | `IPlacementPatch` | `{ success, placement }` or 404 | Operator-editable on every row, including plugin-source. `title: null` clears the override |
+| PATCH | `/api/admin/system/widgets/placements/:id` | `IPlacementPatch` | `{ success, placement }` or 404 | Operator-editable on every row, including plugin-source. `title: null` / `titleUrl: null` clears that field; `titleUrl` must be a root-relative internal path |
 | DELETE | `/api/admin/system/widgets/placements/:id` | — | 204 / 400 / 404 | 400 on plugin-source rows (use disable or restore-defaults) |
 | POST | `/api/admin/system/widgets/placements/:id/restore-defaults` | — | `{ success, placement }` | 400 on operator rows; 409 when plugin has not registered in this process |
 
@@ -115,6 +115,7 @@ The placement service emits via a callback `WidgetsModule.init()` wires to `WebS
 | `routes` | string[] | Route filter — empty matches every route |
 | `order` | number | Sort key within zone (lower renders first); plugin default `100` |
 | `title` | string? | Operator override of widget heading |
+| `titleUrl` | string? | Operator-only root-relative URL that links the heading; only renders when `title` is set |
 | `instanceConfig` | object? | Per-instance config; the type's data fetcher consumes it |
 | `enabled` | boolean | `false` hides the row at SSR resolve |
 | `source` | `'plugin'` \| `'operator'` | Discriminator; controls disable vs. delete semantics |
@@ -127,9 +128,9 @@ Indexes (migration 001): `(typeId, pluginId)` sparse unique for plugin-row atomi
 
 **Plugin enable** — Plugin code calls `widgets.registerWidget(input, pluginId)` during `init()`. The service caches the original args under `${pluginId}::${typeId}` (for restore-defaults), mints a type descriptor via `defineWidgetType` and stores it in the type registry, then calls `placementService.ensurePluginPlacement(...)` which upserts the row with `enabled: true` while preserving operator customisations on existing rows via `$setOnInsert`.
 
-**Plugin disable** — `PluginManagerService` looks up the widgets service from the registry and calls `widgets.unregisterAllForOwner(pluginId)`, which soft-disables every plugin-source placement, disposes every owned widget type, and disposes every owned zone. Placement rows stay in MongoDB; operator customisations to `order`, `routes`, `title`, `instanceConfig` survive the next enable. The plugin-default cache is *not* cleared so restore-defaults continues to work on soft-disabled rows.
+**Plugin disable** — `PluginManagerService` looks up the widgets service from the registry and calls `widgets.unregisterAllForOwner(pluginId)`, which soft-disables every plugin-source placement, disposes every owned widget type, and disposes every owned zone. Placement rows stay in MongoDB; operator customisations to `order`, `routes`, `title`, `titleUrl`, `instanceConfig` survive the next enable. The plugin-default cache is *not* cleared so restore-defaults continues to work on soft-disabled rows.
 
-**Operator create/edit/delete** — flows through the admin REST endpoints, which adapt to `IWidgetsService` methods. Operator-source rows go in with `source: 'operator'` and no `pluginId`. Plugin-source rows can be patched (order, routes, title, enabled) but not deleted via the API.
+**Operator create/edit/delete** — flows through the admin REST endpoints, which adapt to `IWidgetsService` methods. Operator-source rows go in with `source: 'operator'` and no `pluginId`. Plugin-source rows can be patched (order, routes, title, titleUrl, instanceConfig, enabled) but not deleted via the API.
 
 **Restore-defaults** — only valid on plugin-source rows. The service looks up cached registration args by `(pluginId, typeId)` and applies them atomically via `placementService.restoreToPluginDefaults(id, defaults)`; the row's id and `createdAt` survive. Cache misses (plugin never registered this process) throw with a message that translates to HTTP 409 — re-enable the plugin to repopulate.
 

--- a/src/backend/modules/widgets/__tests__/placements.controller.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.controller.test.ts
@@ -315,6 +315,26 @@ describe('PlacementsController titleUrl validation', () => {
         expect(widgets.createPlacement).not.toHaveBeenCalled();
     });
 
+    it.each([
+        '/..//evil.example.com',
+        '/abc/..//evil.example.com',
+        '/markets//holdings'
+    ])('rejects a titleUrl with a traversal or double-slash bypass: %s', async (titleUrl) => {
+        widgets = buildWidgetsServiceStub({
+            createPlacement: vi.fn(async () => { throw new Error('should not reach service'); })
+        });
+        controller = new PlacementsController(widgets, logger);
+
+        const req = {
+            body: { ...validCreateBody, titleUrl }
+        } as Request;
+
+        await controller.createPlacement(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(widgets.createPlacement).not.toHaveBeenCalled();
+    });
+
     it('accepts an internal root-relative titleUrl and forwards it to the service', async () => {
         widgets = buildWidgetsServiceStub({
             createPlacement: vi.fn(async () => ({ id: 'new-id' } as IWidgetPlacement))

--- a/src/backend/modules/widgets/__tests__/placements.controller.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.controller.test.ts
@@ -272,3 +272,83 @@ describe('PlacementsController instanceConfig schema validation', () => {
         });
     });
 });
+
+describe('PlacementsController titleUrl validation', () => {
+    let widgets: IWidgetsService;
+    let logger: ISystemLogService;
+    let controller: PlacementsController;
+    let res: ReturnType<typeof buildResponseStub>;
+
+    beforeEach(() => {
+        logger = buildLoggerStub();
+        res = buildResponseStub();
+    });
+
+    it('rejects an off-site titleUrl with 400 and never reaches the service', async () => {
+        widgets = buildWidgetsServiceStub({
+            createPlacement: vi.fn(async () => { throw new Error('should not reach service'); })
+        });
+        controller = new PlacementsController(widgets, logger);
+
+        const req = {
+            body: { ...validCreateBody, titleUrl: 'https://evil.example.com' }
+        } as Request;
+
+        await controller.createPlacement(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json.mock.calls[0][0].error).toMatch(/titleUrl/);
+        expect(widgets.createPlacement).not.toHaveBeenCalled();
+    });
+
+    it('rejects a protocol-relative titleUrl', async () => {
+        widgets = buildWidgetsServiceStub();
+        controller = new PlacementsController(widgets, logger);
+
+        const req = {
+            body: { ...validCreateBody, titleUrl: '//evil.example.com' }
+        } as Request;
+
+        await controller.createPlacement(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(widgets.createPlacement).not.toHaveBeenCalled();
+    });
+
+    it('accepts an internal root-relative titleUrl and forwards it to the service', async () => {
+        widgets = buildWidgetsServiceStub({
+            createPlacement: vi.fn(async () => ({ id: 'new-id' } as IWidgetPlacement))
+        });
+        controller = new PlacementsController(widgets, logger);
+
+        const req = {
+            body: { ...validCreateBody, titleUrl: '/markets?tab=energy' }
+        } as Request;
+
+        await controller.createPlacement(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(201);
+        expect(widgets.createPlacement).toHaveBeenCalledWith(
+            expect.objectContaining({ titleUrl: '/markets?tab=energy' })
+        );
+    });
+
+    it('forwards titleUrl: null on patch as an explicit clear signal', async () => {
+        widgets = buildWidgetsServiceStub({
+            updatePlacement: vi.fn(async () => ({ id: 'p1' } as IWidgetPlacement))
+        });
+        controller = new PlacementsController(widgets, logger);
+
+        const req = {
+            params: { id: 'p1' },
+            body: { titleUrl: null }
+        } as unknown as Request;
+
+        await controller.updatePlacement(req, res);
+
+        expect(widgets.updatePlacement).toHaveBeenCalledWith(
+            'p1',
+            expect.objectContaining({ titleUrl: null })
+        );
+    });
+});

--- a/src/backend/modules/widgets/__tests__/placements.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.test.ts
@@ -361,6 +361,25 @@ describe('PlacementService CRUD', () => {
         expect(cleared?.title).toBeUndefined();
     });
 
+    it('persists titleUrl on create and clears it with titleUrl: null', async () => {
+        const placement = await service.create({
+            typeId: 't',
+            zoneId: 'main-after',
+            routes: ['/'],
+            title: 'Operator Title',
+            titleUrl: '/markets'
+        });
+        expect(placement.titleUrl).toBe('/markets');
+
+        const updated = await service.update(placement.id, { titleUrl: '/u/TXyz' });
+        expect(updated?.titleUrl).toBe('/u/TXyz');
+
+        const cleared = await service.update(placement.id, { titleUrl: null });
+        expect(cleared?.titleUrl).toBeUndefined();
+        // Clearing the link leaves the title intact.
+        expect(cleared?.title).toBe('Operator Title');
+    });
+
     it('update preserves untouched fields', async () => {
         const placement = await service.create({
             typeId: 't',

--- a/src/backend/modules/widgets/api/placements.controller.ts
+++ b/src/backend/modules/widgets/api/placements.controller.ts
@@ -61,6 +61,25 @@ const MAX_ORDER = 10_000;
 const MAX_TITLE_LENGTH = 80;
 
 /**
+ * Upper bound on a placement `titleUrl` length. Internal paths are
+ * short by nature; 512 leaves ample room for query strings and hash
+ * fragments without inviting pathological inputs.
+ */
+const MAX_TITLE_URL_LENGTH = 512;
+
+/**
+ * Format gate for a placement `titleUrl`. The heading link is
+ * internal-only: the value must be a single-leading-slash root-relative
+ * path (e.g. `/markets`, `/u/TXyz?tab=holdings#summary`). The negative
+ * lookahead rejects protocol-relative (`//host`) and the backslash
+ * trick (`/\host`) that browsers normalise to off-site navigation;
+ * forbidding whitespace and backslash anywhere blocks header/newline
+ * injection. A leading `/` makes scheme URIs (`javascript:`, `data:`)
+ * structurally impossible, so no separate scheme blocklist is needed.
+ */
+const INTERNAL_PATH_PATTERN = /^\/(?![/\\])[^\s\\]*$/;
+
+/**
  * Format gate for zone ids. Lowercase-dotted (letters, digits,
  * hyphens, underscores, colons for namespaced cases), starts with a
  * letter, max 64 chars. Anything else is malformed input and must not
@@ -359,7 +378,7 @@ export class PlacementsController {
     };
 
     private parseCreateBody(body: unknown):
-        | { input: { typeId: string; zoneId: string; routes: string[]; order?: number; title?: string; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
+        | { input: { typeId: string; zoneId: string; routes: string[]; order?: number; title?: string; titleUrl?: string; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
         | { error: string } {
         if (!body || typeof body !== 'object') {
             return { error: 'Request body must be an object' };
@@ -389,6 +408,9 @@ export class PlacementsController {
         const titleResult = this.parseTitle(b.title);
         if ('error' in titleResult) return titleResult;
 
+        const titleUrlResult = this.parseTitleUrl(b.titleUrl);
+        if ('error' in titleUrlResult) return titleUrlResult;
+
         const instanceConfigResult = this.parseInstanceConfig(b.instanceConfig);
         if ('error' in instanceConfigResult) return instanceConfigResult;
 
@@ -401,6 +423,7 @@ export class PlacementsController {
                 routes: routesResult.routes,
                 order: orderResult.order,
                 title: titleResult.title,
+                titleUrl: titleUrlResult.titleUrl,
                 instanceConfig: instanceConfigResult.instanceConfig,
                 enabled
             }
@@ -408,13 +431,13 @@ export class PlacementsController {
     }
 
     private parsePatchBody(body: unknown):
-        | { patch: { zoneId?: string; routes?: string[]; order?: number; title?: string | null; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
+        | { patch: { zoneId?: string; routes?: string[]; order?: number; title?: string | null; titleUrl?: string | null; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
         | { error: string } {
         if (!body || typeof body !== 'object') {
             return { error: 'Request body must be an object' };
         }
         const b = body as Record<string, unknown>;
-        const patch: { zoneId?: string; routes?: string[]; order?: number; title?: string | null; instanceConfig?: Record<string, unknown>; enabled?: boolean } = {};
+        const patch: { zoneId?: string; routes?: string[]; order?: number; title?: string | null; titleUrl?: string | null; instanceConfig?: Record<string, unknown>; enabled?: boolean } = {};
 
         if (b.zoneId !== undefined) {
             if (typeof b.zoneId !== 'string' || b.zoneId.length === 0) {
@@ -445,6 +468,16 @@ export class PlacementsController {
                 const result = this.parseTitle(b.title);
                 if ('error' in result) return result;
                 patch.title = result.title;
+            }
+        }
+
+        if (b.titleUrl !== undefined) {
+            if (b.titleUrl === null) {
+                patch.titleUrl = null;
+            } else {
+                const result = this.parseTitleUrl(b.titleUrl);
+                if ('error' in result) return result;
+                patch.titleUrl = result.titleUrl;
             }
         }
 
@@ -509,6 +542,30 @@ export class PlacementsController {
             return { error: `title must be at most ${MAX_TITLE_LENGTH} characters` };
         }
         return { title: trimmed };
+    }
+
+    /**
+     * Validate a `titleUrl` heading link. Accepts only internal,
+     * root-relative paths — see {@link INTERNAL_PATH_PATTERN} for the
+     * rejected forms. Returns the trimmed value, or a structured error
+     * the caller maps to a 400.
+     */
+    private parseTitleUrl(value: unknown): { titleUrl?: string } | { error: string } {
+        if (value === undefined) return { titleUrl: undefined };
+        if (typeof value !== 'string') {
+            return { error: 'titleUrl must be a string' };
+        }
+        const trimmed = value.trim();
+        if (trimmed.length === 0) {
+            return { error: 'titleUrl must be non-empty when provided' };
+        }
+        if (trimmed.length > MAX_TITLE_URL_LENGTH) {
+            return { error: `titleUrl must be at most ${MAX_TITLE_URL_LENGTH} characters` };
+        }
+        if (!INTERNAL_PATH_PATTERN.test(trimmed)) {
+            return { error: "titleUrl must be a root-relative path beginning with '/' (e.g. '/markets'); absolute or off-site URLs are not allowed" };
+        }
+        return { titleUrl: trimmed };
     }
 
     private parseInstanceConfig(value: unknown):

--- a/src/backend/modules/widgets/api/placements.controller.ts
+++ b/src/backend/modules/widgets/api/placements.controller.ts
@@ -74,10 +74,14 @@ const MAX_TITLE_URL_LENGTH = 512;
  * lookahead rejects protocol-relative (`//host`) and the backslash
  * trick (`/\host`) that browsers normalise to off-site navigation;
  * forbidding whitespace and backslash anywhere blocks header/newline
- * injection. A leading `/` makes scheme URIs (`javascript:`, `data:`)
+ * injection. The `(?!.*\/\/)` and `(?!.*\.\.)` guards forbid a `//`
+ * sequence or `..` traversal segment *anywhere* in the value, closing
+ * the normalisation bypass where `/..//evil.com` collapses to the
+ * protocol-relative `//evil.com` once a client resolves dot segments.
+ * A leading `/` makes scheme URIs (`javascript:`, `data:`)
  * structurally impossible, so no separate scheme blocklist is needed.
  */
-const INTERNAL_PATH_PATTERN = /^\/(?![/\\])[^\s\\]*$/;
+const INTERNAL_PATH_PATTERN = /^\/(?![/\\])(?!.*\/\/)(?!.*\.\.)[^\s\\]*$/;
 
 /**
  * Format gate for zone ids. Lowercase-dotted (letters, digits,

--- a/src/backend/modules/widgets/database/IWidgetPlacementDocument.ts
+++ b/src/backend/modules/widgets/database/IWidgetPlacementDocument.ts
@@ -23,8 +23,8 @@ import type { PlacementSource } from '@/types';
  * Placements survive plugin disable/re-enable cycles because plugin
  * lifecycle calls `softDisable` (flip `enabled: false`) rather than
  * deleting rows. Operator customisations to `order`, `routes`,
- * `title`, or `instanceConfig` therefore persist across plugin
- * lifecycle events. Hard delete is reserved for the admin API.
+ * `title`, `titleUrl`, or `instanceConfig` therefore persist across
+ * plugin lifecycle events. Hard delete is reserved for the admin API.
  */
 export interface IWidgetPlacementDocument {
     _id: ObjectId;
@@ -38,6 +38,8 @@ export interface IWidgetPlacementDocument {
     order: number;
     /** Optional heading rendered above the widget. */
     title?: string;
+    /** Optional root-relative URL linking the heading. Operator-only. */
+    titleUrl?: string;
     /** Per-instance configuration. */
     instanceConfig?: Record<string, unknown>;
     /** Whether the placement currently renders. */

--- a/src/backend/modules/widgets/placements/placement-resolver.ts
+++ b/src/backend/modules/widgets/placements/placement-resolver.ts
@@ -151,6 +151,7 @@ export class PlacementResolver {
                 pluginId: owner,
                 order: placement.order,
                 title: placement.title,
+                titleUrl: placement.titleUrl,
                 data,
                 // Forward the same instance config the fetcher received so
                 // the frontend component can branch on it. Mirror the

--- a/src/backend/modules/widgets/placements/placement.service.ts
+++ b/src/backend/modules/widgets/placements/placement.service.ts
@@ -295,6 +295,7 @@ export class PlacementService implements IPlacementService {
             updatedAt: now
         };
         if (input.title !== undefined) doc.title = input.title;
+        if (input.titleUrl !== undefined) doc.titleUrl = input.titleUrl;
         if (input.instanceConfig !== undefined) doc.instanceConfig = input.instanceConfig;
         if (source === 'plugin' && options.pluginId !== undefined) doc.pluginId = options.pluginId;
 
@@ -324,6 +325,13 @@ export class PlacementService implements IPlacementService {
             unsetOps.title = '';
         } else if (patch.title !== undefined) {
             setOps.title = patch.title;
+        }
+        if (patch.titleUrl === null) {
+            // Explicit unset signal — drop the heading link so the
+            // title renders as plain text again.
+            unsetOps.titleUrl = '';
+        } else if (patch.titleUrl !== undefined) {
+            setOps.titleUrl = patch.titleUrl;
         }
         if (patch.instanceConfig !== undefined) setOps.instanceConfig = patch.instanceConfig;
         if (patch.enabled !== undefined) setOps.enabled = patch.enabled;
@@ -368,10 +376,11 @@ export class PlacementService implements IPlacementService {
      * restore from a plain update.
      *
      * @param id - Placement id (stringified ObjectId).
-     * @param defaults - Plugin defaults to apply. `instanceConfig` is
-     *   not part of plugin registration args — it is operator state —
-     *   so it is intentionally absent from the input. The row's
-     *   existing `instanceConfig` survives restore.
+     * @param defaults - Plugin defaults to apply. `instanceConfig` and
+     *   `titleUrl` are not part of plugin registration args — they are
+     *   operator state — so they are intentionally absent from the
+     *   input. The row's existing `instanceConfig` and `titleUrl`
+     *   survive restore.
      * @returns Updated placement, or null when no row matches.
      */
     async restoreToPluginDefaults(
@@ -458,6 +467,7 @@ function toPublic(doc: IWidgetPlacementDocument): IWidgetPlacement {
         routes: doc.routes,
         order: doc.order,
         title: doc.title,
+        titleUrl: doc.titleUrl,
         instanceConfig: doc.instanceConfig,
         enabled: doc.enabled,
         source: doc.source,

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -78,6 +78,7 @@ interface IPlacement {
     routes: string[];
     order: number;
     title?: string;
+    titleUrl?: string;
     instanceConfig?: Record<string, unknown>;
     enabled: boolean;
     source: 'plugin' | 'operator';
@@ -88,13 +89,15 @@ interface IPlacement {
 
 /**
  * Patch shape sent to PATCH /placements/:id. `title: null` is the
- * explicit unset signal honored server-side as `$unset: { title }`.
+ * explicit unset signal honored server-side as `$unset: { title }`;
+ * `titleUrl: null` clears the heading link the same way.
  */
 interface IPlacementPatch {
     zoneId?: string;
     routes?: string[];
     order?: number;
     title?: string | null | undefined;
+    titleUrl?: string | null | undefined;
     instanceConfig?: Record<string, unknown>;
     enabled?: boolean;
 }
@@ -109,6 +112,7 @@ interface IPlacementCreate {
     routes: string[];
     order?: number;
     title?: string;
+    titleUrl?: string;
     instanceConfig?: Record<string, unknown>;
     enabled?: boolean;
 }
@@ -1187,6 +1191,7 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
     const [routeDraft, setRouteDraft] = useState<string>('');
     const [order, setOrder] = useState<number>(initial?.order ?? 100);
     const [title, setTitle] = useState<string>(initial?.title ?? '');
+    const [titleUrl, setTitleUrl] = useState<string>(initial?.titleUrl ?? '');
     const [enabled, setEnabled] = useState<boolean>(initial?.enabled ?? true);
     const [saving, setSaving] = useState<boolean>(false);
     const [routeError, setRouteError] = useState<string | null>(null);
@@ -1371,6 +1376,7 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
                         routes,
                         order,
                         title: title.trim().length > 0 ? title.trim() : undefined,
+                        titleUrl: titleUrl.trim().length > 0 ? titleUrl.trim() : undefined,
                         instanceConfig: parsedInstanceConfig,
                         enabled
                     };
@@ -1390,11 +1396,23 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
                             : hadInitialTitle
                                 ? null
                                 : undefined;
+                    // titleUrl follows the same three-state convention
+                    // as title: set when non-empty, explicit null clear
+                    // when blanked after having a value, omit otherwise.
+                    const trimmedTitleUrl = titleUrl.trim();
+                    const hadInitialTitleUrl = typeof initial?.titleUrl === 'string' && initial.titleUrl.length > 0;
+                    const titleUrlPatch: string | null | undefined =
+                        trimmedTitleUrl.length > 0
+                            ? trimmedTitleUrl
+                            : hadInitialTitleUrl
+                                ? null
+                                : undefined;
                     const payload: IPlacementPatch = {
                         zoneId,
                         routes,
                         order,
                         title: titlePatch,
+                        titleUrl: titleUrlPatch,
                         instanceConfig: parsedInstanceConfig,
                         enabled
                     };
@@ -1404,7 +1422,7 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
                 setSaving(false);
             }
         },
-        [configFields, configValue, enabled, initial?.title, mode, onSubmit, order, rawMode, rawText, routes, title, typeId, zoneId]
+        [configFields, configValue, enabled, initial?.title, initial?.titleUrl, mode, onSubmit, order, rawMode, rawText, routes, title, titleUrl, typeId, zoneId]
     );
 
     const canSubmit = typeId.length > 0 && zoneId.length > 0;
@@ -1528,6 +1546,20 @@ function PlacementForm({ mode, initial, types, zones, onSubmit, onCancel }: Plac
                         maxLength={80}
                         disabled={saving}
                     />
+                </div>
+                <div className={styles.field}>
+                    <label htmlFor="wp-title-url">Title link</label>
+                    <Input
+                        id="wp-title-url"
+                        value={titleUrl}
+                        onChange={(e) => setTitleUrl(e.target.value)}
+                        placeholder="/markets (optional)"
+                        maxLength={512}
+                        disabled={saving}
+                    />
+                    <span className={styles.field_hint}>
+                        Internal path only (must start with <code>/</code>). Links the title; needs a title override to show.
+                    </span>
                 </div>
             </div>
 

--- a/src/frontend/components/widgets/WidgetZone.tsx
+++ b/src/frontend/components/widgets/WidgetZone.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType } from 'react';
+import Link from 'next/link';
 import type { WidgetData } from './types';
 import { getWidgetComponent } from './widgets.generated';
 import { WidgetWithContext } from './WidgetWithContext';
@@ -120,7 +121,13 @@ export function WidgetZone({
                     data-plugin-id={widget.pluginId}
                 >
                     {widget.title && (
-                        <h2 className="text-xl font-semibold mb-4">{widget.title}</h2>
+                        <h2 className="text-xl font-semibold mb-4">
+                            {widget.titleUrl ? (
+                                <Link href={widget.titleUrl}>{widget.title}</Link>
+                            ) : (
+                                widget.title
+                            )}
+                        </h2>
                     )}
                     <WidgetRenderer widget={widget} route={route} params={params} />
                 </div>

--- a/src/frontend/components/widgets/types.ts
+++ b/src/frontend/components/widgets/types.ts
@@ -31,6 +31,12 @@ export interface WidgetData {
     title?: string;
 
     /**
+     * Optional root-relative URL that turns the rendered title into a
+     * link. Only takes effect when `title` is also present.
+     */
+    titleUrl?: string;
+
+    /**
      * Pre-fetched data for SSR rendering.
      *
      * The structure is defined by the individual plugin and can be any


### PR DESCRIPTION
Adds an optional `titleUrl` to widget placements so operators can link a widget's heading to an internal route directly from `/system/widgets`.

## What changed

- **Types** — `titleUrl?: string` on `IWidgetPlacement`, `IPlacementInput`, `IPlacementPatch`, `IWidgetData`, and the placement document. Operator-only state: plugins never seed it, and it survives restore-defaults alongside `instanceConfig`.
- **Controller** — validates `titleUrl` at the admin boundary against `INTERNAL_PATH_PATTERN` (single-leading-slash root-relative path), rejecting protocol-relative (`//host`), backslash (`/\\host`), scheme, whitespace/newline-injection, and over-length (>512) inputs. Follows the same three-state PATCH convention as `title`: set / `null`-clear / omit.
- **Service** — persists `titleUrl` on create, `$set`/`$unset` on patch, forwards through the resolver.
- **Frontend** — `/system/widgets` placement form gains a "Title link" field; `WidgetZone` renders the heading as a `next/link` when `titleUrl` is set and a title exists.
- **Docs + tests** — README, widget-zone and system-api docs updated; controller and service tests cover accept/reject/clear paths.

A heading link only renders when `title` is also set, since the host chrome links the title text.