### PR TITLE
Add chart legendValue + showLegend so the legend can act as a complete key

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delphian/tronrelic-types",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "description": "Core type definitions for the TronRelic platform",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -283,6 +283,8 @@ export interface IChartComponents {
             data: Array<{ date: string; value: number; max?: number; count?: number }>;
             color?: string;
             fill?: boolean;
+            /** Optional aggregate annotation rendered after the label in the legend only (not the tooltip). Lets the legend act as a complete key, e.g. a window total. */
+            legendValue?: React.ReactNode;
         }>;
         yAxisFormatter?: (value: number) => string;
         xAxisFormatter?: (value: Date) => string;
@@ -291,6 +293,8 @@ export interface IChartComponents {
         emptyLabel?: string;
         height?: number;
         className?: string;
+        /** Render the legend. Defaults to true. Set false to suppress it (e.g. when a host supplies its own key). */
+        showLegend?: boolean;
         /** Fixed minimum date for X-axis (prevents auto-scaling when data is sparse) */
         minDate?: Date;
         /** Fixed maximum date for X-axis (prevents auto-scaling when data is sparse) */
@@ -315,6 +319,8 @@ export interface IChartComponents {
             label: string;
             data: Array<{ date: string; value: number; metadata?: Record<string, unknown> }>;
             color?: string;
+            /** Optional aggregate annotation rendered after the label in the legend only (not the tooltip or bar title). Lets the legend act as a complete key, e.g. a window total. */
+            legendValue?: React.ReactNode;
         }>;
         /** Rendering density (default: 'normal') */
         mode?: 'normal' | 'widget';
@@ -322,6 +328,8 @@ export interface IChartComponents {
         height?: number;
         yAxisFormatter?: (value: number) => string;
         xAxisFormatter?: (value: Date) => string;
+        /** Render the legend. Defaults to the mode's behavior (shown in 'normal', hidden in 'widget'); set explicitly to override — e.g. true to show a key in a compact widget. */
+        showLegend?: boolean;
         emptyLabel?: string;
         className?: string;
         /** Fixed minimum value for Y-axis (overrides auto-calculated minimum) */

--- a/src/frontend/features/charts/components/BarChart/BarChart.module.css
+++ b/src/frontend/features/charts/components/BarChart/BarChart.module.css
@@ -156,3 +156,9 @@
     color: var(--color-text-subtle);
     font-size: var(--font-size-body-sm);
 }
+
+.legend__value {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-body-sm);
+    font-weight: var(--font-weight-medium);
+}

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { cn } from '../../../../lib/cn';
 import styles from './BarChart.module.css';
 
@@ -31,6 +31,12 @@ export interface BarChartSeries {
      * (`var(--chart-color-2)`). Defaults to the `--chart-color-*` palette by index.
      */
     color?: string;
+    /**
+     * Optional aggregate annotation rendered after the label in the legend only
+     * (never the tooltip or bar title), letting the legend serve as a complete
+     * key — e.g. a per-series window total.
+     */
+    legendValue?: ReactNode;
 }
 
 /**
@@ -71,6 +77,12 @@ interface BarChartProps {
     yAxisMin?: number;
     /** Fixed maximum value for Y-axis (overrides auto-calculated maximum) */
     yAxisMax?: number;
+    /**
+     * Render the legend. Defaults to the mode's behavior (`normal` shows it,
+     * `widget` hides it); set explicitly to override — e.g. `true` to surface a
+     * key in a compact widget that no longer renders its own summary line.
+     */
+    showLegend?: boolean;
 }
 
 /**
@@ -242,11 +254,15 @@ export function BarChart({
     className,
     emptyLabel = 'Not enough data to render a chart.',
     yAxisMin: fixedYMin,
-    yAxisMax: fixedYMax
+    yAxisMax: fixedYMax,
+    showLegend
 }: BarChartProps) {
     const chrome = CHROME[mode];
     const height = propHeight ?? chrome.defaultHeight;
     const isWidget = mode === 'widget';
+    // Tri-state: an explicit prop overrides the mode default, so a compact
+    // widget can opt into the legend as its key. Left undefined, the mode rules.
+    const resolvedShowLegend = showLegend ?? chrome.showLegend;
 
     const [container, setContainer] = useState<HTMLElement | null>(null);
     const [containerWidth, setContainerWidth] = useState(chrome.minWidth);
@@ -653,7 +669,7 @@ export function BarChart({
                 </div>
             )}
 
-            {chrome.showLegend && (
+            {resolvedShowLegend && (
                 <figcaption className={styles.legend}>
                     {series.filter(item => item.data.length > 0).map(item => {
                         const isHidden = hiddenSeries.has(item.id);
@@ -672,6 +688,9 @@ export function BarChart({
                                     style={{ background: isHidden ? 'transparent' : color, borderColor: color }}
                                 />
                                 <span className={styles.legend__label}>{item.label}</span>
+                                {item.legendValue !== undefined && (
+                                    <span className={styles.legend__value}>{item.legendValue}</span>
+                                )}
                             </button>
                         );
                     })}

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -688,7 +688,7 @@ export function BarChart({
                                     style={{ background: isHidden ? 'transparent' : color, borderColor: color }}
                                 />
                                 <span className={styles.legend__label}>{item.label}</span>
-                                {item.legendValue !== undefined && (
+                                {item.legendValue != null && (
                                     <span className={styles.legend__value}>{item.legendValue}</span>
                                 )}
                             </button>

--- a/src/frontend/features/charts/components/LineChart/LineChart.module.css
+++ b/src/frontend/features/charts/components/LineChart/LineChart.module.css
@@ -115,3 +115,9 @@
     color: var(--color-text-subtle);
     font-size: var(--font-size-sm);
 }
+
+.legend__value {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+}

--- a/src/frontend/features/charts/components/LineChart/LineChart.tsx
+++ b/src/frontend/features/charts/components/LineChart/LineChart.tsx
@@ -615,7 +615,7 @@ export function LineChart({
                                         style={{ background: isHidden ? 'transparent' : color, borderColor: color }}
                                     />
                                     <span className={styles.legend__label}>{item.label}</span>
-                                    {item.legendValue !== undefined && (
+                                    {item.legendValue != null && (
                                         <span className={styles.legend__value}>{item.legendValue}</span>
                                     )}
                                 </button>

--- a/src/frontend/features/charts/components/LineChart/LineChart.tsx
+++ b/src/frontend/features/charts/components/LineChart/LineChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { cn } from '../../../../lib/cn';
 import styles from './LineChart.module.css';
 
@@ -30,6 +30,12 @@ export interface ChartSeries {
     color?: string;
     /** Whether to fill area under the line (default: true) */
     fill?: boolean;
