### PR TITLE
feat(ai-tools): central curation queue with verifiable curationTypeId binding

### DIFF
--- a/docs/system/system-ai-tools.md
+++ b/docs/system/system-ai-tools.md
@@ -48,10 +48,13 @@ Classify every tool before it ships; the class drives the guardrails the governo
 | Sensitivity | `public` · `internal` · `secret` | Audit redaction + trifecta accounting |
 | Surfaces untrusted content | yes / no | Trifecta accounting (injection source) |
 | Forces curator review | yes / no | Tool self-gates every effect → no governor approval added; safe unattended |
+| Curation binding (`curationTypeId`) | type id / none | Verifies `forcesCuratorReview` against a live curation type; re-tightens if the owner is disabled |
 
 A transaction lookup is read / internal. A log query is read / secret / surfaces-untrusted. A tweet is external / irreversible and forces-curator-review (its plugin holds every post for human approval). An image generation is external / spends-money.
 
 `forcesCuratorReview` is the only governance field a tool may declare, and it is a *description* of behaviour, not a request: the governor derives the approval gate and the autonomous-path rule from it. There is no field that lets a tool exempt itself from review — an external, irreversible effect is always reviewed by someone (the tool's own curator, or the governor). Dropping review for a tool that does not self-curate is an operator-only decision (an admin policy override), never a tool self-grant.
+
+A tool can harden that declaration from honour-system to verified by also setting `curationTypeId` — the id of a [central curation type](./system-curation.md) it routes every effect into. The governor then honours the review relaxation only while that type is registered and re-tightens the moment its owning plugin is disabled. The boolean alone stays valid (legacy self-hosted queues); the id makes the claim checkable. See [system-curation.md](./system-curation.md).
 
 ## Accountability and Security
 
@@ -65,7 +68,7 @@ Mandatory for every tool; scale to the class. A read-only lookup needs little, a
 
 **Bound side-effecting and paid tools.** Rate-limit, quota, and cap cost. A looping or injected model must not drain an API budget or flood a channel. `TransactionToolGuard` is the reference limiter.
 
-**Require human approval for irreversible or public effects.** Either let the governor park the action for admin approval, or declare `forcesCuratorReview: true` when the tool holds every effect in its own review queue. `trp-x-poster` is the reference: it declares `forcesCuratorReview` and every AI-authored post waits for a human in its History tab.
+**Require human approval for irreversible or public effects.** Either let the governor park the action for admin approval, or declare `forcesCuratorReview: true` when the tool holds every effect in its own review queue. `trp-x-poster` is the reference: it declares `forcesCuratorReview`, binds `curationTypeId: 'x-poster:tweet'`, and routes every AI-authored post into the [central curation queue](./system-curation.md) (also still reviewable in its History tab).
 
 **Audit every invocation.** Record who triggered it (interactive admin / scheduled / programmatic), the arguments, the outcome, and the cost — enough to reconstruct what happened. `trp-image-gen`'s per-call history is the reference shape.
 
@@ -129,6 +132,7 @@ const tool: IAiTool = {
 
 ## Further Reading
 
+- [system-curation.md](./system-curation.md) — the central curation queue and the verifiable `curationTypeId` binding
 - [trp-ai-assistant/README.md](../../src/plugins/trp-ai-assistant/README.md) — the reference AI provider plugin: registration, dispatch, programmatic queries
 - [plugins-service-registry.md](../plugins/plugins-service-registry.md) — `watch()` vs `get()`, registration lifecycle
 - [system-hooks.md](./system-hooks.md) — declared seams that tool governance attaches to

--- a/docs/system/system-curation.md
+++ b/docs/system/system-curation.md
@@ -1,0 +1,80 @@
+# Central Curation Queue
+
+One core admin surface for every effect held for human review before it takes hold — drafted tweets, generated images, any future reviewable content. Lives in the [`ai-tools` module](../../src/backend/modules/ai-tools/README.md) and is published as the `'curation'` service.
+
+## Why This Matters
+
+Without it, every plugin that needs human review re-implements its own approval queue and its own review UI — `trp-x-poster` held drafted tweets in a private collection reviewed from its own History tab. Operators then hunt across plugins for things to approve, and each queue re-solves the same problem unevenly. Centralizing gives one inbox and, crucially, turns `forcesCuratorReview` from an honor-system boolean into a **verifiable binding**: the governor relaxes a tool's gates only while a real curation type backs the claim. The pattern mirrors CMS editorial queues (Drupal Content Moderation, Sanity's separate workflow-metadata document).
+
+## How It Works
+
+Core owns only the **decision** (held → approved / rejected) and the **envelope**; the owning content type owns the payload, the preview, and what approval *does*. The envelope is a pointer, never the payload: it stores an opaque `ref` (e.g. `{ postId }`) the type resolves back to its own record, plus a cached `preview` used only as the disabled-owner fallback. While the owner is registered the queue renders from a live `describe()`, so the snapshot never goes stale.
+
+A provider registers an `ICurationType` and producers call `hold()`; the admin surface lists and decides. Core records the decision first (the queue's atomic gate), then invokes the type's callback — so a callback failure leaves the item decided rather than re-opening a half-committed effect. A type whose plugin is disabled is unregistered, so its held items **block** on decision until the plugin returns; this is intentional, not data loss.
+
+### The Type Contract
+
+A provider gives core the content-specific operations it cannot infer. Core stays payload-agnostic — it only ever sees the generic `ICurationPreview` (`title` / `body` / `media` / `fields` / `editable`).
+
+| Member | Role |
+|---|---|
+| `typeId` | Namespaced `<provider>:<name>` (e.g. `x-poster:tweet`); the binding key |
+| `describe(ref)` | Flatten the record into the generic preview; resolves cross-plugin URLs |
+| `onApprove(item)` | Commit the effect (publish, schedule) |
+| `onReject(item)` | Discard the effect |
+| `applyEdit?(item, patch)` | Optional: apply a generic edit (today `{ body }`); the type validates and owns the write |
+
+### The Verifiable Binding
+
+An AI tool keeps `forcesCuratorReview: boolean` (the declaration) and adds `curationTypeId` (the verification). Three valid states:
+
+| Capability | Governor behavior |
+|---|---|
+| Neither | Ordinary external tool — default-deny, parks for approval |
+| `forcesCuratorReview: true` only | Legacy honor system — trusted on the tool's word (its own private queue) |
+| `forcesCuratorReview: true` + `curationTypeId` | Honored **only while** that type is registered; re-tightens the moment the owner is disabled |
+
+The governor resolves the binding live against the curation registry (`ToolPolicyEngine.setCurationResolver` → `CurationService.hasType`). Declaring `curationTypeId` without `forcesCuratorReview: true` is incoherent and rejected at tool registration.
+
+### Editing
+
+The admin edits the neutral `body` text in a core modal; the write routes core → `CurationService.edit` → the type's `applyEdit` → the plugin's own record, then core re-derives and re-caches the preview. The type is the validation authority (x-poster enforces the ≤280 tweet limit and throws on violation). A type without `applyEdit` is not editable and shows no edit affordance. Rich per-type editors are a future extension on the same seam.
+
+## Quick Reference
+
+| Surface | Value |
+|---|---|
+| Service registry name | `'curation'` → `ICurationService` |
+| Owned collection | `module_ai-tools_curations` |
+| Admin tab | `/system/ai-tools` → Curation |
+| WebSocket signal | `ai-tools:curations-changed` (refetch cue) |
+| REST | `GET /curations`, `GET /curations/count`, `PATCH /curations/:id`, `POST /curations/:id/{approve,reject}` under `/api/admin/system/ai-tools` |
+| Types | `@delphian/tronrelic-types` → `ICurationType`, `ICurationItem`, `ICurationPreview`, `ICurationService`, `ICurationEditPatch` |
+
+## Example
+
+A provider registers its type and routes held effects in:
+
+```typescript
+// On init, via the registry (watch covers boot-order + churn):
+context.services.watch<ICurationService>('curation', {
+    onAvailable: (curation) => curation.registerType({
+        typeId: 'x-poster:tweet',
+        label: 'X Tweet',
+        describe: async (ref) => ({ body: (await poster.getPost(String(ref.postId)))?.text }),
+        onApprove: (item) => poster.approvePost(String(item.ref.postId)),  // → scheduled
+        onReject: (item) => poster.rejectPost(String(item.ref.postId)),
+        applyEdit: (item, patch) => poster.editPostText(String(item.ref.postId), patch.body ?? '')
+    }, manifest.id)
+});
+
+// The tool's handler holds the effect rather than performing it:
+await curation.hold({ typeId: 'x-poster:tweet', ref: { postId }, source: 'ai-tool:x-post-tweet' });
+```
+
+## Further Reading
+
+- [system-ai-tools.md](./system-ai-tools.md) — the AI tool standard; `forcesCuratorReview` and the capability vocabulary the binding hardens
+- [AI Tools Module README](../../src/backend/modules/ai-tools/README.md) — the module that owns the curation service, governor, and registry
+- [trp-x-poster README](../../src/plugins/trp-x-poster/README.md) — the reference curation type and the History/central-queue coexistence
+- [plugins-service-registry.md](../plugins/plugins-service-registry.md) — `watch()` vs `get()` for registering a type and discovering `'curation'`

--- a/docs/system/system.md
+++ b/docs/system/system.md
@@ -70,6 +70,10 @@ Typed extension points where core invites plugins into its own execution. Descri
 
 The contract and governance for tools a model can invoke during an AI query. Core owns the tool shape, the capability classes (read / write / external, sensitivity, reversibility), and the accountability and security every tool must meet — input validation, object authorization, rate/quota/cost limits, human approval for irreversible effects, and per-invocation audit — so every AI provider plugin and tool inherits the same guarantees. Provider-neutral: `trp-ai-assistant` is only the Anthropic transport. See [system-ai-tools.md](./system-ai-tools.md).
 
+### Curation
+
+One core admin surface (`/system/ai-tools` → Curation, in the AI Tools module) for every effect held for human review before it takes hold. Plugins register a content type (preview / approve / reject / optional edit); core owns the decision and a pointer-plus-preview envelope while the type owns the payload and what approval does. It also hardens a tool's `forcesCuratorReview` into a verifiable `curationTypeId` binding the governor checks live. See [system-curation.md](./system-curation.md).
+
 ### Logging
 
 Pino-based logger with MongoDB persistence for historical queries. See [system-logging.md](./system-logging.md).
@@ -106,6 +110,7 @@ Inspect health at `/system` (auth: `ADMIN_API_TOKEN`) — fastest path to blockc
 | [system-database-migrations.md](./system-database-migrations.md) | Migration discovery, transactions, REST API, admin UI |
 | [system-hooks.md](./system-hooks.md) | Declared seams, four archetypes, plugin facade, introspection, admin UI |
 | [system-ai-tools.md](./system-ai-tools.md) | AI tool contract, capability classes, accountability and security requirements |
+| [system-curation.md](./system-curation.md) | Central curation queue, the type contract, the verifiable `curationTypeId` binding |
 | [system-logging.md](./system-logging.md) | Pino, MongoDB persistence, log queries |
 | [Menu Module README](../../src/backend/modules/menu/README.md) | Menu service, plugin integration, WebSocket events |
 | [Pages Module README](../../src/backend/modules/pages/README.md) | Markdown CMS, storage providers, file uploads |

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delphian/tronrelic-types",
-    "version": "3.9.0",
+    "version": "3.11.0",
     "description": "Core type definitions for the TronRelic platform",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/types/src/ai-tools/IAiToolCapability.ts
+++ b/packages/types/src/ai-tools/IAiToolCapability.ts
@@ -72,4 +72,17 @@ export interface IAiToolCapability {
      * policy override is the only way to drop review for a tool that does not.
      */
     forcesCuratorReview?: boolean;
+
+    /**
+     * Namespaced id of the core curation type this tool routes every effect
+     * into (e.g. `x-poster:tweet`). It turns `forcesCuratorReview` from a
+     * self-attestation into a verifiable binding: when present, the governor
+     * honours the curator-review relaxation only while a matching type is
+     * registered on the `'curation'` service, and re-tightens the tool's gates
+     * the moment that owner goes away. Omit it to keep the legacy honour-system
+     * behaviour, where `forcesCuratorReview: true` is trusted on the tool's word
+     * (the tool runs its own private review queue). Declaring it without
+     * `forcesCuratorReview: true` is incoherent and rejected at registration.
+     */
+    curationTypeId?: string;
 }

--- a/packages/types/src/curation/ICurationItem.ts
+++ b/packages/types/src/curation/ICurationItem.ts
@@ -1,0 +1,71 @@
+/**
+ * @file ICurationItem.ts
+ *
+ * The envelope core stores for one held effect in the central curation queue.
+ * Core owns the envelope and the decision; the owning curation type owns the
+ * payload. The envelope therefore carries an opaque `ref` (a pointer the type
+ * resolves back to its own record) and a cached `preview` (the disabled-owner
+ * fallback), never the content itself.
+ */
+
+import type { ICurationPreview } from './ICurationPreview.js';
+
+/**
+ * Lifecycle status of a held item. Core advances `pending` to a terminal
+ * `approved` or `rejected`; the owning type's `onApprove` / `onReject` runs
+ * after the decision is recorded and owns whatever happens next (publish,
+ * schedule, discard). Downstream states (scheduled, posted, failed) belong to
+ * the provider, not to core.
+ */
+export type CurationItemStatus = 'pending' | 'approved' | 'rejected';
+
+/**
+ * One held effect awaiting (or having received) a curator decision.
+ */
+export interface ICurationItem {
+    /** Server-assigned id (string form of the stored document `_id`). */
+    id: string;
+
+    /** Namespaced curation type id, e.g. `x-poster:tweet`. */
+    typeId: string;
+
+    /**
+     * Id of the plugin or module that registered the owning type. Drives queue
+     * grouping and tells core which provider must be present to resolve or
+     * commit the item.
+     */
+    providerId: string;
+
+    /**
+     * Opaque pointer the owning type resolves back to its own record (e.g.
+     * `{ postId: '...' }`). Core never interprets it — it is passed verbatim to
+     * `describe()`, `onApprove()`, and `onReject()`.
+     */
+    ref: Record<string, unknown>;
+
+    /**
+     * Preview snapshot cached when the item was held. Core renders the queue
+     * from a live `describe()` while the owner is registered and falls back to
+     * this snapshot when the owning plugin is disabled.
+     */
+    preview: ICurationPreview;
+
+    /** Current lifecycle status. */
+    status: CurationItemStatus;
+
+    /**
+     * Free-form attribution of what produced the item (e.g.
+     * `ai-tool:x-post-tweet`). Provider-neutral so any producer, not only AI
+     * tools, can record where a held effect came from.
+     */
+    source?: string;
+
+    /** When the item was held. */
+    createdAt: Date;
+
+    /** When a curator decided it; absent while pending. */
+    decidedAt?: Date;
+
+    /** Better Auth user id of the deciding curator; absent while pending. */
+    decidedBy?: string;
+}

--- a/packages/types/src/curation/ICurationPreview.ts
+++ b/packages/types/src/curation/ICurationPreview.ts
@@ -1,0 +1,66 @@
+/**
+ * @file ICurationPreview.ts
+ *
+ * The content-agnostic descriptor a curation type produces so core can render
+ * any held item in the central queue without understanding its payload. A
+ * provider flattens its own record (a drafted tweet, a generated image, a
+ * pending page) into this fixed shape; core renders every type from it and
+ * never interprets the underlying payload. This is the seam that lets the
+ * queue stay generic while content types remain plugin-defined.
+ */
+
+/**
+ * A single labelled fact shown in an item's detail view (e.g. "Scheduled for"
+ * → "2026-06-20 14:00"). Supplementary context, not the primary content.
+ */
+export interface ICurationPreviewField {
+    /** Short label for the fact. */
+    label: string;
+
+    /** Display value, already formatted for presentation. */
+    value: string;
+}
+
+/**
+ * A piece of media to render inline in the queue. The provider resolves its
+ * own storage reference (e.g. a `trp-files` file id) to a public URL in
+ * `describe()`; core never resolves ids itself.
+ */
+export interface ICurationPreviewMedia {
+    /** Public URL the queue renders inline. The provider must resolve this. */
+    url: string;
+
+    /** Rendering hint. `image` renders inline; `link` renders as an anchor. */
+    kind?: 'image' | 'link';
+
+    /** Accessible alt text / link label. */
+    alt?: string;
+}
+
+/**
+ * The generic preview core caches at hold time and re-derives live while the
+ * owning type is registered. Every field is optional so a type surfaces only
+ * what it has — a tweet sets `body` (and `media` when it has an image); a
+ * future page type might set `title` and `body`.
+ */
+export interface ICurationPreview {
+    /** One-line heading for the queue row. */
+    title?: string;
+
+    /** Primary draft content — the text a curator reviews. */
+    body?: string;
+
+    /** Media rendered inline, with provider-resolved public URLs. */
+    media?: ICurationPreviewMedia[];
+
+    /** Supplementary labelled facts shown in the detail view. */
+    fields?: ICurationPreviewField[];
+
+    /**
+     * Whether the owning type offers an interactive editor for this item. The
+     * queue shows an Edit affordance only when this is true *and* the frontend
+     * has a registered editor for the type; editing always writes through the
+     * provider's own routes, never core.
+     */
+    editable?: boolean;
+}

--- a/packages/types/src/curation/ICurationService.ts
+++ b/packages/types/src/curation/ICurationService.ts
@@ -1,0 +1,147 @@
+/**
+ * @file ICurationService.ts
+ *
+ * The central curation surface. It splits into two responsibilities: a
+ * registry (`ICurationRegistry`) where providers publish reviewable types and
+ * the governor verifies an AI tool's `curationTypeId` binding, and the queue
+ * operations (`ICurationService`) that producers and the admin dashboard use to
+ * hold, list, and decide items. Core publishes one `'curation'` service that
+ * implements the combined contract.
+ */
+
+import type { ICurationItem } from './ICurationItem.js';
+import type { ICurationType, ICurationEditPatch } from './ICurationType.js';
+
+/** Summary of a registered curation type, for admin listing. */
+export interface ICurationTypeInfo {
+    /** Namespaced type id. */
+    typeId: string;
+
+    /** Human-readable label. */
+    label: string;
+
+    /** Id of the registering plugin or module. */
+    providerId: string;
+}
+
+/** What a producer passes to `hold()` to enqueue an effect for review. */
+export interface ICurationHoldInput {
+    /** Namespaced id of a registered curation type. */
+    typeId: string;
+
+    /** Opaque pointer the owning type resolves back to its own record. */
+    ref: Record<string, unknown>;
+
+    /** Optional attribution of what produced the effect (e.g. a tool name). */
+    source?: string;
+}
+
+/**
+ * Type registration and lookup. Providers register on `init()` and unregister
+ * on `disable()`; the governor calls `hasType()` to verify that an AI tool's
+ * declared `curationTypeId` resolves to a live type before relaxing its gates.
+ */
+export interface ICurationRegistry {
+    /**
+     * Register a reviewable content type.
+     *
+     * @param type - The type contract (describe / onApprove / onReject).
+     * @param providerId - Id of the registering plugin or module.
+     */
+    registerType(type: ICurationType, providerId: string): void;
+
+    /**
+     * Unregister a type. Held items of this type remain in the queue but cannot
+     * be decided until the type re-registers (the disabled-owner case).
+     *
+     * @param typeId - The namespaced type id.
+     * @returns True if a type was removed.
+     */
+    unregisterType(typeId: string): boolean;
+
+    /**
+     * Resolve a registered type.
+     *
+     * @param typeId - The namespaced type id.
+     * @returns The type, or undefined when no owner is registered.
+     */
+    getType(typeId: string): ICurationType | undefined;
+
+    /**
+     * Whether a type is registered right now. The governor's binding check.
+     *
+     * @param typeId - The namespaced type id.
+     */
+    hasType(typeId: string): boolean;
+
+    /** List all registered types for the admin dashboard. */
+    listTypes(): ICurationTypeInfo[];
+}
+
+/**
+ * The full curation service: type registration plus the queue lifecycle. Core
+ * publishes this as the `'curation'` service on the service registry.
+ */
+export interface ICurationService extends ICurationRegistry {
+    /**
+     * Hold an effect for review. Core resolves the type, caches a preview via
+     * `describe()`, persists the envelope as `pending`, and returns it. The
+     * envelope's `providerId` is the registered type's owner — the provider that
+     * must be present to render or commit the item; record the producer's
+     * identity in `input.source`. Throws when the `typeId` is not registered.
+     *
+     * @param input - The type id, opaque ref, and optional attribution.
+     * @returns The stored pending envelope.
+     */
+    hold(input: ICurationHoldInput): Promise<ICurationItem>;
+
+    /**
+     * List pending items newest-first for the admin queue.
+     *
+     * @param limit - Maximum items to return.
+     */
+    listPending(limit?: number): Promise<ICurationItem[]>;
+
+    /** Count pending items — drives the dashboard badge. */
+    countPending(): Promise<number>;
+
+    /**
+     * Fetch one item by id.
+     *
+     * @param id - The envelope id.
+     * @returns The item, or null when absent.
+     */
+    get(id: string): Promise<ICurationItem | null>;
+
+    /**
+     * Approve a pending item: record the decision, then invoke the owning
+     * type's `onApprove`. Returns null when the item is missing or no longer
+     * pending, or when the owning type is unregistered (decision blocked).
+     *
+     * @param id - The envelope id.
+     * @param decidedBy - Better Auth user id of the deciding curator.
+     */
+    approve(id: string, decidedBy?: string): Promise<ICurationItem | null>;
+
+    /**
+     * Reject a pending item: record the decision, then invoke the owning type's
+     * `onReject`. Returns null under the same conditions as `approve`.
+     *
+     * @param id - The envelope id.
+     * @param decidedBy - Better Auth user id of the deciding curator.
+     */
+    reject(id: string, decidedBy?: string): Promise<ICurationItem | null>;
+
+    /**
+     * Apply an operator's inline edit to a pending item through its owning type,
+     * then re-derive and cache the preview. Returns the updated item, or null
+     * when the item is missing, no longer pending, its owner is unregistered, or
+     * the type is not editable (no `applyEdit`). The owning type validates the
+     * patch and may throw — callers should surface that error.
+     *
+     * @param id - The envelope id.
+     * @param patch - The generic, payload-agnostic edit.
+     * @param editedBy - Better Auth user id of the editing operator.
+     */
+    edit(id: string, patch: ICurationEditPatch, editedBy?: string): Promise<ICurationItem | null>;
+}

--- a/packages/types/src/curation/ICurationType.ts
+++ b/packages/types/src/curation/ICurationType.ts
@@ -1,0 +1,84 @@
+/**
+ * @file ICurationType.ts
+ *
+ * The contract a provider registers with the curation service to make a content
+ * type reviewable in the central queue. It is the three delegations core needs
+ * to stay content-agnostic: how to *preview* an item, what to do on *approve*,
+ * and what to do on *reject*. Editing is a frontend concern (an `EditorComponent`
+ * registered separately) and writes through the provider's own routes, so it is
+ * not part of this backend contract.
+ */
+
+import type { ICurationItem } from './ICurationItem.js';
+import type { ICurationPreview } from './ICurationPreview.js';
+
+/**
+ * A generic, payload-agnostic edit an operator applies to a held item before
+ * deciding it. Core knows only these neutral fields; the owning type maps them
+ * onto its own record. Today just the body text — the one field the preview
+ * already exposes as editable — kept small and extensible.
+ */
+export interface ICurationEditPatch {
+    /** Replacement body text for the held content. */
+    body?: string;
+}
+
+/**
+ * A reviewable content type. One provider may register several — a tweet, a
+ * generated image — each with its own namespaced `typeId`.
+ */
+export interface ICurationType {
+    /**
+     * Namespaced id `<provider>:<name>`, e.g. `x-poster:tweet`. The prefix
+     * mirrors plugin collection and WebSocket namespacing and is how an AI
+     * tool's `curationTypeId` binding is verified.
+     */
+    typeId: string;
+
+    /** Human-readable label for queue grouping and headings. */
+    label: string;
+
+    /**
+     * Flatten the record identified by `ref` into a content-agnostic preview
+     * core can render. Runs server-side and may resolve cross-plugin references
+     * (e.g. a file id to a public URL). Core calls this at hold time to cache a
+     * snapshot and again live while the type is registered, so it must be safe
+     * to call repeatedly and must not mutate the record.
+     *
+     * @param ref - The opaque pointer supplied when the item was held.
+     * @returns The preview descriptor, or a promise of it.
+     */
+    describe(ref: Record<string, unknown>): ICurationPreview | Promise<ICurationPreview>;
+
+    /**
+     * Commit the held effect. Core records the approval first, then calls this;
+     * the provider does whatever "approved" means for the type (release for
+     * publication, enqueue, schedule). Throwing surfaces the failure to the
+     * admin but does not roll the recorded decision back — design `onApprove`
+     * to be safe to retry.
+     *
+     * @param item - The decided envelope, including `ref` and metadata.
+     */
+    onApprove(item: ICurationItem): void | Promise<void>;
+
+    /**
+     * Discard the held effect. Core records the rejection first, then calls
+     * this so the provider can clean up its own record.
+     *
+     * @param item - The decided envelope, including `ref` and metadata.
+     */
+    onReject(item: ICurationItem): void | Promise<void>;
+
+    /**
+     * Apply an operator's inline edit to the held content before a decision.
+     * Optional — a type that omits it is not editable and core surfaces no edit
+     * affordance. Core passes a generic, payload-agnostic patch; the type maps it
+     * onto its own record and enforces its own validation, throwing a descriptive
+     * Error the queue surfaces. Invoked only while the item is pending; core
+     * re-derives the cached preview from `describe()` afterward.
+     *
+     * @param item - The held envelope (its `ref` addresses the record).
+     * @param patch - The generic edit to apply.
+     */
+    applyEdit?(item: ICurationItem, patch: ICurationEditPatch): void | Promise<void>;
+}

--- a/packages/types/src/curation/index.ts
+++ b/packages/types/src/curation/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @file index.ts
+ *
+ * Barrel for the central curation contracts. Curation is provider-neutral core
+ * infrastructure: any producer can hold an effect for a human curator, and any
+ * plugin or module can register a reviewable content type. AI tools bind to it
+ * through the `curationTypeId` field on `IAiToolCapability`, but curation does
+ * not depend on the AI-tools types.
+ */
+
+export type {
+    ICurationPreview,
+    ICurationPreviewField,
+    ICurationPreviewMedia
+} from './ICurationPreview.js';
+export type { ICurationItem, CurationItemStatus } from './ICurationItem.js';
+export type { ICurationType, ICurationEditPatch } from './ICurationType.js';
+export type {
+    ICurationService,
+    ICurationRegistry,
+    ICurationTypeInfo,
+    ICurationHoldInput
+} from './ICurationService.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -75,6 +75,19 @@ export type {
 export { isPrivateIp, assertPublicHttpUrl } from './egress/index.js';
 export type { IEgressCheckResult, IEgressCheckOptions } from './egress/index.js';
 export type {
+    ICurationPreview,
+    ICurationPreviewField,
+    ICurationPreviewMedia,
+    ICurationItem,
+    CurationItemStatus,
+    ICurationType,
+    ICurationEditPatch,
+    ICurationService,
+    ICurationRegistry,
+    ICurationTypeInfo,
+    ICurationHoldInput
+} from './curation/index.js';
+export type {
     HookDescriptor,
     HookKind,
     HookPhase,

--- a/src/backend/modules/ai-tools/AiToolsModule.ts
+++ b/src/backend/modules/ai-tools/AiToolsModule.ts
@@ -33,6 +33,8 @@ import { ToolAuditStore } from './services/tool-audit-store.js';
 import { ToolApprovalQueue } from './services/tool-approval-queue.js';
 import { AiToolGovernor } from './services/ai-tool-governor.js';
 import { AiProviderRegistry } from './services/ai-provider-registry.js';
+import { CurationQueue } from './services/curation-queue.js';
+import { CurationService } from './services/curation-service.js';
 import { AiToolsController } from './api/ai-tools.controller.js';
 import { createAiToolsAdminRouter } from './api/ai-tools.router.js';
 
@@ -44,6 +46,9 @@ export const AI_TOOL_GOVERNOR_SERVICE = 'ai-tool-governor';
 
 /** Service-registry name for the installed-AI-provider registry. */
 export const AI_PROVIDERS_SERVICE = 'ai-providers';
+
+/** Service-registry name for the central curation queue. */
+export const CURATION_SERVICE = 'curation';
 
 /** Scheduler job that prunes audit records past the retention window. */
 export const AUDIT_PRUNE_JOB = 'ai-tools:prune-audit';
@@ -96,6 +101,8 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
     private policy!: ToolPolicyEngine;
     private audit!: ToolAuditStore;
     private approvals!: ToolApprovalQueue;
+    private curationQueue!: CurationQueue;
+    private curation!: CurationService;
     private governor!: AiToolGovernor;
     private providerRegistry!: AiProviderRegistry;
     private controller!: AiToolsController;
@@ -130,9 +137,19 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
         this.approvals = new ToolApprovalQueue(this.logger, this.database);
         await this.approvals.ensureIndexes();
 
+        this.curationQueue = new CurationQueue(this.logger, this.database);
+        await this.curationQueue.ensureIndexes();
+        this.curation = new CurationService(this.logger, this.curationQueue);
+
+        // Verify a tool's `curationTypeId` binding against the live curation
+        // registry. A declared binding relaxes the tool's gates only while its
+        // owning type is registered, and re-tightens the moment that owner is
+        // disabled — verification rather than the honour-system boolean alone.
+        this.policy.setCurationResolver((typeId) => this.curation.hasType(typeId));
+
         this.governor = new AiToolGovernor(this.logger, this.registry, this.policy, this.audit, this.approvals, this.hookRegistry);
         this.providerRegistry = new AiProviderRegistry(this.logger);
-        this.controller = new AiToolsController(this.registry, this.policy, this.audit, this.approvals, this.governor, this.providerRegistry);
+        this.controller = new AiToolsController(this.registry, this.policy, this.audit, this.approvals, this.governor, this.providerRegistry, this.curation);
 
         this.logger.info('ai-tools module initialized');
     }
@@ -153,9 +170,16 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
             WebSocketService.getInstance().emit({ event, payload });
         });
 
