### PR TITLE
Add transaction-detail service, IBlockTransaction type, and get-transaction AI tool

### DIFF
--- a/docs/system/system-block-provider-migration.md
+++ b/docs/system/system-block-provider-migration.md
@@ -145,3 +145,4 @@ Risk concentrates in Step 4 and is mitigated by the Step 1 golden suite — with
 - [modules-architecture.md](./modules/modules-architecture.md) — singleton `setDependencies`/`getInstance` and DI conventions the steps follow
 - [system-testing.md](./system-testing.md) — Vitest mock infrastructure used by the fixture and adapter contract suites
 - [environment.md](../environment.md) — env var behaviors; Step 8 adds the `BLOCK_PROVIDER` family
+- [system-domain-types.md](./system-domain-types.md) — the contract-layer complement: the source-independence rule for return types like `IBlockTransaction` that this provider decoupling makes safe to expose

--- a/docs/system/system-domain-types.md
+++ b/docs/system/system-domain-types.md
@@ -1,0 +1,59 @@
+# Source-Independent Domain Types
+
+The `@delphian/tronrelic-types` package is a contract surface, not a dumping ground for whatever shape a value happens to have in transit. A type earns a place there only if it describes a domain fact that any data source must satisfy — independent of which database stores it or which provider supplied it.
+
+## Why This Matters
+
+A return type that leaks its source couples every consumer to that source. The failure is silent: an `any` or an open `Record<string, unknown>` stores fine in MongoDB, MySQL, or ClickHouse alike, so nothing breaks at the storage layer — but the *meaning* of those bytes is dictated by whoever filled them. The moment the source changes (a new block provider, a columnar mirror, a different store), the field holds differently-shaped data or nothing, and because the type declared no contract, the compiler warns no one. Consumers break at runtime.
+
+The defect is never "this engine can't hold the value." It is that the type delegates meaning to the source instead of obligating the source to a meaning. A field like `amountSun: number` is source-independent — every backend is obligated to produce a number. A field like `info: any` is the opposite — it imposes no obligation, so its contents default to the current pipeline's native shape. That is source coupling achieved through a type that looks source-agnostic.
+
+`IBlockTransaction` exists because the path that started it — mapping a memo's `txId` to its block — kept colliding with `ITransaction`, the observer-delivery envelope whose `rawValue`, `info`, and `snapshot` members are raw TronGrid and Socket.IO artifacts. The envelope is correct for observers; it is wrong as a read contract.
+
+## How It Works
+
+The package holds domain contracts. Core (`src/shared`, `src/backend`) holds implementation and pipeline artifacts. Persistence shapes (`TronTransactionDocument`), provider wire structs (`TronGridBlock`), and delivery envelopes (`ITransaction`) stay in core because they describe *how a layer works*, not *what a transaction is*.
+
+Apply one admission test before adding a type — or a field — to the package:
+
+> Could a MySQL or ClickHouse backend, fed by a non-TronGrid provider, populate every field by obligation, with no `any` and no provider envelope?
+
+If yes, it belongs. If a field can only be filled by replaying the current source's native structure, it is an enrichment or a pipeline artifact — model it elsewhere, or mark it optional only when a bare provider can honestly omit it. An open `Record<string, unknown>` is admissible only when the *domain* is genuinely open (decoded ABI arguments, identical across any decoder), never as a stand-in for an un-modeled provider blob.
+
+Canonical examples already in the package: `IBlock` and `IBlockTransaction`. Both are flat projections of on-chain facts with a service-side mapper from the storage document.
+
+### Known Debt (Do Not Copy)
+
+These predate the rule and violate it. They are migration targets, not precedent:
+
+| Type | Location | Problem |
+|---|---|---|
+| `ITransaction` | `packages/types/src/transaction/` | Observer envelope in the contract package; `rawValue`/`info`/`snapshot` are provider/transport artifacts. Legitimate for observers, never as a read contract. |
+| `TronTransactionDocument` | `src/shared/types/` | Mongo persistence shape; correctly in core, but referenced where a domain type belongs. |
+
+## Example
+
+```typescript
+// CORRECT — every field is an on-chain fact the source must satisfy
+export interface IResourceUsage {
+    consumed: number; // net_usage or energy_usage — units the chain recorded
+    feeSun: number;   // net_fee or energy_fee — TRX burned, in sun
+}
+
+// WRONG — pipeline envelope; meaning supplied by the source, not the contract
+export interface ITransaction {
+    rawValue: Record<string, unknown>; // raw TronGrid contract params
+    info: any;                         // provider-varying receipt
+    snapshot: any;                     // Socket.IO frame
+}
+```
+
+## Further Reading
+
+**Detailed documentation:**
+- [system-block-provider-migration.md](./system-block-provider-migration.md) - The same decoupling thesis at the ingestion layer: a provider-neutral `IBlockProvider` behind the sync pipeline. Source-independent types are its contract-layer complement.
+- [system-database.md](./system-database.md) - `IDatabaseService` abstraction and why persistence shapes stay in core.
+
+**Related topics:**
+- [modules.md](./modules/modules.md) - Service interface conventions (`IXxxService`) that return these contracts.
+- [documentation.md](../documentation.md) - Documentation standards.

--- a/docs/system/system.md
+++ b/docs/system/system.md
@@ -90,6 +90,7 @@ Inspect health at `/system` (auth: `ADMIN_API_TOKEN`) — fastest path to blockc
 | [system-database.md](./system-database.md) | `IDatabaseService`, three-tier access, namespace isolation |
 | [system-blockchain-sync-architecture.md](./system-blockchain-sync-architecture.md) | Block retrieval, enrichment pipeline, observer dispatch |
 | [system-block-provider-migration.md](./system-block-provider-migration.md) | Proposed TronGrid decoupling — `IBlockProvider` design, provider research, migration plan |
+| [system-domain-types.md](./system-domain-types.md) | Source-independence rule for the types package — admission test, `IBlockTransaction`, known debt |
 | [system-scheduler-operations.md](./system-scheduler-operations.md) | Job control, cron syntax, persistence, troubleshooting |
 | [system-api.md](./system-api.md) | Admin API gateway — auth, conventions, troubleshooting, links to per-domain detail docs |
 | [system-api-overview.md](./system-api-overview.md) | `/health/*` (database, clickhouse, redis, server), `/config`, `/config/system` |

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delphian/tronrelic-types",
-    "version": "3.2.0",
+    "version": "3.3.0",
     "description": "Core type definitions for the TronRelic platform",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/types/src/blockchain/IBlockTransaction.ts
+++ b/packages/types/src/blockchain/IBlockTransaction.ts
@@ -1,0 +1,107 @@
+/**
+ * Source-independent domain record for a single blockchain transaction.
+ *
+ * Every field is an on-chain fact or a deterministic conversion of one, so any
+ * block provider — TronGrid today, a node RPC or a ClickHouse mirror tomorrow —
+ * is obligated to populate it. Service-derived enrichments (USD valuation,
+ * address labels, pattern/risk analysis) are intentionally absent: this models
+ * what the chain itself records, not what a particular pipeline layers on top.
+ *
+ * Contrast with `ITransaction` (the observer-delivery envelope), which carries
+ * provider-shaped artifacts (`rawValue`, `info`, `snapshot`) and is therefore
+ * not a source-independent contract. See
+ * `docs/system/system-domain-types.md` for the admission rule this type obeys.
+ */
+
+/**
+ * A party to a transaction.
+ *
+ * Base58 address only. Names, labels, and exchange classification are
+ * TronRelic enrichments sourced from other services, not properties of the
+ * on-chain record, and are deliberately excluded.
+ */
+export interface IBlockTransactionParty {
+    /** Base58 address (`owner_address` for the sender, `to_address` for the recipient). */
+    address: string;
+}
+
+/**
+ * Per-resource accounting exactly as the chain reports it.
+ *
+ * TRON records, for each resource, the units drawn from the account and the
+ * TRX (in sun) burned when that resource was insufficient. There is no
+ * per-unit price on a transaction — unit prices are network-wide protocol
+ * parameters, so they belong to chain-parameter state, never to this record.
+ */
+export interface IResourceUsage {
+    /** Units consumed: `net_usage` for bandwidth, `energy_usage` for energy. */
+    consumed: number;
+    /** TRX burned in sun when the resource was insufficient: `net_fee` or `energy_fee`. */
+    feeSun: number;
+}
+
+/**
+ * Smart-contract call detail for transactions that invoke one.
+ */
+export interface IBlockTransactionContract {
+    /** Base58 address of the called contract (`contract_address`). */
+    address: string;
+    /** Decoded method selector or name, when resolvable. */
+    method?: string;
+    /**
+     * Decoded ABI arguments. This is a genuinely open domain — the argument
+     * shape varies per contract method — and any provider decoding the same
+     * call yields the same map, so it remains source-independent. Distinct
+     * from an un-modeled provider envelope, which this type forbids.
+     */
+    parameters?: Record<string, unknown>;
+}
+
+/**
+ * A blockchain transaction projected to its source-independent essentials.
+ *
+ * Returned by read methods on `IBlockchainService`. Optional fields are absent
+ * when the transaction type does not carry them (e.g. `amountSun` for a TRC20
+ * call, whose token amount lives in the contract data rather than the native
+ * value field), never as a placeholder for missing-but-expected data.
+ */
+export interface IBlockTransaction {
+    /** Transaction hash. */
+    txId: string;
+    /** Height of the block that included this transaction. */
+    blockNumber: number;
+    /** Block execution time, from the native `blockTimeStamp`. */
+    timestamp: Date;
+    /** Native contract type, e.g. `'TransferContract'`, `'TriggerSmartContract'`. */
+    type: string;
+    /**
+     * Native execution result from `ret.contractRet`, e.g. `'SUCCESS'`,
+     * `'REVERT'`, `'OUT_OF_ENERGY'`, `'OUT_OF_TIME'`. Typed as `string` rather
+     * than a closed union so new protocol result codes cannot stale the
+     * contract.
+     */
+    status: string;
+    /** Sender. */
+    from: IBlockTransactionParty;
+    /** Recipient. */
+    to: IBlockTransactionParty;
+    /**
+     * Native TRX value moved, in sun. Absent for transactions that carry no
+     * native value (e.g. TRC20 transfers via `TriggerSmartContract`).
+     */
+    amountSun?: number;
+    /**
+     * Total TRX burned by the transaction, in sun, from the native `fee`:
+     * resource fees plus account activation, memo, multi-signature, and other
+     * fees. A superset of the per-resource `feeSun` values.
+     */
+    feeSun?: number;
+    /** Energy accounting from the receipt. */
+    energy?: IResourceUsage;
+    /** Bandwidth ("net") accounting from the receipt. */
+    bandwidth?: IResourceUsage;
+    /** Smart-contract call detail, when the transaction invoked a contract. */
+    contract?: IBlockTransactionContract;
+    /** Decoded memo from the native `raw_data.data` field; null when none. */
+    memo?: string | null;
+}

