### PR TITLE
refactor(ai-tools): make tool capability purely declarative

### DIFF
--- a/docs/system/system-ai-tools.md
+++ b/docs/system/system-ai-tools.md
@@ -47,15 +47,17 @@ Classify every tool before it ships; the class drives the guardrails the governo
 | Spends money | yes / no | Cost cap + quota |
 | Sensitivity | `public` · `internal` · `secret` | Audit redaction + trifecta accounting |
 | Surfaces untrusted content | yes / no | Trifecta accounting (injection source) |
-| Requires approval | yes / no | Human-in-the-loop gate |
+| Forces curator review | yes / no | Tool self-gates every effect → no governor approval added; safe unattended |
 
-A transaction lookup is read / internal. A log query is read / secret / surfaces-untrusted. A tweet is external / irreversible / requires-approval. An image generation is external / spends-money.
+A transaction lookup is read / internal. A log query is read / secret / surfaces-untrusted. A tweet is external / irreversible and forces-curator-review (its plugin holds every post for human approval). An image generation is external / spends-money.
+
+`forcesCuratorReview` is the only governance field a tool may declare, and it is a *description* of behaviour, not a request: the governor derives the approval gate and the autonomous-path rule from it. There is no field that lets a tool exempt itself from review — an external, irreversible effect is always reviewed by someone (the tool's own curator, or the governor). Dropping review for a tool that does not self-curate is an operator-only decision (an admin policy override), never a tool self-grant.
 
 ## Accountability and Security
 
 Mandatory for every tool; scale to the class. A read-only lookup needs little, an external action needs all of it.
 
-**Least privilege, default-deny for danger.** External, irreversible, and money-spending tools are opt-in and ship disabled. They must not run on autonomous paths (scheduled prompts, programmatic `ask()` from other plugins) unless explicitly authorized — an unattended run has no human to catch a mistake. Authorize a genuinely-safe external tool for unattended use by declaring `allowUnattended: true` on its capability, or via an admin policy override.
+**Least privilege, default-deny for danger.** External, irreversible, and money-spending tools are opt-in and ship disabled. They must not run on autonomous paths (scheduled prompts, programmatic `ask()` from other plugins) — an unattended run has no human to catch a mistake. A tool that declares `forcesCuratorReview: true` is the exception: because every effect it produces is held for a human curator, an unattended call can do no more than draft into that queue, so the governor treats it as autonomous-safe. Any other external tool runs unattended only via an admin policy override.
 
 **Validate every input.** The schema is a hint to the model, not a guarantee. Re-check every argument in the handler (format, range, enum) and reject with a descriptive error the model can correct from. Never pass model-supplied values into a query, path, command, or URL unchecked.
 
@@ -63,7 +65,7 @@ Mandatory for every tool; scale to the class. A read-only lookup needs little, a
 
 **Bound side-effecting and paid tools.** Rate-limit, quota, and cap cost. A looping or injected model must not drain an API budget or flood a channel. `TransactionToolGuard` is the reference limiter.
 
-**Require human approval for irreversible or public effects.** Park the action for admin approval instead of executing inline. `trp-x-poster` is the reference: every AI-authored post waits for a human.
+**Require human approval for irreversible or public effects.** Either let the governor park the action for admin approval, or declare `forcesCuratorReview: true` when the tool holds every effect in its own review queue. `trp-x-poster` is the reference: it declares `forcesCuratorReview` and every AI-authored post waits for a human in its History tab.
 
 **Audit every invocation.** Record who triggered it (interactive admin / scheduled / programmatic), the arguments, the outcome, and the cost — enough to reconstruct what happened. `trp-image-gen`'s per-call history is the reference shape.
 
@@ -114,7 +116,7 @@ const tool: IAiTool = {
 
 ## Pre-Ship Checklist
 
-- [ ] Classified: side effect, reversibility, spend, sensitivity, untrusted-content, approval
+- [ ] Classified: side effect, reversibility, spend, sensitivity, untrusted-content, forces-curator-review
 - [ ] `description` states purpose, when (not) to use, params, return shape, limits
 - [ ] Every input re-validated in the handler; descriptive errors returned
 - [ ] Object access authorized for id-addressed tools

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delphian/tronrelic-types",
-    "version": "3.8.0",
+    "version": "3.9.0",
     "description": "Core type definitions for the TronRelic platform",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/types/src/ai-tools/IAiToolCapability.ts
+++ b/packages/types/src/ai-tools/IAiToolCapability.ts
@@ -7,8 +7,6 @@
  * class instead of trusting prose in the tool description.
  */
 
-import type { IToolPolicy } from './IToolPolicy.js';
-
 /**
  * What a tool does to the world.
  * - `read` — returns data, mutates nothing.
@@ -61,22 +59,17 @@ export interface IAiToolCapability {
      */
     surfacesUntrustedContent?: boolean;
 
-    /** Whether each invocation must be approved by a human before it runs. */
-    requiresApproval?: boolean;
-
     /**
-     * Whether the tool is safe to run on autonomous trigger paths (scheduled
-     * prompts, programmatic `ask()` from other plugins). Defaults to false for
-     * `external` tools — an unattended run has no human to catch a mistake — and
-     * true otherwise. Declaring it lets a tool author opt a genuinely-safe
-     * external tool into unattended use without an operator policy override; an
-     * admin policy override still wins over this declaration.
+     * Whether the tool guarantees, by its own construction, that every effect it
+     * produces is held for a human curator's review before it takes hold — a
+     * built-in approval queue, for example. This describes what the tool *does*,
+     * not what it *wants*: the governor derives its gates from the fact rather
+     * than accepting a request to relax them. A self-curated external/irreversible
+     * tool needs no governor approval (its curator is the approval, so a second
+     * gate would be redundant) and is safe on autonomous trigger paths (an
+     * unattended call can do no more than draft into the curator's queue). Leave
+     * false unless the tool truly enforces its own human review — an operator
+     * policy override is the only way to drop review for a tool that does not.
      */
-    allowUnattended?: boolean;
-
-    /**
-     * Named policy id, or an inline policy, overriding the class-derived
-     * defaults. Resolved by the governor's policy engine.
-     */
-    policy?: string | IToolPolicy;
+    forcesCuratorReview?: boolean;
 }

--- a/src/backend/modules/ai-tools/README.md
+++ b/src/backend/modules/ai-tools/README.md
@@ -48,10 +48,10 @@ A tool declares `IAiToolCapability`; the registry sets its first-boot enabled st
 |---|---|---|
 | `sideEffect: 'read'` | enabled | light rate cap |
 | `sideEffect: 'write'` | enabled | rate cap + full-arg audit |
-| `sideEffect: 'external'` / `reversible: false` / `spendsMoney` | **disabled** | rate cap + approval (when irreversible) + **autonomous default-deny** |
+| `sideEffect: 'external'` / `reversible: false` / `spendsMoney` | **disabled** | rate cap + approval (irreversible & not self-curated) + **autonomous default-deny** (unless self-curated) |
 | `sensitivity: 'secret'` | — | arguments redacted in the audit record |
 
-**Autonomous default-deny:** on `triggerPath` `scheduled` or `programmatic`, an `external` tool is denied unless `allowUnattended` is set — declared on the tool's capability for a genuinely-safe tool, or forced by an admin policy override. **Approval:** irreversible/public effects park as `pending-approval` and run only when an admin approves.
+**Autonomous default-deny:** on `triggerPath` `scheduled` or `programmatic`, an `external` tool is denied unless it declares `forcesCuratorReview: true` — its own human-review queue makes an unattended call safe, because the call can only draft into that queue — or an admin policy override grants `allowUnattended`. **Approval:** an external/irreversible tool that does not self-curate parks as `pending-approval` and runs only when an admin approves; a `forcesCuratorReview` tool relies on its own queue, so the governor adds no second gate. Both gates derive from the capability — a tool cannot opt itself out of either; only an admin policy override (`IToolPolicy`) can relax them.
 
 **Lethal-trifecta detection:** `detectTrifecta()` scans the *enabled* set for the co-presence of a `sensitivity: 'secret'` reader, a `surfacesUntrustedContent` source, and an `external` sink — the combination that lets injected text read a secret and exfiltrate it in one turn. `GET /trifecta` surfaces `present` plus the tool names forming each leg, so an operator can break the chain by disabling one.
 

--- a/src/backend/modules/ai-tools/__tests__/ai-tools-module.test.ts
+++ b/src/backend/modules/ai-tools/__tests__/ai-tools-module.test.ts
@@ -69,13 +69,18 @@ function externalTool(handler = vi.fn(async () => ({ posted: true }))): IAiTool 
     };
 }
 
