### PR TITLE
fix(ai-tools): stop query composer auto-resizing on input

### DIFF
--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
@@ -28,6 +28,7 @@
     --query-chat-height-sm: 22rem;
     --query-chat-height-md: 32rem;
     --query-composer-min-height: 4.5rem;
+    --query-transcript-min-height: 6rem;
 
     container-type: inline-size;
     container-name: ai-query;
@@ -61,16 +62,18 @@
     flex-direction: column;
     padding: 0;
     overflow: hidden;
-    /* Fixed resting height so the panel does not grow as the conversation
-       fills — the transcript scrolls within and the composer stays on screen.
-       resize: vertical lets the admin drag it taller. */
-    height: var(--query-chat-height-sm);
+    /* Resting height so the panel does not grow as the conversation fills — the
+       transcript scrolls within. It is a min-height, not a fixed height, so
+       dragging the composer textarea taller grows the card to contain it rather
+       than collapsing the transcript or clipping the toolbar. resize: vertical
+       additionally lets the admin drag the whole card taller. */
+    min-height: var(--query-chat-height-sm);
     resize: vertical;
 }
 
 @container ai-query (min-width: #{$breakpoint-mobile-md}) {
     .chat_card {
-        height: var(--query-chat-height-md);
+        min-height: var(--query-chat-height-md);
     }
 }
 
@@ -121,10 +124,12 @@
     50% { opacity: var(--opacity-35); }
 }
 
-/* Scrolling transcript region. */
+/* Scrolling transcript region. Keeps a min-height floor so dragging the
+   composer taller shrinks it only to that floor, then grows the card — the
+   transcript never collapses to zero. */
 .transcript {
     flex: 1 1 auto;
-    min-height: 0;
+    min-height: var(--query-transcript-min-height);
     overflow-y: auto;
     display: flex;
     flex-direction: column;

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
@@ -399,10 +399,9 @@
     color: var(--color-text);
     font-size: var(--font-size-body-sm);
     font-family: inherit;
-    resize: none;
+    resize: vertical;
     overflow-y: auto;
     min-height: var(--query-composer-min-height);
-    max-height: 40vh;
     transition: var(--input-transition);
 
     &:focus-visible {

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
@@ -305,15 +305,6 @@ export function QueryTab() {
         }
     }, [messages]);
 
-    // Auto-grow the composer textarea with its content, capped by CSS max-height.
-    useEffect(() => {
-        const ta = textareaRef.current;
-        if (ta) {
-            ta.style.height = 'auto';
-            ta.style.height = `${ta.scrollHeight}px`;
-        }
-    }, [input]);
-
     /**
      * Send the composer text as the next chat turn. Snapshots the completed
      * transcript as the history payload, appends a user turn and an empty pending


### PR DESCRIPTION
The Query tab composer textarea grew vertically on every keystroke or paste: a `useEffect` set the element height to its `scrollHeight` on each `input` change, with CSS `resize: none`. Pasting a large prompt visibly resized the box.

This removes that effect and switches the CSS to `resize: vertical`, so the composer holds a fixed height and only resizes when the user drags its bottom edge. The hardcoded `max-height: 40vh` cap is dropped so manual drag isn't limited; `min-height` still enforces the 3-row floor and overflowing content scrolls.