--- a/packages/types/src/blockchain/ITransactionDetailService.ts
+++ b/packages/types/src/blockchain/ITransactionDetailService.ts
@@ -1,0 +1,35 @@
+import type { IBlockTransaction } from './IBlockTransaction.js';
+
+/**
+ * Read-through lookup of full transaction detail by id.
+ *
+ * Backed by a permanent cache (`core_transaction_details`): a cache hit is an
+ * indexed local read; a miss fetches the transaction from the block provider,
+ * persists it, and returns it. Because a confirmed transaction is immutable,
+ * the cache never goes stale.
+ *
+ * Published on the service registry as `'transaction-details'`. Consume via
+ * `services.get<ITransactionDetailService>('transaction-details')`.
+ *
+ * Cold reads can fail: a cache miss performs network calls to the provider, so
+ * implementations may return null when a transaction cannot be resolved (never
+ * persisted, unknown id, or provider unavailable). Callers must handle null.
+ */
+export interface ITransactionDetailService {
+    /**
+     * Resolve a single transaction by id. Returns null when the transaction
+     * cannot be resolved from cache or the provider.
+     *
+     * @param txId - Transaction hash.
+     */
+    getTransactionById(txId: string): Promise<IBlockTransaction | null>;
+
+    /**
+     * Resolve many transactions by id in one call. Returns only the
+     * transactions that resolved; the result may be shorter than the input and
+     * its order is not guaranteed to match. Map by `txId` if alignment matters.
+     *
+     * @param txIds - Transaction hashes.
+     */
+    getTransactionsByIds(txIds: string[]): Promise<IBlockTransaction[]>;
+}

--- a/packages/types/src/blockchain/index.ts
+++ b/packages/types/src/blockchain/index.ts
@@ -1,3 +1,10 @@
 export type { IBlockStats } from './IBlockStats.js';
 export type { IBlock } from './IBlock.js';
+export type {
+    IBlockTransaction,
+    IBlockTransactionParty,
+    IBlockTransactionContract,
+    IResourceUsage
+} from './IBlockTransaction.js';
 export type { IBlockchainService, ITransactionTimeseriesPoint } from './IBlockchainService.js';
+export type { ITransactionDetailService } from './ITransactionDetailService.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -46,7 +46,7 @@ export type { IModule, IModuleMetadata } from './module/index.js';
 export type { IWalletService, ILinkedWallet, WalletAction, IWalletChallenge, IWalletMutationInput, IAccountDirectoryService, IAccountSummary, IListAccountsOptions, IListAccountsResult } from './identity/index.js';
 export type { IUserGroup, ICreateUserGroupInput, IUpdateUserGroupInput, IUserGroupService } from './user/index.js';
 export type { ITronGridService, ITronGridAccountResponse, ITronGridAccountPermission } from './tron-grid/index.js';
-export type { IBlockStats, IBlock, IBlockchainService, ITransactionTimeseriesPoint } from './blockchain/index.js';
+export type { IBlockStats, IBlock, IBlockTransaction, IBlockTransactionParty, IBlockTransactionContract, IResourceUsage, IBlockchainService, ITransactionTimeseriesPoint, ITransactionDetailService } from './blockchain/index.js';
 export type { IToolsService, IAddressConversionResult, IAddressValidationResult } from './tools/index.js';
 export type { IAiTool, IAiToolInputSchema, IAiConversationMessage, IAiAssistantService, IAiQueryOptions, IAiQueryResult, IModelInfo } from './ai-tools/index.js';
 export { AI_TOOL_NAME_PATTERN } from './ai-tools/index.js';

--- a/packages/types/src/transaction/ITransaction.ts
+++ b/packages/types/src/transaction/ITransaction.ts
@@ -8,6 +8,12 @@ import type { ITransactionCategoryFlags } from './ITransactionCategoryFlags.js';
  * service has parsed raw TronGrid data, enriched it with USD prices, categorized it,
  * and prepared both database and real-time representations. Observers never see raw
  * blockchain data, only this structured, framework-independent format.