+        // Curation decisions and new holds nudge the dashboard to refetch, the
+        // same lightweight signal the governor uses for approvals.
+        this.curation.setBroadcast((event, payload) => {
+            WebSocketService.getInstance().emit({ event, payload });
+        });
+
         this.serviceRegistry.register(AI_TOOLS_SERVICE, this.registry);
         this.serviceRegistry.register(AI_TOOL_GOVERNOR_SERVICE, this.governor);
         this.serviceRegistry.register(AI_PROVIDERS_SERVICE, this.providerRegistry);
+        this.serviceRegistry.register(CURATION_SERVICE, this.curation);
 
         // Daily audit retention sweep. A Mongo TTL index can't enforce this —
         // `createdAt` is an ISO string, not a Date — so retention is a scheduled
@@ -183,7 +207,7 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
         });
 
         this.logger.info(
-            { services: [AI_TOOLS_SERVICE, AI_TOOL_GOVERNOR_SERVICE, AI_PROVIDERS_SERVICE] },
+            { services: [AI_TOOLS_SERVICE, AI_TOOL_GOVERNOR_SERVICE, AI_PROVIDERS_SERVICE, CURATION_SERVICE] },
             'ai-tools module running (admin router mounted, services registered)'
         );
     }
@@ -212,5 +236,18 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
             throw new Error('AiToolsModule not initialized - call init() first');
         }
         return this.registry;