-/** An external tool the author cleared for unattended use (reversible, opt-in). */
-function unattendedExternalTool(handler = vi.fn(async () => ({ sent: true }))): IAiTool {
+/**
+ * A self-curated external/irreversible tool: it forces its own human curator
+ * review, so the governor derives no approval gate (the curator is the approval)
+ * and it is safe on autonomous paths (an unattended call can only draft into the
+ * curator's queue).
+ */
+function curatedExternalTool(handler = vi.fn(async () => ({ sent: true }))): IAiTool {
     return {
-        name: 'test-unattended',
-        description: 'An external but reversible tool cleared for unattended use.',
+        name: 'test-curated',
+        description: 'An external, irreversible tool that forces its own curator review.',
         inputSchema: { type: 'object', properties: {}, required: [], additionalProperties: false },
-        capability: { sideEffect: 'external', reversible: true, sensitivity: 'internal', allowUnattended: true },
+        capability: { sideEffect: 'external', reversible: false, sensitivity: 'public', forcesCuratorReview: true },
         handler
     };
 }
@@ -222,13 +227,13 @@ describe('AiToolsModule', () => {
             expect(result.status).toBe('denied');
         });
 
-        it('permits an allowUnattended external tool on an autonomous run', async () => {
+        it('permits a self-curated external tool on an autonomous run', async () => {
             const handler = vi.fn(async () => ({ sent: true }));
             const registry = module.getRegistry();
-            registry.registerTool(unattendedExternalTool(handler), 'test');
-            await registry.setEnabled('test-unattended', true); // external ships disabled
+            registry.registerTool(curatedExternalTool(handler), 'test');
+            await registry.setEnabled('test-curated', true); // external ships disabled
 
-            const result = await module.getGovernor().invoke('test-unattended', {}, scheduledCtx);
+            const result = await module.getGovernor().invoke('test-curated', {}, scheduledCtx);
             expect(result.status).toBe('ok');
             expect(handler).toHaveBeenCalledOnce();
         });

--- a/src/backend/modules/ai-tools/services/tool-policy-engine.ts
+++ b/src/backend/modules/ai-tools/services/tool-policy-engine.ts
@@ -102,11 +102,23 @@ export class ToolPolicyEngine {
      * @returns The merged policy the engine will enforce.
      */
     effectivePolicyFor(name: string, cap: IAiToolCapability): IToolPolicy {
-        const requireApproval = cap.requiresApproval ?? (cap.sideEffect === 'external' && cap.reversible === false);
+        // An external, irreversible effect must be reviewed by a human before it
+        // takes hold. A tool that forces its own curator review supplies that
+        // review itself, so the governor adds no second gate; otherwise the
+        // governor owns the approval. Both gates are derived purely from the
+        // tool's declared nature — a tool cannot opt itself out of either. Only
+        // the admin override merged below can relax them, which keeps the bypass
+        // an on-record operator decision rather than a tool self-grant.
+        const isUnreviewedDangerousEffect =
+            cap.sideEffect === 'external' && cap.reversible === false && cap.forcesCuratorReview !== true;
         const base: IToolPolicy = {
             rateLimit: RATE_DEFAULTS[cap.sideEffect],
-            requireApproval,
-            allowUnattended: cap.allowUnattended ?? (cap.sideEffect !== 'external')
+            requireApproval: isUnreviewedDangerousEffect,
+            // Non-external tools are unattended-safe. An external tool is safe on
+            // autonomous paths only when it forces its own curator review — an
+            // unattended trigger can then do no more than draft into that review
+            // queue. Every other external tool is barred from autonomous runs.
+            allowUnattended: cap.sideEffect !== 'external' || cap.forcesCuratorReview === true
         };
         return { ...base, ...this.overrides[name] };
     }

--- a/src/backend/modules/ai-tools/services/tool-policy-engine.ts
+++ b/src/backend/modules/ai-tools/services/tool-policy-engine.ts
@@ -102,6 +102,13 @@ export class ToolPolicyEngine {
      * @returns The merged policy the engine will enforce.
      */
     effectivePolicyFor(name: string, cap: IAiToolCapability): IToolPolicy {
+        // Merge over DEFAULT_CAPABILITY so a partial or empty capability object
+        // (possible from an untyped/`as any` caller) can never leave a field
+        // undefined: an undefined sideEffect would otherwise skip both the rate
+        // limit (RATE_DEFAULTS[undefined]) and the external autonomous-deny,
+        // failing open. A partial object then falls back to the read/internal
+        // default — the same safe class an unclassified tool receives.
+        const fullCap = { ...DEFAULT_CAPABILITY, ...cap };
         // An external, irreversible effect must be reviewed by a human before it
         // takes hold. A tool that forces its own curator review supplies that
         // review itself, so the governor adds no second gate; otherwise the
@@ -110,15 +117,15 @@ export class ToolPolicyEngine {
         // the admin override merged below can relax them, which keeps the bypass
         // an on-record operator decision rather than a tool self-grant.
         const isUnreviewedDangerousEffect =
-            cap.sideEffect === 'external' && cap.reversible === false && cap.forcesCuratorReview !== true;
+            fullCap.sideEffect === 'external' && fullCap.reversible === false && fullCap.forcesCuratorReview !== true;
         const base: IToolPolicy = {
-            rateLimit: RATE_DEFAULTS[cap.sideEffect],
+            rateLimit: RATE_DEFAULTS[fullCap.sideEffect],
             requireApproval: isUnreviewedDangerousEffect,
             // Non-external tools are unattended-safe. An external tool is safe on
             // autonomous paths only when it forces its own curator review — an
             // unattended trigger can then do no more than draft into that review
             // queue. Every other external tool is barred from autonomous runs.
-            allowUnattended: cap.sideEffect !== 'external' || cap.forcesCuratorReview === true
+            allowUnattended: fullCap.sideEffect !== 'external' || fullCap.forcesCuratorReview === true
         };
         return { ...base, ...this.overrides[name] };
     }

--- a/src/frontend/app/(core)/system/ai-tools/components/CapabilityBadges.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/CapabilityBadges.tsx
@@ -28,7 +28,10 @@ interface CapabilityBadge {
  */
 function badgesFor(cap?: IAiToolCapability): CapabilityBadge[] {
     const badges: CapabilityBadge[] = [];
-    if (!cap) {
+    // A capability with no declared side effect (absent, or a partial/malformed
+    // object) is unclassified — render the single warning badge rather than an
+    // empty one from an undefined sideEffect label.
+    if (!cap || !cap.sideEffect) {
         badges.push({ label: 'unclassified', tone: 'warning' });
         return badges;
     }

--- a/src/frontend/app/(core)/system/ai-tools/components/CapabilityBadges.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/CapabilityBadges.tsx
@@ -3,8 +3,10 @@
 /**
  * @fileoverview Renders an AI tool's capability classification as a row of
  * tone-coded badges (side effect, reversibility, spend, sensitivity,
- * untrusted-content, approval, unattended). Shared by the Registry, Activity,
- * and Policy tabs so the risk class reads consistently everywhere.
+ * untrusted-content, self-curated review). Shared by the Registry, Activity,
+ * and Policy tabs so the risk class reads consistently everywhere. These badges
+ * show what the tool *declares*; the effective approval/unattended gates the
+ * governor derives from that declaration live on the Policy tab.
  */
 
 import type { IAiToolCapability } from '@/types';
@@ -48,11 +50,8 @@ function badgesFor(cap?: IAiToolCapability): CapabilityBadge[] {
     if (cap.surfacesUntrustedContent) {
         badges.push({ label: 'untrusted content', tone: 'warning' });
     }
-    if (cap.requiresApproval) {
-        badges.push({ label: 'approval', tone: 'info' });
-    }
-    if (cap.allowUnattended && cap.sideEffect === 'external') {
-        badges.push({ label: 'unattended ok', tone: 'neutral' });
+    if (cap.forcesCuratorReview) {
+        badges.push({ label: 'forces review', tone: 'info' });
     }
     return badges;
 }


### PR DESCRIPTION
Makes the AI-tool capability contract purely declarative.

## What changed
- `IAiToolCapability` loses the three tool-side override fields — `requiresApproval`, `allowUnattended`, and the dead/unwired `policy` — and gains one descriptive field, `forcesCuratorReview`. A tool can now only *describe* whether it holds its own effects for a human curator; it can no longer request a relaxed gate.
- The governor derives both gates from declared facts (`tool-policy-engine.ts`): approval = `external && irreversible && !forcesCuratorReview`; autonomous-safe = `non-external || forcesCuratorReview`.
- The operator-override surface (`IToolPolicy.requireApproval` / `allowUnattended`, the Policy tab) is unchanged — dropping review for a non-self-curating tool stays an on-record operator decision, never a tool self-grant.

## Why
The override fields let a tool weaken its own guardrails — the failure mode the declarative model exists to prevent. A scan confirmed they were near-unused (`policy` dead, `allowUnattended` declared by zero tools, `requiresApproval` by one). One declarative field subsumes the legitimate cases.

## Notes
- `trp-x-poster`'s post tool declares `forcesCuratorReview: true` and is now permitted on autonomous paths, where it can only draft into its own review queue. That plugin lives in a separate repo and is not part of this PR.
- `@delphian/tronrelic-types` bumped to 3.9.0; it must be published for plugin standalone/CI builds to resolve the new shape.
- Core typecheck green; ai-tools governor tests 25/25.