### PR TITLE
feat(ai-tools): Redis-backed rate/cost limits and policy admin UX

### DIFF
--- a/src/backend/modules/ai-tools/AiToolsModule.ts
+++ b/src/backend/modules/ai-tools/AiToolsModule.ts
@@ -25,10 +25,11 @@ import type {
     IServiceRegistry
 } from '@/types';
 import { logger } from '../../lib/logger.js';
+import { getRedisClient } from '../../loaders/redis.js';
 import { WebSocketService } from '../../services/websocket.service.js';
 import { MAIN_SYSTEM_CONTAINER_ID } from '../menu/index.js';
 import { AiToolRegistry } from './services/ai-tool-registry.js';
-import { ToolPolicyEngine } from './services/tool-policy-engine.js';
+import { ToolPolicyEngine, type IRateLimitRedis } from './services/tool-policy-engine.js';
 import { ToolAuditStore } from './services/tool-audit-store.js';
 import { ToolApprovalQueue } from './services/tool-approval-queue.js';
 import { AiToolGovernor } from './services/ai-tool-governor.js';
@@ -148,7 +149,18 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
         this.registry = new AiToolRegistry(this.logger, this.database);
         await this.registry.loadStates();
 
-        this.policy = new ToolPolicyEngine(this.logger, this.database);
+        // Back the rate/cost windows with Redis so the limits are one shared
+        // budget across backend instances and survive a restart. getRedisClient
+        // throws if Redis is not initialized (e.g. a test boot); the engine then
+        // degrades to per-instance in-memory counters rather than failing.
+        let rateLimitRedis: IRateLimitRedis | undefined;
+        try {
+            rateLimitRedis = getRedisClient();
+        } catch (error) {
+            this.logger.warn({ error }, 'Redis unavailable at init; AI tool rate/cost limits will be per-instance in-memory');
+        }
+
+        this.policy = new ToolPolicyEngine(this.logger, this.database, rateLimitRedis);
         await this.policy.loadOverrides();
 
         this.audit = new ToolAuditStore(this.logger, this.database);