+    }
+
+    /**
+     * The curation service, for tests and in-process consumers.
+     *
+     * @returns The curation service instance.
+     * @throws If called before `init()`.
+     */
+    getCuration(): CurationService {
+        if (!this.curation) {
+            throw new Error('AiToolsModule not initialized - call init() first');
+        }
+        return this.curation;
     }
 }

--- a/src/backend/modules/ai-tools/README.md
+++ b/src/backend/modules/ai-tools/README.md
@@ -8,14 +8,14 @@ Provider-agnostic governance for AI tools — the registry every tool registers 
 |---|---|
 | Module id | `ai-tools` |
 | Module class | `src/backend/modules/ai-tools/AiToolsModule.ts` |
-| Service registry names | `'ai-tools'` → `IAiToolRegistry`, `'ai-tool-governor'` → `IAiToolGovernor`, `'ai-providers'` → `IAiProviderRegistry` |
+| Service registry names | `'ai-tools'` → `IAiToolRegistry`, `'ai-tool-governor'` → `IAiToolGovernor`, `'ai-providers'` → `IAiProviderRegistry`, `'curation'` → `ICurationService` |
 | Admin API base | `/api/admin/system/ai-tools` (rate-limited + `requireAdmin`) |
-| Admin dashboard | `/system/ai-tools` (Registry · Activity · Approvals · Policy tabs + trifecta banner + provider panel) |
+| Admin dashboard | `/system/ai-tools` (Registry · Activity · Approvals · Curation · Policy tabs + trifecta banner + provider panel) |
 | Types package | `@delphian/tronrelic-types` → `IAiTool`, `IAiToolCapability`, `IAiToolRegistry`, `IAiToolGovernor`, `IAiProviderRegistry`, `ITrifectaStatus`, `IToolInvocation{Context,Result,Record}`, `IToolPolicy`, `IAiToolInvokeContext` |
-| Owned collections | `module_ai-tools_invocations`, `module_ai-tools_approvals` |
+| Owned collections | `module_ai-tools_invocations`, `module_ai-tools_approvals`, `module_ai-tools_curations` |
 | KV keys (core `_kv`) | `ai-tools:tool-states`, `ai-tools:policy-overrides` |
 | Hook seams | `ai.toolInvoke` (series, veto/hold), `ai.toolInvoked` (observer, audit fan-out) |
-| WebSocket signals | `ai-tools:activity`, `ai-tools:approvals-changed` (timestamp-only refetch cues; data stays behind the gated REST feed) |
+| WebSocket signals | `ai-tools:activity`, `ai-tools:approvals-changed`, `ai-tools:curations-changed` (timestamp-only refetch cues; data stays behind the gated REST feed) |
 | Scheduler jobs | `ai-tools:prune-audit` (daily 04:00) — range-deletes `module_ai-tools_invocations` past the 90-day window; registered only when a scheduler is injected |
 | Bootstrap order | Inits/runs alongside the other modules, before `loadPlugins` |
 | Standard | [system-ai-tools.md](../../../../docs/system/system-ai-tools.md) |
