### PR TITLE
fix(ai-tools): correct breakpoints import path in QueryTab styles

### DIFF
--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
@@ -8,7 +8,7 @@
  * tab adapts whether the dashboard renders full-width or in a narrower panel.
  */
 
-@use '../../../breakpoints' as *;
+@use '../../../../breakpoints' as *;
 
 @mixin focus-outline {
     outline: var(--focus-outline-width) solid var(--focus-outline-color);


### PR DESCRIPTION
## Summary

`QueryTab.module.scss` lives in `app/(core)/system/ai-tools/tabs/` — one directory deeper than its sibling `page.module.scss`. Its `@use '../../../breakpoints'` therefore resolved to a nonexistent `(core)/breakpoints` and broke the production frontend build with `Can't find stylesheet to import.` (`npm run build:frontend`, exit 1).

The fix uses four `../` to reach `app/_breakpoints.scss`, matching the documented import convention.

## Verification

- Standalone `sass` compile of the module now exits 0 (the step that failed in CI).
- `npm run typecheck` passes.