### PR TITLE
Consolidate segmented controls onto shared utility; add LineChart tooltip date formatter

### DIFF
--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -286,6 +286,8 @@ export interface IChartComponents {
         }>;
         yAxisFormatter?: (value: number) => string;
         xAxisFormatter?: (value: Date) => string;
+        /** Custom formatter for the tooltip's date heading; falls back to xAxisFormatter. Lets the axis keep compact relative labels while the tooltip shows an absolute localized date. */
+        tooltipDateFormatter?: (value: Date) => string;
         emptyLabel?: string;
         height?: number;
         className?: string;

--- a/src/frontend/app/globals.scss
+++ b/src/frontend/app/globals.scss
@@ -262,7 +262,6 @@ button:focus-visible {
   border: var(--segmented-control-border);
   border-radius: var(--segmented-control-border-radius);
   padding: var(--segmented-control-padding);
-  overflow: hidden;
 }
 
 .segmented-control button {
@@ -274,6 +273,20 @@ button:focus-visible {
   padding: var(--segmented-control-button-padding);
   cursor: pointer;
   transition: background-color var(--transition-base), color var(--transition-base);
+}
+
+/* Round the end buttons rather than clipping the container with overflow:hidden,
+   so the active button's background still follows the rounded corners while the
+   global :focus-visible outline (offset + shadow) stays fully visible on the
+   first/last buttons. */
+.segmented-control button:first-child {
+  border-top-left-radius: var(--segmented-control-border-radius);
+  border-bottom-left-radius: var(--segmented-control-border-radius);
+}
+
+.segmented-control button:last-child {
+  border-top-right-radius: var(--segmented-control-border-radius);
+  border-bottom-right-radius: var(--segmented-control-border-radius);
 }
 
 .segmented-control button:not(:last-child) {

--- a/src/frontend/app/globals.scss
+++ b/src/frontend/app/globals.scss
@@ -259,9 +259,10 @@ button:focus-visible {
 .segmented-control {
   display: inline-flex;
   background: var(--segmented-control-background);
-  border-radius: var(--radius-full);
-  padding: var(--segmented-control-padding);
   border: var(--segmented-control-border);
+  border-radius: var(--segmented-control-border-radius);
+  padding: var(--segmented-control-padding);
+  overflow: hidden;
 }
 
 .segmented-control button {
@@ -269,10 +270,23 @@ button:focus-visible {
   background: transparent;
   color: var(--color-text-muted);
   font-size: var(--segmented-control-button-font-size);
+  font-weight: var(--font-weight-medium);
   padding: var(--segmented-control-button-padding);
-  border-radius: var(--radius-full);
   cursor: pointer;
   transition: background-color var(--transition-base), color var(--transition-base);
+}
+
+.segmented-control button:not(:last-child) {
+  border-right: var(--segmented-control-divider);
+}
+
+.segmented-control button:not(.is-active):hover {
+  color: var(--color-text);
+}
+
+.segmented-control button:disabled {
+  opacity: var(--opacity-60);
+  cursor: not-allowed;
 }
 
 .segmented-control button.is-active {

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -561,13 +561,15 @@
      * SEGMENTED CONTROL TOKENS
      * ======================================================================== */
 
-    --segmented-control-background: var(--color-surface-muted);
-    --segmented-control-border: var(--border-width-thin) solid var(--color-primary-alpha-18);
-    --segmented-control-padding: var(--spacing-1);  /* 0.25rem */
-    --segmented-control-button-padding: var(--spacing-3) var(--spacing-7); /* 0.45rem 0.9rem */
-    --segmented-control-button-font-size: var(--font-size-sm);
-    --segmented-control-active-background: var(--gradient-primary);
-    --segmented-control-active-color: var(--color-text);
+    --segmented-control-background: var(--color-surface-elevated);
+    --segmented-control-border: var(--border-width-thin) solid var(--color-border);
+    --segmented-control-border-radius: var(--radius-sm);
+    --segmented-control-divider: var(--border-width-thin) solid var(--color-border);
+    --segmented-control-padding: 0;
+    --segmented-control-button-padding: var(--spacing-1) var(--spacing-3); /* 0.25rem 0.4rem */
+    --segmented-control-button-font-size: var(--font-size-xs);
+    --segmented-control-active-background: var(--color-primary);
+    --segmented-control-active-color: var(--color-on-primary);
 
     /* ========================================================================
      * METER/PROGRESS TOKENS

--- a/src/frontend/features/blockchain/components/CurrentBlock/CurrentBlock.module.scss
+++ b/src/frontend/features/blockchain/components/CurrentBlock/CurrentBlock.module.scss
@@ -241,36 +241,6 @@
     margin-bottom: var(--spacing-5);
 }
 
-.period_selector {
-    display: flex;
-    gap: var(--spacing-2);
-    background: var(--color-surface-elevated);
-    padding: 0.2rem;
-    border-radius: var(--radius-sm);
-    border: var(--border-width-thin) solid var(--color-border-strong);
-}
-
-.period_button {
-    padding: 0.25rem 0.5rem;
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-medium);
-    background: transparent;
-    color: var(--color-text-subtle);
-    border: none;
-    border-radius: 3px;
-    cursor: pointer;
-    transition: all var(--transition-base);
-}
-
-.period_button:hover {
-    background: var(--color-border-strong);
-    color: var(--color-text-muted);
-}
-
-.period_button_active {
-    background: var(--color-primary-alpha-15);
-    color: var(--color-primary);
-}
 
 .graph_content {
     position: relative;
@@ -354,11 +324,6 @@
 
     .graph_content {
         min-height: 160px;
-    }
-
-    .period_button {
-        padding: 0.2rem 0.4rem;
-        font-size: var(--font-size-xs);
     }
 }
 

--- a/src/frontend/features/blockchain/components/CurrentBlock/CurrentBlock.tsx
+++ b/src/frontend/features/blockchain/components/CurrentBlock/CurrentBlock.tsx
@@ -290,14 +290,11 @@ export function CurrentBlock({ initialBlock }: CurrentBlockProps) {
                                 <div className={styles.graph_section}>
                                     <div className={styles.graph_header}>
                                         <h3 className={styles.section_title}>Transaction Volume</h3>
-                                        <div className={styles.period_selector}>
+                                        <div className="segmented-control">
                                             {(['live', 1, 7, 30] as const).map(period => (
                                                 <button
                                                     key={period}
-                                                    className={cn(
-                                                        styles.period_button,
-                                                        selectedPeriod === period && styles.period_button_active
-                                                    )}
+                                                    className={selectedPeriod === period ? 'is-active' : undefined}
                                                     onClick={() => setSelectedPeriod(period)}
                                                 >
                                                     {period === 'live' ? 'Live' : `${period}d`}

--- a/src/frontend/features/charts/components/LineChart/LineChart.tsx
+++ b/src/frontend/features/charts/components/LineChart/LineChart.tsx
@@ -42,8 +42,16 @@ interface LineChartProps {
     height?: number;
     /** Custom formatter for Y-axis labels */
     yAxisFormatter?: (value: number) => string;
-    /** Custom formatter for X-axis and tooltip dates */
+    /** Custom formatter for X-axis tick labels (also the tooltip date heading when no tooltipDateFormatter is given) */
     xAxisFormatter?: (value: Date) => string;
+    /**
+     * Custom formatter for the tooltip's date heading; falls back to
+     * `xAxisFormatter` when omitted. Lets a chart keep compact relative axis
+     * labels ("3h", "now") while the tooltip shows an absolute localized date —
+     * matching the BarChart's tooltip behavior. The tooltip mounts only on
+     * hover (client-only), so a localized value here is hydration-safe.
+     */
+    tooltipDateFormatter?: (value: Date) => string;
     /** Additional CSS class names */
     className?: string;
     /** Message to show when no data is available */
@@ -156,6 +164,7 @@ export function LineChart({
     height = 320,
     yAxisFormatter = value => value.toLocaleString(),
     xAxisFormatter = value => value.toLocaleDateString(),
+    tooltipDateFormatter,
     className,
     emptyLabel = 'Not enough data to render a chart.',
     minDate: fixedMinDate,
@@ -557,7 +566,7 @@ export function LineChart({
                     style={{ left: tooltip.x, top: tooltip.y }}
                     role="presentation"
                 >
-                    <span className={styles.tooltip__label}>{xAxisFormatter(tooltip.date)}</span>
+                    <span className={styles.tooltip__label}>{(tooltipDateFormatter ?? xAxisFormatter)(tooltip.date)}</span>
                     {tooltip.items.map(item => (
                         <div key={item.label} className={styles.tooltip__meta}>
                             <span style={{ color: item.color }}>{item.label}</span>

--- a/src/frontend/modules/tools/components/TimestampConverter/TimestampConverter.module.scss
+++ b/src/frontend/modules/tools/components/TimestampConverter/TimestampConverter.module.scss
@@ -5,35 +5,6 @@
     container-name: timestamp-converter;
 }
 
-.type_selector {
-    display: flex;
-    gap: var(--spacing-2);
-    background: var(--color-surface-muted);
-    border-radius: var(--radius-full);
-    padding: var(--spacing-1);
-    border: var(--border-width-thin) solid var(--color-border);
-}
-
-.type_button {
-    border: none;
-    background: transparent;
-    color: var(--color-text-muted);
-    font-size: var(--font-size-sm);
-    padding: var(--spacing-3) var(--spacing-7);
-    border-radius: var(--radius-full);
-    cursor: pointer;
-    transition: background-color var(--transition-base), color var(--transition-base);
-
-    &:hover {
-        color: var(--color-text);
-    }
-}
-
-.type_button_active {
-    background: var(--gradient-primary);
-    color: var(--color-text);
-}
-
 .label {
     display: block;
     font-size: var(--font-size-sm);
@@ -106,10 +77,6 @@
     .input_row {
         flex-direction: column;
         align-items: stretch;
-    }
-
-    .type_selector {
-        flex-direction: column;
     }
 
     .stat__value {

--- a/src/frontend/modules/tools/components/TimestampConverter/TimestampConverter.tsx
+++ b/src/frontend/modules/tools/components/TimestampConverter/TimestampConverter.tsx
@@ -88,12 +88,12 @@ export function TimestampConverter() {
             <div className={styles.container}>
             <Card>
                 <Stack gap="md">
-                    <div className={styles.type_selector}>
+                    <div className="segmented-control">
                         {(Object.keys(INPUT_CONFIG) as InputType[]).map(type => (
                             <button
                                 key={type}
                                 type="button"
-                                className={`${styles.type_button} ${type === inputType ? styles.type_button_active : ''}`}
+                                className={type === inputType ? 'is-active' : undefined}
                                 onClick={() => { setInputType(type); setResult(null); setError(null); }}
                             >
                                 {INPUT_CONFIG[type].label.split(' (')[0]}


### PR DESCRIPTION
## Summary

Consolidates two ad-hoc segmented-control implementations onto a single shared global `.segmented-control` utility and adds an absolute-date tooltip option to `LineChart`.

## Changes

- **Shared segmented control.** `CurrentBlock` (Transaction Volume period selector) and `TimestampConverter` (input type selector) both dropped their bespoke `period_selector`/`type_selector` styles and now use the global `.segmented-control` utility from `globals.scss`, with `is-active` marking the selected button.
- **Restyled tokens.** `semantic-tokens.scss` segmented-control tokens move to an elevated surface with a divider between buttons, compact padding, smaller font, and a solid primary active state (replacing the gradient/pill look). Added hover, disabled, and divider rules in `globals.scss`.
- **LineChart tooltip date formatter.** New `tooltipDateFormatter` prop falls back to `xAxisFormatter` when omitted, letting a chart keep compact relative axis labels while the tooltip shows an absolute localized date — mirroring `BarChart`. Reflected in `IFrontendPluginContext` chart types.

Type check passes (`tsc --noEmit`).