@@ -34,6 +34,8 @@ The AI *provider* is a swappable plugin (`trp-ai-assistant` for Anthropic today;
 | `services/tool-policy-engine.ts` | Capability-classed defaults, admin overrides, fixed-window rate limiter, autonomous default-deny |
 | `services/tool-audit-store.ts` | `module_ai-tools_invocations` writes/queries, retention prune |
 | `services/tool-approval-queue.ts` | `module_ai-tools_approvals` — park/list/resolve held invocations |
+| `services/curation-queue.ts` | `module_ai-tools_curations` — persist/list/decide/edit held envelopes |
+| `services/curation-service.ts` | `'curation'` → `ICurationService`: type registry + hold/approve/reject/edit orchestration |
 | `api/ai-tools.controller.ts` · `api/ai-tools.router.ts` | Admin REST surface |
 
 ## The Governed Pipeline
@@ -69,6 +71,10 @@ The AI provider plugin consumes this. `invoke(name, input, ctx)` returns `IToolI
 
 The installed AI provider plugin registers itself here (`registerProvider`/`unregisterProvider`/`listProviders`) so the Provider panel stays provider-agnostic — `trp-ai-assistant` registers on enable and unregisters on disable.
 
+### `'curation'` → `ICurationService`
+
+The central queue of effects held for human review across content types. Providers `registerType`/`unregisterType` an `ICurationType` (`describe` / `onApprove` / `onReject` / optional `applyEdit`); producers `hold()`; the admin surface lists and `approve`/`reject`/`edit`. Core owns the decision and the pointer-plus-cached-preview envelope; the owning type owns the payload and what a decision does. The governor reads `hasType()` to verify a tool's `curationTypeId` binding (wired via `ToolPolicyEngine.setCurationResolver` in `init()`). Full design: [system-curation.md](../../../../docs/system/system-curation.md).
+
 ## Admin REST API
 
 All under `/api/admin/system/ai-tools` (rate-limited + `requireAdmin`).
@@ -87,6 +93,9 @@ All under `/api/admin/system/ai-tools` (rate-limited + `requireAdmin`).
 | POST | `/approvals/:id/reject` | Reject without running |
 | GET | `/policy` | Per-tool overrides + usage tallies |
 | PUT/DELETE | `/policy/:name` | Set / clear a per-tool override |
+| GET | `/curations` · `/curations/count` | Pending curation queue + count (Curation tab + badge) |
+| PATCH | `/curations/:id` | Apply an operator inline edit (`{ body }`) via the type's `applyEdit` |
+| POST | `/curations/:id/approve` · `/curations/:id/reject` | Decide a held item (404 not-pending · 409 owner-unavailable) |
 
 ## Hook Seams
 
@@ -94,11 +103,12 @@ Declared in `src/backend/hooks/registry.ts`. `ai.toolInvoke` (series, `IAiToolIn
 
 ## Lifecycle Obligations
 
-`init()` constructs the registry, policy engine, audit store, approval queue, governor, and provider registry; loads persisted tool-states and policy overrides; and ensures the two collections' indexes (the collections are new, so index creation here is correct rather than a migration). `run()` mounts the admin router, registers `'ai-tools'` / `'ai-tool-governor'` / `'ai-providers'`, wires the governor's broadcast sink to `WebSocketService`, registers the daily `ai-tools:prune-audit` retention job (only when a scheduler is injected), and registers the `/system/ai-tools` admin nav item under the System container. Errors in either phase fail the boot — there is no degraded mode.
+`init()` constructs the registry, policy engine, audit store, approval queue, curation queue + service, governor, and provider registry; loads persisted tool-states and policy overrides; ensures the collections' indexes (the collections are new, so index creation here is correct rather than a migration); and injects the curation binding resolver into the policy engine (`policy.setCurationResolver(curation.hasType)`). `run()` mounts the admin router, registers `'ai-tools'` / `'ai-tool-governor'` / `'ai-providers'` / `'curation'`, wires the governor's and curation service's broadcast sinks to `WebSocketService`, registers the daily `ai-tools:prune-audit` retention job (only when a scheduler is injected), and registers the `/system/ai-tools` admin nav item under the System container. Errors in either phase fail the boot — there is no degraded mode.
 
 ## Related
 
 - [system-ai-tools.md](../../../../docs/system/system-ai-tools.md) — the AI tool standard this module enforces
+- [system-curation.md](../../../../docs/system/system-curation.md) — the central curation queue, the type contract, and the verifiable binding
 - [system-hooks.md](../../../../docs/system/system-hooks.md) — the seam mechanism the governor invokes
 - [plugins-service-registry.md](../../../../docs/plugins/plugins-service-registry.md) — how providers discover `'ai-tools'`
 - [modules-architecture.md](../../../../docs/system/modules/modules-architecture.md) — the `IModule` contract and bootstrap order

--- a/src/backend/modules/ai-tools/__tests__/ai-tools-module.test.ts
+++ b/src/backend/modules/ai-tools/__tests__/ai-tools-module.test.ts
@@ -485,16 +485,54 @@ describe('CurationService', () => {
         expect(await service.countPending()).toBe(1); // not lost — waits for the owner to return
     });
 
-    it('keeps the decision recorded even when the type callback throws', async () => {
+    it('surfaces a failed commit to the caller while leaving the decision recorded', async () => {
         const service = makeService();
         const type = spyCurationType({ onApprove: vi.fn(async () => { throw new Error('publish failed'); }) });
         service.registerType(type, 'x-poster');
         const held = await service.hold({ typeId: 'x-poster:tweet', ref: {} });
 
-        const decided = await service.approve(held.id, 'admin-1');
-
-        expect(decided?.status).toBe('approved'); // decision stands; callback failure is isolated
+        // The commit failure propagates so the curator is not shown a false success...
+        await expect(service.approve(held.id, 'admin-1')).rejects.toThrow('publish failed');
+        // ...but the decision still stands — the item has left the pending queue.
         expect(await service.countPending()).toBe(0);
+    });
+
+    it('resolves a live preview for pending items in listPending and get', async () => {
+        const service = makeService();
+        let stored = 'v1';
+        const type = spyCurationType({ describe: vi.fn(async () => ({ body: stored })) });
+        service.registerType(type, 'x-poster');
+        const held = await service.hold({ typeId: 'x-poster:tweet', ref: { postId: 'p1' } });
+        expect(held.preview.body).toBe('v1');
+
+        // The provider's record changes out of band; the cached snapshot is stale.
+        stored = 'v2';
+        expect((await service.listPending())[0].preview.body).toBe('v2');
+        expect((await service.get(held.id))?.preview.body).toBe('v2');
+    });
+
+    it('edit falls back to the patched body when re-describe fails', async () => {
+        const service = makeService();
+        let calls = 0;
+        const type = spyCurationType({
+            describe: vi.fn(async () => {
+                calls += 1;
+                if (calls === 1) {
+                    return { body: 'original', editable: true }; // hold-time snapshot
+                }
+                throw new Error('describe boom'); // re-describe after the edit
+            }),
+            applyEdit: vi.fn(async () => undefined)
+        });
+        service.registerType(type, 'x-poster');
+        const held = await service.hold({ typeId: 'x-poster:tweet', ref: {} });
+
+        const updated = await service.edit(held.id, { body: 'edited' }, 'admin-1');
+
+        expect(type.applyEdit).toHaveBeenCalledOnce();
+        // The edit applied; a failed re-describe must not report failure — fall
+        // back to the patched body so the snapshot still advances.
+        expect(updated?.preview.body).toBe('edited');
     });
 
     it('edit applies the patch through the type, then re-derives and re-caches the preview', async () => {

--- a/src/backend/modules/ai-tools/__tests__/ai-tools-module.test.ts
+++ b/src/backend/modules/ai-tools/__tests__/ai-tools-module.test.ts
@@ -9,8 +9,8 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { HookAbortError } from '@/types';
-import type { IAiTool, IAiToolCapability, IHookRegistry, IMenuService, ISchedulerService, ISystemLogService, IToolInvocationContext } from '@/types';
-import { AiToolsModule, AUDIT_PRUNE_JOB, ToolApprovalQueue, detectTrifecta } from '../index.js';
+import type { IAiTool, IAiToolCapability, ICurationType, IHookRegistry, IMenuService, ISchedulerService, ISystemLogService, IToolInvocationContext } from '@/types';
+import { AiToolsModule, AUDIT_PRUNE_JOB, CurationQueue, CurationService, ToolApprovalQueue, detectTrifecta } from '../index.js';
 import { ToolPolicyEngine } from '../services/tool-policy-engine.js';
 import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
 import { createMockServiceRegistry } from '../../../tests/vitest/mocks/service-registry.js';
@@ -82,6 +82,33 @@ function curatedExternalTool(handler = vi.fn(async () => ({ sent: true }))): IAi
         inputSchema: { type: 'object', properties: {}, required: [], additionalProperties: false },
         capability: { sideEffect: 'external', reversible: false, sensitivity: 'public', forcesCuratorReview: true },
         handler
+    };
+}
+
+/**
+ * A self-curated external tool bound to a core curation type. The binding turns
+ * `forcesCuratorReview` from a claim into something the governor verifies: the
+ * relaxation applies only while the bound type is registered.
+ */
+function boundCuratedTool(curationTypeId: string, handler = vi.fn(async () => ({ sent: true }))): IAiTool {
+    return {
+        name: 'test-bound',
+        description: 'An external tool that routes every effect into a core curation type.',
+        inputSchema: { type: 'object', properties: {}, required: [], additionalProperties: false },
+        capability: { sideEffect: 'external', reversible: false, sensitivity: 'public', forcesCuratorReview: true, curationTypeId },
+        handler
+    };
+}
+
+/** Build a curation type whose callbacks are spies, overridable per test. */
+function spyCurationType(over: Partial<ICurationType> = {}): ICurationType {
+    return {
+        typeId: 'x-poster:tweet',
+        label: 'Tweet',
+        describe: vi.fn(async (ref: Record<string, unknown>) => ({ body: `draft ${String(ref.postId ?? '')}` })),
+        onApprove: vi.fn(async () => undefined),
+        onReject: vi.fn(async () => undefined),
+        ...over
     };
 }
 
@@ -327,6 +354,176 @@ describe('AiToolsModule', () => {
             expect(status.present).toBe(false);
             expect(status.exfiltration).toHaveLength(0);
         });
+    });
+
+    describe('curation binding', () => {
+        it('rejects a tool that declares curationTypeId without forcesCuratorReview', () => {
+            const incoherent: IAiTool = {
+                name: 'test-incoherent',
+                description: 'binds to a curation type but does not force review',
+                inputSchema: { type: 'object', properties: {}, required: [], additionalProperties: false },
+                capability: { sideEffect: 'external', reversible: false, sensitivity: 'public', curationTypeId: 'x-poster:tweet' },
+                handler: vi.fn(async () => ({}))
+            };
+            expect(() => module.getRegistry().registerTool(incoherent, 'test')).toThrow(/curationTypeId/);
+        });
+
+        it('bars a bound tool on an autonomous run until its curation type is registered', async () => {
+            const handler = vi.fn(async () => ({ sent: true }));
+            const registry = module.getRegistry();
+            registry.registerTool(boundCuratedTool('x-poster:tweet', handler), 'test');
+            await registry.setEnabled('test-bound', true); // external ships disabled
+
+            // Binding unresolved (no curation type registered): the verified claim
+            // does not hold, so the external tool is barred on the autonomous path.
+            const barred = await module.getGovernor().invoke('test-bound', {}, scheduledCtx);
+            expect(barred.status).toBe('denied');
+            expect(handler).not.toHaveBeenCalled();
+
+            // Register the matching type: the binding resolves and the tool is
+            // autonomous-safe (an unattended call can only draft into the queue).
+            module.getCuration().registerType(spyCurationType(), 'x-poster');
+            const permitted = await module.getGovernor().invoke('test-bound', {}, scheduledCtx);
+            expect(permitted.status).toBe('ok');
+            expect(handler).toHaveBeenCalledOnce();
+        });
+
+        it('re-tightens a bound tool when its curation type is unregistered', async () => {
+            const registry = module.getRegistry();
+            registry.registerTool(boundCuratedTool('x-poster:tweet'), 'test');
+            await registry.setEnabled('test-bound', true);
+            const curation = module.getCuration();
+            curation.registerType(spyCurationType(), 'x-poster');
+
+            expect((await module.getGovernor().invoke('test-bound', {}, scheduledCtx)).status).toBe('ok');
+
+            // Disabling the owning provider unregisters its type; the binding stops
+            // resolving and the tool's autonomous bar returns.
+            curation.unregisterType('x-poster:tweet');
+            expect((await module.getGovernor().invoke('test-bound', {}, scheduledCtx)).status).toBe('denied');
+        });
+    });
+});
+
+describe('CurationService', () => {
+    /** Build a curation service over a fresh mock database. */
+    function makeService(): CurationService {
+        const logger = createMockLogger();
+        const queue = new CurationQueue(logger, createMockDatabaseService());
+        return new CurationService(logger, queue);
+    }
+
+    it('registers types and reports them', () => {
+        const service = makeService();
+        const type = spyCurationType();
+        service.registerType(type, 'x-poster');
+
+        expect(service.hasType('x-poster:tweet')).toBe(true);
+        expect(service.getType('x-poster:tweet')).toBe(type);
+        expect(service.listTypes()).toEqual([{ typeId: 'x-poster:tweet', label: 'Tweet', providerId: 'x-poster' }]);
+    });
+
+    it('holds an effect: caches the preview from describe() and stores it pending', async () => {
+        const service = makeService();
+        const type = spyCurationType();
+        service.registerType(type, 'x-poster');
+
+        const item = await service.hold({ typeId: 'x-poster:tweet', ref: { postId: 'p1' }, source: 'ai-tool:x-post-tweet' });
+
+        expect(item.status).toBe('pending');
+        expect(item.preview.body).toBe('draft p1');
+        expect(item.providerId).toBe('x-poster');
+        expect(item.source).toBe('ai-tool:x-post-tweet');
+        expect(type.describe).toHaveBeenCalledWith({ postId: 'p1' });
+        expect(await service.countPending()).toBe(1);
+    });
+
+    it('throws when holding for an unregistered type', async () => {
+        const service = makeService();
+        await expect(service.hold({ typeId: 'nope:thing', ref: {} })).rejects.toThrow(/nope:thing/);
+    });
+
+    it('approve records the decision then commits via onApprove', async () => {
+        const service = makeService();
+        const type = spyCurationType();
+        service.registerType(type, 'x-poster');
+        const held = await service.hold({ typeId: 'x-poster:tweet', ref: { postId: 'p1' } });
+
+        const decided = await service.approve(held.id, 'admin-1');
+
+        expect(decided?.status).toBe('approved');
+        expect(decided?.decidedBy).toBe('admin-1');
+        expect(type.onApprove).toHaveBeenCalledOnce();
+        expect(type.onReject).not.toHaveBeenCalled();
+        expect(await service.countPending()).toBe(0);
+    });
+
+    it('reject records the decision then discards via onReject', async () => {
+        const service = makeService();
+        const type = spyCurationType();
+        service.registerType(type, 'x-poster');
+        const held = await service.hold({ typeId: 'x-poster:tweet', ref: {} });
+
+        const decided = await service.reject(held.id, 'admin-1');
+
+        expect(decided?.status).toBe('rejected');
+        expect(type.onReject).toHaveBeenCalledOnce();
+        expect(type.onApprove).not.toHaveBeenCalled();
+    });
+
+    it('blocks a decision when the owning type is unregistered, leaving the item pending', async () => {
+        const service = makeService();
+        const type = spyCurationType();
+        service.registerType(type, 'x-poster');
+        const held = await service.hold({ typeId: 'x-poster:tweet', ref: {} });
+
+        service.unregisterType('x-poster:tweet');
+        const decided = await service.approve(held.id, 'admin-1');
+
+        expect(decided).toBeNull();
+        expect(type.onApprove).not.toHaveBeenCalled();
+        expect(await service.countPending()).toBe(1); // not lost — waits for the owner to return
+    });
+
+    it('keeps the decision recorded even when the type callback throws', async () => {
+        const service = makeService();
+        const type = spyCurationType({ onApprove: vi.fn(async () => { throw new Error('publish failed'); }) });
+        service.registerType(type, 'x-poster');
+        const held = await service.hold({ typeId: 'x-poster:tweet', ref: {} });
+
+        const decided = await service.approve(held.id, 'admin-1');
+
+        expect(decided?.status).toBe('approved'); // decision stands; callback failure is isolated
+        expect(await service.countPending()).toBe(0);
+    });
+
+    it('edit applies the patch through the type, then re-derives and re-caches the preview', async () => {
+        const service = makeService();
+        // Simulate the owning plugin's record: applyEdit mutates it, describe reads it.
+        let stored = 'original';
+        const type = spyCurationType({
+            describe: vi.fn(async () => ({ body: stored, editable: true })),
+            applyEdit: vi.fn(async (_item, patch) => { if (typeof patch.body === 'string') stored = patch.body; })
+        });
+        service.registerType(type, 'x-poster');
+        const held = await service.hold({ typeId: 'x-poster:tweet', ref: { postId: 'p1' } });
+        expect(held.preview.body).toBe('original');
+
+        const updated = await service.edit(held.id, { body: 'edited' }, 'admin-1');
+
+        expect(type.applyEdit).toHaveBeenCalledWith(expect.objectContaining({ id: held.id }), { body: 'edited' });
+        expect(updated?.preview.body).toBe('edited');
+        // The cached snapshot is refreshed too, so the disabled-owner fallback is current.
+        expect((await service.get(held.id))?.preview.body).toBe('edited');
+        expect(await service.countPending()).toBe(1); // edit does not decide the item
+    });
+
+    it('edit returns null for a type that is not editable', async () => {
+        const service = makeService();
+        service.registerType(spyCurationType(), 'x-poster'); // no applyEdit
+        const held = await service.hold({ typeId: 'x-poster:tweet', ref: {} });
+
+        expect(await service.edit(held.id, { body: 'x' })).toBeNull();
     });
 });
 

--- a/src/backend/modules/ai-tools/api/ai-tools.controller.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.controller.ts
@@ -282,13 +282,22 @@ export class AiToolsController {
             });
             return;
         }
-        const result = action === 'approve'
-            ? await this.curation.approve(id, actorId(req))
-            : await this.curation.reject(id, actorId(req));
-        if (!result) {
-            res.status(409).json({ error: 'Curation item could not be decided; it may have just been resolved.' });
-            return;
+        try {
+            const result = action === 'approve'
+                ? await this.curation.approve(id, actorId(req))
+                : await this.curation.reject(id, actorId(req));
+            if (!result) {
+                res.status(409).json({ error: 'Curation item could not be decided; it may have just been resolved.' });
+                return;
+            }
+            res.json(serializeCurationItem(result));
+        } catch (error) {
+            // The decision was recorded but the owning type could not complete the
+            // effect (publish/cleanup failed). The item has left the pending queue,
+            // so surface the failure rather than reporting a false success.
+            res.status(502).json({
+                error: `Decision recorded, but the provider could not complete it: ${error instanceof Error ? error.message : String(error)}`
+            });
         }
-        res.json(serializeCurationItem(result));
     };
 }

--- a/src/backend/modules/ai-tools/api/ai-tools.controller.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.controller.ts
@@ -9,14 +9,38 @@
  */
 
 import type { Request, Response } from 'express';
-import type { IToolPolicy, ToolInvocationStatus, ToolTriggerPath } from '@/types';
+import type { ICurationItem, IToolPolicy, ToolInvocationStatus, ToolTriggerPath } from '@/types';
 import type { AiToolRegistry } from '../services/ai-tool-registry.js';
 import type { ToolPolicyEngine } from '../services/tool-policy-engine.js';
 import type { ToolAuditStore, IToolInvocationQuery } from '../services/tool-audit-store.js';
 import type { ToolApprovalQueue } from '../services/tool-approval-queue.js';
 import type { AiToolGovernor } from '../services/ai-tool-governor.js';
 import type { AiProviderRegistry } from '../services/ai-provider-registry.js';
+import type { CurationService } from '../services/curation-service.js';
 import { detectTrifecta } from '../services/trifecta-detector.js';