+    /**
+     * Optional aggregate annotation rendered after the label in the legend only
+     * (never the tooltip), letting the legend serve as a complete key — e.g. a
+     * headline metric the host would otherwise render in a separate row.
+     */
+    legendValue?: ReactNode;
 }
 
 /**
@@ -54,6 +60,8 @@ interface LineChartProps {
     tooltipDateFormatter?: (value: Date) => string;
     /** Additional CSS class names */
     className?: string;
+    /** Render the legend. Defaults to true; set false to suppress it. */
+    showLegend?: boolean;
     /** Message to show when no data is available */
     emptyLabel?: string;
     /** Fixed minimum date for X-axis (prevents auto-scaling when data is sparse) */
@@ -166,6 +174,7 @@ export function LineChart({
     xAxisFormatter = value => value.toLocaleDateString(),
     tooltipDateFormatter,
     className,
+    showLegend = true,
     emptyLabel = 'Not enough data to render a chart.',
     minDate: fixedMinDate,
     maxDate: fixedMaxDate,
@@ -586,30 +595,35 @@ export function LineChart({
                 </div>
             )}
 
-            <figcaption className={styles.legend}>
-                <div className={styles.legend__items}>
-                    {series.filter(item => item.data.length > 0).map((item, index) => {
-                        const isHidden = hiddenSeries.has(item.id);
-                        const color = item.color ?? DEFAULT_COLORS[index % DEFAULT_COLORS.length];
-                        return (
-                            <button
-                                key={`legend-${item.id}`}
-                                className={cn(styles.legend__item, isHidden && styles['legend__item--hidden'])}
-                                onClick={() => toggleSeries(item.id)}
-                                type="button"
-                                aria-pressed={!isHidden}
-                                title={isHidden ? `Show ${item.label}` : `Hide ${item.label}`}
-                            >
-                                <span
-                                    className={styles.legend__dot}
-                                    style={{ background: isHidden ? 'transparent' : color, borderColor: color }}
-                                />
-                                <span className={styles.legend__label}>{item.label}</span>
-                            </button>
-                        );
-                    })}
-                </div>
-            </figcaption>
+            {showLegend && (
+                <figcaption className={styles.legend}>
+                    <div className={styles.legend__items}>
+                        {series.filter(item => item.data.length > 0).map((item, index) => {
+                            const isHidden = hiddenSeries.has(item.id);
+                            const color = item.color ?? DEFAULT_COLORS[index % DEFAULT_COLORS.length];
+                            return (
+                                <button
+                                    key={`legend-${item.id}`}
+                                    className={cn(styles.legend__item, isHidden && styles['legend__item--hidden'])}
+                                    onClick={() => toggleSeries(item.id)}
+                                    type="button"
+                                    aria-pressed={!isHidden}
+                                    title={isHidden ? `Show ${item.label}` : `Hide ${item.label}`}
+                                >
+                                    <span
+                                        className={styles.legend__dot}
+                                        style={{ background: isHidden ? 'transparent' : color, borderColor: color }}
+                                    />
+                                    <span className={styles.legend__label}>{item.label}</span>
+                                    {item.legendValue !== undefined && (
+                                        <span className={styles.legend__value}>{item.legendValue}</span>
+                                    )}
+                                </button>
+                            );
+                        })}
+                    </div>
+                </figcaption>
+            )}
         </figure>
     );
 }


### PR DESCRIPTION
## Summary

Makes the `BarChart` and `LineChart` legend a first-class, self-sufficient key, so widgets no longer need to hand-roll a summary line beside the chart. This is the core/types half of a three-part change; the resource-tracker and dust-tracker widgets adopt it in follow-up PRs.

## Why

The chart `series.label` was overloaded for the legend, the tooltip rows, and the bar title, and legend visibility was hard-bundled into BarChart's `mode` preset. Because the legend couldn't carry an aggregate or be toggled independently, every widget reinvented a summary line next to the chart (duplicate keys, duplicate code). These two additions let the legend be the single key.

## Changes

- **`legendValue?: ReactNode` per series** — rendered only in the legend, as a new `legend__value` span after the label. The tooltip rows and bar `<title>` keep using `label`, so series identity and its aggregate annotation stay separate.
- **`showLegend?: boolean` on both charts** — `LineChart` defaults to `true`; `BarChart` resolves tri-state (`showLegend ?? chrome.showLegend` from `mode`), so an explicit `true` surfaces the legend even in compact `widget` mode.
- Mirrored both on the plugin-facing `BarChart`/`LineChart` types in `IFrontendPluginContext.ts`; bumped `@delphian/tronrelic-types` `3.1.0 → 3.2.0` so the consuming plugins can declare the new contract.

Type checks pass for the types package and the core root (`tsc --noEmit`).