--- a/src/backend/modules/ai-tools/__tests__/ai-tools-module.test.ts
+++ b/src/backend/modules/ai-tools/__tests__/ai-tools-module.test.ts
@@ -977,9 +977,9 @@ describe('ToolPolicyEngine cost ceiling', () => {
         const tool = paidTool(0.04);
 
         const verdicts = [
-            engine.check(tool, interactiveCtx).verdict, // spend → 0.04
-            engine.check(tool, interactiveCtx).verdict, // spend → 0.08
-            engine.check(tool, interactiveCtx).verdict  // 0.12 would exceed 0.10
+            (await engine.check(tool, interactiveCtx)).verdict, // spend → 0.04
+            (await engine.check(tool, interactiveCtx)).verdict, // spend → 0.08
+            (await engine.check(tool, interactiveCtx)).verdict  // 0.12 would exceed 0.10
         ];
 
         expect(verdicts).toEqual(['allow', 'allow', 'deny']);
@@ -990,16 +990,19 @@ describe('ToolPolicyEngine cost ceiling', () => {
         await engine.setOverride('paid-gen', { costCeilingUsd: 0.01 });
         const tool = paidTool(undefined); // spendsMoney but nothing to charge
 
-        const verdicts = [0, 1, 2].map(() => engine.check(tool, interactiveCtx).verdict);
+        const verdicts: string[] = [];
+        for (let i = 0; i < 3; i++) {
+            verdicts.push((await engine.check(tool, interactiveCtx)).verdict);
+        }
         expect(verdicts).toEqual(['allow', 'allow', 'allow']);
     });
 
-    it('leaves a paid tool uncapped when no ceiling override is set', () => {
+    it('leaves a paid tool uncapped when no ceiling override is set', async () => {
         const engine = makeEngine();
         const tool = paidTool(5); // expensive per call, but no ceiling
 
-        expect(engine.check(tool, interactiveCtx).verdict).toBe('allow');
-        expect(engine.check(tool, interactiveCtx).verdict).toBe('allow');
+        expect((await engine.check(tool, interactiveCtx)).verdict).toBe('allow');
+        expect((await engine.check(tool, interactiveCtx)).verdict).toBe('allow');
     });
 
     it('gates and charges the approved-execution path (tryChargeCost) at the ceiling', async () => {
@@ -1010,7 +1013,10 @@ describe('ToolPolicyEngine cost ceiling', () => {
         await engine.setOverride('paid-gen', { costCeilingUsd: 0.10 });
         const tool = paidTool(0.04);
 
-        const admits = [engine.tryChargeCost(tool), engine.tryChargeCost(tool), engine.tryChargeCost(tool)];
+        const admits: boolean[] = [];
+        for (let i = 0; i < 3; i++) {
+            admits.push(await engine.tryChargeCost(tool));
+        }
 
         expect(admits).toEqual([true, true, false]);
     });
@@ -1018,16 +1024,66 @@ describe('ToolPolicyEngine cost ceiling', () => {
     it('admits a call that exactly meets the ceiling despite float accumulation', async () => {
         const engine = makeEngine();
         await engine.setOverride('paid-gen', { costCeilingUsd: 0.30 });
-        const tool = paidTool(0.10); // 0.1 + 0.1 + 0.1 === 0.30000000000000004 in IEEE 754
+        const tool = paidTool(0.10); // ceiling/cost = 0.30/0.10 = 2.9999999999999996 in IEEE 754
 
-        const admits = [
-            engine.tryChargeCost(tool),
-            engine.tryChargeCost(tool),
-            engine.tryChargeCost(tool), // exactly meets 0.30 — the epsilon must admit, not float-deny
-            engine.tryChargeCost(tool)  // genuinely exceeds
-        ];
+        const admits: boolean[] = [];
+        for (let i = 0; i < 4; i++) {
+            // calls 1-3 fit the 3-call cap (the epsilon must admit, not float-deny); the 4th exceeds.
+            admits.push(await engine.tryChargeCost(tool));
+        }
 
         expect(admits).toEqual([true, true, true, false]);
+    });
+});
+
+describe('ToolPolicyEngine Redis-backed shared limits', () => {
+    /** Minimal in-memory stand-in for the Redis commands the engine uses. */
+    function fakeRedis() {
+        const store = new Map<string, number>();
+        return {
+            store,
+            incr: async (key: string) => {
+                const next = (store.get(key) ?? 0) + 1;
+                store.set(key, next);
+                return next;
+            },
+            expire: async () => 1,
+            get: async (key: string) => {
+                const value = store.get(key);
+                return value === undefined ? null : String(value);
+            }
+        };
+    }
+
+    it('enforces one shared budget across instances backed by the same Redis', async () => {
+        // Two engines model two backend instances. With a shared store the
+        // per-tool rate window is a single budget, not one-per-instance — the
+        // F5 fix. Without it, each instance would admit its own full quota.
+        const redis = fakeRedis();
+        const a = new ToolPolicyEngine(createMockLogger(), createMockDatabaseService(), redis);
+        const b = new ToolPolicyEngine(createMockLogger(), createMockDatabaseService(), redis);
+        await a.setOverride('paid-gen', { rateLimit: { max: 1, windowMs: 60_000 } });
+        await b.setOverride('paid-gen', { rateLimit: { max: 1, windowMs: 60_000 } });
+        const tool = paidTool(0.04);
+
+        expect((await a.check(tool, interactiveCtx)).verdict).toBe('allow');
+        // Second instance, same shared window: the single slot is already spent.
+        expect((await b.check(tool, interactiveCtx)).verdict).toBe('deny');
+    });
+
+    it('falls back to per-instance in-memory limiting when Redis errors', async () => {
+        const downRedis = {
+            incr: async () => { throw new Error('redis down'); },
+            expire: async () => { throw new Error('redis down'); },
+            get: async () => { throw new Error('redis down'); }
+        };
+        const engine = new ToolPolicyEngine(createMockLogger(), createMockDatabaseService(), downRedis);
+        await engine.setOverride('paid-gen', { rateLimit: { max: 1, windowMs: 60_000 } });
+        const tool = paidTool(0.04);
+
+        // Degrades safely: still limits (in-memory), never throws.
+        expect((await engine.check(tool, interactiveCtx)).verdict).toBe('allow');
+        expect((await engine.check(tool, interactiveCtx)).verdict).toBe('deny');
     });
 });
 
@@ -1046,21 +1102,21 @@ describe('ToolPolicyEngine object-authorization precondition', () => {
         handler: vi.fn(async () => ({}))
     };
 
-    it('denies when the context carries no end-user principal — evaluated before every other gate', () => {
+    it('denies when the context carries no end-user principal — evaluated before every other gate', async () => {
         // Admin/interactive does not satisfy it: an admin is ambient authority,
         // not a specific end user.
-        expect(makeEngine().check(userScoped, interactiveCtx).verdict).toBe('deny');
+        expect((await makeEngine().check(userScoped, interactiveCtx)).verdict).toBe('deny');
     });
 
-    it('allows when an end-user principal is present', () => {
-        expect(makeEngine().check(userScoped, principalCtx).verdict).toBe('allow');
+    it('allows when an end-user principal is present', async () => {
+        expect((await makeEngine().check(userScoped, principalCtx)).verdict).toBe('allow');
     });
 
-    it('denies when the end-user principal has an empty or whitespace userId', () => {
+    it('denies when the end-user principal has an empty or whitespace userId', async () => {
         // A blank id would scope to nothing — it is treated as no principal at
         // all, so it must not slip the confused-deputy guard.
         const emptyUserCtx: IToolInvocationContext = { ...interactiveCtx, endUser: { userId: '   ' } };
-        expect(makeEngine().check(userScoped, emptyUserCtx).verdict).toBe('deny');
+        expect((await makeEngine().check(userScoped, emptyUserCtx)).verdict).toBe('deny');
     });
 });
 

--- a/src/backend/modules/ai-tools/__tests__/ai-tools-module.test.ts
+++ b/src/backend/modules/ai-tools/__tests__/ai-tools-module.test.ts
@@ -1085,6 +1085,42 @@ describe('ToolPolicyEngine Redis-backed shared limits', () => {
         expect((await engine.check(tool, interactiveCtx)).verdict).toBe('allow');
         expect((await engine.check(tool, interactiveCtx)).verdict).toBe('deny');
     });
+
+    it('enforces one shared COST budget across instances (atomic admission)', async () => {
+        // The cost ceiling is charged atomically (INCR-then-compare), so two
+        // instances sharing one store cannot both be admitted over the ceiling —
+        // the TOCTOU hole the peek-then-charge version had.
+        const redis = fakeRedis();
+        const a = new ToolPolicyEngine(createMockLogger(), createMockDatabaseService(), redis);
+        const b = new ToolPolicyEngine(createMockLogger(), createMockDatabaseService(), redis);
+        await a.setOverride('paid-gen', { costCeilingUsd: 0.04 }); // floor(0.04/0.04) = 1 call
+        await b.setOverride('paid-gen', { costCeilingUsd: 0.04 });
+        const tool = paidTool(0.04);
+
+        expect((await a.check(tool, interactiveCtx)).verdict).toBe('allow');
+        // Second instance, same shared cost window: the single paid call is spent.
+        expect((await b.check(tool, interactiveCtx)).verdict).toBe('deny');
+    });
+
+    it('sets every counter TTL with NX so a lost expiry self-heals', async () => {
+        // EXPIRE … NX runs on every hit (not just the first), so a key left
+        // without a TTL gets one on its next hit instead of blocking forever.
+        const store = new Map<string, number>();
+        const expireCalls: Array<string | undefined> = [];
+        const redis = {
+            incr: async (key: string) => { const next = (store.get(key) ?? 0) + 1; store.set(key, next); return next; },
+            expire: async (_key: string, _seconds: number, mode?: 'NX') => { expireCalls.push(mode); return 1; }
+        };
+        const engine = new ToolPolicyEngine(createMockLogger(), createMockDatabaseService(), redis);
+        await engine.setOverride('paid-gen', { rateLimit: { max: 5, windowMs: 60_000 } });
+        const tool = paidTool(0.04);
+
+        await engine.check(tool, interactiveCtx);
+        await engine.check(tool, interactiveCtx); // second hit must still issue EXPIRE NX
+
+        expect(expireCalls.length).toBeGreaterThan(1);
+        expect(expireCalls.every(mode => mode === 'NX')).toBe(true);
+    });
 });
 
 describe('ToolPolicyEngine object-authorization precondition', () => {

--- a/src/backend/modules/ai-tools/api/ai-tools.controller.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.controller.ts
@@ -648,9 +648,23 @@ export class AiToolsController {
         res.json(request);
     };
 
-    /** GET /policy — per-tool overrides and usage tallies. */
+    /**
+     * GET /policy — per-tool overrides, usage tallies, and the resolved
+     * class-default behaviour each tool inherits. The defaults let the admin UI
+     * label an inherited ("Default") cell with what it actually resolves to,
+     * rather than the opaque word "Default". Computed from the same engine the
+     * governor enforces with, so the displayed default cannot drift from reality.
+     */
     getPolicy = async (_req: Request, res: Response): Promise<void> => {
-        res.json({ overrides: this.policy.getOverrides(), usage: this.policy.snapshot() });
+        const defaults: Record<string, { requireApproval: boolean; allowUnattended: boolean }> = {};
+        for (const tool of this.registry.listToolInfo()) {
+            const base = this.policy.defaultPolicyFor(tool.capability);
+            defaults[tool.name] = {
+                requireApproval: base.requireApproval ?? false,
+                allowUnattended: base.allowUnattended ?? false
+            };
+        }
+        res.json({ overrides: this.policy.getOverrides(), usage: this.policy.snapshot(), defaults });
     };
 
     /** PUT /policy/:name — set a per-tool policy override. */

--- a/src/backend/modules/ai-tools/services/ai-tool-governor.ts
+++ b/src/backend/modules/ai-tools/services/ai-tool-governor.ts
@@ -233,7 +233,7 @@ export class AiToolGovernor implements IAiToolGovernor {
             return this.fail(name, providerId, input, ctx, cap, 'error', 'A governance hook failed; the tool was not run.');
         }
 
-        const decision = this.policy.check(tool, ctx);
+        const decision = await this.policy.check(tool, ctx);
         if (decision.verdict === 'deny') {
             return this.fail(name, providerId, input, ctx, cap, 'denied', decision.reason ?? 'Denied by policy.');
         }
@@ -281,7 +281,7 @@ export class AiToolGovernor implements IAiToolGovernor {
             const cap = tool?.capability ?? DEFAULT_CAPABILITY;
             if (!tool) {
                 result = await this.fail(request.toolName, request.providerId, request.input, request.context, cap, 'error', 'Tool is no longer registered.');
-            } else if (!this.policy.tryChargeCost(tool)) {
+            } else if (!(await this.policy.tryChargeCost(tool))) {
                 // An approved hold bypasses check(), so gate and charge the cost
                 // ceiling here too — otherwise paid tools that require approval
                 // (the default for external/irreversible) would never be metered.

--- a/src/backend/modules/ai-tools/services/tool-policy-engine.ts
+++ b/src/backend/modules/ai-tools/services/tool-policy-engine.ts
@@ -68,14 +68,13 @@ const RL_PREFIX = 'aitool:rl:';
 const GLOBAL_KEY = '__global__';
 
 /**
- * The subset of the Redis client the rate store uses. Structural so a test can
- * pass a fake and the engine never imports the ioredis type; the platform's
- * ioredis client satisfies it as-is.
+ * The subset of the Redis client the rate store uses — `INCR` plus an
+ * idempotent `EXPIRE … NX`. Structural so a test can pass a fake and the engine
+ * never imports the ioredis type; the platform's ioredis client satisfies it.
  */
 export interface IRateLimitRedis {
     incr(key: string): Promise<number>;
-    expire(key: string, seconds: number): Promise<unknown>;
-    get(key: string): Promise<string | null>;
+    expire(key: string, seconds: number, mode?: 'NX'): Promise<unknown>;
 }
 
 /** In-memory fixed-window counter (fallback when Redis is absent or down). */
@@ -276,14 +275,17 @@ export class ToolPolicyEngine {
     }
 
     /**
-     * Evaluate a single invocation. On an `allow` verdict the call's rate-limit
-     * budget is consumed; `needs-approval` and `deny` consume nothing.
+     * Evaluate a single invocation. On an `allow` verdict the rate and cost
+     * budgets are consumed. A deny by the approval, authorization, or autonomous
+     * gates consumes nothing; a rate or cost denial leaves only the conservative
+     * increment its fixed-window counter uses (never an over-admit).
      *
      * Order: object-authorization precondition, autonomous-path default-deny for
-     * external tools, approval, cost ceiling, then rate limiting. Cost is peeked
-     * (not charged) before the rate budget is spent and charged only after the
-     * rate check passes, so a cost denial never spends a rate slot and a rate
-     * denial never charges cost.
+     * external tools, approval, rate limiting, then the cost ceiling. Both the
+     * rate and cost budgets are charged atomically (INCR-then-compare) so two
+     * concurrent calls can never both be admitted past a limit. Cost is charged
+     * last, so a call the rate gate already rejected never touches the dollar
+     * budget.
      *
      * @param tool - The resolved tool, including its capability.
      * @param ctx - Caller and trigger context.
@@ -325,21 +327,20 @@ export class ToolPolicyEngine {
         } else if (policy.requireApproval) {
             counters.needsApproval++;
             decision = { verdict: 'needs-approval', reason: 'This tool requires human approval before it runs.' };
-        } else if (costCap !== undefined && await this.wouldExceedCostCalls(tool.name, costCap)) {
-            // Peeked before consuming rate budget so a cost denial does not spend
-            // a rate slot.
-            counters.denied++;
-            decision = { verdict: 'deny', reason: `Cost ceiling of $${policy.costCeilingUsd} reached for "${tool.name}". Try again later.` };
         } else if (policy.rateLimit && !(await this.consumeRate(tool.name, policy.rateLimit))) {
             counters.rateLimited++;
             counters.denied++;
             decision = { verdict: 'deny', reason: `Rate limit exceeded for "${tool.name}". Try again shortly.` };
+        } else if (costCap !== undefined && !(await this.admitCostCall(tool.name, costCap))) {
+            // Charged last and atomically (INCR-then-compare), after the rate
+            // gate, so a rate-rejected call never charges the dollar budget and
+            // two concurrent paid calls can never both be admitted over the
+            // ceiling. A cost denial leaves only its own increment, which makes
+            // the window more conservative (never over-admits) and self-heals at
+            // expiry — the same benign increment-before-reject consumeRate accepts.
+            counters.denied++;
+            decision = { verdict: 'deny', reason: `Cost ceiling of $${policy.costCeilingUsd} reached for "${tool.name}". Try again later.` };
         } else {
-            // Charge one call against the cost cap only now that the call is
-            // allowed (rate already consumed above).
-            if (costCap !== undefined) {
-                await this.chargeCostCall(tool.name);
-            }
             counters.allowed++;
             decision = { verdict: 'allow' };
         }
@@ -363,11 +364,7 @@ export class ToolPolicyEngine {
         if (costCap === undefined) {
             return true;
         }
-        if (await this.wouldExceedCostCalls(tool.name, costCap)) {
-            return false;
-        }
-        await this.chargeCostCall(tool.name);
-        return true;
+        return this.admitCostCall(tool.name, costCap);
     }
 
     /**
@@ -436,33 +433,27 @@ export class ToolPolicyEngine {
     }
 
     /**
-     * Whether charging one more call would push the tool's windowed call count
-     * over its cap. Peeks without incrementing.
+     * Atomically charge one call against the tool's cost window and report
+     * whether it stays within the cap. INCR-then-compare — the same primitive
+     * {@link consumeRate} uses — so two concurrent paid calls can never both be
+     * admitted over the ceiling. A denied call leaves its increment, which only
+     * makes the window more conservative (never over-admits) and self-heals at
+     * expiry.
      *
      * @param name - Tool name.
      * @param maxCalls - The tool's per-window call cap.
-     * @returns `true` when this call must be denied to stay within the ceiling.
+     * @returns `true` when this call fits within the cap.
      */
-    private async wouldExceedCostCalls(name: string, maxCalls: number): Promise<boolean> {
-        const current = await this.peek(`cost:${name}`, COST_WINDOW_MS);
-        return current + 1 > maxCalls;
-    }
-
-    /**
-     * Record one call against the tool's cost window. Call only when allowed.
-     *
-     * @param name - Tool name.
-     * @returns Resolves when counted.
-     */
-    private async chargeCostCall(name: string): Promise<void> {
-        await this.hit(`cost:${name}`, COST_WINDOW_MS);
+    private async admitCostCall(name: string, maxCalls: number): Promise<boolean> {
+        const count = await this.hit(`cost:${name}`, COST_WINDOW_MS);
+        return count <= maxCalls;
     }
 
     /**
      * Increment a fixed-window counter and return its new count. Uses Redis
-     * `INCR` (+ first-hit `EXPIRE`) when a client is present so the window is a
-     * single shared budget across instances; falls back to the in-memory counter
-     * when no client is configured or a Redis call throws.
+     * `INCR` (+ an idempotent `EXPIRE … NX`) when a client is present so the
+     * window is a single shared budget across instances; falls back to the
+     * in-memory counter when no client is configured or a Redis call throws.
      *
      * @param key - Logical counter key (prefixed for Redis).
      * @param windowMs - Window duration.
@@ -473,35 +464,19 @@ export class ToolPolicyEngine {
             try {
                 const redisKey = RL_PREFIX + key;
                 const count = await this.redis.incr(redisKey);
-                if (count === 1) {
-                    await this.redis.expire(redisKey, Math.ceil(windowMs / 1000));
-                }
+                // EXPIRE … NX sets the TTL only when the key has none, so it
+                // self-heals a key left without an expiry — a crash or a failed
+                // EXPIRE between this INCR and the next would otherwise leave a
+                // TTL-less counter (most damagingly the 24h cost window) to
+                // accumulate forever and permanently deny the budget. NX leaves
+                // an existing TTL untouched, so the fixed window never slides.
+                await this.redis.expire(redisKey, Math.ceil(windowMs / 1000), 'NX');
                 return count;
             } catch (error) {
                 this.logger.warn({ error, key }, 'AI tool rate store: Redis unavailable, falling back to in-memory counter');
             }
         }
         return this.memHit(key, windowMs);
-    }
-
-    /**
-     * Read a fixed-window counter without incrementing. Returns 0 for a missing
-     * or expired window. Falls back to the in-memory counter on Redis failure.
-     *
-     * @param key - Logical counter key (prefixed for Redis).
-     * @param windowMs - Window duration (used only by the in-memory fallback).
-     * @returns The counter's current value.
-     */
-    private async peek(key: string, windowMs: number): Promise<number> {
-        if (this.redis) {
-            try {
-                const raw = await this.redis.get(RL_PREFIX + key);
-                return raw ? Number(raw) : 0;
-            } catch (error) {
-                this.logger.warn({ error, key }, 'AI tool rate store: Redis unavailable, falling back to in-memory counter');
-            }
-        }
-        return this.memPeek(key, windowMs);
     }
 
     /**
@@ -519,23 +494,6 @@ export class ToolPolicyEngine {
             this.memWindows.set(key, window);
         }
         window.count++;
-        return window.count;
-    }
-
-    /**
-     * In-memory fixed-window read without incrementing. Returns 0 for a missing
-     * or elapsed window.
-     *
-     * @param key - Counter key.
-     * @param windowMs - Window duration.
-     * @returns The counter's current value.
-     */
-    private memPeek(key: string, windowMs: number): number {
-        const now = Date.now();
-        const window = this.memWindows.get(key);
-        if (!window || now - window.windowStart >= windowMs) {
-            return 0;
-        }
         return window.count;
     }
 

--- a/src/backend/modules/ai-tools/services/tool-policy-engine.ts
+++ b/src/backend/modules/ai-tools/services/tool-policy-engine.ts
@@ -3,16 +3,25 @@
  *
  * Decides whether a tool invocation may proceed, must be held for human
  * approval, or is denied. Defaults derive from the tool's capability class and
- * are overridable per tool by an admin. A fixed-window rate limiter (promoted
- * from the core blockchain module's TransactionToolGuard) caps invocations per
- * tool and globally, protecting upstream providers and the model's context
- * budget from a looping or prompt-injected agent. A parallel fixed-window
- * accumulator caps a paid tool's spend against its declared per-call cost
- * (`capability.costPerCallUsd`) so an operator's cost ceiling is enforceable
- * without the handler reporting actual spend.
+ * are overridable per tool by an admin. A fixed-window rate limiter caps
+ * invocations per tool and globally, protecting upstream providers and the
+ * model's context budget from a looping or prompt-injected agent. A paid tool's
+ * spend is capped the same way: because windowed spend is `calls × costPerCall`,
+ * the dollar ceiling is enforced as a cap on the number of calls
+ * (`floor(costCeilingUsd / costPerCallUsd)`) per window — one counter, no float
+ * accumulator.
+ *
+ * The counters are backed by Redis when a client is injected, so the limits are
+ * a single shared budget across every backend instance and survive a restart —
+ * the same `INCR`+`EXPIRE` fixed-window primitive the platform's API rate
+ * limiter uses (`services/rate-limit.service.ts`). When no client is present
+ * (unit tests) or a Redis call fails (outage), the engine degrades to a
+ * process-local in-memory counter: fail-safe per-instance limiting, never
+ * fail-open and never a self-inflicted denial.
  *
  * The engine is provider-neutral and owns no I/O beyond loading and persisting
- * admin overrides through the injected database.
+ * admin overrides through the injected database and incrementing the rate
+ * counters through the injected Redis client.
  */
 
 import type {
@@ -44,16 +53,35 @@ const GLOBAL_RATE = { max: 240, windowMs: 60_000 };
 /** Fixed window over which a tool's spend accumulates against its cost ceiling. */
 const COST_WINDOW_MS = 86_400_000;
 
-/** Rolling fixed-window counter. */
+/**
+ * Absorbs binary-float error when deriving the call cap from a dollar ceiling so
+ * a ceiling that is an exact multiple of the per-call cost is not under-counted
+ * by one (e.g. `0.30 / 0.10` is `2.9999999999999996` in IEEE 754, which would
+ * floor to 2 and wrongly deny the third call).
+ */
+const COST_EPSILON = 1e-9;
+
+/** Redis key prefix for every rate/cost counter this engine owns. */
+const RL_PREFIX = 'aitool:rl:';
+
+/** Shared counter key for the global cross-tool rate backstop. */
+const GLOBAL_KEY = '__global__';
+
+/**
+ * The subset of the Redis client the rate store uses. Structural so a test can
+ * pass a fake and the engine never imports the ioredis type; the platform's
+ * ioredis client satisfies it as-is.
+ */
+export interface IRateLimitRedis {
+    incr(key: string): Promise<number>;
+    expire(key: string, seconds: number): Promise<unknown>;
+    get(key: string): Promise<string | null>;
+}
+
+/** In-memory fixed-window counter (fallback when Redis is absent or down). */
 interface IWindowState {
     windowStart: number;
     count: number;
-}
-
-/** Fixed-window spend accumulator for a tool's cost ceiling. */
-interface ICostWindowState {
-    windowStart: number;
-    spentUsd: number;
 }
 
 /** Per-tool usage tally surfaced to the admin policy view. */
@@ -69,9 +97,7 @@ interface IToolCounters {
  * Resolves and enforces per-tool governance policy for the AI tool governor.
  */
 export class ToolPolicyEngine {
-    private readonly perToolWindows = new Map<string, IWindowState>();
-    private readonly costWindows = new Map<string, ICostWindowState>();
-    private globalWindow: IWindowState = { windowStart: Date.now(), count: 0 };
+    private readonly memWindows = new Map<string, IWindowState>();
     private readonly counters = new Map<string, IToolCounters>();
     private overrides: Record<string, IToolPolicy> = {};
     private curationTypeResolver: ((typeId: string) => boolean) | null = null;
@@ -79,10 +105,13 @@ export class ToolPolicyEngine {
     /**
      * @param logger - Module-scoped logger.
      * @param database - Core database for persisting admin policy overrides.
+     * @param redis - Optional Redis client backing the rate/cost counters. When
+     *          omitted, counters are process-local and reset on restart.
      */
     constructor(
         private readonly logger: ISystemLogService,
-        private readonly database: IDatabaseService
+        private readonly database: IDatabaseService,
+        private readonly redis?: IRateLimitRedis
     ) {}
 
     /**
@@ -108,28 +137,32 @@ export class ToolPolicyEngine {
     }
 
     /**
-     * Compute the effective policy for a tool: capability-class defaults with
-     * any admin override merged on top.
+     * The class-default policy for a capability, *before* any admin override —
+     * the behaviour the governor enforces when a tool inherits its class
+     * defaults. Exposed so the admin policy view can show what an inherited
+     * ("Default") cell actually resolves to, rather than the opaque word
+     * "Default". Because it reads the live curation-binding state through
+     * {@link curatorReviewHonored}, a tool bound to a curation type whose owner
+     * is currently disabled reports its re-tightened default here too.
      *
-     * @param name - Tool name (override lookup key).
-     * @param cap - The tool's capability classification.
-     * @returns The merged policy the engine will enforce.
+     * @param cap - The tool's capability (may be partial or undefined).
+     * @returns The pre-override class-default policy.
      */
-    effectivePolicyFor(name: string, cap: IAiToolCapability): IToolPolicy {
+    defaultPolicyFor(cap: IAiToolCapability | undefined): IToolPolicy {
         // Merge over DEFAULT_CAPABILITY so a partial or empty capability object
         // (possible from an untyped/`as any` caller) can never leave a field
         // undefined: an undefined sideEffect would otherwise skip both the rate
         // limit (RATE_DEFAULTS[undefined]) and the external autonomous-deny,
         // failing open. A partial object then falls back to the read/internal
         // default — the same safe class an unclassified tool receives.
-        const fullCap = { ...DEFAULT_CAPABILITY, ...cap };
+        const fullCap = { ...DEFAULT_CAPABILITY, ...(cap ?? {}) };
         // An external, irreversible effect must be reviewed by a human before it
         // takes hold. A tool that forces its own curator review supplies that
         // review itself, so the governor adds no second gate; otherwise the
         // governor owns the approval. Both gates are derived purely from the
         // tool's declared nature — a tool cannot opt itself out of either. Only
-        // the admin override merged below can relax them, which keeps the bypass
-        // an on-record operator decision rather than a tool self-grant.
+        // an admin override can relax them, which keeps the bypass an on-record
+        // operator decision rather than a tool self-grant.
         const curatorReviewHonored = this.curatorReviewHonored(fullCap);
         const isUnreviewedDangerousEffect =
             fullCap.sideEffect === 'external' && fullCap.reversible === false && !curatorReviewHonored;
@@ -150,7 +183,19 @@ export class ToolPolicyEngine {
         if (curatorReviewHonored) {
             base.curation = 'require';
         }
-        return { ...base, ...this.overrides[name] };
+        return base;
+    }
+
+    /**
+     * Compute the effective policy for a tool: the capability-class default with
+     * any admin override merged on top — what the governor actually enforces.
+     *
+     * @param name - Tool name (override lookup key).
+     * @param cap - The tool's capability classification.
+     * @returns The merged policy the engine will enforce.
+     */
+    effectivePolicyFor(name: string, cap: IAiToolCapability): IToolPolicy {
+        return { ...this.defaultPolicyFor(cap), ...this.overrides[name] };
     }
 
     /**
@@ -234,24 +279,25 @@ export class ToolPolicyEngine {
      * Evaluate a single invocation. On an `allow` verdict the call's rate-limit
      * budget is consumed; `needs-approval` and `deny` consume nothing.
      *
-     * Order: autonomous-path default-deny for external tools, then approval,
-     * then rate limiting. This keeps an approval-bound call from spending rate
-     * budget and bars unattended runs before any limiter math.
+     * Order: object-authorization precondition, autonomous-path default-deny for
+     * external tools, approval, cost ceiling, then rate limiting. Cost is peeked
+     * (not charged) before the rate budget is spent and charged only after the
+     * rate check passes, so a cost denial never spends a rate slot and a rate
+     * denial never charges cost.
      *
      * @param tool - The resolved tool, including its capability.
      * @param ctx - Caller and trigger context.
      * @returns The governor's enforcement decision.
      */
-    check(tool: IAiTool, ctx: IToolInvocationContext): IToolPolicyDecision {
+    async check(tool: IAiTool, ctx: IToolInvocationContext): Promise<IToolPolicyDecision> {
         const cap = tool.capability ?? DEFAULT_CAPABILITY;
         const policy = this.effectivePolicyFor(tool.name, cap);
         const counters = this.counterFor(tool.name);
         counters.invocations++;
 
-        // The declared per-call cost (≥ 0) is the unit charged against the
-        // operator's ceiling; without it, cost enforcement cannot apply.
-        const costPerCall = typeof cap.costPerCallUsd === 'number' && cap.costPerCallUsd >= 0 ? cap.costPerCallUsd : undefined;
-        const ceiling = policy.costCeilingUsd;
+        // The dollar ceiling expressed as a max number of calls per window;
+        // undefined when the tool is not cost-capped.
+        const costCap = this.costCapFor(cap, policy);
 
         let decision: IToolPolicyDecision;
         if (cap.operatesOnUserOwnedObjects === true && !ctx.endUser?.userId?.trim()) {
@@ -279,19 +325,20 @@ export class ToolPolicyEngine {
         } else if (policy.requireApproval) {
             counters.needsApproval++;
             decision = { verdict: 'needs-approval', reason: 'This tool requires human approval before it runs.' };
-        } else if (ceiling !== undefined && ceiling >= 0 && costPerCall !== undefined && this.wouldExceedCostCeiling(tool.name, costPerCall, ceiling)) {
-            // Checked before consuming rate budget so a cost denial does not
-            // spend a rate slot.
+        } else if (costCap !== undefined && await this.wouldExceedCostCalls(tool.name, costCap)) {
+            // Peeked before consuming rate budget so a cost denial does not spend
+            // a rate slot.
             counters.denied++;
-            decision = { verdict: 'deny', reason: `Cost ceiling of $${ceiling} reached for "${tool.name}". Try again later.` };
-        } else if (policy.rateLimit && !this.consume(tool.name, policy.rateLimit)) {
+            decision = { verdict: 'deny', reason: `Cost ceiling of $${policy.costCeilingUsd} reached for "${tool.name}". Try again later.` };
+        } else if (policy.rateLimit && !(await this.consumeRate(tool.name, policy.rateLimit))) {
             counters.rateLimited++;
             counters.denied++;
             decision = { verdict: 'deny', reason: `Rate limit exceeded for "${tool.name}". Try again shortly.` };
         } else {
-            // Charge the declared cost only now that the call is allowed.
-            if (ceiling !== undefined && ceiling >= 0 && costPerCall !== undefined) {
-                this.chargeCost(tool.name, costPerCall);
+            // Charge one call against the cost cap only now that the call is
+            // allowed (rate already consumed above).
+            if (costCap !== undefined) {
+                await this.chargeCostCall(tool.name);
             }
             counters.allowed++;
             decision = { verdict: 'allow' };
@@ -304,24 +351,22 @@ export class ToolPolicyEngine {
      * ceiling, for execution paths that bypass {@link check} — notably an
      * approved hold, which the governor runs directly without re-checking
      * policy. Returns false (charging nothing) when the call would exceed the
-     * ceiling, true otherwise, charging the declared cost when the tool has both
-     * a ceiling and a per-call cost.
+     * ceiling, true otherwise, charging one call when the tool is cost-capped.
      *
      * @param tool - The tool about to run.
      * @returns Whether the invocation is admitted within its cost ceiling.
      */
-    tryChargeCost(tool: IAiTool): boolean {
+    async tryChargeCost(tool: IAiTool): Promise<boolean> {
         const cap = tool.capability ?? DEFAULT_CAPABILITY;
         const policy = this.effectivePolicyFor(tool.name, cap);
-        const costPerCall = typeof cap.costPerCallUsd === 'number' && cap.costPerCallUsd >= 0 ? cap.costPerCallUsd : undefined;
-        const ceiling = policy.costCeilingUsd;
-        if (ceiling === undefined || ceiling < 0 || costPerCall === undefined) {
+        const costCap = this.costCapFor(cap, policy);
+        if (costCap === undefined) {
             return true;
         }
-        if (this.wouldExceedCostCeiling(tool.name, costPerCall, ceiling)) {
+        if (await this.wouldExceedCostCalls(tool.name, costCap)) {
             return false;
         }
-        this.chargeCost(tool.name, costPerCall);
+        await this.chargeCostCall(tool.name);
         return true;
     }
 
@@ -354,55 +399,144 @@ export class ToolPolicyEngine {
     }
 
     /**
-     * Roll both the global and per-tool windows and, when both have budget,
-     * consume one unit from each.
+     * Derive the per-window call cap that enforces a tool's dollar ceiling.
+     * Windowed spend is `calls × costPerCall`, so a cap of
+     * `floor(costCeilingUsd / costPerCallUsd)` calls is the dollar ceiling — one
+     * counter, no float accumulator. Returns undefined when the tool is not
+     * cost-capped (no ceiling override, or no positive per-call cost to charge).
+     *
+     * @param cap - The tool's capability.
+     * @param policy - The tool's effective policy (carries the ceiling override).
+     * @returns The max calls per window, or undefined when uncapped.
+     */
+    private costCapFor(cap: IAiToolCapability, policy: IToolPolicy): number | undefined {
+        const costPerCall = typeof cap.costPerCallUsd === 'number' && cap.costPerCallUsd > 0 ? cap.costPerCallUsd : undefined;
+        const ceiling = policy.costCeilingUsd;
+        if (ceiling === undefined || ceiling < 0 || costPerCall === undefined) {
+            return undefined;
+        }
+        return Math.floor(ceiling / costPerCall + COST_EPSILON);
+    }
+
+    /**
+     * Roll both the global and per-tool rate windows and consume one unit from
+     * each. The two counters are independent — a call the global backstop
+     * rejects may have already ticked the per-tool counter, the same benign
+     * increment-before-reject the platform's API rate limiter accepts. It only
+     * over-rejects, never over-admits, so the ceiling holds.
      *
      * @param name - Tool name.
      * @param limit - The tool's effective rate limit.
      * @returns `true` when the invocation fits both windows.
      */
-    private consume(name: string, limit: { max: number; windowMs: number }): boolean {
-        const now = Date.now();
-        const tool = this.windowFor(name);
-        this.roll(this.globalWindow, GLOBAL_RATE.windowMs, now);
-        this.roll(tool, limit.windowMs, now);
-
-        let consumed = false;
-        if (this.globalWindow.count < GLOBAL_RATE.max && tool.count < limit.max) {
-            this.globalWindow.count++;
-            tool.count++;
-            consumed = true;
-        }
-        return consumed;
+    private async consumeRate(name: string, limit: { max: number; windowMs: number }): Promise<boolean> {
+        const toolCount = await this.hit(`tool:${name}`, limit.windowMs);
+        const globalCount = await this.hit(GLOBAL_KEY, GLOBAL_RATE.windowMs);
+        return toolCount <= limit.max && globalCount <= GLOBAL_RATE.max;
     }
 
     /**
-     * Reset a window when its duration has elapsed.
-     *
-     * @param window - The window to roll in place.
-     * @param windowMs - Window duration.
-     * @param now - Current epoch milliseconds.
-     */
-    private roll(window: IWindowState, windowMs: number, now: number): void {
-        if (now - window.windowStart >= windowMs) {
-            window.windowStart = now;
-            window.count = 0;
-        }
-    }
-
-    /**
-     * Get or create the per-tool rate window.
+     * Whether charging one more call would push the tool's windowed call count
+     * over its cap. Peeks without incrementing.
      *
      * @param name - Tool name.
-     * @returns The tool's window state.
+     * @param maxCalls - The tool's per-window call cap.
+     * @returns `true` when this call must be denied to stay within the ceiling.
      */
-    private windowFor(name: string): IWindowState {
-        let window = this.perToolWindows.get(name);
-        if (!window) {
-            window = { windowStart: Date.now(), count: 0 };
-            this.perToolWindows.set(name, window);
+    private async wouldExceedCostCalls(name: string, maxCalls: number): Promise<boolean> {
+        const current = await this.peek(`cost:${name}`, COST_WINDOW_MS);
+        return current + 1 > maxCalls;
+    }
+
+    /**
+     * Record one call against the tool's cost window. Call only when allowed.
+     *
+     * @param name - Tool name.
+     * @returns Resolves when counted.
+     */
+    private async chargeCostCall(name: string): Promise<void> {
+        await this.hit(`cost:${name}`, COST_WINDOW_MS);
+    }
+
+    /**
+     * Increment a fixed-window counter and return its new count. Uses Redis
+     * `INCR` (+ first-hit `EXPIRE`) when a client is present so the window is a
+     * single shared budget across instances; falls back to the in-memory counter
+     * when no client is configured or a Redis call throws.
+     *
+     * @param key - Logical counter key (prefixed for Redis).
+     * @param windowMs - Window duration.
+     * @returns The counter's value after this increment.
+     */
+    private async hit(key: string, windowMs: number): Promise<number> {
+        if (this.redis) {
+            try {
+                const redisKey = RL_PREFIX + key;
+                const count = await this.redis.incr(redisKey);
+                if (count === 1) {
+                    await this.redis.expire(redisKey, Math.ceil(windowMs / 1000));
+                }
+                return count;
+            } catch (error) {
+                this.logger.warn({ error, key }, 'AI tool rate store: Redis unavailable, falling back to in-memory counter');
+            }
         }
-        return window;
+        return this.memHit(key, windowMs);
+    }
+
+    /**
+     * Read a fixed-window counter without incrementing. Returns 0 for a missing
+     * or expired window. Falls back to the in-memory counter on Redis failure.
+     *
+     * @param key - Logical counter key (prefixed for Redis).
+     * @param windowMs - Window duration (used only by the in-memory fallback).
+     * @returns The counter's current value.
+     */
+    private async peek(key: string, windowMs: number): Promise<number> {
+        if (this.redis) {
+            try {
+                const raw = await this.redis.get(RL_PREFIX + key);
+                return raw ? Number(raw) : 0;
+            } catch (error) {
+                this.logger.warn({ error, key }, 'AI tool rate store: Redis unavailable, falling back to in-memory counter');
+            }
+        }
+        return this.memPeek(key, windowMs);
+    }
+
+    /**
+     * In-memory fixed-window increment: roll the window when elapsed, then count.
+     *
+     * @param key - Counter key.
+     * @param windowMs - Window duration.
+     * @returns The counter's value after this increment.
+     */
+    private memHit(key: string, windowMs: number): number {
+        const now = Date.now();
+        let window = this.memWindows.get(key);
+        if (!window || now - window.windowStart >= windowMs) {
+            window = { windowStart: now, count: 0 };
+            this.memWindows.set(key, window);
+        }
+        window.count++;
+        return window.count;
+    }
+
+    /**
+     * In-memory fixed-window read without incrementing. Returns 0 for a missing
+     * or elapsed window.
+     *
+     * @param key - Counter key.
+     * @param windowMs - Window duration.
+     * @returns The counter's current value.
+     */
+    private memPeek(key: string, windowMs: number): number {
+        const now = Date.now();
+        const window = this.memWindows.get(key);
+        if (!window || now - window.windowStart >= windowMs) {
+            return 0;
+        }
+        return window.count;
     }
 
     /**
@@ -418,63 +552,5 @@ export class ToolPolicyEngine {
             this.counters.set(name, counters);
         }
         return counters;
-    }
-
-    /**
-     * Whether charging one more invocation's declared cost would push the tool's
-     * windowed spend over its ceiling. Rolls the window first; records nothing.
-     * The 1e-9 epsilon absorbs binary-float accumulation error so a call that
-     * exactly meets the ceiling is not denied (e.g. 0.01*9 + 0.01 > 0.10).
-     *
-     * @param name - Tool name.
-     * @param costPerCall - Declared USD cost of this invocation.
-     * @param ceiling - The tool's cost ceiling in USD.
-     * @returns `true` when this call must be denied to stay within the ceiling.
-     */
-    private wouldExceedCostCeiling(name: string, costPerCall: number, ceiling: number): boolean {
-        const window = this.costWindowFor(name);
-        this.rollCost(window, Date.now());
-        return window.spentUsd + costPerCall - ceiling > 1e-9;
-    }
-
-    /**
-     * Record one invocation's declared cost against the tool's rolling window.
-     * Call only when the invocation is allowed.
-     *
-     * @param name - Tool name.
-     * @param costPerCall - Declared USD cost to add.
-     */
-    private chargeCost(name: string, costPerCall: number): void {
-        const window = this.costWindowFor(name);
-        this.rollCost(window, Date.now());
-        window.spentUsd += costPerCall;
-    }
-
-    /**
-     * Reset a cost window when its duration has elapsed.
-     *
-     * @param window - The cost window to roll in place.
-     * @param now - Current epoch milliseconds.
-     */
-    private rollCost(window: ICostWindowState, now: number): void {
-        if (now - window.windowStart >= COST_WINDOW_MS) {
-            window.windowStart = now;
-            window.spentUsd = 0;
-        }
-    }
-
-    /**
-     * Get or create the per-tool cost window.
-     *
-     * @param name - Tool name.
-     * @returns The tool's cost window state.
-     */
-    private costWindowFor(name: string): ICostWindowState {
-        let window = this.costWindows.get(name);
-        if (!window) {
-            window = { windowStart: Date.now(), spentUsd: 0 };
-            this.costWindows.set(name, window);
-        }
-        return window;
     }
 }

--- a/src/frontend/app/(core)/system/ai-tools/components/TrifectaPanel.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/TrifectaPanel.tsx
@@ -78,11 +78,15 @@ export function TrifectaPanel({ status }: { status: ITrifectaStatus }) {
                 <div className={styles.trifecta_legs}>
                     <Leg label="Private data" tools={[...status.privateData, ...status.privateDataVariables]} tone={accent.tone} />
                     <Leg label="Untrusted content" tools={status.untrustedContent} tone={accent.tone} />
-                    {status.exfiltrationOpen.length > 0 && (
-                        <Leg label="Exfiltration (open)" tools={status.exfiltrationOpen} tone="danger" />
-                    )}
-                    {status.exfiltrationGated.length > 0 && (
-                        <Leg label="Exfiltration (curator-gated)" tools={status.exfiltrationGated} tone="warning" />
+                    {(status.exfiltrationOpen.length > 0 || status.exfiltrationGated.length > 0) && (
+                        <Stack gap="sm">
+                            {status.exfiltrationOpen.length > 0 && (
+                                <Leg label="Exfiltration (open)" tools={status.exfiltrationOpen} tone="danger" />
+                            )}
+                            {status.exfiltrationGated.length > 0 && (
+                                <Leg label="Exfiltration (curator-gated)" tools={status.exfiltrationGated} tone="warning" />
+                            )}
+                        </Stack>
                     )}
                 </div>
             </Stack>

--- a/src/frontend/app/(core)/system/ai-tools/page.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/page.module.scss
@@ -194,12 +194,15 @@
     word-break: break-word;
 }
 
-/* Tool name + override badge, inline in the first (expanding) column. */
+/* Tool name + override badge, inline in the first column. Never wraps, so the
+ * column hugs its content (the longest tool name on one line) instead of
+ * expanding — no min-width needed. */
 .tool_cell {
     display: flex;
     align-items: center;
     gap: var(--gap-sm);
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    white-space: nowrap;
 }
 
 /* Keep the usage tally on one line so its column hugs the content. */

--- a/src/frontend/app/(core)/system/ai-tools/page.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/page.tsx
@@ -3,8 +3,9 @@
 /**
  * @fileoverview /system/ai-tools — the AI tool governance dashboard.
  *
- * Four tabs (Registry, Activity, Approvals, Policy) plus a lethal-trifecta
- * banner and a live pending-approval count on the Approvals tab. Admin-gated by
+ * Six tabs (Query — the default — then Registry, Activity, Approvals, Curation,
+ * Policy) plus a lethal-trifecta banner and a live pending-approval count on the
+ * Approvals tab. Admin-gated by
  * the /system layout; like the other system pages it is a client component that
  * fetches over the cookie-authenticated admin API. Governed events arrive as
  * WebSocket refetch signals — the data itself always comes from the gated REST
@@ -30,8 +31,8 @@ import styles from './page.module.scss';
 type TabId = 'registry' | 'query' | 'activity' | 'approvals' | 'curation' | 'policy';
 
 const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
-    { id: 'registry', label: 'Registry' },
     { id: 'query', label: 'Query' },
+    { id: 'registry', label: 'Registry' },
     { id: 'activity', label: 'Activity' },
     { id: 'approvals', label: 'Approvals' },
     { id: 'curation', label: 'Curation' },
@@ -44,7 +45,7 @@ const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
  * @returns The page.
  */
 export default function AiToolsAdminPage() {
-    const [activeTab, setActiveTab] = useState<TabId>('registry');
+    const [activeTab, setActiveTab] = useState<TabId>('query');
     const [trifecta, setTrifecta] = useState<ITrifectaStatus | null>(null);
     const [pending, setPending] = useState(0);
     const [pendingCuration, setPendingCuration] = useState(0);

--- a/src/frontend/app/(core)/system/ai-tools/tabs/PolicyTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/PolicyTab.tsx
@@ -67,10 +67,11 @@ function curationFrom(value: IToolPolicy['curation'] | undefined): CurationMode 
  * Editable policy row for one tool. Local form state is seeded from the tool's
  * current override so each row edits independently.
  */
-function PolicyRow({ tool, override, usage, onSaved }: {
+function PolicyRow({ tool, override, usage, defaults, onSaved }: {
     tool: IAiToolInfo;
     override?: IToolPolicy;
     usage?: Usage;
+    defaults?: { requireApproval: boolean; allowUnattended: boolean };
     onSaved: () => void;
 }) {
     const [requireApproval, setRequireApproval] = useState<TriState>(triFrom(override?.requireApproval));
@@ -85,6 +86,13 @@ function PolicyRow({ tool, override, usage, onSaved }: {
     // The curation control only bites on tools that route effects through the
     // central queue; others render a dash so the column isn't a live no-op.
     const curationCapable = tool.capability?.forcesCuratorReview === true;
+
+    // Label the inherited ("Default") option with the value it resolves to, so
+    // an admin reading a row sees the actual behaviour rather than the opaque
+    // word "Default". The resolved value is the governor's own class default
+    // (from GET /policy), not a re-derivation here.
+    const approvalDefaultLabel = defaults ? `Default (${defaults.requireApproval ? 'On' : 'Off'})` : 'Default';
+    const unattendedDefaultLabel = defaults ? `Default (${defaults.allowUnattended ? 'On' : 'Off'})` : 'Default';
 
     // Pending edits relative to the saved override. Save stays disabled until a
     // field actually changes, so a long tool list doesn't present a column of
@@ -161,7 +169,7 @@ function PolicyRow({ tool, override, usage, onSaved }: {
                     onChange={(e) => setRequireApproval(e.target.value as TriState)}
                     aria-label={`Require approval for ${tool.name}`}
                 >
-                    <option value="inherit">Default</option>
+                    <option value="inherit">{approvalDefaultLabel}</option>
                     <option value="on">On</option>
                     <option value="off">Off</option>
                 </select>
@@ -173,7 +181,7 @@ function PolicyRow({ tool, override, usage, onSaved }: {
                     onChange={(e) => setAllowUnattended(e.target.value as TriState)}
                     aria-label={`Allow unattended runs for ${tool.name}`}
                 >
-                    <option value="inherit">Default</option>
+                    <option value="inherit">{unattendedDefaultLabel}</option>
                     <option value="on">On</option>
                     <option value="off">Off</option>
                 </select>
@@ -217,7 +225,7 @@ function PolicyRow({ tool, override, usage, onSaved }: {
  */
 export function PolicyTab() {
     const [tools, setTools] = useState<IAiToolInfo[]>([]);
-    const [policy, setPolicyState] = useState<IPolicyResponse>({ overrides: {}, usage: {} });
+    const [policy, setPolicyState] = useState<IPolicyResponse>({ overrides: {}, usage: {}, defaults: {} });
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
@@ -248,10 +256,12 @@ export function PolicyTab() {
             </p>
             <p className="text-muted" style={{ margin: 0, fontSize: 'var(--font-size-body-sm)' }}>
                 Both dropdowns are three-way: <strong>Default</strong> keeps the tool&apos;s capability-class
-                default, while <strong>On</strong>/<strong>Off</strong> force it. <strong>Require approval</strong> On
+                default and shows the value it resolves to in parentheses — <em>Default (On)</em> or <em>Default
+                (Off)</em> — while <strong>On</strong>/<strong>Off</strong> force it. <strong>Require approval</strong> On
                 holds every call in the Approvals tab before it runs (by default only external, irreversible tools are
-                held). <strong>Unattended</strong> sets whether the tool may run on autonomous paths — scheduled prompts
-                and programmatic queries — where external tools are otherwise barred. <strong>Rate / min</strong> caps
+                held). <strong>Allow unattended</strong> sets whether the tool may run on autonomous paths — scheduled
+                prompts and programmatic queries — where external tools are otherwise barred; <em>On</em> allows them,
+                <em>Off</em> blocks them. <strong>Rate / min</strong> caps
                 invocations per minute across all callers; blank inherits the class default (120 read, 60 write, 30
                 external), under a 240/min global ceiling. <strong>Cost ceiling (USD)</strong> caps a paid tool&apos;s spend
                 over a fixed 24-hour window — each call that runs is charged the tool&apos;s declared per-call cost, and
@@ -266,17 +276,17 @@ export function PolicyTab() {
                 re-arms the lethal-trifecta banner for that tool. Tools that don&apos;t self-curate show “—”.
             </p>
             <div className="table-scroll">
-                <Table>
+                <Table stickyHeader>
                     <Thead>
                         <Tr>
-                            <Th width="expand">Tool</Th>
-                            <Th width="shrink">Usage</Th>
-                            <Th>Require approval</Th>
-                            <Th>Unattended</Th>
-                            <Th>Curation</Th>
-                            <Th>Rate / min</Th>
-                            <Th>Cost ceiling (USD)</Th>
-                            <Th width="shrink">Actions</Th>
+                            <Th width="shrink" title="Registered tool name; the “override” badge marks a custom policy.">Tool</Th>
+                            <Th width="shrink" title="Calls, denials, and held counts since the last server start.">Usage</Th>
+                            <Th title="Hold every call for human approval before it runs. On = held; Off = runs without approval.">Require approval</Th>
+                            <Th title="Whether the tool may run on autonomous (scheduled / programmatic) paths. On = allowed; Off = blocked.">Allow unattended</Th>
+                            <Th title="How a self-curating tool releases effects: require review, or auto-approve.">Curation</Th>
+                            <Th title="Max invocations per minute across all callers; blank inherits the class default.">Rate / min</Th>
+                            <Th title="Max spend per rolling 24h window for paid tools; blank means no cap.">Cost ceiling (USD)</Th>
+                            <Th width="shrink" title="Save or clear this tool’s policy override.">Actions</Th>
                         </Tr>
                     </Thead>
                     <Tbody>
@@ -286,6 +296,7 @@ export function PolicyTab() {
                                 tool={tool}
                                 override={policy.overrides[tool.name]}
                                 usage={policy.usage[tool.name]}
+                                defaults={policy.defaults[tool.name]}
                                 onSaved={load}
                             />
                         ))}

--- a/src/frontend/components/ui/Table/Table.module.scss
+++ b/src/frontend/components/ui/Table/Table.module.scss
@@ -29,6 +29,29 @@
     padding: var(--spacing-3) var(--spacing-4);
 }
 
+/*
+ * Sticky-header variant. The base wrapper uses `overflow: hidden`, which makes
+ * it a scroll box that captures `position: sticky` and never scrolls — so a
+ * sticky header cannot work against it. This modifier turns the wrapper into a
+ * bounded vertical scroll container; the header then sticks to its top while the
+ * body scrolls. Height is tunable via `--table-sticky-max-height`.
+ */
+.table_wrapper_sticky {
+    overflow: auto;
+    max-height: var(--table-sticky-max-height, 70vh);
+}
+
+.table_wrapper_sticky .thead .th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    /* The header cell must paint its own background and divider: with
+     * border-collapse the header's bottom border scrolls away under the body,
+     * so an inset shadow keeps a stable divider as rows pass beneath. */
+    background: var(--table-header-background);
+    box-shadow: inset 0 calc(-1 * var(--border-width-thin)) 0 var(--color-border);
+}
+
 /* Table Header */
 .thead {
     background: var(--table-header-background);

--- a/src/frontend/components/ui/Table/Table.tsx
+++ b/src/frontend/components/ui/Table/Table.tsx
@@ -21,6 +21,12 @@ interface TableProps extends TableHTMLAttributes<HTMLTableElement> {
      * @default 'default'
      */
     variant?: TableVariant;
+    /**
+     * Pin the header row while the body scrolls. Bounds the wrapper height and
+     * makes it the scroll container so the header stays visible on long tables.
+     * @default false
+     */
+    stickyHeader?: boolean;
 }
 
 /**
@@ -51,9 +57,9 @@ interface TableProps extends TableHTMLAttributes<HTMLTableElement> {
  * @param props - Table component properties
  * @returns A styled table element with wrapper
  */
-export function Table({ variant = 'default', className, children, ...props }: TableProps) {
+export function Table({ variant = 'default', stickyHeader = false, className, children, ...props }: TableProps) {
     return (
-        <div className={styles.table_wrapper}>
+        <div className={cn(styles.table_wrapper, stickyHeader && styles.table_wrapper_sticky)}>
             <table
                 className={cn(
                     styles.table,

--- a/src/frontend/modules/ai-tools/api/client.ts
+++ b/src/frontend/modules/ai-tools/api/client.ts
@@ -109,7 +109,7 @@ export interface IQueryHistoryQuery {
     offset?: number;
 }
 
-/** Per-tool policy overrides plus usage tallies, as returned by `GET /policy`. */
+/** Per-tool policy overrides, usage tallies, and resolved class defaults, as returned by `GET /policy`. */
 export interface IPolicyResponse {
     overrides: Record<string, IToolPolicy>;
     usage: Record<string, {
@@ -119,6 +119,12 @@ export interface IPolicyResponse {
         rateLimited: number;
         needsApproval: number;
     }>;
+    /**
+     * The class-default behaviour each tool inherits, before any override —
+     * lets an inherited cell show what "Default" actually resolves to. Keyed by
+     * tool name; a tool absent here has no resolvable default to display.
+     */
+    defaults: Record<string, { requireApproval: boolean; allowUnattended: boolean }>;
 }
 
 /**


### PR DESCRIPTION
## Governance limits (F5)

Back the per-tool and global rate windows **and** the cost ceiling with Redis (`INCR`+`EXPIRE`, the existing `RateLimitService` primitive) so the limits are a single shared budget across backend instances and survive a restart. When no Redis client is present or a call errors, the engine degrades to per-instance in-memory counters — fail-safe, never fail-open. The dollar ceiling is now enforced as a per-window **call cap** (`floor(costCeilingUsd / costPerCallUsd)`), retiring the float accumulator. `check()` and `tryChargeCost()` are now async; both governor call sites already awaited.

## Policy tab admin UX

- Sticky table header on scroll via a new opt-in `stickyHeader` prop on the shared `Table` (default off; no other table affected).
- **Tool** column no longer wraps or expands (was ~50%); it now hugs its content.
- Inherited cells read **"Default (On/Off)"** — the resolved class default is surfaced on `GET /policy` from the engine itself, so the displayed default cannot drift from what the governor enforces.
- Rename **Unattended → Allow unattended** (On = allowed on autonomous paths, Off = blocked) and add pithy tooltips to every column header.

## Other ai-tools admin

- **Query** tab is now first and the default tab.
- Group the lethal-trifecta **exfiltration** legs (open + curator-gated) into a single column.

Verified: `tsc --noEmit` clean; ai-tools module suite green (77 tests, incl. new shared-budget and Redis-fallback cases).