+
+/**
+ * Serialize a curation envelope for the admin dashboard: dates to ISO strings,
+ * and only the fields the queue UI needs (including `ref`, which the type's
+ * editor uses to address its own record). Drops the Mongo `_id`.
+ *
+ * @param item - The stored envelope.
+ * @returns A JSON-safe view of the item.
+ */
+function serializeCurationItem(item: ICurationItem): Record<string, unknown> {
+    return {
+        id: item.id,
+        typeId: item.typeId,
+        providerId: item.providerId,
+        ref: item.ref,
+        preview: item.preview,
+        status: item.status,
+        source: item.source,
+        createdAt: item.createdAt instanceof Date ? item.createdAt.toISOString() : item.createdAt,
+        decidedAt: item.decidedAt instanceof Date ? item.decidedAt.toISOString() : item.decidedAt,
+        decidedBy: item.decidedBy
+    };
+}
 
 /**
  * Read the Better Auth admin id `requireAdmin` set on the request, for audit
@@ -41,6 +65,7 @@ export class AiToolsController {
      * @param approvals - Approval queue.
      * @param governor - Tool governor (for approve/reject execution).
      * @param providers - Installed-AI-provider registry (for the Provider panel).
+     * @param curation - Central curation queue (for the Curation tab).
      */
     constructor(
         private readonly registry: AiToolRegistry,
@@ -48,7 +73,8 @@ export class AiToolsController {
         private readonly audit: ToolAuditStore,
         private readonly approvals: ToolApprovalQueue,
         private readonly governor: AiToolGovernor,
-        private readonly providers: AiProviderRegistry
+        private readonly providers: AiProviderRegistry,
+        private readonly curation: CurationService
     ) {}
 
     /** GET /tools — registry with capability, provider, and enabled state. */
@@ -175,5 +201,94 @@ export class AiToolsController {
     clearPolicy = async (req: Request, res: Response): Promise<void> => {
         await this.policy.setOverride(req.params.name, null);
         res.json({ name: req.params.name, cleared: true });
+    };
+
+    /** GET /curations — pending items held across every content type. */
+    listCurations = async (_req: Request, res: Response): Promise<void> => {
+        const items = await this.curation.listPending();
+        res.json({ curations: items.map(serializeCurationItem) });
+    };
+
+    /** GET /curations/count — pending curation count for the nav badge. */
+    getCurationsCount = async (_req: Request, res: Response): Promise<void> => {
+        res.json({ count: await this.curation.countPending() });
+    };
+
+    /** POST /curations/:id/approve — approve a held item and commit it via its type. */
+    approveCuration = async (req: Request, res: Response): Promise<void> => {
+        await this.decideCuration(req, res, 'approve');
+    };
+
+    /** POST /curations/:id/reject — reject a held item and discard it via its type. */
+    rejectCuration = async (req: Request, res: Response): Promise<void> => {
+        await this.decideCuration(req, res, 'reject');
+    };
+
+    /** PATCH /curations/:id — apply an operator's inline edit to a held item. */
+    editCuration = async (req: Request, res: Response): Promise<void> => {
+        const id = req.params.id;
+        const body = (req.body as { body?: unknown })?.body;
+        if (typeof body !== 'string') {
+            res.status(400).json({ error: 'Body must include a string "body".' });
+            return;
+        }
+        const item = await this.curation.get(id);
+        if (!item || item.status !== 'pending') {
+            res.status(404).json({ error: 'No pending curation item matched that id.' });
+            return;
+        }
+        if (!this.curation.hasType(item.typeId)) {
+            res.status(409).json({ error: 'The owning provider is unavailable; this item cannot be edited until it is re-enabled.' });
+            return;
+        }
+        if (!this.curation.getType(item.typeId)?.applyEdit) {
+            res.status(409).json({ error: 'This content type does not support inline editing.' });
+            return;
+        }
+        try {
+            // The owning type validates the patch (e.g. tweet length) and may
+            // throw; surface that as a 400 the operator can correct from.
+            const updated = await this.curation.edit(id, { body }, actorId(req));
+            if (!updated) {
+                res.status(409).json({ error: 'Curation item could not be edited; it may have just been resolved.' });
+                return;
+            }
+            res.json(serializeCurationItem(updated));
+        } catch (error) {
+            res.status(400).json({ error: error instanceof Error ? error.message : 'Edit rejected.' });
+        }
+    };
+
+    /**
+     * Shared approve/reject path. Distinguishes the not-pending case (404) from a
+     * blocked decision whose owning provider is disabled (409) so the operator
+     * sees why an item cannot be actioned, then delegates to the service.
+     *
+     * @param req - The admin request (`:id` param, admin actor).
+     * @param res - The response.
+     * @param action - Which terminal decision to apply.
+     * @returns Resolves once a response is sent.
+     */
+    private decideCuration = async (req: Request, res: Response, action: 'approve' | 'reject'): Promise<void> => {
+        const id = req.params.id;
+        const item = await this.curation.get(id);
+        if (!item || item.status !== 'pending') {
+            res.status(404).json({ error: 'No pending curation item matched that id.' });
+            return;
+        }
+        if (!this.curation.hasType(item.typeId)) {
+            res.status(409).json({
+                error: 'The owning provider is unavailable; this item cannot be decided until it is re-enabled.'
+            });
+            return;
+        }
+        const result = action === 'approve'
+            ? await this.curation.approve(id, actorId(req))
+            : await this.curation.reject(id, actorId(req));
+        if (!result) {
+            res.status(409).json({ error: 'Curation item could not be decided; it may have just been resolved.' });
+            return;
+        }
+        res.json(serializeCurationItem(result));
     };
 }

--- a/src/backend/modules/ai-tools/api/ai-tools.router.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.router.ts
@@ -42,5 +42,11 @@ export function createAiToolsAdminRouter(controller: AiToolsController): Router 
     router.put('/policy/:name', controller.setPolicy);
     router.delete('/policy/:name', controller.clearPolicy);
 
+    router.get('/curations', controller.listCurations);
+    router.get('/curations/count', controller.getCurationsCount);
+    router.patch('/curations/:id', controller.editCuration);
+    router.post('/curations/:id/approve', controller.approveCuration);
+    router.post('/curations/:id/reject', controller.rejectCuration);
+
     return router;
 }

--- a/src/backend/modules/ai-tools/index.ts
+++ b/src/backend/modules/ai-tools/index.ts
@@ -6,8 +6,10 @@
  * registry (`'ai-tools'`, `'ai-tool-governor'`) rather than these exports.
  */
 
-export { AiToolsModule, AI_TOOLS_SERVICE, AI_TOOL_GOVERNOR_SERVICE, AI_PROVIDERS_SERVICE, AUDIT_PRUNE_JOB } from './AiToolsModule.js';
+export { AiToolsModule, AI_TOOLS_SERVICE, AI_TOOL_GOVERNOR_SERVICE, AI_PROVIDERS_SERVICE, CURATION_SERVICE, AUDIT_PRUNE_JOB } from './AiToolsModule.js';
 export { AiProviderRegistry } from './services/ai-provider-registry.js';
+export { CurationQueue } from './services/curation-queue.js';
+export { CurationService, CURATIONS_CHANGED_EVENT } from './services/curation-service.js';
 export type { IAiToolsModuleDependencies } from './AiToolsModule.js';
 export { AiToolRegistry } from './services/ai-tool-registry.js';
 export { AiToolGovernor } from './services/ai-tool-governor.js';