+ *
+ * NOTE: This is the observer-delivery *pipeline envelope*, not a source-independent
+ * domain contract. `rawValue`, `info`, and `snapshot` carry provider- and
+ * transport-shaped data, so this type must never be used as the return shape of a
+ * blockchain read. New read methods return `IBlockTransaction` instead. See
+ * `docs/system/system-domain-types.md` for the distinction.
  */
 export interface ITransaction {
     /** Complete transaction data ready for database persistence */

--- a/packages/types/src/transaction/ITransactionPersistencePayload.ts
+++ b/packages/types/src/transaction/ITransactionPersistencePayload.ts
@@ -17,6 +17,12 @@ export interface ITransactionPersistencePayload {
     type: string;
     /** Optional sub-categorization for complex transaction types */
     subType?: string;
+    /**
+     * Native execution result from the transaction's `ret[].contractRet`
+     * (e.g. 'SUCCESS', 'REVERT', 'OUT_OF_ENERGY'). Optional: absent on records
+     * persisted before status capture was added, populated for all new rows.
+     */
+    status?: string;
     /** Source address with enriched metadata (exchange vs wallet, known names) */
     from: {
         address: string;

--- a/src/backend/api/routes/system.router.ts
+++ b/src/backend/api/routes/system.router.ts
@@ -6,6 +6,7 @@ import { SystemMonitorController } from '../../modules/system/system-monitor.con
 import { getRedisClient } from '../../loaders/redis.js';
 import { PluginWebSocketRegistry } from '../../services/plugin-websocket-registry.js';
 import { createSystemLogRouter } from '../../modules/logs/index.js';
+import { TransactionToolGuard } from '../../modules/blockchain/transaction-tool-guard.js';
 
 export function systemRouter(database: IDatabaseService) {
   const router = Router();
@@ -21,6 +22,11 @@ export function systemRouter(database: IDatabaseService) {
   router.get('/blockchain/metrics', controller.getBlockProcessingMetrics);
   router.get('/blockchain/observers', controller.getObserverStats);
   router.post('/blockchain/sync', controller.triggerBlockchainSync);
+
+  // Usage and rate-limit stats for the transaction-detail AI tool.
+  router.get('/blockchain/transaction-tool/stats', (_req, res) => {
+    res.json({ success: true, stats: TransactionToolGuard.getInstance().snapshot() });
+  });
 
   // Scheduler endpoints moved to SchedulerModule (/api/admin/system/scheduler/*)
 

--- a/src/backend/database/models/transaction-model.ts
+++ b/src/backend/database/models/transaction-model.ts
@@ -21,6 +21,7 @@ const TransactionSchema = new Schema<TransactionDoc>({
   timestamp: { type: Date, index: true, required: true },
   type: { type: String, required: true },
   subType: String,
+  status: String,
   from: {
     address: { type: String, required: true },
     name: String,

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -40,6 +40,9 @@ import { SystemConfigService } from './services/system-config/index.js';
 import { CacheService } from './services/cache.service.js';
 import { ChainParametersFetcher } from './modules/chain-parameters/chain-parameters-fetcher.js';
 import { ChainParametersService } from './modules/chain-parameters/chain-parameters.service.js';
+import { TransactionDetailService } from './modules/blockchain/transaction-detail.service.js';
+import { registerTransactionAiTools } from './modules/blockchain/transaction-ai-tools.js';
+import { TronGridClient } from './modules/blockchain/tron-grid.client.js';
 import { UsdtParametersFetcher } from './modules/usdt-parameters/usdt-parameters-fetcher.js';
 import { UsdtParametersService } from './modules/usdt-parameters/usdt-parameters.service.js';
 import { createApiRouter } from './api/routes/index.js';
@@ -297,6 +300,19 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     // plugins can discover them via late-binding DI instead of importing
     // concrete classes.
     serviceRegistry.register('chain-parameters', ChainParametersService.getInstance());
+
+    // Transaction-detail lookup: a lazily-populated, permanent cache that fills
+    // misses from the injected provider. Dependencies are injected here rather
+    // than self-instantiated so the provider stays swappable.
+    TransactionDetailService.setDependencies(coreDatabase, TronGridClient.getInstance());
+    const transactionDetailService = TransactionDetailService.getInstance();
+    await transactionDetailService.ensureIndexes();
+    serviceRegistry.register('transaction-details', transactionDetailService);
+
+    // Expose the transaction-detail lookup to the AI assistant as a read-only,
+    // rate-limited core tool. Watches for the assistant service rather than
+    // resolving it once, since it is a runtime-toggleable plugin.
+    registerTransactionAiTools(serviceRegistry, transactionDetailService);
 
     // Menu module next (others need menuService)
     const menuModule = new MenuModule();

--- a/src/backend/modules/blockchain/__tests__/transaction-ai-tools.test.ts
+++ b/src/backend/modules/blockchain/__tests__/transaction-ai-tools.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for the core transaction-detail AI tool and its safeguard. Covers the
+ * behaviors that protect the system: malformed ids are rejected before any
+ * lookup, the global rate limiter caps invocations and rejects past the cap,
+ * resolved/not-found outcomes are recorded, and the stats snapshot reflects
+ * all of it for the admin endpoint.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ITransactionDetailService, IBlockTransaction } from '@/types';
+import { buildTransactionTool } from '../transaction-ai-tools.js';
+import { TransactionToolGuard } from '../transaction-tool-guard.js';
+
+const VALID_TXID = 'a'.repeat(64);
+
+/** A minimal resolved transaction for the detail-service mock. */
+function sampleTx(txId: string): IBlockTransaction {
+    return {
+        txId,
+        blockNumber: 100,
+        timestamp: new Date(),
+        type: 'TransferContract',
+        status: 'SUCCESS',
+        from: { address: 'Tfrom' },
+        to: { address: 'Tto' },
+        feeSun: 0,
+        memo: null
+    };
+}
+
+describe('transaction AI tool', () => {
+    let detailService: { getTransactionById: ReturnType<typeof vi.fn> };
+    let guard: TransactionToolGuard;
+    let handler: (input: Record<string, unknown>) => Promise<unknown>;
+
+    beforeEach(() => {
+        TransactionToolGuard.resetForTests();
+        guard = TransactionToolGuard.getInstance();
+        detailService = { getTransactionById: vi.fn() };
+        const tool = buildTransactionTool(detailService as unknown as ITransactionDetailService, guard);
+        handler = tool.handler;
+    });
+
+    it('rejects a malformed txId before any lookup and counts it', async () => {
+        const result = await handler({ txId: 'not-a-hash' });
+
+        expect(result).toMatchObject({ success: false });
+        expect(detailService.getTransactionById).not.toHaveBeenCalled();
+        expect(guard.snapshot()).toMatchObject({ invocations: 1, invalidInput: 1, allowed: 0 });
+    });
+
+    it('resolves a valid transaction and records the outcome', async () => {
+        detailService.getTransactionById.mockResolvedValue(sampleTx(VALID_TXID));
+
+        const result = await handler({ txId: VALID_TXID });
+
+        expect(result).toMatchObject({ success: true, transaction: { txId: VALID_TXID } });
+        expect(detailService.getTransactionById).toHaveBeenCalledWith(VALID_TXID);
+        expect(guard.snapshot()).toMatchObject({ allowed: 1, resolved: 1, notFound: 0 });
+    });
+
+    it('records a not-found outcome when the lookup returns null', async () => {
+        detailService.getTransactionById.mockResolvedValue(null);
+
+        const result = await handler({ txId: VALID_TXID });
+
+        expect(result).toMatchObject({ success: true, transaction: null });
+        expect(guard.snapshot()).toMatchObject({ resolved: 0, notFound: 1 });
+    });
+
+    it('rate-limits once the window budget is exhausted', async () => {
+        detailService.getTransactionById.mockResolvedValue(sampleTx(VALID_TXID));
+
+        // Drain the window: the limit is read from the snapshot so the test
+        // stays correct if the cap changes.
+        const limit = guard.snapshot().window.limit;
+        for (let i = 0; i < limit; i++) {
+            await handler({ txId: VALID_TXID });
+        }
+
+        const rejected = await handler({ txId: VALID_TXID });
+
+        expect(rejected).toMatchObject({ success: false });
+        const stats = guard.snapshot();
+        expect(stats.allowed).toBe(limit);
+        expect(stats.rateLimited).toBe(1);
+        expect(stats.window.remaining).toBe(0);
+        expect(stats.lastRateLimitedAt).not.toBeNull();
+    });
+});

--- a/src/backend/modules/blockchain/__tests__/transaction-detail.service.test.ts
+++ b/src/backend/modules/blockchain/__tests__/transaction-detail.service.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for TransactionDetailService — the read-through, permanently-cached
+ * transaction lookup. Covers the orchestration that matters: cache hits avoid
+ * the provider, misses fetch-assemble-persist, repeat lookups serve from cache,
+ * batches fill only their misses, ids are de-duplicated, and an unresolvable
+ * transaction returns null.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IDatabaseService } from '@/types';
+import { TransactionDetailService } from '../transaction-detail.service.js';
+import type { TronGridClient, TronGridTransaction, TronGridTransactionInfo } from '../tron-grid.client.js';
+import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+
+const COLLECTION = 'core_transaction_details';
+const HEX_ADDRESS = '41a614f803b6fd780986a42c78ec9c7f77e6ded13c';
+
+/** Build a minimal raw transaction (TransferContract) for the given id. */
+function rawTransfer(txId: string): TronGridTransaction {
+    return {
+        txID: txId,
+        raw_data: {
+            contract: [{
+                type: 'TransferContract',
+                parameter: { value: { owner_address: HEX_ADDRESS, to_address: HEX_ADDRESS, amount: 1_000_000 } }
+            }]
+        },
+        ret: [{ contractRet: 'SUCCESS', fee: 0 }]
+    } as unknown as TronGridTransaction;
+}
+
+/** Build the matching receipt for the given id. */
+function infoFor(txId: string): TronGridTransactionInfo {
+    return {
+        id: txId,
+        fee: 1100,
+        blockNumber: 555,
+        blockTimeStamp: 1_700_000_000_000,
+        receipt: { energy_usage_total: 0, energy_fee: 0, net_usage: 268, net_fee: 1100, result: 'SUCCESS' }
+    } as TronGridTransactionInfo;
+}
+
+interface MockProvider {
+    getTransactionById: ReturnType<typeof vi.fn>;
+    getTransactionInfo: ReturnType<typeof vi.fn>;
+}
+
+describe('TransactionDetailService', () => {
+    let database: IDatabaseService;
+    let provider: MockProvider;
+    let service: TransactionDetailService;
+
+    beforeEach(() => {
+        // Reset the singleton so each test wires fresh mocks.
+        (TransactionDetailService as unknown as { instance: TransactionDetailService | null }).instance = null;
+        database = createMockDatabaseService();
+        provider = {
+            getTransactionById: vi.fn(),
+            getTransactionInfo: vi.fn()
+        };
+        TransactionDetailService.setDependencies(database, provider as unknown as TronGridClient);
+        service = TransactionDetailService.getInstance();
+    });
+
+    it('serves a cache hit without calling the provider', async () => {
+        await database.insertOne(COLLECTION, {
+            txId: 'tx1',
+            blockNumber: 999,
+            timestamp: new Date(),
+            type: 'TransferContract',
+            status: 'SUCCESS',
+            from: { address: 'Tfrom' },
+            to: { address: 'Tto' },
+            feeSun: 0,
+            memo: null
+        });
+
+        const tx = await service.getTransactionById('tx1');
+
+        expect(tx?.blockNumber).toBe(999);
+        expect(provider.getTransactionById).not.toHaveBeenCalled();
+        expect(provider.getTransactionInfo).not.toHaveBeenCalled();
+    });
+
+    it('fills a miss from the provider and maps chain fields', async () => {
+        provider.getTransactionById.mockResolvedValue(rawTransfer('tx2'));
+        provider.getTransactionInfo.mockResolvedValue(infoFor('tx2'));
+
+        const tx = await service.getTransactionById('tx2');
+
+        expect(tx).toMatchObject({
+            txId: 'tx2',
+            blockNumber: 555,
+            type: 'TransferContract',
+            status: 'SUCCESS',
+            amountSun: 1_000_000,
+            feeSun: 1100,
+            bandwidth: { consumed: 268, feeSun: 1100 }
+        });
+        // energy was neither consumed nor charged → omitted entirely.
+        expect(tx?.energy).toBeUndefined();
+        // No native contract call → no contract detail on a plain transfer.
+        expect(tx?.contract).toBeUndefined();
+        expect(tx?.memo).toBeNull();
+    });
+
+    it('persists a miss so the next lookup is a cache hit', async () => {
+        provider.getTransactionById.mockResolvedValue(rawTransfer('tx3'));
+        provider.getTransactionInfo.mockResolvedValue(infoFor('tx3'));
+
+        await service.getTransactionById('tx3');
+        await service.getTransactionById('tx3');
+
+        expect(provider.getTransactionById).toHaveBeenCalledTimes(1);
+        expect(provider.getTransactionInfo).toHaveBeenCalledTimes(1);
+    });
+
+    it('fills only the misses in a batch', async () => {
+        await database.insertOne(COLLECTION, {
+            txId: 'hit', blockNumber: 1, timestamp: new Date(), type: 'TransferContract',
+            status: 'SUCCESS', from: { address: 'a' }, to: { address: 'b' }, feeSun: 0, memo: null
+        });
+        provider.getTransactionById.mockResolvedValue(rawTransfer('miss'));
+        provider.getTransactionInfo.mockResolvedValue(infoFor('miss'));
+
+        const txs = await service.getTransactionsByIds(['hit', 'miss']);
+
+        expect(txs.map(t => t.txId).sort()).toEqual(['hit', 'miss']);
+        expect(provider.getTransactionById).toHaveBeenCalledTimes(1);
+        expect(provider.getTransactionById).toHaveBeenCalledWith('miss');
+    });
+
+    it('de-duplicates repeated ids into a single provider fetch', async () => {
+        provider.getTransactionById.mockResolvedValue(rawTransfer('dup'));
+        provider.getTransactionInfo.mockResolvedValue(infoFor('dup'));
+
+        const txs = await service.getTransactionsByIds(['dup', 'dup', 'dup']);
+
+        expect(txs).toHaveLength(1);
+        expect(provider.getTransactionById).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null when the receipt cannot be resolved', async () => {
+        provider.getTransactionById.mockResolvedValue(rawTransfer('gone'));
+        provider.getTransactionInfo.mockResolvedValue(null);
+
+        expect(await service.getTransactionById('gone')).toBeNull();
+    });
+});

--- a/src/backend/modules/blockchain/__tests__/transaction-detail.service.test.ts
+++ b/src/backend/modules/blockchain/__tests__/transaction-detail.service.test.ts
@@ -14,6 +14,16 @@ import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-
 const COLLECTION = 'core_transaction_details';
 const HEX_ADDRESS = '41a614f803b6fd780986a42c78ec9c7f77e6ded13c';
 
+// Real TRON transaction ids are 64-char hex; the service validates this shape
+// and drops anything else, so test fixtures must use well-formed ids.
+const TX_CACHED = 'a'.repeat(64);
+const TX_MISS = 'b'.repeat(64);
+const TX_PERSIST = 'c'.repeat(64);
+const TX_BATCH_HIT = 'd'.repeat(64);
+const TX_BATCH_MISS = 'e'.repeat(64);
+const TX_DUP = 'f'.repeat(64);
+const TX_GONE = '0'.repeat(64);
+
 /** Build a minimal raw transaction (TransferContract) for the given id. */
 function rawTransfer(txId: string): TronGridTransaction {
     return {
@@ -63,7 +73,7 @@ describe('TransactionDetailService', () => {
 
     it('serves a cache hit without calling the provider', async () => {
         await database.insertOne(COLLECTION, {
-            txId: 'tx1',
+            txId: TX_CACHED,
             blockNumber: 999,
             timestamp: new Date(),
             type: 'TransferContract',
@@ -74,7 +84,7 @@ describe('TransactionDetailService', () => {
             memo: null
         });
 
-        const tx = await service.getTransactionById('tx1');
+        const tx = await service.getTransactionById(TX_CACHED);
 
         expect(tx?.blockNumber).toBe(999);
         expect(provider.getTransactionById).not.toHaveBeenCalled();
@@ -82,13 +92,13 @@ describe('TransactionDetailService', () => {
     });
 
     it('fills a miss from the provider and maps chain fields', async () => {
-        provider.getTransactionById.mockResolvedValue(rawTransfer('tx2'));
-        provider.getTransactionInfo.mockResolvedValue(infoFor('tx2'));
+        provider.getTransactionById.mockResolvedValue(rawTransfer(TX_MISS));
+        provider.getTransactionInfo.mockResolvedValue(infoFor(TX_MISS));
 
-        const tx = await service.getTransactionById('tx2');
+        const tx = await service.getTransactionById(TX_MISS);
 
         expect(tx).toMatchObject({
-            txId: 'tx2',
+            txId: TX_MISS,
             blockNumber: 555,
             type: 'TransferContract',
             status: 'SUCCESS',
@@ -104,11 +114,11 @@ describe('TransactionDetailService', () => {
     });
 
     it('persists a miss so the next lookup is a cache hit', async () => {
-        provider.getTransactionById.mockResolvedValue(rawTransfer('tx3'));
-        provider.getTransactionInfo.mockResolvedValue(infoFor('tx3'));
+        provider.getTransactionById.mockResolvedValue(rawTransfer(TX_PERSIST));
+        provider.getTransactionInfo.mockResolvedValue(infoFor(TX_PERSIST));
 
-        await service.getTransactionById('tx3');
-        await service.getTransactionById('tx3');
+        await service.getTransactionById(TX_PERSIST);
+        await service.getTransactionById(TX_PERSIST);
 
         expect(provider.getTransactionById).toHaveBeenCalledTimes(1);
         expect(provider.getTransactionInfo).toHaveBeenCalledTimes(1);
@@ -116,33 +126,33 @@ describe('TransactionDetailService', () => {
 
     it('fills only the misses in a batch', async () => {
         await database.insertOne(COLLECTION, {
-            txId: 'hit', blockNumber: 1, timestamp: new Date(), type: 'TransferContract',
+            txId: TX_BATCH_HIT, blockNumber: 1, timestamp: new Date(), type: 'TransferContract',
             status: 'SUCCESS', from: { address: 'a' }, to: { address: 'b' }, feeSun: 0, memo: null
         });
-        provider.getTransactionById.mockResolvedValue(rawTransfer('miss'));
-        provider.getTransactionInfo.mockResolvedValue(infoFor('miss'));
+        provider.getTransactionById.mockResolvedValue(rawTransfer(TX_BATCH_MISS));
+        provider.getTransactionInfo.mockResolvedValue(infoFor(TX_BATCH_MISS));
 
-        const txs = await service.getTransactionsByIds(['hit', 'miss']);
+        const txs = await service.getTransactionsByIds([TX_BATCH_HIT, TX_BATCH_MISS]);
 
-        expect(txs.map(t => t.txId).sort()).toEqual(['hit', 'miss']);
+        expect(txs.map(t => t.txId).sort()).toEqual([TX_BATCH_HIT, TX_BATCH_MISS].sort());
         expect(provider.getTransactionById).toHaveBeenCalledTimes(1);
-        expect(provider.getTransactionById).toHaveBeenCalledWith('miss');
+        expect(provider.getTransactionById).toHaveBeenCalledWith(TX_BATCH_MISS);
     });
 
     it('de-duplicates repeated ids into a single provider fetch', async () => {
-        provider.getTransactionById.mockResolvedValue(rawTransfer('dup'));
-        provider.getTransactionInfo.mockResolvedValue(infoFor('dup'));
+        provider.getTransactionById.mockResolvedValue(rawTransfer(TX_DUP));
+        provider.getTransactionInfo.mockResolvedValue(infoFor(TX_DUP));
 
-        const txs = await service.getTransactionsByIds(['dup', 'dup', 'dup']);
+        const txs = await service.getTransactionsByIds([TX_DUP, TX_DUP, TX_DUP]);
 
         expect(txs).toHaveLength(1);
         expect(provider.getTransactionById).toHaveBeenCalledTimes(1);
     });
 
     it('returns null when the receipt cannot be resolved', async () => {
-        provider.getTransactionById.mockResolvedValue(rawTransfer('gone'));
+        provider.getTransactionById.mockResolvedValue(rawTransfer(TX_GONE));
         provider.getTransactionInfo.mockResolvedValue(null);
 
-        expect(await service.getTransactionById('gone')).toBeNull();
+        expect(await service.getTransactionById(TX_GONE)).toBeNull();
     });
 });

--- a/src/backend/modules/blockchain/__tests__/transaction-parse.test.ts
+++ b/src/backend/modules/blockchain/__tests__/transaction-parse.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the shared transaction-parse module. These pure functions are
+ * the single source of truth for turning a TronGrid contract bag into
+ * normalized on-chain fields, consumed by both the sync pipeline and the
+ * transaction-detail service — so their behavior is pinned here.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+    normalizeContractType,
+    resolveOwnerAddress,
+    resolveRecipient,
+    resolveAmounts,
+    describeContract
+} from '../transaction-parse.js';
+
+/** A real TRON address in TronGrid hex form (the USDT TRC20 contract). */
+const HEX_ADDRESS = '41a614f803b6fd780986a42c78ec9c7f77e6ded13c';
+const BASE58 = /^T[1-9A-HJ-NP-Za-km-z]{33}$/;
+
+describe('normalizeContractType', () => {
+    it('passes through known contract types', () => {
+        expect(normalizeContractType('TransferContract')).toBe('TransferContract');
+        expect(normalizeContractType('TriggerSmartContract')).toBe('TriggerSmartContract');
+    });
+
+    it('maps unknown or missing types to Unknown', () => {
+        expect(normalizeContractType('NotAType')).toBe('Unknown');
+        expect(normalizeContractType(undefined)).toBe('Unknown');
+    });
+});
+
+describe('resolveOwnerAddress', () => {
+    it('converts a valid owner_address to base58', () => {
+        expect(resolveOwnerAddress({ owner_address: HEX_ADDRESS })).toMatch(BASE58);
+    });
+
+    it('falls back to "unknown" when absent or undecodable', () => {
+        expect(resolveOwnerAddress({})).toBe('unknown');
+    });
+});
+
+describe('resolveRecipient', () => {
+    it('reads to_address for a transfer', () => {
+        const to = resolveRecipient('TransferContract', { to_address: HEX_ADDRESS }, 'fallback');
+        expect(to).toMatch(BASE58);
+    });
+
+    it('reads contract_address for a smart-contract call', () => {
+        const to = resolveRecipient('TriggerSmartContract', { contract_address: HEX_ADDRESS }, 'fallback');
+        expect(to).toMatch(BASE58);
+    });
+
+    it('returns the fallback when no recipient field resolves', () => {
+        expect(resolveRecipient('TransferContract', {}, 'sender')).toBe('sender');
+    });
+});
+
+describe('resolveAmounts', () => {
+    it('reads the native amount for a transfer (sun and TRX)', () => {
+        expect(resolveAmounts('TransferContract', { amount: 1_500_000 })).toEqual({
+            rawAmountSun: 1_500_000,
+            amountTRX: 1.5
+        });
+    });
+
+    it('reads call_value for a smart-contract call and parses string values', () => {
+        expect(resolveAmounts('TriggerSmartContract', { call_value: '2000000' })).toEqual({
+            rawAmountSun: 2_000_000,
+            amountTRX: 2
+        });
+    });
+
+    it('is zero for types that carry no native value', () => {
+        expect(resolveAmounts('TriggerSmartContract', {})).toEqual({ rawAmountSun: 0, amountTRX: 0 });
+    });
+});
+
+describe('describeContract', () => {
+    it('describes a transfer with the transfer method', () => {
+        const contract = describeContract('TransferContract', { to_address: HEX_ADDRESS, amount: 1_000_000 });
+        expect(contract.method).toBe('transfer');
+        expect(contract.address).toMatch(BASE58);
+    });
+
+    it('decodes the 4-byte selector for a smart-contract call', () => {
+        const contract = describeContract('TriggerSmartContract', {
+            contract_address: HEX_ADDRESS,
+            data: 'a9059cbb0000000000000000000000000000000000000000000000000000000000000001'
+        });
+        expect(contract.method).toBe('0xa9059cbb');
+    });
+});

--- a/src/backend/modules/blockchain/blockchain.service.ts
+++ b/src/backend/modules/blockchain/blockchain.service.ts
@@ -11,6 +11,7 @@ import { DelegationFlowModel, ContractActivityModel, TokenModel } from '../../da
 import { QueueService } from '../../services/queue.service.js';
 import { blockchainConfig } from '../../config/blockchain.js';
 import { TronGridClient, type TronGridBlock, type TronGridTransaction, type TronGridTransactionInfo } from './tron-grid.client.js';
+import { normalizeContractType, resolveOwnerAddress, resolveRecipient, resolveAmounts, describeContract } from './transaction-parse.js';
 import { logger } from '../../lib/logger.js';
 import { env } from '../../config/env.js';
 import { getRedisClient } from '../../loaders/redis.js';
@@ -60,9 +61,7 @@ interface TransactionBuildContext {
 }
 
 
-type TransactionType = TransactionDoc['type'];
 type TransactionAddress = TransactionDoc['from'];
-type TransactionContract = TransactionDoc['contract'];
 type TransactionResource = TransactionDoc['energy'];
 type TransactionAnalysis = TransactionDoc['analysis'];
 
@@ -1265,16 +1264,16 @@ export class BlockchainService implements IBlockchainService {
             return null;
         }
 
-        const contractType = this.normalizeContractType(contract.type);
+        const contractType = normalizeContractType(contract.type);
         const value = (contract.parameter?.value ?? {}) as Record<string, unknown>;
 
         const timestamp = new Date(context.blockTime.getTime());
         const blockNumber = block.block_header.raw_data.number;
 
-        const ownerAddress = TronGridClient.toBase58Address(value.owner_address as string) ?? 'unknown';
-        const recipientAddress = this.resolveRecipient(contractType, value, ownerAddress);
+        const ownerAddress = resolveOwnerAddress(value);
+        const recipientAddress = resolveRecipient(contractType, value, ownerAddress);
 
-        const { rawAmountSun, amountTRX } = this.resolveAmounts(contractType, value);
+        const { rawAmountSun, amountTRX } = resolveAmounts(contractType, value);
         const amountUSD = context.priceUSD ? Number((amountTRX * context.priceUSD).toFixed(2)) : undefined;
 
         // Store raw hex memo data - consumers decode on frontend for display
@@ -1283,6 +1282,10 @@ export class BlockchainService implements IBlockchainService {
 
         const energyMetrics = this.buildEnergyMetrics(info);
         const bandwidthMetrics = this.buildBandwidthMetrics(info);
+
+        // Native execution result rides in the block payload (ret[].contractRet),
+        // so capturing it costs no extra API call. Empty string → undefined.
+        const status = transaction.ret?.[0]?.contractRet || undefined;
 
         const fromInsight = this.addressInsights.enrich(ownerAddress);
         const toInsight = this.addressInsights.enrich(recipientAddress);
@@ -1295,6 +1298,7 @@ export class BlockchainService implements IBlockchainService {
             // TRON protocol: resource field is "ENERGY" for energy operations, or undefined/null for BANDWIDTH
             // Observers must interpret undefined as BANDWIDTH (default resource type per TRON specification)
             subType: typeof value.resource === 'string' ? (value.resource as string) : undefined,
+            status,
             from: {
                 address: ownerAddress,
                 type: fromInsight.type ?? 'wallet',
@@ -1310,7 +1314,7 @@ export class BlockchainService implements IBlockchainService {
             amountUSD,
             energy: energyMetrics,
             bandwidth: bandwidthMetrics,
-            contract: this.describeContract(contractType, value),
+            contract: describeContract(contractType, value),
             memo,
             internalTransactions,
             notifications: [],
@@ -1347,93 +1351,6 @@ export class BlockchainService implements IBlockchainService {
         const rawTransaction: ITransaction = { payload, snapshot, categories: emptyCategories, rawValue, info };
 
         return new ProcessedTransaction(rawTransaction);
-    }
-
-    /**
-     * Extract the recipient address from a transaction based on contract type.
-     *
-     * Different contract types store the recipient in different fields - TransferContract uses to_address, TriggerSmartContract uses contract_address,
-     * delegation uses receiver_address, and so on. This method normalizes that variation so downstream code always has a consistent recipient field
-     * regardless of transaction type, falling back to the sender address for self-directed transactions like stake operations.
-     */
-    private resolveRecipient(contractType: TransactionType, value: Record<string, unknown>, fallback: string): string {
-        const candidates: Array<string | null | undefined> = [];
-
-        switch (contractType) {
-            case 'TransferContract':
-            case 'TransferAssetContract':
-                candidates.push(value.to_address as string);
-                break;
-            case 'TriggerSmartContract':
-                candidates.push(value.contract_address as string);
-                break;
-            case 'DelegateResourceContract':
-            case 'UnDelegateResourceContract':
-                candidates.push(value.receiver_address as string);
-                break;
-            case 'FreezeBalanceContract':
-            case 'FreezeBalanceV2Contract':
-            case 'UnfreezeBalanceContract':
-                candidates.push(value.receiver_address as string);
-                break;
-            default:
-                candidates.push(value.to_address as string);
-        }
-
-        for (const candidate of candidates) {
-            const address = TronGridClient.toBase58Address(candidate ?? undefined);
-            if (address) {
-                return address;
-            }
-        }
-
-        return fallback;
-    }
-
-    /**
-     * Extract transaction amounts from contract parameters based on transaction type.
-     *
-     * Amount fields vary by contract type - TransferContract uses 'amount', TriggerSmartContract uses 'call_value', delegation uses 'balance', and so on.
-     * This method normalizes those differences and handles both string and numeric values from TronGrid, returning amounts in both sun (atomic units)
-     * and TRX (human-readable) formats for consistent downstream handling.
-     */
-    private resolveAmounts(contractType: TransactionType, value: Record<string, unknown>) {
-        let rawAmountSun = 0;
-
-        const extract = (field: string) => {
-            const val = value[field];
-            if (typeof val === 'number') {
-                return val;
-            }
-            if (typeof val === 'string') {
-                const parsed = Number(val);
-                return Number.isFinite(parsed) ? parsed : 0;
-            }
-            return 0;
-        };
-
-        switch (contractType) {
-            case 'TransferContract':
-                rawAmountSun = extract('amount');
-                break;
-            case 'TriggerSmartContract':
-                rawAmountSun = extract('call_value');
-                break;
-            case 'DelegateResourceContract':
-            case 'UnDelegateResourceContract':
-                rawAmountSun = extract('balance');
-                break;
-            case 'FreezeBalanceContract':
-            case 'FreezeBalanceV2Contract':
-            case 'UnfreezeBalanceContract':
-                rawAmountSun = extract('frozen_balance') || extract('amount');
-                break;
-            default:
-                rawAmountSun = extract('amount');
-        }
-
-        const amountTRX = rawAmountSun / 1_000_000;
-        return { rawAmountSun, amountTRX };
     }
 
     /**
@@ -1487,120 +1404,6 @@ export class BlockchainService implements IBlockchainService {
     }
 
     /**
-     * Build a structured contract description with method name and relevant parameters.
-     *
-     * Extracts contract-specific details based on transaction type - for TransferContract it captures the recipient and amount, for TriggerSmartContract
-     * it decodes the method selector from calldata, for delegation it includes resource type and balance, and so on. This normalization provides a
-     * consistent contract representation across different transaction types so observers and analytics code don't need transaction-specific parsing logic.
-     */
-    private describeContract(contractType: TransactionType, value: Record<string, unknown>): TransactionContract {
-        switch (contractType) {
-            case 'TransferContract':
-                return {
-                    address: TronGridClient.toBase58Address(value.to_address as string) ?? 'unknown',
-                    method: 'transfer',
-                    parameters: {
-                        amountTRX: this.resolveAmounts(contractType, value).amountTRX
-                    }
-                };
-            case 'TriggerSmartContract': {
-                const data = typeof value.data === 'string' ? value.data : '';
-                const method = data?.length >= 8 ? `0x${data.slice(0, 8)}` : undefined;
-                return {
-                    address: TronGridClient.toBase58Address(value.contract_address as string) ?? 'unknown',
-                    method,
-                    parameters: {
-                        rawData: data,
-                        callValueTRX: this.resolveAmounts(contractType, value).amountTRX
-                    }
-                };
-            }
-            case 'DelegateResourceContract':
-                return {
-                    address: TronGridClient.toBase58Address(value.receiver_address as string) ?? 'unknown',
-                    method: 'delegateResource',
-                    parameters: {
-                        resource: value.resource,
-                        balanceTRX: this.resolveAmounts(contractType, value).amountTRX
-                    }
-                };
-            case 'UnDelegateResourceContract':
-                return {
-                    address: TronGridClient.toBase58Address(value.receiver_address as string) ?? 'unknown',
-                    method: 'undelegateResource',
-                    parameters: {
-                        resource: value.resource,
-                        balanceTRX: this.resolveAmounts(contractType, value).amountTRX
-                    }
-                };
-            case 'FreezeBalanceContract':
-            case 'FreezeBalanceV2Contract':
-                return {
-                    address: TronGridClient.toBase58Address(value.receiver_address as string) ?? 'unknown',
-                    method: 'freezeBalance',
-                    parameters: {
-                        resource: value.resource,
-                        duration: value.frozen_duration,
-                        balanceTRX: this.resolveAmounts(contractType, value).amountTRX
-                    }
-                };
-            case 'UnfreezeBalanceContract':
-                return {
-                    address: TronGridClient.toBase58Address(value.receiver_address as string) ?? 'unknown',
-                    method: 'unfreezeBalance',
-                    parameters: {
-                        resource: value.resource
-                    }
-                };
-            case 'AssetIssueContract':
-                return {
-                    address: TronGridClient.toBase58Address(value.owner_address as string) ?? 'unknown',
-                    method: 'assetIssue',
-                    parameters: {
-                        name: value.name,
-                        abbr: value.abbr,
-                        totalSupply: value.total_supply
-                    }
-                };
-            default:
-                return {
-                    address: TronGridClient.toBase58Address(value.contract_address as string) ?? 'unknown',
-                    method: contractType,
-                    parameters: value
-                };
-        }
-    }
-
-    /**
-     * Map raw TronGrid contract type strings to normalized transaction types.
-     * Ensures consistent type names across the application by validating against a known list, defaulting to 'Unknown' for unrecognized contract types.
-     */
-    private normalizeContractType(rawType: string | undefined): TransactionType {
-        const knownTypes: TransactionType[] = [
-            'TransferContract',
-            'TransferAssetContract',
-            'TriggerSmartContract',
-            'ParticipateAssetIssueContract',
-            'FreezeBalanceContract',
-            'FreezeBalanceV2Contract',
-            'UnfreezeBalanceContract',
-            'DelegateResourceContract',
-            'UnDelegateResourceContract',
-            'VoteWitnessContract',
-            'AssetIssueContract',
-            'CreateSmartContract',
-            'Unknown'
-        ];
-
-        if (rawType && knownTypes.includes(rawType as TransactionType)) {
-            return rawType as TransactionType;
-        }
-
-        return 'Unknown';
-    }
-
-
-    /**
      * Broadcast real-time block completion events to connected WebSocket clients.
      *
      * Emits block:new events with aggregate statistics so the frontend can display live sync progress and transaction volume metrics.
@@ -1638,6 +1441,7 @@ export class BlockchainService implements IBlockchainService {
             timestamp: payload.timestamp.toISOString(),
             type: (payload.type as TronTransactionDocument['type']) ?? 'Unknown',
             subType: payload.subType,
+            status: payload.status,
             from: payload.from,
             to: payload.to,
             amount: payload.amount ?? 0,

--- a/src/backend/modules/blockchain/transaction-ai-tools.ts
+++ b/src/backend/modules/blockchain/transaction-ai-tools.ts
@@ -1,0 +1,113 @@
+/**
+ * Core AI tool: retrieve a single TRON transaction's detail by id.
+ *
+ * Registered against the `ai-assistant` service through the service-registry
+ * watch pattern (the assistant is a runtime-toggleable plugin that loads after
+ * core, so we subscribe to its presence rather than resolving it once), the
+ * same approach the logs module uses. The tool is strictly read-only and
+ * backed by the cached `ITransactionDetailService`; every invocation passes
+ * through `TransactionToolGuard`, which rate-limits and records usage for the
+ * admin stats endpoint.
+ */
+import type {
+    IAiAssistantService,
+    IAiTool,
+    IServiceRegistry,
+    ITransactionDetailService,
+    ServiceWatchDisposer
+} from '@/types';
+import { logger } from '../../lib/logger.js';
+import { TransactionToolGuard } from './transaction-tool-guard.js';
+
+/** Provider id passed to `registerTool` so the admin UI groups the tool under core. */
+const PROVIDER_ID = 'core-blockchain';
+
+/** Tool name. The `tronrelic-` prefix marks a platform-default tool. */
+export const TRANSACTION_TOOL_NAME = 'tronrelic-get-transaction';
+
+/** A TRON transaction id is a 64-character hex hash. */
+const TXID_PATTERN = /^[0-9a-fA-F]{64}$/;
+
+/**
+ * Build the read-only transaction-lookup tool bound to a detail service and a
+ * usage guard. Exported so tests can exercise the handler directly.
+ *
+ * @param detailService - Cached transaction-detail lookup service.
+ * @param guard - Rate limiter and usage counter.
+ * @returns The tool definition ready for `registerTool`.
+ */
+export function buildTransactionTool(detailService: ITransactionDetailService, guard: TransactionToolGuard): IAiTool {
+    return {
+        name: TRANSACTION_TOOL_NAME,
+        description:
+            'Retrieve the full on-chain detail of a single TRON transaction by its ' +
+            'transaction id (hash). Use when the user asks about one specific ' +
+            'transaction — its block number, execution status (e.g. SUCCESS, REVERT, ' +
+            'OUT_OF_ENERGY), sender and recipient addresses, TRX amount, fee, energy or ' +
+            'bandwidth usage, or memo. The txId parameter (required) is the ' +
+            '64-character hexadecimal transaction hash. Returns one transaction object, ' +
+            'or a null transaction when the id cannot be resolved on-chain (which is not ' +
+            'an error). Returns factual blockchain data only. This tool is read-only and ' +
+            'rate-limited: it never submits, modifies, or broadcasts anything.',
+        inputSchema: {
+            type: 'object',
+            description: 'The transaction to look up.',
+            properties: {
+                txId: {
+                    type: 'string',
+                    description: 'The 64-character hexadecimal TRON transaction hash to retrieve.'
+                }
+            },
+            required: ['txId'],
+            additionalProperties: false
+        },
+        handler: async (input: Record<string, unknown>) => {
+            guard.beginInvocation();
+
+            const txId = typeof input.txId === 'string' ? input.txId.trim() : '';
+            if (!TXID_PATTERN.test(txId)) {
+                guard.rejectInvalid();
+                return { success: false, error: 'txId must be a 64-character hexadecimal transaction hash' };
+            }
+
+            if (!guard.tryConsume()) {
+                return { success: false, error: 'Rate limit exceeded for the transaction lookup tool. Try again shortly.' };
+            }
+
+            const transaction = await detailService.getTransactionById(txId);
+            guard.recordResolved(transaction !== null);
+            return { success: true, transaction };
+        }
+    };
+}
+
+/**
+ * Register the transaction-lookup tool with the ai-assistant service whenever
+ * it becomes available. Unregister-then-register keeps re-availability
+ * (plugin disable/enable, hot reload) from tripping the duplicate-name guard.
+ * Registration failures are logged and swallowed — AI tooling is optional and
+ * must never destabilize core.
+ *
+ * @param serviceRegistry - Shared registry to watch for `ai-assistant`.
+ * @param detailService - Cached transaction-detail lookup service.
+ * @returns Disposer that removes the watch subscription.
+ */
+export function registerTransactionAiTools(
+    serviceRegistry: IServiceRegistry,
+    detailService: ITransactionDetailService
+): ServiceWatchDisposer {
+    const log = logger.child({ module: 'transaction-ai-tools' });
+    const tool = buildTransactionTool(detailService, TransactionToolGuard.getInstance());
+
+    return serviceRegistry.watch<IAiAssistantService>('ai-assistant', {
+        onAvailable: (ai) => {
+            try {
+                ai.unregisterTool(tool.name);
+                ai.registerTool(tool, PROVIDER_ID);
+                log.info({ tool: tool.name }, 'Registered transaction AI tool with ai-assistant');
+            } catch (error) {
+                log.error({ error }, 'Failed to register transaction AI tool with ai-assistant');
+            }
+        }
+    });
+}

--- a/src/backend/modules/blockchain/transaction-ai-tools.ts
+++ b/src/backend/modules/blockchain/transaction-ai-tools.ts
@@ -74,9 +74,14 @@ export function buildTransactionTool(detailService: ITransactionDetailService, g
                 return { success: false, error: 'Rate limit exceeded for the transaction lookup tool. Try again shortly.' };
             }
 
-            const transaction = await detailService.getTransactionById(txId);
-            guard.recordResolved(transaction !== null);
-            return { success: true, transaction };
+            try {
+                const transaction = await detailService.getTransactionById(txId);
+                guard.recordResolved(transaction !== null);
+                return { success: true, transaction };
+            } catch (error) {
+                logger.error({ error, txId }, 'Transaction lookup tool failed');
+                return { success: false, error: 'An internal error occurred while retrieving the transaction.' };
+            }
         }
     };
 }

--- a/src/backend/modules/blockchain/transaction-detail.service.ts
+++ b/src/backend/modules/blockchain/transaction-detail.service.ts
@@ -20,6 +20,16 @@ import { normalizeContractType, resolveOwnerAddress, resolveRecipient, resolveAm
 /** Permanent cache collection for resolved transaction detail. */
 const COLLECTION = 'core_transaction_details';
 
+/** A TRON transaction id is a 64-character hex hash. Guards the public contract. */
+const TXID_PATTERN = /^[0-9a-fA-F]{64}$/;
+
+/**
+ * Max cache misses filled concurrently per chunk. Each miss issues two provider
+ * requests, and the provider's request queue is shared (with the sync pipeline)
+ * and capped, so 25 keeps in-flight requests (≤50) well under that ceiling.
+ */
+const FILL_CHUNK_SIZE = 25;
+
 /** Stored cache document — the contract shape plus Mongo's id. */
 type CachedTransaction = IBlockTransaction & { _id?: unknown };
 
@@ -95,7 +105,7 @@ export class TransactionDetailService implements ITransactionDetailService {
      * @returns Resolved transactions.
      */
     public async getTransactionsByIds(txIds: string[]): Promise<IBlockTransaction[]> {
-        const unique = [...new Set(txIds)].filter(id => id);
+        const unique = [...new Set(txIds)].filter(id => id && TXID_PATTERN.test(id));
         if (unique.length === 0) {
             return [];
         }
@@ -105,9 +115,22 @@ export class TransactionDetailService implements ITransactionDetailService {
         const found = new Set(hits.map(tx => tx.txId));
 
         const missing = unique.filter(id => !found.has(id));
-        const filled = await Promise.all(missing.map(id => this.fetchAndCache(id)));
 
-        return [...hits, ...filled.filter((tx): tx is IBlockTransaction => tx !== null)];
+        // Fill misses in bounded chunks. Each miss issues two provider requests
+        // against a shared, capped queue, so an unbounded fan-out would overflow
+        // it (and starve the sync pipeline) on large batches.
+        const filled: IBlockTransaction[] = [];
+        for (let i = 0; i < missing.length; i += FILL_CHUNK_SIZE) {
+            const chunk = missing.slice(i, i + FILL_CHUNK_SIZE);
+            const results = await Promise.all(chunk.map(id => this.fetchAndCache(id)));
+            for (const tx of results) {
+                if (tx !== null) {
+                    filled.push(tx);
+                }
+            }
+        }
+
+        return [...hits, ...filled];
     }
 
     /**
@@ -158,7 +181,7 @@ export class TransactionDetailService implements ITransactionDetailService {
             return null;
         }
 
-        const contract = rawTx.raw_data.contract?.[0];
+        const contract = rawTx.raw_data?.contract?.[0];
         if (!contract) {
             return null;
         }
@@ -179,7 +202,7 @@ export class TransactionDetailService implements ITransactionDetailService {
             from: { address: ownerAddress },
             to: { address: recipientAddress },
             feeSun: info.fee,
-            memo: TronGridClient.decodeMemo(rawTx.raw_data.data)
+            memo: TronGridClient.decodeMemo(rawTx.raw_data?.data)
         };
 
         if (rawAmountSun > 0) {

--- a/src/backend/modules/blockchain/transaction-detail.service.ts
+++ b/src/backend/modules/blockchain/transaction-detail.service.ts
@@ -1,0 +1,230 @@
+/**
+ * Read-through cache of full transaction detail, keyed by transaction id.
+ *
+ * A confirmed TRON transaction is immutable, so its detail is cached
+ * permanently in `core_transaction_details`: a hit is an indexed local read; a
+ * miss fetches the transaction from the provider (two calls — raw transaction
+ * plus receipt), persists it in the clean `IBlockTransaction` shape, and
+ * returns it. The cache shape *is* the contract, so there is no legacy-shape
+ * mapping and no retention gap.
+ *
+ * Published on the service registry as `'transaction-details'`. Singleton with
+ * injected resources (database + provider), matching the registry convention
+ * for `IXxxService` implementations.
+ */
+import type { IDatabaseService, IBlockTransaction, IResourceUsage, ITransactionDetailService } from '@/types';
+import { logger } from '../../lib/logger.js';
+import { TronGridClient, type TronGridTransaction, type TronGridTransactionInfo } from './tron-grid.client.js';
+import { normalizeContractType, resolveOwnerAddress, resolveRecipient, resolveAmounts, describeContract } from './transaction-parse.js';
+
+/** Permanent cache collection for resolved transaction detail. */
+const COLLECTION = 'core_transaction_details';
+
+/** Stored cache document — the contract shape plus Mongo's id. */
+type CachedTransaction = IBlockTransaction & { _id?: unknown };
+
+/**
+ * Lazily-populated, permanent transaction-detail lookup service.
+ */
+export class TransactionDetailService implements ITransactionDetailService {
+    private static instance: TransactionDetailService | null = null;
+
+    private readonly logger = logger.child({ service: 'transaction-detail' });
+
+    /**
+     * @param database - Core database for the cache collection.
+     * @param provider - Block provider used to fill cache misses.
+     */
+    private constructor(
+        private readonly database: IDatabaseService,
+        private readonly provider: TronGridClient
+    ) {}
+
+    /**
+     * Wire dependencies and create the singleton on first call. Subsequent
+     * calls are ignored so the instance and its resources stay stable.
+     *
+     * @param database - Core database service.
+     * @param provider - Block provider (TronGrid today).
+     */
+    public static setDependencies(database: IDatabaseService, provider: TronGridClient): void {
+        if (!TransactionDetailService.instance) {
+            TransactionDetailService.instance = new TransactionDetailService(database, provider);
+        }
+    }
+
+    /**
+     * Retrieve the singleton. Throws if `setDependencies` has not run.
+     */
+    public static getInstance(): TransactionDetailService {
+        if (!TransactionDetailService.instance) {
+            throw new Error('TransactionDetailService.setDependencies() must be called before getInstance()');
+        }
+        return TransactionDetailService.instance;
+    }
+
+    /**
+     * Create the cache indexes. Idempotent — safe to call once at bootstrap.
+     * The address indexes back per-account retrieval; `txId` is the unique
+     * lookup and dedup key.
+     */
+    public async ensureIndexes(): Promise<void> {
+        await this.database.createIndex(COLLECTION, { txId: 1 }, { unique: true });
+        await this.database.createIndex(COLLECTION, { 'from.address': 1 });
+        await this.database.createIndex(COLLECTION, { 'to.address': 1 });
+    }
+
+    /**
+     * Resolve a single transaction, cache-first.
+     *
+     * @param txId - Transaction hash.
+     * @returns The transaction, or null if it cannot be resolved.
+     */
+    public async getTransactionById(txId: string): Promise<IBlockTransaction | null> {
+        const [tx] = await this.getTransactionsByIds([txId]);
+        return tx ?? null;
+    }
+
+    /**
+     * Resolve many transactions, cache-first. Reads all cache hits in one
+     * indexed `$in` query, then fills only the misses from the provider
+     * concurrently. Returns the transactions that resolved, in no guaranteed
+     * order — map by `txId` if alignment matters.
+     *
+     * @param txIds - Transaction hashes (duplicates are de-duplicated).
+     * @returns Resolved transactions.
+     */
+    public async getTransactionsByIds(txIds: string[]): Promise<IBlockTransaction[]> {
+        const unique = [...new Set(txIds)].filter(id => id);
+        if (unique.length === 0) {
+            return [];
+        }
+
+        const cached = await this.database.find<CachedTransaction>(COLLECTION, { txId: { $in: unique } });
+        const hits = cached.map(stripId);
+        const found = new Set(hits.map(tx => tx.txId));
+
+        const missing = unique.filter(id => !found.has(id));
+        const filled = await Promise.all(missing.map(id => this.fetchAndCache(id)));
+
+        return [...hits, ...filled.filter((tx): tx is IBlockTransaction => tx !== null)];
+    }
+
+    /**
+     * Fetch a transaction's raw data and receipt from the provider, assemble
+     * the clean record, persist it, and return it. Returns null when either
+     * provider call fails to resolve the transaction.
+     */
+    private async fetchAndCache(txId: string): Promise<IBlockTransaction | null> {
+        const [rawTx, info] = await Promise.all([
+            this.provider.getTransactionById(txId),
+            this.provider.getTransactionInfo(txId)
+        ]);
+
+        const tx = this.assemble(rawTx, info);
+        if (!tx) {
+            return null;
+        }
+
+        await this.persist(tx);
+        return tx;
+    }
+
+    /**
+     * Persist a resolved transaction. Write-once: a duplicate-key race (two
+     * concurrent fills of the same id) is expected and ignored. Other write
+     * failures are logged but not thrown — the lookup still returns its data.
+     */
+    private async persist(tx: IBlockTransaction): Promise<void> {
+        try {
+            await this.database.insertOne(COLLECTION, { ...tx });
+        } catch (error) {
+            if ((error as { code?: number }).code === 11000) {
+                return;
+            }
+            this.logger.warn({ error, txId: tx.txId }, 'Failed to cache transaction detail');
+        }
+    }
+
+    /**
+     * Assemble an `IBlockTransaction` from a raw transaction and its receipt.
+     * Both are required: `raw_data` carries type/parties/amount/memo/status,
+     * the receipt carries the only source of block number, fee, and resource
+     * accounting. Returns null if either is absent or the transaction has no
+     * contract.
+     */
+    private assemble(rawTx: TronGridTransaction | null, info: TronGridTransactionInfo | null): IBlockTransaction | null {
+        if (!rawTx || !info) {
+            return null;
+        }
+
+        const contract = rawTx.raw_data.contract?.[0];
+        if (!contract) {
+            return null;
+        }
+
+        const contractType = normalizeContractType(contract.type);
+        const value = (contract.parameter?.value ?? {}) as Record<string, unknown>;
+        const ownerAddress = resolveOwnerAddress(value);
+        const recipientAddress = resolveRecipient(contractType, value, ownerAddress);
+        const { rawAmountSun } = resolveAmounts(contractType, value);
+        const isContractCall = contractType === 'TriggerSmartContract' || contractType === 'CreateSmartContract';
+
+        const tx: IBlockTransaction = {
+            txId: rawTx.txID,
+            blockNumber: info.blockNumber,
+            timestamp: new Date(info.blockTimeStamp),
+            type: contractType,
+            status: rawTx.ret?.[0]?.contractRet || info.receipt?.result || 'UNKNOWN',
+            from: { address: ownerAddress },
+            to: { address: recipientAddress },
+            feeSun: info.fee,
+            memo: TronGridClient.decodeMemo(rawTx.raw_data.data)
+        };
+
+        if (rawAmountSun > 0) {
+            tx.amountSun = rawAmountSun;
+        }
+
+        const energy = toResourceUsage(info.receipt?.energy_usage_total, info.receipt?.energy_fee);
+        if (energy) {
+            tx.energy = energy;
+        }
+
+        const bandwidth = toResourceUsage(info.receipt?.net_usage, info.receipt?.net_fee);
+        if (bandwidth) {
+            tx.bandwidth = bandwidth;
+        }
+
+        if (isContractCall) {
+            tx.contract = describeContract(contractType, value);
+        }
+
+        return tx;
+    }
+}
+
+/**
+ * Drop Mongo's `_id` from a cached document so callers receive the clean
+ * `IBlockTransaction` contract.
+ */
+function stripId(doc: CachedTransaction): IBlockTransaction {
+    const { _id, ...tx } = doc;
+    return tx;
+}
+
+/**
+ * Project chain receipt usage/fee into the clean `IResourceUsage` shape, or
+ * undefined when the resource was neither consumed nor charged.
+ *
+ * @param consumed - Units drawn (`energy_usage_total` or `net_usage`).
+ * @param feeSun - TRX burned in sun (`energy_fee` or `net_fee`).
+ */
+function toResourceUsage(consumed?: number, feeSun?: number): IResourceUsage | undefined {
+    const units = consumed ?? 0;
+    const fee = feeSun ?? 0;
+    if (!units && !fee) {
+        return undefined;
+    }
+    return { consumed: units, feeSun: fee };
+}

--- a/src/backend/modules/blockchain/transaction-parse.ts
+++ b/src/backend/modules/blockchain/transaction-parse.ts
@@ -1,0 +1,237 @@
+/**
+ * Pure parsing of TronGrid transaction `raw_data` into normalized on-chain
+ * fields. Extracted from `BlockchainService.buildTransactionRecord` so the
+ * sync pipeline and the lazy `TransactionDetailService` derive identical
+ * field values from the same source — preventing the two paths from drifting
+ * in how they interpret a contract's owner, recipient, amount, or method.
+ *
+ * Every function here is provider-shaped on input (it reads a TronGrid
+ * contract `parameter.value` bag) but provider-neutral on output: addresses
+ * are Base58, amounts are split into sun and TRX. Nothing here touches the
+ * database, the network, or instance state.
+ */
+import type { TronTransactionType, ContractDetails } from '@/shared';
+import { TronGridClient } from './tron-grid.client.js';
+
+/**
+ * Map a raw TronGrid contract type string to a normalized `TronTransactionType`,
+ * defaulting to `'Unknown'` for anything outside the known set.
+ *
+ * @param rawType - Raw `raw_data.contract[].type` string from TronGrid.
+ * @returns The normalized transaction type.
+ */
+export function normalizeContractType(rawType: string | undefined): TronTransactionType {
+    const knownTypes: TronTransactionType[] = [
+        'TransferContract',
+        'TransferAssetContract',
+        'TriggerSmartContract',
+        'ParticipateAssetIssueContract',
+        'FreezeBalanceContract',
+        'FreezeBalanceV2Contract',
+        'UnfreezeBalanceContract',
+        'DelegateResourceContract',
+        'UnDelegateResourceContract',
+        'VoteWitnessContract',
+        'AssetIssueContract',
+        'CreateSmartContract',
+        'Unknown'
+    ];
+
+    if (rawType && knownTypes.includes(rawType as TronTransactionType)) {
+        return rawType as TronTransactionType;
+    }
+
+    return 'Unknown';
+}
+
+/**
+ * Resolve the sender (owner) address of a contract to Base58, falling back to
+ * `'unknown'` when the owner address is absent or undecodable.
+ *
+ * @param value - Contract `parameter.value` bag.
+ * @returns Base58 owner address, or `'unknown'`.
+ */
+export function resolveOwnerAddress(value: Record<string, unknown>): string {
+    return TronGridClient.toBase58Address(value.owner_address as string) ?? 'unknown';
+}
+
+/**
+ * Resolve the recipient address for a contract to Base58. The recipient field
+ * varies by contract type (`to_address`, `contract_address`, `receiver_address`),
+ * so this normalizes that variation and falls back to the sender for
+ * self-directed operations like staking.
+ *
+ * @param contractType - Normalized transaction type.
+ * @param value - Contract `parameter.value` bag.
+ * @param fallback - Address to return when no recipient field resolves.
+ * @returns Base58 recipient address, or `fallback`.
+ */
+export function resolveRecipient(contractType: TronTransactionType, value: Record<string, unknown>, fallback: string): string {
+    const candidates: Array<string | null | undefined> = [];
+
+    switch (contractType) {
+        case 'TransferContract':
+        case 'TransferAssetContract':
+            candidates.push(value.to_address as string);
+            break;
+        case 'TriggerSmartContract':
+            candidates.push(value.contract_address as string);
+            break;
+        case 'DelegateResourceContract':
+        case 'UnDelegateResourceContract':
+            candidates.push(value.receiver_address as string);
+            break;
+        case 'FreezeBalanceContract':
+        case 'FreezeBalanceV2Contract':
+        case 'UnfreezeBalanceContract':
+            candidates.push(value.receiver_address as string);
+            break;
+        default:
+            candidates.push(value.to_address as string);
+    }
+
+    for (const candidate of candidates) {
+        const address = TronGridClient.toBase58Address(candidate ?? undefined);
+        if (address) {
+            return address;
+        }
+    }
+
+    return fallback;
+}
+
+/**
+ * Extract the native value moved by a transaction, in both sun and TRX. The
+ * amount field varies by contract type (`amount`, `call_value`, `balance`,
+ * `frozen_balance`); types without a native value resolve to zero.
+ *
+ * @param contractType - Normalized transaction type.
+ * @param value - Contract `parameter.value` bag.
+ * @returns `{ rawAmountSun, amountTRX }` (TRX is `rawAmountSun / 1e6`).
+ */
+export function resolveAmounts(contractType: TronTransactionType, value: Record<string, unknown>): { rawAmountSun: number; amountTRX: number } {
+    let rawAmountSun = 0;
+
+    const extract = (field: string): number => {
+        const val = value[field];
+        if (typeof val === 'number') {
+            return val;
+        }
+        if (typeof val === 'string') {
+            const parsed = Number(val);
+            return Number.isFinite(parsed) ? parsed : 0;
+        }
+        return 0;
+    };
+
+    switch (contractType) {
+        case 'TransferContract':
+            rawAmountSun = extract('amount');
+            break;
+        case 'TriggerSmartContract':
+            rawAmountSun = extract('call_value');
+            break;
+        case 'DelegateResourceContract':
+        case 'UnDelegateResourceContract':
+            rawAmountSun = extract('balance');
+            break;
+        case 'FreezeBalanceContract':
+        case 'FreezeBalanceV2Contract':
+        case 'UnfreezeBalanceContract':
+            rawAmountSun = extract('frozen_balance') || extract('amount');
+            break;
+        default:
+            rawAmountSun = extract('amount');
+    }
+
+    const amountTRX = rawAmountSun / 1_000_000;
+    return { rawAmountSun, amountTRX };
+}
+
+/**
+ * Build a structured contract description (address, method, relevant parameters)
+ * for a transaction, normalizing the per-type differences so consumers don't
+ * need transaction-specific parsing. For `TriggerSmartContract` the method is
+ * the 4-byte selector decoded from calldata.
+ *
+ * @param contractType - Normalized transaction type.
+ * @param value - Contract `parameter.value` bag.
+ * @returns Normalized contract details.
+ */
+export function describeContract(contractType: TronTransactionType, value: Record<string, unknown>): ContractDetails {
+    switch (contractType) {
+        case 'TransferContract':
+            return {
+                address: TronGridClient.toBase58Address(value.to_address as string) ?? 'unknown',
+                method: 'transfer',
+                parameters: {
+                    amountTRX: resolveAmounts(contractType, value).amountTRX
+                }
+            };
+        case 'TriggerSmartContract': {
+            const data = typeof value.data === 'string' ? value.data : '';
+            const method = data?.length >= 8 ? `0x${data.slice(0, 8)}` : undefined;
+            return {
+                address: TronGridClient.toBase58Address(value.contract_address as string) ?? 'unknown',
+                method,
+                parameters: {
+                    rawData: data,
+                    callValueTRX: resolveAmounts(contractType, value).amountTRX
+                }
+            };
+        }
+        case 'DelegateResourceContract':
+            return {
+                address: TronGridClient.toBase58Address(value.receiver_address as string) ?? 'unknown',
+                method: 'delegateResource',
+                parameters: {
+                    resource: value.resource,
+                    balanceTRX: resolveAmounts(contractType, value).amountTRX
+                }
+            };
+        case 'UnDelegateResourceContract':
+            return {
+                address: TronGridClient.toBase58Address(value.receiver_address as string) ?? 'unknown',
+                method: 'undelegateResource',
+                parameters: {
+                    resource: value.resource,
+                    balanceTRX: resolveAmounts(contractType, value).amountTRX
+                }
+            };
+        case 'FreezeBalanceContract':
+        case 'FreezeBalanceV2Contract':
+            return {
+                address: TronGridClient.toBase58Address(value.receiver_address as string) ?? 'unknown',
+                method: 'freezeBalance',
+                parameters: {
+                    resource: value.resource,
+                    duration: value.frozen_duration,
+                    balanceTRX: resolveAmounts(contractType, value).amountTRX
+                }
+            };
+        case 'UnfreezeBalanceContract':
+            return {
+                address: TronGridClient.toBase58Address(value.receiver_address as string) ?? 'unknown',
+                method: 'unfreezeBalance',
+                parameters: {
+                    resource: value.resource
+                }
+            };
+        case 'AssetIssueContract':
+            return {
+                address: TronGridClient.toBase58Address(value.owner_address as string) ?? 'unknown',
+                method: 'assetIssue',
+                parameters: {
+                    name: value.name,
+                    abbr: value.abbr,
+                    totalSupply: value.total_supply
+                }
+            };
+        default:
+            return {
+                address: TronGridClient.toBase58Address(value.contract_address as string) ?? 'unknown',
+                method: contractType,
+                parameters: value
+            };
+    }
+}

--- a/src/backend/modules/blockchain/transaction-tool-guard.ts
+++ b/src/backend/modules/blockchain/transaction-tool-guard.ts
@@ -1,0 +1,144 @@
+/**
+ * Process-wide safeguard for the transaction-detail AI tool.
+ *
+ * The tool handler receives only its input — no caller or conversation
+ * identity — so abuse protection cannot be per-user. Instead this guard is a
+ * global fixed-window rate limiter that caps how often the tool runs across
+ * all callers, protecting the upstream provider and the model's context budget
+ * from an agent that fans out dozens of calls in seconds. It also accumulates
+ * usage counters so an admin can review tool activity and rejections.
+ *
+ * A singleton (like `PluginWebSocketRegistry`) because the limiter window and
+ * counters are shared per-process state with no external dependencies. The
+ * admin stats endpoint and the tool handler read the same instance.
+ */
+
+/** Rolling window length for the rate limiter. */
+const WINDOW_MS = 60_000;
+
+/** Maximum tool invocations allowed within one window, across all callers. */
+const MAX_PER_WINDOW = 60;
+
+/** Usage snapshot surfaced to the admin monitoring API. */
+export interface ITransactionToolStats {
+    /** Total handler invocations since boot. */
+    invocations: number;
+    /** Invocations that passed the rate limiter and ran. */
+    allowed: number;
+    /** Invocations rejected by the rate limiter. */
+    rateLimited: number;
+    /** Invocations rejected for a malformed transaction id. */
+    invalidInput: number;
+    /** Allowed lookups that resolved a transaction. */
+    resolved: number;
+    /** Allowed lookups that found no transaction. */
+    notFound: number;
+    /** Current rate-limiter window state. */
+    window: {
+        limit: number;
+        windowMs: number;
+        used: number;
+        remaining: number;
+        resetInMs: number;
+    };
+    /** ISO timestamp of the most recent invocation, or null. */
+    lastInvocationAt: string | null;
+    /** ISO timestamp of the most recent rate-limit rejection, or null. */
+    lastRateLimitedAt: string | null;
+}
+
+/**
+ * Global rate limiter and usage counter for the transaction-detail AI tool.
+ */
+export class TransactionToolGuard {
+    private static instance: TransactionToolGuard | null = null;
+
+    private windowStart = Date.now();
+    private windowCount = 0;
+    private invocations = 0;
+    private allowed = 0;
+    private rateLimited = 0;
+    private invalidInput = 0;
+    private resolved = 0;
+    private notFound = 0;
+    private lastInvocationAt: number | null = null;
+    private lastRateLimitedAt: number | null = null;
+
+    /** Retrieve the shared guard, creating it on first use. */
+    public static getInstance(): TransactionToolGuard {
+        if (!TransactionToolGuard.instance) {
+            TransactionToolGuard.instance = new TransactionToolGuard();
+        }
+        return TransactionToolGuard.instance;
+    }
+
+    /** Drop the singleton so each test starts from a clean window and counters. */
+    public static resetForTests(): void {
+        TransactionToolGuard.instance = null;
+    }
+
+    /** Record that an invocation arrived. Call once at the top of the handler. */
+    public beginInvocation(): void {
+        this.invocations++;
+        this.lastInvocationAt = Date.now();
+    }
+
+    /** Record an invocation rejected for malformed input. */
+    public rejectInvalid(): void {
+        this.invalidInput++;
+    }
+
+    /**
+     * Attempt to consume one unit of the rate budget. Rolls the window when it
+     * has elapsed. Returns false (and records the rejection) when the window is
+     * already exhausted.
+     */
+    public tryConsume(): boolean {
+        const now = Date.now();
+        if (now - this.windowStart >= WINDOW_MS) {
+            this.windowStart = now;
+            this.windowCount = 0;
+        }
+        if (this.windowCount >= MAX_PER_WINDOW) {
+            this.rateLimited++;
+            this.lastRateLimitedAt = now;
+            return false;
+        }
+        this.windowCount++;
+        this.allowed++;
+        return true;
+    }
+
+    /** Record the outcome of an allowed lookup. */
+    public recordResolved(found: boolean): void {
+        if (found) {
+            this.resolved++;
+        } else {
+            this.notFound++;
+        }
+    }
+
+    /** Produce a point-in-time usage snapshot for the admin API. */
+    public snapshot(): ITransactionToolStats {
+        const elapsed = Date.now() - this.windowStart;
+        const expired = elapsed >= WINDOW_MS;
+        const used = expired ? 0 : this.windowCount;
+        return {
+            invocations: this.invocations,
+            allowed: this.allowed,
+            rateLimited: this.rateLimited,
+            invalidInput: this.invalidInput,
+            resolved: this.resolved,
+            notFound: this.notFound,
+            window: {
+                limit: MAX_PER_WINDOW,
+                windowMs: WINDOW_MS,
+                used,
+                remaining: Math.max(0, MAX_PER_WINDOW - used),
+                resetInMs: expired ? 0 : WINDOW_MS - elapsed
+            },
+            lastInvocationAt: this.lastInvocationAt ? new Date(this.lastInvocationAt).toISOString() : null,
+            lastRateLimitedAt: this.lastRateLimitedAt ? new Date(this.lastRateLimitedAt).toISOString() : null
+        };
+    }
+}

--- a/src/backend/modules/blockchain/tron-grid.client.ts
+++ b/src/backend/modules/blockchain/tron-grid.client.ts
@@ -359,6 +359,35 @@ export class TronGridClient {
         });
     }
 
+    /**
+     * Fetch a single raw transaction by id via `/wallet/gettransactionbyid`.
+     *
+     * Returns the transaction's `raw_data` (contract, memo, type) and `ret`
+     * (contractRet status). This is the complement to `getTransactionInfo`,
+     * which carries the receipt, fee, and block number but not `raw_data`.
+     * Returns null on any error or when the id is unknown so callers can treat
+     * a miss as "not resolvable" rather than throwing.
+     *
+     * @param txId - Transaction hash to fetch.
+     * @returns The raw transaction, or null.
+     */
+    async getTransactionById(txId: string): Promise<TronGridTransaction | null> {
+        try {
+            const tx = await retry(
+                () => this.post<TronGridTransaction>('/wallet/gettransactionbyid', { value: txId }),
+                {
+                    ...blockchainConfig.retry,
+                    onRetry: (attempt, error) => logger.warn({ attempt, error, txId }, 'Retrying TronGrid getTransactionById')
+                }
+            );
+            // An unknown id returns an empty object `{}` (no txID), not an error.
+            return tx?.txID ? tx : null;
+        } catch (error) {
+            logger.error({ error, txId }, 'Failed to fetch transaction by id');
+            return null;
+        }
+    }
+
     async getTransactionInfo(txId: string): Promise<TronGridTransactionInfo | null> {
         try {
             return await retry(

--- a/src/frontend/app/(core)/system/system/components/TransactionToolSection.module.scss
+++ b/src/frontend/app/(core)/system/system/components/TransactionToolSection.module.scss
@@ -1,0 +1,63 @@
+/**
+ * TransactionToolSection styles.
+ *
+ * Mirrors the compact sub-block layout used by the other console sections:
+ * tiny caps block titles, an inline metadata note in the block header, and
+ * StatStrip rows for the metric grids. Collapses block headers to a column
+ * at narrow container widths.
+ */
+
+@use '../../../../../app/breakpoints' as *;
+
+.subsection {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+    container-type: inline-size;
+    container-name: transaction-tool-subsection;
+}
+
+.block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+}
+
+.block_header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--gap-sm);
+    flex-wrap: wrap;
+}
+
+.block_title {
+    margin: 0;
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-wide);
+    color: var(--color-text-muted);
+}
+
+.block_note {
+    margin: 0;
+    font-size: var(--font-size-caption);
+    color: var(--color-text-subtle);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-xs);
+}
+
+.error_inline {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-xs);
+}
+
+@container transaction-tool-subsection (max-width: #{$breakpoint-mobile-md}) {
+    .block_header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}

--- a/src/frontend/app/(core)/system/system/components/TransactionToolSection.tsx
+++ b/src/frontend/app/(core)/system/system/components/TransactionToolSection.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { AlertCircle } from 'lucide-react';
+import { ClientTime } from '../../../../../components/ui/ClientTime';
+import { StatStrip } from './StatStrip';
+import styles from './TransactionToolSection.module.scss';
+
+/** Mirrors the backend `ITransactionToolStats` shape. */
+interface TransactionToolStats {
+    invocations: number;
+    allowed: number;
+    rateLimited: number;
+    invalidInput: number;
+    resolved: number;
+    notFound: number;
+    window: {
+        limit: number;
+        windowMs: number;
+        used: number;
+        remaining: number;
+        resetInMs: number;
+    };
+    lastInvocationAt: string | null;
+    lastRateLimitedAt: string | null;
+}
+
+/**
+ * Usage and safeguard readout for the core `tronrelic-get-transaction` AI tool.
+ *
+ * Polls the admin stats endpoint and renders three StatStrip blocks — request
+ * throughput, lookup outcomes, and the global rate-limiter window — so an
+ * operator can see at a glance how often the tool runs, how many calls the
+ * limiter rejects, and how much budget remains in the current window.
+ */
+export function TransactionToolSection() {
+    const [stats, setStats] = useState<TransactionToolStats | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchData = useCallback(async () => {
+        try {
+            const response = await fetch('/api/admin/system/blockchain/transaction-tool/stats');
+            if (!response.ok) {
+                throw new Error(`Transaction tool stats unavailable (status ${response.status})`);
+            }
+            setStats((await response.json()).stats ?? null);
+            setError(null);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to fetch transaction tool stats');
+        }
+    }, []);
+
+    useEffect(() => {
+        void fetchData();
+        const interval = setInterval(() => void fetchData(), 10000);
+        return () => clearInterval(interval);
+    }, [fetchData]);
+
+    return (
+        <div className={styles.subsection}>
+            {error && (
+                <div className="alert alert--danger" role="alert">
+                    <span className={styles.error_inline}>
+                        <AlertCircle size={14} aria-hidden="true" />
+                        {error}
+                    </span>
+                </div>
+            )}
+
+            {stats && (
+                <>
+                    <div className={styles.block}>
+                        <header className={styles.block_header}>
+                            <h4 className={styles.block_title}>Request Throughput</h4>
+                            {stats.lastInvocationAt && (
+                                <span className={styles.block_note}>
+                                    Last call: <ClientTime date={stats.lastInvocationAt} format="datetime" />
+                                </span>
+                            )}
+                        </header>
+                        <StatStrip
+                            items={[
+                                { label: 'Invocations', value: stats.invocations.toLocaleString(), detail: 'Total since boot' },
+                                { label: 'Allowed', value: stats.allowed.toLocaleString(), detail: 'Passed the limiter' },
+                                {
+                                    label: 'Rate Limited',
+                                    value: stats.rateLimited.toLocaleString(),
+                                    detail: 'Rejected by limiter',
+                                    tone: stats.rateLimited > 0 ? 'warning' : 'neutral'
+                                },
+                                {
+                                    label: 'Invalid Input',
+                                    value: stats.invalidInput.toLocaleString(),
+                                    detail: 'Malformed txId',
+                                    tone: stats.invalidInput > 0 ? 'danger' : 'neutral'
+                                }
+                            ]}
+                        />
+                    </div>
+
+                    <div className={styles.block}>
+                        <h4 className={styles.block_title}>Lookup Outcomes</h4>
+                        <StatStrip
+                            items={[
+                                { label: 'Resolved', value: stats.resolved.toLocaleString(), detail: 'Transaction found' },
+                                { label: 'Not Found', value: stats.notFound.toLocaleString(), detail: 'No transaction' },
+                                {
+                                    label: 'Resolve Rate',
+                                    value: stats.allowed > 0
+                                        ? `${((stats.resolved / stats.allowed) * 100).toFixed(1)}%`
+                                        : '—',
+                                    detail: 'Resolved / allowed'
+                                }
+                            ]}
+                        />
+                    </div>
+
+                    <div className={styles.block}>
+                        <header className={styles.block_header}>
+                            <h4 className={styles.block_title}>Rate Limiter Window</h4>
+                            {stats.lastRateLimitedAt && (
+                                <span className={styles.block_note}>
+                                    Last rejection: <ClientTime date={stats.lastRateLimitedAt} format="datetime" />
+                                </span>
+                            )}
+                        </header>
+                        <StatStrip
+                            items={[
+                                {
+                                    label: 'Limit',
+                                    value: `${stats.window.limit}`,
+                                    detail: `Per ${Math.round(stats.window.windowMs / 1000)}s window`
+                                },
+                                { label: 'Used', value: `${stats.window.used}`, detail: 'This window' },
+                                {
+                                    label: 'Remaining',
+                                    value: `${stats.window.remaining}`,
+                                    detail: 'Budget left',
+                                    tone: getRemainingTone(stats.window.remaining, stats.window.limit)
+                                },
+                                {
+                                    label: 'Resets In',
+                                    value: stats.window.resetInMs > 0
+                                        ? `${Math.ceil(stats.window.resetInMs / 1000)}s`
+                                        : 'now'
+                                }
+                            ]}
+                        />
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+/**
+ * Tone for the remaining-budget cell: danger when exhausted, warning when
+ * under a fifth of the window remains, otherwise success.
+ */
+function getRemainingTone(remaining: number, limit: number): 'success' | 'warning' | 'danger' {
+    if (remaining <= 0) return 'danger';
+    if (remaining < limit * 0.2) return 'warning';
+    return 'success';
+}

--- a/src/frontend/app/(core)/system/system/page.tsx
+++ b/src/frontend/app/(core)/system/system/page.tsx
@@ -7,6 +7,7 @@ import { OverviewBar } from './components/OverviewBar';
 import { SystemConfigSection } from './components/SystemConfigSection';
 import { ServerSection } from './components/ServerSection';
 import { BlockchainSection } from './components/BlockchainSection';
+import { TransactionToolSection } from './components/TransactionToolSection';
 import { WebSocketsSection } from './components/WebSocketsSection';
 import { MongoSection } from './components/MongoSection';
 import { ClickHouseSection } from './components/ClickHouseSection';
@@ -35,6 +36,9 @@ export default function SystemAdminPage() {
                     </ConsoleRow>
                     <ConsoleRow id="blockchain" title="Blockchain" status="idle">
                         <BlockchainSection />
+                    </ConsoleRow>
+                    <ConsoleRow id="transaction-tool" title="Transaction Tool" status="idle">
+                        <TransactionToolSection />
                     </ConsoleRow>
                     <ConsoleRow id="websockets" title="WebSockets" status="idle">
                         <WebSocketsSection />

--- a/src/shared/types/transaction.ts
+++ b/src/shared/types/transaction.ts
@@ -54,6 +54,7 @@ export interface TronTransactionDocument {
   timestamp: string;
   type: TronTransactionType;
   subType?: string;
+  status?: string;
   from: AddressMetadata;
   to: AddressMetadata;
   amount: number;


### PR DESCRIPTION
Adds a permanent read-through transaction-detail cache and a read-only AI tool for resolving a single TRON transaction by id.

- `IBlockTransaction`: a source-independent domain type for a transaction, with a new `system-domain-types.md` convention doc establishing that the types package holds only source-independent contracts.
- `TransactionDetailService` (registered as `transaction-details`): cache-first lookup over `core_transaction_details`, filling misses from the provider and returning the clean shape. A confirmed transaction is immutable, so the cache never goes stale.
- Shared `transaction-parse` module extracted from `buildTransactionRecord` so the sync pipeline and the detail service derive identical fields. Native `ret.contractRet` is now persisted as transaction status on ingest.
- Read-only `tronrelic-get-transaction` AI tool behind a global rate-limit guard; usage stats exposed at `/api/admin/system/blockchain/transaction-tool/stats` and a panel on the `/system` dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)