--- a/src/backend/modules/ai-tools/services/ai-tool-registry.ts
+++ b/src/backend/modules/ai-tools/services/ai-tool-registry.ts
@@ -96,6 +96,16 @@ export class AiToolRegistry implements IAiToolRegistry {
         if (this.tools.has(tool.name)) {
             throw new Error(`Tool "${tool.name}" is already registered`);
         }
+        if (tool.capability?.curationTypeId && tool.capability.forcesCuratorReview !== true) {
+            // A curation binding is only meaningful for a tool that forces
+            // curator review — it is the verification of that claim. Declaring
+            // the binding without the claim is incoherent, so reject it rather
+            // than silently honour a binding that grants nothing.
+            throw new Error(
+                `AI tool "${tool.name}" declares curationTypeId "${tool.capability.curationTypeId}" ` +
+                'without forcesCuratorReview: true. Set forcesCuratorReview: true or remove curationTypeId.'
+            );
+        }
 
         const provider = providerId || UNKNOWN_PROVIDER;
         if (!tool.capability) {

--- a/src/backend/modules/ai-tools/services/curation-queue.ts
+++ b/src/backend/modules/ai-tools/services/curation-queue.ts
@@ -1,0 +1,139 @@
+/**
+ * @file curation-queue.ts
+ *
+ * Persistent store for the central curation queue — the envelopes of effects
+ * held for a human curator's decision. It is the storage half of the curation
+ * subsystem: execution-free, like the approval queue it sits beside. It records
+ * a held item and its decision; the owning curation type (not this store) owns
+ * what "approved" does. Generalizes each plugin's private pending queue into one
+ * core-owned collection so a single admin surface reviews every content type.
+ */
+
+import type {
+    CurationItemStatus,
+    ICurationItem,
+    ICurationPreview,
+    IDatabaseService,
+    ISystemLogService
+} from '@/types';
+
+/** Physical collection name (modules prefix `module_<id>_` manually). */
+const COLLECTION = 'module_ai-tools_curations';
+
+/**
+ * Persistent store of curation envelopes awaiting or carrying a decision.
+ */
+export class CurationQueue {
+    /**
+     * @param logger - Module-scoped logger.
+     * @param database - Core database owning the curations collection.
+     */
+    constructor(
+        private readonly logger: ISystemLogService,
+        private readonly database: IDatabaseService
+    ) {}
+
+    /**
+     * Create the collection's indexes. Called once during module init.
+     *
+     * @returns Resolves when all indexes exist.
+     */
+    async ensureIndexes(): Promise<void> {
+        await this.database.createIndex(COLLECTION, { id: 1 }, { unique: true });
+        await this.database.createIndex(COLLECTION, { status: 1, createdAt: -1 });
+        await this.database.createIndex(COLLECTION, { typeId: 1, status: 1 });
+    }
+
+    /**
+     * Persist a held envelope in its `pending` state.
+     *
+     * @param item - The envelope to store.
+     * @returns The stored envelope.
+     */
+    async insert(item: ICurationItem): Promise<ICurationItem> {
+        await this.database.insertOne(COLLECTION, item);
+        this.logger.info({ id: item.id, typeId: item.typeId }, 'Curation item held for review');
+        return item;
+    }
+
+    /**
+     * Fetch one envelope by id.
+     *
+     * @param id - The envelope id.
+     * @returns The envelope, or null when not found.
+     */
+    async get(id: string): Promise<ICurationItem | null> {
+        return this.database.findOne<ICurationItem>(COLLECTION, { id });
+    }
+
+    /**
+     * List pending envelopes, newest first.
+     *
+     * @param limit - Maximum envelopes to return (default 100, capped at 500).
+     * @returns The pending envelopes.
+     */
+    async listPending(limit = 100): Promise<ICurationItem[]> {
+        const capped = Math.min(Math.max(1, limit), 500);
+        const collection = this.database.getCollection<ICurationItem>(COLLECTION);
+        return collection
+            .find({ status: 'pending' })
+            .sort({ createdAt: -1 })
+            .limit(capped)
+            .toArray();
+    }
+
+    /**
+     * Count envelopes still awaiting a decision, for the dashboard badge.
+     *
+     * @returns The number of `pending` envelopes.
+     */
+    async countPending(): Promise<number> {
+        return this.database.count(COLLECTION, { status: 'pending' });
+    }
+
+    /**
+     * Replace a pending envelope's cached preview after an inline edit, so the
+     * disabled-owner fallback snapshot stays current. Scoped to `pending` so a
+     * decided item is never mutated.
+     *
+     * @param id - The envelope id.
+     * @param preview - The freshly re-derived preview.
+     * @returns Resolves when the update settles.
+     */
+    async updatePreview(id: string, preview: ICurationPreview): Promise<void> {
+        await this.database.updateMany(COLLECTION, { id, status: 'pending' }, { $set: { preview } });
+    }
+
+    /**
+     * Transition a pending envelope to `approved` or `rejected`. The conditional
+     * update on `status: 'pending'` is the atomic gate: two concurrent decisions
+     * serialize on the document, so only the first transitions it and gets the
+     * envelope back, ensuring the owning type's callback runs exactly once.
+     *
+     * @param id - The envelope id.
+     * @param status - The terminal state.
+     * @param decidedBy - Better Auth user id of the deciding curator.
+     * @returns The updated envelope, or null when no pending envelope matched.
+     */
+    async resolve(
+        id: string,
+        status: Exclude<CurationItemStatus, 'pending'>,
+        decidedBy?: string
+    ): Promise<ICurationItem | null> {
+        const existing = await this.database.findOne<ICurationItem>(COLLECTION, { id, status: 'pending' });
+        let resolved: ICurationItem | null = null;
+        if (existing) {
+            const decidedAt = new Date();
+            const setFields: Partial<ICurationItem> = { status, decidedAt };
+            if (decidedBy !== undefined) {
+                setFields.decidedBy = decidedBy;
+            }
+            const modified = await this.database.updateMany(COLLECTION, { id, status: 'pending' }, { $set: setFields });
+            if (modified > 0) {
+                resolved = { ...existing, status, decidedAt, decidedBy };
+                this.logger.info({ id, status, decidedBy }, `Curation item ${status}: ${existing.typeId}`);
+            }
+        }
+        return resolved;
+    }
+}

--- a/src/backend/modules/ai-tools/services/curation-service.ts
+++ b/src/backend/modules/ai-tools/services/curation-service.ts
@@ -161,7 +161,8 @@ export class CurationService implements ICurationService {
      * @returns The pending envelopes.
      */
     async listPending(limit?: number): Promise<ICurationItem[]> {
-        return this.queue.listPending(limit);
+        const items = await this.queue.listPending(limit);
+        return Promise.all(items.map(item => this.withLivePreview(item)));
     }
 
     /**
@@ -174,13 +175,38 @@ export class CurationService implements ICurationService {
     }
 
     /**
-     * Fetch one envelope by id.
+     * Fetch one envelope by id, resolving a live preview while it is pending and
+     * its owner is registered.
      *
      * @param id - The envelope id.
      * @returns The envelope, or null when absent.
      */
     async get(id: string): Promise<ICurationItem | null> {
-        return this.queue.get(id);
+        const item = await this.queue.get(id);
+        return item && item.status === 'pending' ? this.withLivePreview(item) : item;
+    }
+
+    /**
+     * Resolve an item's preview live from its registered type so the queue never
+     * shows a stale snapshot while the owner is present (the cached preview is the
+     * disabled-owner fallback, per the curation design). Falls back to the cached
+     * snapshot when the owner is unregistered or `describe()` fails.
+     *
+     * @param item - The stored envelope.
+     * @returns The envelope with a freshly resolved preview, or the original.
+     */
+    private async withLivePreview(item: ICurationItem): Promise<ICurationItem> {
+        const entry = this.types.get(item.typeId);
+        let resolved = item;
+        if (entry) {
+            try {
+                const preview = await entry.type.describe(item.ref);
+                resolved = { ...item, preview };
+            } catch (error) {
+                this.logger.warn({ error, id: item.id }, 'Live preview resolution failed; using cached snapshot');
+            }
+        }
+        return resolved;
     }
 
     /**
@@ -190,6 +216,8 @@ export class CurationService implements ICurationService {
      * @param decidedBy - Better Auth user id of the deciding curator.
      * @returns The decided envelope, or null when blocked (missing, no longer
      *          pending, or owner unregistered).
+     * @throws When the owning type's `onApprove` fails; the decision is still
+     *         recorded, so the caller surfaces the failure rather than retrying.
      */
     async approve(id: string, decidedBy?: string): Promise<ICurationItem | null> {
         return this.decide(id, 'approved', decidedBy);
@@ -201,6 +229,8 @@ export class CurationService implements ICurationService {
      * @param id - The envelope id.
      * @param decidedBy - Better Auth user id of the deciding curator.
      * @returns The decided envelope, or null under the same conditions as approve.
+     * @throws When the owning type's `onReject` fails; the decision is still
+     *         recorded.
      */
     async reject(id: string, decidedBy?: string): Promise<ICurationItem | null> {
         return this.decide(id, 'rejected', decidedBy);
@@ -225,12 +255,32 @@ export class CurationService implements ICurationService {
         if (existing && existing.status === 'pending') {
             const entry = this.types.get(existing.typeId);
             if (entry?.type.applyEdit) {
-                await entry.type.applyEdit(existing, patch);
-                const preview = await entry.type.describe(existing.ref);
-                await this.queue.updatePreview(id, preview);
-                await this.notifyChanged();
-                this.logger.info({ id, typeId: existing.typeId, editedBy }, 'Curation item edited');
-                result = { ...existing, preview };
+                // Re-confirm pending immediately before mutating the provider
+                // payload, narrowing the edit-vs-decide race. The window is not
+                // fully closed, so a registered type's applyEdit should also guard
+                // on its own pending state (x-poster's editPostText conditions on
+                // pending_approval) for complete safety.
+                const latest = await this.queue.get(id);
+                if (latest && latest.status === 'pending') {
+                    await entry.type.applyEdit(latest, patch);
+                    // The edit already landed in the provider's record; a failure
+                    // to re-derive the preview must not report the edit as failed.
+                    // Fall back to patching the cached body so the snapshot still
+                    // advances and the API returns success.
+                    let preview = latest.preview;
+                    try {
+                        preview = await entry.type.describe(latest.ref);
+                    } catch (error) {
+                        this.logger.error({ error, id }, 'Re-describe after edit failed; falling back to the patched body');
+                        if (patch.body !== undefined) {
+                            preview = { ...preview, body: patch.body };
+                        }
+                    }
+                    await this.queue.updatePreview(id, preview);
+                    await this.notifyChanged();
+                    this.logger.info({ id, typeId: latest.typeId, editedBy }, 'Curation item edited');
+                    result = { ...latest, preview };
+                }
             }
         }
         return result;
@@ -238,14 +288,16 @@ export class CurationService implements ICurationService {
 
     /**
      * Record a terminal decision and invoke the owning type's callback. The
-     * decision is persisted before the callback runs, so a callback failure
-     * leaves the item decided (the contract requires callbacks be retry-safe)
-     * rather than re-opening an effect that may already have partly committed.
+     * decision is persisted and broadcast before the callback runs; a callback
+     * failure then propagates to the caller (the item stays decided and won't
+     * reappear, so the curator is told the provider-side effect failed rather than
+     * seeing a false success). Callbacks must be retry-safe.
      *
      * @param id - The envelope id.
      * @param status - The terminal state.
      * @param decidedBy - Better Auth user id of the deciding curator.
      * @returns The decided envelope, or null when the decision cannot proceed.
+     * @throws When the owning type's callback fails after the decision is recorded.
      */
     private async decide(
         id: string,
@@ -269,8 +321,13 @@ export class CurationService implements ICurationService {
             } else {
                 const resolved = await this.queue.resolve(id, status, decidedBy);
                 if (resolved) {
-                    await this.commit(entry.type, resolved);
+                    // The decision is recorded; broadcast it before committing so
+                    // the queue badge updates regardless of the commit outcome.
                     await this.notifyChanged();
+                    // A commit failure propagates to the caller: the item has left
+                    // the pending queue and won't reappear, so the curator must be
+                    // told the provider-side effect did not complete.
+                    await this.commit(entry.type, resolved);
                 }
                 result = resolved;
             }
@@ -279,25 +336,20 @@ export class CurationService implements ICurationService {
     }
 
     /**
-     * Invoke the owning type's terminal callback, isolating its failure from the
-     * already-recorded decision.
+     * Invoke the owning type's terminal callback. A failure propagates to the
+     * caller so the curator learns the provider-side effect did not complete; the
+     * decision is already recorded and is not rolled back (callbacks must be
+     * retry-safe).
      *
      * @param type - The owning curation type.
      * @param item - The decided envelope.
-     * @returns Resolves once the callback settles.
+     * @returns Resolves once the callback settles; rejects if it throws.
      */
     private async commit(type: ICurationType, item: ICurationItem): Promise<void> {
-        try {
-            if (item.status === 'approved') {
-                await type.onApprove(item);
-            } else {
-                await type.onReject(item);
-            }
-        } catch (error) {
-            this.logger.error(
-                { error, id: item.id, typeId: item.typeId, status: item.status },
-                'Curation type callback threw after decision recorded'
-            );
+        if (item.status === 'approved') {
+            await type.onApprove(item);
+        } else {
+            await type.onReject(item);
         }
     }
 

--- a/src/backend/modules/ai-tools/services/curation-service.ts
+++ b/src/backend/modules/ai-tools/services/curation-service.ts
@@ -1,0 +1,315 @@
+/**
+ * @file curation-service.ts
+ *
+ * The central curation service: the registry of reviewable content types and
+ * the orchestration of the held-item lifecycle. It is the single `'curation'`
+ * service core publishes. Providers register a type (describe / onApprove /
+ * onReject); producers `hold()` effects into the queue; the admin surface lists
+ * and decides them. Core owns the decision and the envelope; the owning type
+ * owns the payload, the preview, and what approval does.
+ *
+ * Decision flow records the terminal state first (the queue's atomic gate),
+ * then invokes the owning type's callback. A disabled owner — its type no longer
+ * registered — blocks the decision rather than dropping the effect, so a held
+ * item simply waits for its provider to return.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type {
+    ICurationEditPatch,
+    ICurationHoldInput,
+    ICurationItem,
+    ICurationService,
+    ICurationType,
+    ICurationTypeInfo,
+    ISystemLogService,
+    CurationItemStatus
+} from '@/types';
+import type { CurationQueue } from './curation-queue.js';
+
+/** A registered type with the id of the provider that owns it. */
+interface IRegisteredType {
+    type: ICurationType;
+    providerId: string;
+}
+
+/** Broadcast sink for dashboard refetch signals (a no-op until wired). */
+type BroadcastFn = (event: string, payload: unknown) => void;
+
+/** WebSocket event the dashboard listens on to refetch the queue. */
+export const CURATIONS_CHANGED_EVENT = 'ai-tools:curations-changed';
+
+/**
+ * Registry + lifecycle orchestrator for the central curation queue.
+ */
+export class CurationService implements ICurationService {
+    private readonly types = new Map<string, IRegisteredType>();
+    private broadcast: BroadcastFn | null = null;
+
+    /**
+     * @param logger - Module-scoped logger.
+     * @param queue - Persistent store of curation envelopes.
+     */
+    constructor(
+        private readonly logger: ISystemLogService,
+        private readonly queue: CurationQueue
+    ) {}
+
+    /**
+     * Wire a broadcast sink so decisions and new holds nudge the dashboard to
+     * refetch. Optional; until set, notifications are dropped.
+     *
+     * @param fn - Sink invoked with an event name and payload.
+     */
+    setBroadcast(fn: BroadcastFn): void {
+        this.broadcast = fn;
+    }
+
+    /**
+     * Register a reviewable content type. A later registration for the same id
+     * replaces the earlier one (an operator re-enabling a provider).
+     *
+     * @param type - The type contract.
+     * @param providerId - Id of the registering plugin or module.
+     */
+    registerType(type: ICurationType, providerId: string): void {
+        this.types.set(type.typeId, { type, providerId });
+        this.logger.info({ typeId: type.typeId, providerId }, 'Curation type registered');
+    }
+
+    /**
+     * Unregister a type. Held items of this type remain but cannot be decided
+     * until it re-registers.
+     *
+     * @param typeId - The namespaced type id.
+     * @returns True if a type was removed.
+     */
+    unregisterType(typeId: string): boolean {
+        const removed = this.types.delete(typeId);
+        if (removed) {
+            this.logger.info({ typeId }, 'Curation type unregistered');
+        }
+        return removed;
+    }
+
+    /**
+     * Resolve a registered type.
+     *
+     * @param typeId - The namespaced type id.
+     * @returns The type, or undefined when no owner is registered.
+     */
+    getType(typeId: string): ICurationType | undefined {
+        return this.types.get(typeId)?.type;
+    }
+
+    /**
+     * Whether a type is registered right now — the governor's binding check.
+     *
+     * @param typeId - The namespaced type id.
+     * @returns True when an owner is registered.
+     */
+    hasType(typeId: string): boolean {
+        return this.types.has(typeId);
+    }
+
+    /**
+     * List all registered types for the admin dashboard.
+     *
+     * @returns One info record per registered type.
+     */
+    listTypes(): ICurationTypeInfo[] {
+        return Array.from(this.types.entries()).map(([typeId, entry]) => ({
+            typeId,
+            label: entry.type.label,
+            providerId: entry.providerId
+        }));
+    }
+
+    /**
+     * Hold an effect for review: resolve the type, cache a preview, persist the
+     * envelope as `pending`, and signal the dashboard.
+     *
+     * @param input - The type id, opaque ref, and optional attribution.
+     * @returns The stored pending envelope.
+     * @throws When the type id is not registered.
+     */
+    async hold(input: ICurationHoldInput): Promise<ICurationItem> {
+        const entry = this.types.get(input.typeId);
+        if (!entry) {
+            throw new Error(`No curation type registered for "${input.typeId}"`);
+        }
+        const preview = await entry.type.describe(input.ref);
+        const item: ICurationItem = {
+            id: randomUUID(),
+            typeId: input.typeId,
+            providerId: entry.providerId,
+            ref: input.ref,
+            preview,
+            status: 'pending',
+            source: input.source,
+            createdAt: new Date()
+        };
+        await this.queue.insert(item);
+        await this.notifyChanged();
+        return item;
+    }
+
+    /**
+     * List pending envelopes newest-first for the admin queue.
+     *
+     * @param limit - Maximum envelopes to return.
+     * @returns The pending envelopes.
+     */
+    async listPending(limit?: number): Promise<ICurationItem[]> {
+        return this.queue.listPending(limit);
+    }
+
+    /**
+     * Count pending envelopes for the dashboard badge.
+     *
+     * @returns The pending count.
+     */
+    async countPending(): Promise<number> {
+        return this.queue.countPending();
+    }
+
+    /**
+     * Fetch one envelope by id.
+     *
+     * @param id - The envelope id.
+     * @returns The envelope, or null when absent.
+     */
+    async get(id: string): Promise<ICurationItem | null> {
+        return this.queue.get(id);
+    }
+
+    /**
+     * Approve a pending envelope, then commit it through the owning type.
+     *
+     * @param id - The envelope id.
+     * @param decidedBy - Better Auth user id of the deciding curator.
+     * @returns The decided envelope, or null when blocked (missing, no longer
+     *          pending, or owner unregistered).
+     */
+    async approve(id: string, decidedBy?: string): Promise<ICurationItem | null> {
+        return this.decide(id, 'approved', decidedBy);
+    }
+
+    /**
+     * Reject a pending envelope, then discard it through the owning type.
+     *
+     * @param id - The envelope id.
+     * @param decidedBy - Better Auth user id of the deciding curator.
+     * @returns The decided envelope, or null under the same conditions as approve.
+     */
+    async reject(id: string, decidedBy?: string): Promise<ICurationItem | null> {
+        return this.decide(id, 'rejected', decidedBy);
+    }
+
+    /**
+     * Apply an operator's inline edit to a pending item through its owning type,
+     * then re-derive and re-cache the preview. The owning type validates the
+     * patch and owns the write (core never touches the payload), mirroring how
+     * approve/reject delegate. Returns null when the item is gone, decided, its
+     * owner is unregistered, or the type is not editable. Propagates a throw from
+     * the type's `applyEdit` (validation) so the caller surfaces it.
+     *
+     * @param id - The envelope id.
+     * @param patch - The generic edit to apply.
+     * @param editedBy - Better Auth user id of the editing operator.
+     * @returns The item with refreshed preview, or null when not editable.
+     */
+    async edit(id: string, patch: ICurationEditPatch, editedBy?: string): Promise<ICurationItem | null> {
+        const existing = await this.queue.get(id);
+        let result: ICurationItem | null = null;
+        if (existing && existing.status === 'pending') {
+            const entry = this.types.get(existing.typeId);
+            if (entry?.type.applyEdit) {
+                await entry.type.applyEdit(existing, patch);
+                const preview = await entry.type.describe(existing.ref);
+                await this.queue.updatePreview(id, preview);
+                await this.notifyChanged();
+                this.logger.info({ id, typeId: existing.typeId, editedBy }, 'Curation item edited');
+                result = { ...existing, preview };
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Record a terminal decision and invoke the owning type's callback. The
+     * decision is persisted before the callback runs, so a callback failure
+     * leaves the item decided (the contract requires callbacks be retry-safe)
+     * rather than re-opening an effect that may already have partly committed.
+     *
+     * @param id - The envelope id.
+     * @param status - The terminal state.
+     * @param decidedBy - Better Auth user id of the deciding curator.
+     * @returns The decided envelope, or null when the decision cannot proceed.
+     */
+    private async decide(
+        id: string,
+        status: Exclude<CurationItemStatus, 'pending'>,
+        decidedBy?: string
+    ): Promise<ICurationItem | null> {
+        const existing = await this.queue.get(id);
+        let result: ICurationItem | null = null;
+        if (!existing || existing.status !== 'pending') {
+            result = null;
+        } else {
+            const entry = this.types.get(existing.typeId);
+            if (!entry) {
+                // Disabled owner: the decision is blocked, not lost. The item
+                // waits in the queue until its provider re-registers the type.
+                this.logger.warn(
+                    { id, typeId: existing.typeId },
+                    'Curation decision blocked — owning type is not registered'
+                );
+                result = null;
+            } else {
+                const resolved = await this.queue.resolve(id, status, decidedBy);
+                if (resolved) {
+                    await this.commit(entry.type, resolved);
+                    await this.notifyChanged();
+                }
+                result = resolved;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Invoke the owning type's terminal callback, isolating its failure from the
+     * already-recorded decision.
+     *
+     * @param type - The owning curation type.
+     * @param item - The decided envelope.
+     * @returns Resolves once the callback settles.
+     */
+    private async commit(type: ICurationType, item: ICurationItem): Promise<void> {
+        try {
+            if (item.status === 'approved') {
+                await type.onApprove(item);
+            } else {
+                await type.onReject(item);
+            }
+        } catch (error) {
+            this.logger.error(
+                { error, id: item.id, typeId: item.typeId, status: item.status },
+                'Curation type callback threw after decision recorded'
+            );
+        }
+    }
+
+    /**
+     * Emit a dashboard refetch signal carrying the current pending count.
+     *
+     * @returns Resolves once the count is read and broadcast.
+     */
+    private async notifyChanged(): Promise<void> {
+        if (this.broadcast) {
+            const count = await this.queue.countPending();
+            this.broadcast(CURATIONS_CHANGED_EVENT, { count });
+        }
+    }
+}

--- a/src/backend/modules/ai-tools/services/tool-policy-engine.ts
+++ b/src/backend/modules/ai-tools/services/tool-policy-engine.ts
@@ -74,6 +74,7 @@ export class ToolPolicyEngine {
     private globalWindow: IWindowState = { windowStart: Date.now(), count: 0 };
     private readonly counters = new Map<string, IToolCounters>();
     private overrides: Record<string, IToolPolicy> = {};
+    private curationTypeResolver: ((typeId: string) => boolean) | null = null;
 
     /**
      * @param logger - Module-scoped logger.
@@ -91,6 +92,19 @@ export class ToolPolicyEngine {
      */
     async loadOverrides(): Promise<void> {
         this.overrides = (await this.database.get<Record<string, IToolPolicy>>(POLICY_OVERRIDES_KEY)) ?? {};
+    }
+
+    /**
+     * Wire the predicate that verifies an AI tool's `curationTypeId` binding —
+     * whether a matching curation type is registered right now. The module
+     * injects `curationService.hasType` here. Until it is set, a declared
+     * `curationTypeId` fails safe (treated as unresolved), so the binding can
+     * only ever tighten a tool's gates, never loosen them by default.
+     *
+     * @param resolver - Live predicate: does this curation type exist now?
+     */
+    setCurationResolver(resolver: (typeId: string) => boolean): void {
+        this.curationTypeResolver = resolver;
     }
 
     /**
@@ -116,8 +130,9 @@ export class ToolPolicyEngine {
         // tool's declared nature — a tool cannot opt itself out of either. Only
         // the admin override merged below can relax them, which keeps the bypass
         // an on-record operator decision rather than a tool self-grant.
+        const curatorReviewHonored = this.curatorReviewHonored(fullCap);
         const isUnreviewedDangerousEffect =
-            fullCap.sideEffect === 'external' && fullCap.reversible === false && fullCap.forcesCuratorReview !== true;
+            fullCap.sideEffect === 'external' && fullCap.reversible === false && !curatorReviewHonored;
         const base: IToolPolicy = {
             rateLimit: RATE_DEFAULTS[fullCap.sideEffect],
             requireApproval: isUnreviewedDangerousEffect,
@@ -125,9 +140,33 @@ export class ToolPolicyEngine {
             // autonomous paths only when it forces its own curator review — an
             // unattended trigger can then do no more than draft into that review
             // queue. Every other external tool is barred from autonomous runs.
-            allowUnattended: fullCap.sideEffect !== 'external' || fullCap.forcesCuratorReview === true
+            allowUnattended: fullCap.sideEffect !== 'external' || curatorReviewHonored
         };
         return { ...base, ...this.overrides[name] };
+    }
+
+    /**
+     * Whether the governor honours a tool's forced-curator-review claim. A tool
+     * that does not declare it is never honoured. A tool that declares it with no
+     * `curationTypeId` is trusted on its word (the legacy honour-system: the tool
+     * runs its own private review queue). A tool that declares a `curationTypeId`
+     * binds to a core curation type and is honoured only while that type is
+     * registered — verification, not trust — so the moment the owning provider is
+     * disabled the binding stops resolving and the tool's gates re-tighten.
+     *
+     * @param cap - The tool's full capability (already merged over defaults).
+     * @returns Whether the curator-review relaxation applies.
+     */
+    private curatorReviewHonored(cap: IAiToolCapability): boolean {
+        let honored: boolean;
+        if (cap.forcesCuratorReview !== true) {
+            honored = false;
+        } else if (!cap.curationTypeId) {
+            honored = true;
+        } else {
+            honored = this.curationTypeResolver?.(cap.curationTypeId) ?? false;
+        }
+        return honored;
     }
 
     /**

--- a/src/frontend/app/(core)/system/ai-tools/page.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/page.module.scss
@@ -133,6 +133,59 @@
     flex-wrap: wrap;
 }
 
+/* Curation queue preview cell: body text, media thumbnail, labelled fields. */
+.curation_preview {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+    max-width: var(--max-width-prose);
+}
+
+.curation_body {
+    color: var(--color-text);
+    font-size: var(--font-size-body-sm);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.curation_thumb {
+    max-width: var(--avatar-size-lg);
+    max-height: var(--avatar-size-lg);
+    width: auto;
+    height: auto;
+    border-radius: var(--radius-sm);
+    border: var(--border-width-thin) solid var(--color-border);
+    object-fit: cover;
+}
+
+.curation_fields {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-xs);
+}
+
+.curation_field {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+}
+
+.curation_field_label {
+    color: var(--color-text-subtle);
+}
+
+/* Inline editor textarea in the curation edit modal. */
+.curation_textarea {
+    width: 100%;
+    resize: vertical;
+    background: var(--input-background);
+    color: var(--color-text);
+    border: var(--input-border);
+    border-radius: var(--input-border-radius);
+    padding: var(--input-padding);
+    font-size: var(--font-size-body);
+    font-family: inherit;
+}
+
 /* Monospace digest / args preview. */
 .mono {
     font-family: var(--font-mono, monospace);

--- a/src/frontend/app/(core)/system/ai-tools/page.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/page.tsx
@@ -16,21 +16,23 @@ import type { ITrifectaStatus } from '@/types';
 import { Page, PageHeader } from '../../../../components/layout';
 import { Badge } from '../../../../components/ui/Badge';
 import { getSocket } from '../../../../lib/socketClient';
-import { getTrifecta, getApprovalsCount } from '../../../../modules/ai-tools';
+import { getTrifecta, getApprovalsCount, getCurationsCount } from '../../../../modules/ai-tools';
 import { TrifectaPanel } from './components/TrifectaPanel';
 import { RegistryTab } from './tabs/RegistryTab';
 import { ActivityTab } from './tabs/ActivityTab';
 import { ApprovalsTab } from './tabs/ApprovalsTab';
+import { CurationTab } from './tabs/CurationTab';
 import { PolicyTab } from './tabs/PolicyTab';
 import styles from './page.module.scss';
 
 /** The dashboard tabs. */
-type TabId = 'registry' | 'activity' | 'approvals' | 'policy';
+type TabId = 'registry' | 'activity' | 'approvals' | 'curation' | 'policy';
 
 const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
     { id: 'registry', label: 'Registry' },
     { id: 'activity', label: 'Activity' },
     { id: 'approvals', label: 'Approvals' },
+    { id: 'curation', label: 'Curation' },
     { id: 'policy', label: 'Policy' }
 ];
 
@@ -43,6 +45,7 @@ export default function AiToolsAdminPage() {
     const [activeTab, setActiveTab] = useState<TabId>('registry');
     const [trifecta, setTrifecta] = useState<ITrifectaStatus | null>(null);
     const [pending, setPending] = useState(0);
+    const [pendingCuration, setPendingCuration] = useState(0);
 
     const refreshTrifecta = useCallback(async () => {
         try {
@@ -60,18 +63,32 @@ export default function AiToolsAdminPage() {
         }
     }, []);
 
+    const refreshPendingCuration = useCallback(async () => {
+        try {
+            setPendingCuration(await getCurationsCount());
+        } catch {
+            /* secondary data — leave the count as-is on failure */
+        }
+    }, []);
+
     useEffect(() => {
         void refreshTrifecta();
         void refreshPending();
-    }, [refreshTrifecta, refreshPending]);
+        void refreshPendingCuration();
+    }, [refreshTrifecta, refreshPending, refreshPendingCuration]);
 
-    // Keep the pending badge live regardless of which tab is open.
+    // Keep both pending badges live regardless of which tab is open.
     useEffect(() => {
         const socket = getSocket();
-        const handler = () => { void refreshPending(); };
-        socket.on('ai-tools:approvals-changed', handler);
-        return () => { socket.off('ai-tools:approvals-changed', handler); };
-    }, [refreshPending]);
+        const onApprovals = () => { void refreshPending(); };
+        const onCurations = () => { void refreshPendingCuration(); };
+        socket.on('ai-tools:approvals-changed', onApprovals);
+        socket.on('ai-tools:curations-changed', onCurations);
+        return () => {
+            socket.off('ai-tools:approvals-changed', onApprovals);
+            socket.off('ai-tools:curations-changed', onCurations);
+        };
+    }, [refreshPending, refreshPendingCuration]);
 
     return (
         <Page>
@@ -92,6 +109,9 @@ export default function AiToolsAdminPage() {
                             {tab.id === 'approvals' && pending > 0 && (
                                 <> <Badge tone="warning">{pending}</Badge></>
                             )}
+                            {tab.id === 'curation' && pendingCuration > 0 && (
+                                <> <Badge tone="warning">{pendingCuration}</Badge></>
+                            )}
                         </button>
                     ))}
                 </div>
@@ -100,6 +120,7 @@ export default function AiToolsAdminPage() {
                     {activeTab === 'registry' && <RegistryTab onChanged={refreshTrifecta} />}
                     {activeTab === 'activity' && <ActivityTab />}
                     {activeTab === 'approvals' && <ApprovalsTab onChanged={refreshPending} />}
+                    {activeTab === 'curation' && <CurationTab onChanged={refreshPendingCuration} />}
                     {activeTab === 'policy' && <PolicyTab />}
                 </div>
             </div>

--- a/src/frontend/app/(core)/system/ai-tools/tabs/CurationTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/CurationTab.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+/**
+ * @fileoverview Curation tab — the central queue of effects held for human
+ * review across every content type. Each item renders from its content-agnostic
+ * preview (title, body, media, fields); approving commits the effect through its
+ * owning plugin, rejecting discards it. An item whose owning plugin is disabled
+ * returns a 409 the toast surfaces, since it cannot be decided until re-enabled.
+ * Refetches on the `ai-tools:curations-changed` signal and reports the new count
+ * up via `onChanged` so the header badge stays live. Like the sibling tabs this
+ * is an admin client surface, not an SSR-first public component.
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import { Check, X, Pencil } from 'lucide-react';
+import { Stack } from '../../../../../components/layout';
+import { Button } from '../../../../../components/ui/Button';
+import { Badge } from '../../../../../components/ui/Badge';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
+import { ClientTime } from '../../../../../components/ui/ClientTime';
+import { useToast } from '../../../../../components/ui/ToastProvider';
+import { useModal } from '../../../../../components/ui/ModalProvider';
+import { getSocket } from '../../../../../lib/socketClient';
+import { listCurations, approveCuration, rejectCuration, editCuration, type ICurationItemView } from '../../../../../modules/ai-tools';
+import styles from '../page.module.scss';
+
+/** Truncate body text for the inline preview cell. */
+function truncate(text: string, max = 160): string {
+    return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/**
+ * Inline editor body for the edit modal. Edits the generic `body` text; the
+ * owning plugin validates and writes through its own `applyEdit`. `onSave` owns
+ * closing the modal on success and reporting failure, so a rejected edit (e.g.
+ * over the tweet limit) keeps the modal open for correction.
+ *
+ * @param props.initialBody - The body text to prefill.
+ * @param props.onCancel - Close without saving.
+ * @param props.onSave - Persist the edited body; resolves when handled.
+ * @returns The editor form.
+ */
+function CurationEditForm({ initialBody, onCancel, onSave }: {
+    initialBody: string;
+    onCancel: () => void;
+    onSave: (body: string) => Promise<void>;
+}) {
+    const [body, setBody] = useState(initialBody);
+    const [saving, setSaving] = useState(false);
+
+    const submit = useCallback(async () => {
+        setSaving(true);
+        try {
+            await onSave(body);
+        } finally {
+            setSaving(false);
+        }
+    }, [body, onSave]);
+
+    return (
+        <Stack gap="md">
+            <textarea
+                className={styles.curation_textarea}
+                value={body}
+                onChange={event => setBody(event.target.value)}
+                rows={5}
+                aria-label="Edit held content"
+            />
+            <div className={styles.row_actions}>
+                <Button variant="primary" size="sm" loading={saving} onClick={() => { void submit(); }}>Save</Button>
+                <Button variant="ghost" size="sm" disabled={saving} onClick={onCancel}>Cancel</Button>
+            </div>
+        </Stack>
+    );
+}
+
+/**
+ * Render one held item's content-agnostic preview: body, an optional media
+ * thumbnail, and labelled fields. Core knows nothing of the underlying payload —
+ * the owning type flattened it into this descriptor.
+ *
+ * @param props.preview - The preview descriptor from the curation envelope.
+ * @returns The preview cell content.
+ */
+function CurationPreview({ preview }: { preview: ICurationItemView['preview'] }) {
+    const image = preview.media?.find(media => media.kind !== 'link');
+    return (
+        <div className={styles.curation_preview}>
+            {preview.body && <div className={styles.curation_body}>{truncate(preview.body)}</div>}
+            {image && (
+                // Resolved public URL from the owning plugin; next/image adds no
+                // value for an admin-only, externally-sized thumbnail.
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={image.url} alt={image.alt ?? 'Attached media'} className={styles.curation_thumb} loading="lazy" />
+            )}
+            {preview.fields && preview.fields.length > 0 && (
+                <div className={styles.curation_fields}>
+                    {preview.fields.map((field, index) => (
+                        <span key={`${field.label}-${index}`} className={styles.curation_field}>
+                            <span className={styles.curation_field_label}>{field.label}:</span> {field.value}
+                        </span>
+                    ))}
+                </div>
+            )}
+            {preview.editable && <Badge tone="info">editable</Badge>}
+        </div>
+    );
+}
+
+/**
+ * Curation tab content.
+ *
+ * @param props.onChanged - Called after load/approve/reject so the page header
+ *                          pending badge refreshes.
+ * @returns The tab.
+ */
+export function CurationTab({ onChanged }: { onChanged: () => void }) {
+    const [items, setItems] = useState<ICurationItemView[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [busyId, setBusyId] = useState<string | null>(null);
+    const { push } = useToast();
+    const { open, close } = useModal();
+
+    const load = useCallback(async () => {
+        try {
+            setItems(await listCurations());
+            setError(null);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to load curation queue');
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => { void load(); }, [load]);
+
+    useEffect(() => {
+        const socket = getSocket();
+        const handler = () => { void load(); onChanged(); };
+        socket.on('ai-tools:curations-changed', handler);
+        return () => { socket.off('ai-tools:curations-changed', handler); };
+    }, [load, onChanged]);
+
+    const resolve = useCallback(async (id: string, action: 'approve' | 'reject') => {
+        setBusyId(id);
+        try {
+            await (action === 'approve' ? approveCuration(id) : rejectCuration(id));
+            push({ tone: action === 'approve' ? 'success' : 'info', title: action === 'approve' ? 'Approved' : 'Rejected' });
+            await load();
+            onChanged();
+        } catch (err) {
+            push({ tone: 'danger', title: `Failed to ${action}`, description: err instanceof Error ? err.message : String(err) });
+        } finally {
+            setBusyId(null);
+        }
+    }, [load, onChanged, push]);
+
+    const openEditor = useCallback((item: ICurationItemView) => {
+        const modalId = 'curation-edit';
+        open({
+            id: modalId,
+            title: 'Edit before deciding',
+            size: 'md',
+            content: (
+                <CurationEditForm
+                    initialBody={item.preview.body ?? ''}
+                    onCancel={() => close(modalId)}
+                    onSave={async (body) => {
+                        try {
+                            await editCuration(item.id, { body });
+                            push({ tone: 'success', title: 'Saved' });
+                            close(modalId);
+                            await load();
+                            onChanged();
+                        } catch (err) {
+                            // Keep the modal open so the operator can correct a
+                            // rejected edit (e.g. over the tweet length limit).
+                            push({ tone: 'danger', title: 'Failed to save', description: err instanceof Error ? err.message : String(err) });
+                        }
+                    }}
+                />
+            )
+        });
+    }, [open, close, load, onChanged, push]);
+
+    if (loading) {
+        return <div className={styles.placeholder}>Loading curation queue…</div>;
+    }
+
+    return (
+        <Stack gap="md">
+            {error && <div className="alert" role="alert">{error}</div>}
+            <p className="text-muted" style={{ margin: 0, fontSize: 'var(--font-size-body-sm)' }}>
+                Effects held for human review across every content type. Approving commits the effect through its owning
+                plugin; rejecting discards it. An item whose owning plugin is disabled cannot be decided until it is
+                re-enabled.
+            </p>
+            {items.length === 0
+                ? <div className={styles.placeholder}>Nothing is awaiting curation.</div>
+                : (
+                    <div className="table-scroll">
+                        <Table>
+                            <Thead>
+                                <Tr>
+                                    <Th width="shrink">Held</Th>
+                                    <Th width="shrink">Type</Th>
+                                    <Th>Preview</Th>
+                                    <Th width="shrink">Decision</Th>
+                                </Tr>
+                            </Thead>
+                            <Tbody>
+                                {items.map(item => (
+                                    <Tr key={item.id}>
+                                        <Td muted><ClientTime date={item.createdAt} format="datetime" /></Td>
+                                        <Td>
+                                            <div className={styles.tool_name}>{item.preview.title ?? item.typeId}</div>
+                                            <div className={styles.tool_desc}>
+                                                {item.providerId}{item.source ? ` · ${item.source}` : ''}
+                                            </div>
+                                        </Td>
+                                        <Td><CurationPreview preview={item.preview} /></Td>
+                                        <Td>
+                                            <div className={styles.row_actions}>
+                                                <Button variant="primary" size="sm" loading={busyId === item.id} onClick={() => { void resolve(item.id, 'approve'); }}>
+                                                    <Check size={16} /> Approve
+                                                </Button>
+                                                {item.preview.editable && (
+                                                    <Button variant="secondary" size="sm" disabled={busyId === item.id} onClick={() => openEditor(item)}>
+                                                        <Pencil size={16} /> Edit
+                                                    </Button>
+                                                )}
+                                                <Button variant="danger" size="sm" disabled={busyId === item.id} onClick={() => { void resolve(item.id, 'reject'); }}>
+                                                    <X size={16} /> Reject
+                                                </Button>
+                                            </div>
+                                        </Td>
+                                    </Tr>
+                                ))}
+                            </Tbody>
+                        </Table>
+                    </div>
+                )}
+        </Stack>
+    );
+}

--- a/src/frontend/app/(core)/system/ai-tools/tabs/CurationTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/CurationTab.tsx
@@ -65,6 +65,7 @@ function CurationEditForm({ initialBody, onCancel, onSave }: {
                 onChange={event => setBody(event.target.value)}
                 rows={5}
                 aria-label="Edit held content"
+                disabled={saving}
             />
             <div className={styles.row_actions}>
                 <Button variant="primary" size="sm" loading={saving} onClick={() => { void submit(); }}>Save</Button>
@@ -222,15 +223,15 @@ export function CurationTab({ onChanged }: { onChanged: () => void }) {
                                         <Td><CurationPreview preview={item.preview} /></Td>
                                         <Td>
                                             <div className={styles.row_actions}>
-                                                <Button variant="primary" size="sm" loading={busyId === item.id} onClick={() => { void resolve(item.id, 'approve'); }}>
+                                                <Button variant="primary" size="sm" loading={busyId === item.id} disabled={busyId !== null && busyId !== item.id} onClick={() => { void resolve(item.id, 'approve'); }}>
                                                     <Check size={16} /> Approve
                                                 </Button>
                                                 {item.preview.editable && (
-                                                    <Button variant="secondary" size="sm" disabled={busyId === item.id} onClick={() => openEditor(item)}>
+                                                    <Button variant="secondary" size="sm" disabled={busyId !== null} onClick={() => openEditor(item)}>
                                                         <Pencil size={16} /> Edit
                                                     </Button>
                                                 )}
-                                                <Button variant="danger" size="sm" disabled={busyId === item.id} onClick={() => { void resolve(item.id, 'reject'); }}>
+                                                <Button variant="danger" size="sm" disabled={busyId !== null && busyId !== item.id} onClick={() => { void resolve(item.id, 'reject'); }}>
                                                     <X size={16} /> Reject
                                                 </Button>
                                             </div>

--- a/src/frontend/modules/ai-tools/api/client.ts
+++ b/src/frontend/modules/ai-tools/api/client.ts
@@ -10,6 +10,7 @@
 import type {
     IAiToolInfo,
     IAiToolCapability,
+    ICurationPreview,
     ITrifectaStatus,
     IToolInvocationRecord,
     IToolInvocationContext,
@@ -61,6 +62,25 @@ export interface IActivityQuery {
     status?: ToolInvocationStatus;
     limit?: number;
     offset?: number;
+}
+
+/**
+ * One held item in the central curation queue, as returned by `GET /curations`.
+ * Mirrors the backend's serialized envelope (dates as ISO strings); `preview` is
+ * the content-agnostic descriptor the queue renders, and `ref` is the owning
+ * type's opaque pointer (used by an inline editor to address its own record).
+ */
+export interface ICurationItemView {
+    id: string;
+    typeId: string;
+    providerId: string;
+    ref: Record<string, unknown>;
+    preview: ICurationPreview;
+    status: string;
+    source?: string;
+    createdAt: string;
+    decidedAt?: string;
+    decidedBy?: string;
 }
 
 /** Per-tool policy overrides plus usage tallies, as returned by `GET /policy`. */
@@ -189,6 +209,63 @@ export async function approveInvocation(id: string): Promise<void> {
  */
 export async function rejectInvocation(id: string): Promise<void> {
     await parse(await fetch(`${BASE}/approvals/${encodeURIComponent(id)}/reject`, { method: 'POST' }), 'reject invocation');
+}
+
+/**
+ * List pending items in the central curation queue, newest first.
+ *
+ * @returns The pending curation envelopes.
+ */
+export async function listCurations(): Promise<ICurationItemView[]> {
+    const data = await parse<{ curations: ICurationItemView[] }>(await fetch(`${BASE}/curations`), 'load curation queue');
+    return data.curations;
+}
+
+/**
+ * Fetch the count of pending curation items, for the header badge.
+ *
+ * @returns The pending count.
+ */
+export async function getCurationsCount(): Promise<number> {
+    const data = await parse<{ count: number }>(await fetch(`${BASE}/curations/count`), 'load curation count');
+    return data.count;
+}
+
+/**
+ * Apply an inline edit to a held curation item before deciding it. The patch is
+ * generic (today just `body`); the owning type maps it onto its record and
+ * validates it, so a rejected edit surfaces as a thrown error here.
+ *
+ * @param id - The curation envelope id.
+ * @param patch - The generic edit (e.g. replacement body text).
+ * @returns Resolves when the edit is applied.
+ */
+export async function editCuration(id: string, patch: { body: string }): Promise<void> {
+    await parse(await fetch(`${BASE}/curations/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch)
+    }), 'edit curation item');
+}
+
+/**
+ * Approve a held curation item, committing it through its owning type.
+ *
+ * @param id - The curation envelope id.
+ * @returns Resolves when the item resolves.
+ */
+export async function approveCuration(id: string): Promise<void> {
+    await parse(await fetch(`${BASE}/curations/${encodeURIComponent(id)}/approve`, { method: 'POST' }), 'approve curation item');
+}
+
+/**
+ * Reject a held curation item, discarding it through its owning type.
+ *
+ * @param id - The curation envelope id.
+ * @returns Resolves when the item resolves.
+ */
+export async function rejectCuration(id: string): Promise<void> {
+    await parse(await fetch(`${BASE}/curations/${encodeURIComponent(id)}/reject`, { method: 'POST' }), 'reject curation item');
 }
 
 /**


### PR DESCRIPTION
Central curation queue in the ai-tools module — one core admin surface (`/system/ai-tools` → Curation) for every effect held for human review before it takes hold, instead of each plugin self-hosting its own approval queue.

- Core owns the decision and a pointer-plus-cached-preview envelope; content types own the payload, preview, and what a decision does (`describe` / `onApprove` / `onReject` / optional `applyEdit`).
- Hardens a tool's `forcesCuratorReview` into a governor-verified `curationTypeId` binding — resolved live against the curation registry and re-tightened the moment the owning plugin is disabled.
- Adds the `'curation'` service, the `module_ai-tools_curations` store, the `/curations` REST endpoints, and the Curation admin tab (preview, approve/reject, inline body edit).
- `@delphian/tronrelic-types` 3.9.0 → 3.11.0.

The `trp-x-poster` integration (the reference curation type + the `curationTypeId` binding) lands in that plugin's own repo separately, after this PR publishes the new types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)