### PR TITLE
feat(ai-tools): pin saved prompts to a provider/model and report query cost

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delphian/tronrelic-types",
-    "version": "4.6.0",
+    "version": "4.7.0",
     "description": "Core type definitions for the TronRelic platform",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/types/src/ai-tools/IAiProviderRegistry.ts
+++ b/packages/types/src/ai-tools/IAiProviderRegistry.ts
@@ -75,4 +75,18 @@ export interface IAiProviderRegistry {
      * @returns The active provider's executable instance, or `null`.
      */
     getActive(): IAiProvider | null;
+
+    /**
+     * The executable instance of a specific registered provider by id, or `null`
+     * when no provider with that id is installed. Unlike {@link getActive}, this
+     * resolves a provider even when it is not the active transport — used to run
+     * a saved prompt pinned to a particular provider/model regardless of which
+     * provider is currently active. Returns `null` for an unknown id rather than
+     * falling back to the active provider, so the caller decides whether to
+     * substitute the active one or surface "that provider is not installed".
+     *
+     * @param id - The provider plugin id.
+     * @returns The provider's executable instance, or `null`.
+     */
+    getProvider(id: string): IAiProvider | null;
 }

--- a/packages/types/src/ai-tools/IAiQueryRecord.ts
+++ b/packages/types/src/ai-tools/IAiQueryRecord.ts
@@ -38,6 +38,14 @@ export interface IAiQueryRecord {
         cacheReadInputTokens?: number;
     };
 
+    /**
+     * Estimated USD cost of this turn at the time it ran, when the provider
+     * priced it. Persisted so a reopened conversation shows the same cost the
+     * live stream did, rather than re-deriving it against rates that may have
+     * changed since. `null`/absent when the turn could not be priced.
+     */
+    costUsd?: number | null;
+
     /** Failure reason when the query failed, else null. */
     errorMessage: string | null;
 

--- a/packages/types/src/ai-tools/IAiQueryResult.ts
+++ b/packages/types/src/ai-tools/IAiQueryResult.ts
@@ -47,4 +47,12 @@ export interface IAiQueryResult {
          */
         cacheReadInputTokens?: number;
     };
+
+    /**
+     * Estimated USD cost of this query, when the provider can price it. Computed
+     * by the provider from its own per-model rates so core stays vendor-neutral
+     * and only forwards the figure. `null` when the reported usage has no
+     * matching rate; omitted by a provider that does not price queries.
+     */
+    costUsd?: number | null;
 }

--- a/packages/types/src/ai-tools/IAiStreamChunk.ts
+++ b/packages/types/src/ai-tools/IAiStreamChunk.ts
@@ -36,4 +36,14 @@ export interface IAiStreamChunk {
         cacheCreationInputTokens?: number;
         cacheReadInputTokens?: number;
     };
+
+    /**
+     * Estimated USD cost of the query, present on the terminal 'done' chunk
+     * alongside `usage`. The provider computes it from its own per-model rate
+     * card and forwards the number, so core stays vendor-neutral and any
+     * surface (the Query tab) can show cost without knowing how a vendor prices.
+     * `null` when the provider cannot price the reported usage (no matching
+     * rate); omitted entirely by a provider that does not price queries.
+     */
+    costUsd?: number | null;
 }

--- a/packages/types/src/ai-tools/ISavedPrompt.ts
+++ b/packages/types/src/ai-tools/ISavedPrompt.ts
@@ -20,6 +20,23 @@ export interface ISavedPrompt {
     name: string;
     /** The prompt text, potentially including {%variable%} patterns. */
     prompt: string;
+    /**
+     * Optional AI provider this prompt targets, by provider plugin id (e.g.
+     * `'ai-assistant'`). When set, a scheduled run executes against this specific
+     * provider — resolved from the core `'ai-providers'` registry by id — rather
+     * than whatever provider is active at run time, so a prompt pinned to a
+     * model keeps running on that model's provider even after the active
+     * transport changes. Absent means "use the active provider". Models can span
+     * multiple providers, so the provider must be recorded alongside the model.
+     */
+    providerId?: string;
+    /**
+     * Optional model id this prompt runs on, passed to the provider as the
+     * per-query model override. Belongs to `providerId`'s catalog (the editor's
+     * picker lists models grouped by provider). Absent means the provider's
+     * configured default model.
+     */
+    model?: string;
     /** ISO timestamp of when the prompt was saved. */
     createdAt: string;
     /** ISO timestamp of last update. */

--- a/src/backend/modules/ai-tools/AiToolsModule.ts
+++ b/src/backend/modules/ai-tools/AiToolsModule.ts
@@ -253,14 +253,24 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
                     );
                     return;
                 }
-                const provider = this.providerRegistry.getActive();
-                if (!provider) {
+                // Cheap no-op when nothing is installed at all. A prompt may pin a
+                // specific (possibly inactive) provider, so don't gate on an
+                // *active* provider — only on there being no provider registered
+                // whatsoever. The resolver below routes each prompt per its
+                // providerId, falling back to the active provider when unpinned.
+                if (this.providerRegistry.listProviders().length === 0) {
                     return;
                 }
                 promptTickInFlight = true;
                 promptTickStartedAt = Date.now();
                 try {
-                    await runScheduledPrompts(this.savedPrompts, this.logger, provider);
+                    await runScheduledPrompts(
+                        this.savedPrompts,
+                        this.logger,
+                        (providerId) => providerId
+                            ? this.providerRegistry.getProvider(providerId)
+                            : this.providerRegistry.getActive()
+                    );
                 } catch (error) {
                     this.logger.error({ error, job: SCHEDULED_PROMPTS_JOB }, 'Scheduled prompts job failed');
                     throw error;

--- a/src/backend/modules/ai-tools/__tests__/scheduled-prompts-runner.test.ts
+++ b/src/backend/modules/ai-tools/__tests__/scheduled-prompts-runner.test.ts
@@ -6,8 +6,9 @@
  * run-metadata write-back, error isolation between prompts, and the skip/fire
  * branch decisions that drive the scheduled-prompts feature.
  *
- * The runner consumes a SavedPromptsService and an active provider, so these
- * tests mock both interfaces directly.
+ * The runner consumes a SavedPromptsService and a provider resolver (mapping a
+ * prompt's optional providerId to an executable provider), so these tests mock
+ * both directly.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { runScheduledPrompts, type IScheduledPromptRunner } from '../services/scheduled-prompts-runner.js';
@@ -107,7 +108,7 @@ describe('runScheduledPrompts', () => {
 
     it('is a no-op when no scheduled prompts exist', async () => {
         const savedPrompts = createMockSavedPrompts([]);
-        await runScheduledPrompts(savedPrompts as any, logger as any, provider);
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
         expect(provider.query).not.toHaveBeenCalled();
         expect(savedPrompts.recordRunResult).not.toHaveBeenCalled();
     });
@@ -116,7 +117,7 @@ describe('runScheduledPrompts', () => {
         const savedPrompts = createMockSavedPrompts([
             makePrompt({ id: 'bad', cron: 'not-a-cron', lastRunAt: minutesAgo(10) })
         ]);
-        await runScheduledPrompts(savedPrompts as any, logger as any, provider);
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
         expect(provider.query).not.toHaveBeenCalled();
         expect(savedPrompts.recordRunResult).not.toHaveBeenCalled();
         expect(logger.warn).toHaveBeenCalledWith(
@@ -135,7 +136,7 @@ describe('runScheduledPrompts', () => {
                 prompt: 'run me'
             })
         ]);
-        await runScheduledPrompts(savedPrompts as any, logger as any, provider);
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
 
         expect(provider.query).toHaveBeenCalledTimes(1);
         // Autonomous → programmatic mode, so the governor's external-tool
@@ -153,7 +154,7 @@ describe('runScheduledPrompts', () => {
             makePrompt({ id: 'not-due', cron: '0 0 * * *', lastRunAt: tenSecondsAgo })
         ]);
 
-        await runScheduledPrompts(savedPrompts as any, logger as any, provider);
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
         expect(provider.query).not.toHaveBeenCalled();
         expect(savedPrompts.recordRunResult).not.toHaveBeenCalled();
     });
@@ -163,7 +164,7 @@ describe('runScheduledPrompts', () => {
             makePrompt({ id: 'first-run', cron: '* * * * *', createdAt: minutesAgo(10) })
         ]);
 
-        await runScheduledPrompts(savedPrompts as any, logger as any, provider);
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
         expect(provider.query).toHaveBeenCalledTimes(1);
         expect(savedPrompts.recordRunResult).toHaveBeenCalledTimes(1);
     });
@@ -179,7 +180,7 @@ describe('runScheduledPrompts', () => {
             })
         ]);
 
-        await runScheduledPrompts(savedPrompts as any, logger as any, provider);
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
         // The next every-minute occurrence after the just-now anchor is ~1 minute
         // out, so the prompt waits this tick rather than firing on the stale
         // lastRunAt / createdAt.
@@ -193,7 +194,7 @@ describe('runScheduledPrompts', () => {
             makePrompt({ id: 'fails', cron: '* * * * *', lastRunAt: minutesAgo(5) })
         ]);
 
-        await runScheduledPrompts(savedPrompts as any, logger as any, provider);
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
 
         expect(provider.query).toHaveBeenCalledTimes(1);
         // Claim-first: recordRunResult claims with a null error, then
@@ -213,7 +214,7 @@ describe('runScheduledPrompts', () => {
             makePrompt({ id: 'ok', cron: '* * * * *', lastRunAt: minutesAgo(5) })
         ]);
 
-        await runScheduledPrompts(savedPrompts as any, logger as any, provider);
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
         expect(savedPrompts.resetRunFailures).toHaveBeenCalledWith('ok');
     });
 
@@ -224,7 +225,7 @@ describe('runScheduledPrompts', () => {
         ]);
         savedPrompts.recordRunFailure.mockResolvedValueOnce({ disabled: true });
 
-        await runScheduledPrompts(savedPrompts as any, logger as any, provider);
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
 
         expect(logger.error).toHaveBeenCalledWith(
             expect.objectContaining({ promptId: 'broken' }),
@@ -242,13 +243,58 @@ describe('runScheduledPrompts', () => {
             makePrompt({ id: 'second', cron: '* * * * *', lastRunAt: minutesAgo(5), prompt: 'b' })
         ]);
 
-        await runScheduledPrompts(savedPrompts as any, logger as any, provider);
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
 
         expect(provider.query).toHaveBeenCalledTimes(2);
         expect(savedPrompts.recordRunResult).toHaveBeenCalledTimes(2);
         expect(savedPrompts.recordRunFailure).toHaveBeenCalledTimes(1);
         expect(savedPrompts._runResults.get('first')!.lastRunError).toBe('first failed');
         expect(savedPrompts._runResults.get('second')!.lastRunError).toBeNull();
+    });
+
+    it('routes a pinned prompt to its provider and forwards the model override', async () => {
+        const pinned = createMockProvider();
+        const active = createMockProvider();
+        const savedPrompts = createMockSavedPrompts([
+            makePrompt({
+                id: 'pinned',
+                cron: '* * * * *',
+                lastRunAt: minutesAgo(5),
+                prompt: 'run me',
+                providerId: 'other-provider',
+                model: 'some-model'
+            })
+        ]);
+
+        // Resolver returns the pinned provider for its id, the active one otherwise.
+        await runScheduledPrompts(
+            savedPrompts as any,
+            logger as any,
+            (providerId) => (providerId === 'other-provider' ? pinned : active)
+        );
+
+        expect(active.query).not.toHaveBeenCalled();
+        expect(pinned.query).toHaveBeenCalledWith({ prompt: 'run me', model: 'some-model', mode: 'programmatic' });
+    });
+
+    it('records a failed run when a pinned provider is not installed', async () => {
+        const savedPrompts = createMockSavedPrompts([
+            makePrompt({
+                id: 'orphan',
+                cron: '* * * * *',
+                lastRunAt: minutesAgo(5),
+                providerId: 'missing-provider'
+            })
+        ]);
+
+        // Resolver returns null → provider not available.
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => null);
+
+        // The run is claimed, then recorded as failed with a descriptive reason.
+        expect(savedPrompts.recordRunResult).toHaveBeenCalledTimes(1);
+        expect(savedPrompts.recordRunFailure).toHaveBeenCalledTimes(1);
+        const [, , reason] = savedPrompts.recordRunFailure.mock.calls[0];
+        expect(reason).toContain('missing-provider');
     });
 
     it('writes run metadata per-prompt rather than as a single batch', async () => {
@@ -259,7 +305,7 @@ describe('runScheduledPrompts', () => {
             makePrompt({ id: 'bad', cron: 'not-a-cron', lastRunAt: minutesAgo(5) })
         ]);
 
-        await runScheduledPrompts(savedPrompts as any, logger as any, provider);
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
 
         expect(provider.query).toHaveBeenCalledTimes(1);
         expect(provider.query).toHaveBeenCalledWith({ prompt: 'run', mode: 'programmatic' });

--- a/src/backend/modules/ai-tools/api/ai-tools.controller.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.controller.ts
@@ -16,6 +16,7 @@ import type {
     IAiQueryResult,
     IAiStreamChunk,
     IAiToolInfo,
+    IModelInfo,
     ICurationItem,
     IStaticPromptVariable,
     IToolPolicy,
@@ -469,6 +470,34 @@ export class AiToolsController {
         }
     };
 
+    /**
+     * GET /query/providers — every registered AI provider with its model
+     * catalog, for the cross-provider saved-prompt model picker. Unlike
+     * `/query/models` (active provider only), this enumerates all registered
+     * providers so a prompt can be pinned to a model on a non-active provider.
+     * Each provider's `listModels()` is guarded independently: a vendor-API
+     * failure on one provider yields an empty model list for that provider
+     * rather than failing the whole response, and the providers are resolved in
+     * parallel so one slow vendor does not serialize the rest.
+     */
+    listQueryProviders = async (_req: Request, res: Response): Promise<void> => {
+        const providers = await Promise.all(
+            this.providers.listProviders().map(async (info) => {
+                let models: IModelInfo[] = [];
+                try {
+                    const instance = this.providers.getProvider(info.id);
+                    if (instance) {
+                        models = await instance.listModels();
+                    }
+                } catch {
+                    models = [];
+                }
+                return { id: info.id, label: info.label, active: info.active, models };
+            })
+        );
+        res.json({ providers });
+    };
+
     /** GET /query/prompts — saved prompt templates, newest-updated first. */
     listPrompts = async (_req: Request, res: Response): Promise<void> => {
         try {
@@ -486,12 +515,14 @@ export class AiToolsController {
      * client's shared state stays current without a second round-trip.
      */
     savePrompt = async (req: Request, res: Response): Promise<void> => {
-        const { id, name, prompt, cron, scheduleEnabled } = (req.body ?? {}) as {
+        const { id, name, prompt, cron, scheduleEnabled, providerId, model } = (req.body ?? {}) as {
             id?: unknown;
             name?: unknown;
             prompt?: unknown;
             cron?: unknown;
             scheduleEnabled?: unknown;
+            providerId?: unknown;
+            model?: unknown;
         };
         try {
             const hasId = typeof id === 'string' && id.trim().length > 0;
@@ -500,14 +531,18 @@ export class AiToolsController {
                     name: name as string | undefined,
                     prompt: prompt as string | undefined,
                     cron: cron as string | null | undefined,
-                    scheduleEnabled: scheduleEnabled as boolean | undefined
+                    scheduleEnabled: scheduleEnabled as boolean | undefined,
+                    providerId: providerId as string | null | undefined,
+                    model: model as string | null | undefined
                 });
             } else {
                 await this.savedPrompts.create({
                     name: name as string,
                     prompt: prompt as string,
                     cron: (cron as string | null | undefined) ?? undefined,
-                    scheduleEnabled: scheduleEnabled as boolean | undefined
+                    scheduleEnabled: scheduleEnabled as boolean | undefined,
+                    providerId: typeof providerId === 'string' ? providerId : undefined,
+                    model: typeof model === 'string' ? model : undefined
                 });
             }
             res.json({ prompts: await this.savedPrompts.list() });
@@ -566,6 +601,9 @@ export class AiToolsController {
             responseText: result?.responseText ?? null,
             model: result?.model ?? fallbackModel ?? 'unknown',
             usage: result?.usage ?? { inputTokens: 0, outputTokens: 0 },
+            // Provider-computed estimated cost, persisted so reopened
+            // conversations show the same figure the live stream did.
+            costUsd: result?.costUsd ?? null,
             errorMessage,
             status: result ? 'completed' : 'failed',
             createdAt,
@@ -664,7 +702,18 @@ export class AiToolsController {
                 allowUnattended: base.allowUnattended ?? false
             };
         }
-        res.json({ overrides: this.policy.getOverrides(), usage: this.policy.snapshot(), defaults });
+        // Usage comes from the durable audit trail, not the policy engine's
+        // in-memory counters — those reset on restart and left every tool reading
+        // "no activity". Aggregating the persisted invocations keeps the column
+        // accurate across restarts. It is non-critical: a failure here must not
+        // block the policy editor, so fall back to empty tallies.
+        let usage: Record<string, unknown> = {};
+        try {
+            usage = await this.audit.aggregateUsage();
+        } catch {
+            usage = {};
+        }
+        res.json({ overrides: this.policy.getOverrides(), usage, defaults });
     };
 
     /** PUT /policy/:name — set a per-tool policy override. */

--- a/src/backend/modules/ai-tools/api/ai-tools.router.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.router.ts
@@ -40,6 +40,7 @@ export function createAiToolsAdminRouter(controller: AiToolsController): Router 
     router.post('/query/:queryId/cancel', controller.cancelQuery);
     router.get('/query/history', controller.listQueryHistory);
     router.get('/query/models', controller.listQueryModels);
+    router.get('/query/providers', controller.listQueryProviders);
     router.get('/query/conversations/:conversationId', controller.getConversationHistory);
 
     router.get('/query/prompts', controller.listPrompts);

--- a/src/backend/modules/ai-tools/services/ai-provider-registry.ts
+++ b/src/backend/modules/ai-tools/services/ai-provider-registry.ts
@@ -66,4 +66,9 @@ export class AiProviderRegistry implements IAiProviderRegistry {
         }
         return null;
     }
+
+    /** @inheritdoc */
+    getProvider(id: string): IAiProvider | null {
+        return this.providers.get(id)?.instance ?? null;
+    }
 }

--- a/src/backend/modules/ai-tools/services/saved-prompts.service.ts
+++ b/src/backend/modules/ai-tools/services/saved-prompts.service.ts
@@ -65,17 +65,25 @@ export interface ISavedPromptCreate {
     prompt: string;
     cron?: string | null;
     scheduleEnabled?: boolean;
+    /** Optional provider plugin id this prompt targets (with `model`). */
+    providerId?: string;
+    /** Optional model id the prompt runs on, within `providerId`'s catalog. */
+    model?: string;
 }
 
 /**
  * Input shape for update operations. All fields optional — omitted fields
- * preserve their existing values. `cron: null` or `''` clears the schedule.
+ * preserve their existing values. `cron: null` or `''` clears the schedule;
+ * `providerId`/`model` set to `null` or `''` clear the model pin (the prompt
+ * reverts to running on the active provider's default model).
  */
 export interface ISavedPromptUpdate {
     name?: string;
     prompt?: string;
     cron?: string | null;
     scheduleEnabled?: boolean;
+    providerId?: string | null;
+    model?: string | null;
 }
 
 /**
@@ -191,6 +199,18 @@ export class SavedPromptsService {
             created.scheduleAnchorAt = now;
         }
 
+        // A model pin is optional and provider-scoped: both fields travel
+        // together so a scheduled run can route to the right provider even when
+        // it is not the active one. Attach only when both are real strings.
+        const providerId = typeof input.providerId === 'string' ? input.providerId.trim() : '';
+        const model = typeof input.model === 'string' ? input.model.trim() : '';
+        if (providerId) {
+            created.providerId = providerId;
+        }
+        if (model) {
+            created.model = model;
+        }
+
         const collection = this.database.getCollection<ISavedPrompt>(COLLECTION);
         // The unique-name index is the real guard; assertNameUnique above is a
         // fast path. Two concurrent creates of the same name both pass the
@@ -280,12 +300,43 @@ export class SavedPromptsService {
             }
         }
 
+        // Model pin: a non-empty string sets the field; null or '' clears it via
+        // `$unset` (the prompt reverts to the active provider's default model).
+        // Unlike cron, absence and cleared carry no distinct meaning, so unset is
+        // cleaner than persisting an empty value. providerId and model are
+        // independent fields but the editor always sends both together.
+        const unsetFields: Record<string, ''> = {};
+        if (input.providerId !== undefined) {
+            const trimmed = typeof input.providerId === 'string' ? input.providerId.trim() : '';
+            if (trimmed) {
+                setFields.providerId = trimmed;
+            } else {
+                unsetFields.providerId = '';
+            }
+        }
+        if (input.model !== undefined) {
+            const trimmed = typeof input.model === 'string' ? input.model.trim() : '';
+            if (trimmed) {
+                setFields.model = trimmed;
+            } else {
+                unsetFields.model = '';
+            }
+        }
+
         const collection = this.database.getCollection<ISavedPrompt>(COLLECTION);
 
         // Single atomic operation: update + return the post-image in one
         // round-trip. Removes both the previous extra read AND a tiny race
         // window where a concurrent write could have landed between the
         // updateOne and the re-fetch.
+        // Combine the field writes with any model-pin clears into one atomic
+        // update document. `$unset` is only included when there is something to
+        // clear, since Mongo rejects an empty `$unset`.
+        const updateDoc: Record<string, unknown> = { $set: setFields };
+        if (Object.keys(unsetFields).length > 0) {
+            updateDoc.$unset = unsetFields;
+        }
+
         let updated: ISavedPrompt | null;
         try {
             updated = await collection.findOneAndUpdate(
@@ -293,7 +344,7 @@ export class SavedPromptsService {
                 // Mongo operator object — equality-by-id on an admin route,
                 // never injectable.
                 { id: String(id) },
-                { $set: setFields },
+                updateDoc,
                 { returnDocument: 'after' }
             ) as ISavedPrompt | null;
         } catch (error: unknown) {

--- a/src/backend/modules/ai-tools/services/scheduled-prompts-runner.ts
+++ b/src/backend/modules/ai-tools/services/scheduled-prompts-runner.ts
@@ -6,15 +6,23 @@
  * run. Extracted from the module so the logic can be unit-tested against mock
  * services without booting the application.
  *
- * Execution is provider-neutral: the module's scheduler handler resolves the
- * active provider from the core `'ai-providers'` registry (`getActive()`) and
- * passes it in. A scheduled run is autonomous — there is no human present — so
- * it fires through the public `query({ mode: 'programmatic' })` path, which the
- * provider attributes as `triggerPath: 'programmatic'` / `actor: system`. The
- * governor's external-tool default-deny keys on `triggerPath !== 'interactive'`,
- * so unattended runs get the same protection a dedicated `'scheduled'` path
- * would; the public contract deliberately carries no trigger field, which keeps
- * any caller from claiming `interactive` to dodge that default-deny.
+ * Execution is provider-neutral and per-prompt: the module's scheduler handler
+ * passes a resolver that maps a prompt's optional `providerId` to an executable
+ * provider from the core `'ai-providers'` registry — a pinned prompt routes to
+ * its specific provider (`getProvider(id)`) even when that is not the active
+ * one, and an unpinned prompt falls back to the active provider (`getActive()`).
+ * This is why a saved prompt records both `providerId` and `model`: models span
+ * providers, so the model alone cannot say which transport to run on. A prompt
+ * whose pinned provider is not installed is recorded as a failed run (surfacing
+ * the reason and accumulating toward auto-pause), never silently skipped.
+ *
+ * A scheduled run is autonomous — there is no human present — so it fires
+ * through the public `query({ mode: 'programmatic' })` path, which the provider
+ * attributes as `triggerPath: 'programmatic'` / `actor: system`. The governor's
+ * external-tool default-deny keys on `triggerPath !== 'interactive'`, so
+ * unattended runs get the same protection a dedicated `'scheduled'` path would;
+ * the public contract deliberately carries no trigger field, which keeps any
+ * caller from claiming `interactive` to dodge that default-deny.
  */
 // cron-parser v4 is a CommonJS module whose named exports Node 20's ESM loader
 // cannot synthesize; default-import + destructure is the pattern Node itself
@@ -25,13 +33,21 @@ import type { IAiQueryOptions, ISystemLogService } from '@/types';
 import type { SavedPromptsService } from './saved-prompts.service.js';
 
 /**
- * Minimum contract the runner needs from the active AI provider. Declared here
- * rather than importing the full `IAiProvider` so tests can pass a plain mock
- * with a single `query` method. `IAiProvider` satisfies it structurally.
+ * Minimum contract the runner needs from an AI provider. Declared here rather
+ * than importing the full `IAiProvider` so tests can pass a plain mock with a
+ * single `query` method. `IAiProvider` satisfies it structurally.
  */
 export interface IScheduledPromptRunner {
     query(options: IAiQueryOptions): Promise<unknown>;
 }
+
+/**
+ * Resolves a prompt's optional `providerId` to an executable provider. The
+ * module supplies `(id) => id ? registry.getProvider(id) : registry.getActive()`.
+ * Returns `null` when the pinned provider is not installed (or, for an unpinned
+ * prompt, when no provider is active), which the runner records as a failed run.
+ */
+export type ScheduledPromptProviderResolver = (providerId?: string) => IScheduledPromptRunner | null;
 
 /**
  * Fire all due scheduled prompts and persist updated run metadata.
@@ -46,12 +62,13 @@ export interface IScheduledPromptRunner {
  *
  * @param savedPrompts - Service owning the prompts collection.
  * @param logger - Logger for warnings and error context.
- * @param provider - Active AI provider used to execute each due prompt.
+ * @param resolveProvider - Maps a prompt's optional `providerId` to the provider
+ *        that should run it (pinned provider, or the active one when unpinned).
  */
 export async function runScheduledPrompts(
     savedPrompts: SavedPromptsService,
     logger: ISystemLogService,
-    provider: IScheduledPromptRunner
+    resolveProvider: ScheduledPromptProviderResolver
 ): Promise<void> {
     const scheduled = await savedPrompts.listScheduled();
 
@@ -120,15 +137,39 @@ export async function runScheduledPrompts(
             continue;
         }
 
+        // Resolve the provider this prompt should run on. A pinned prompt routes
+        // to its own provider even when inactive; an unpinned one uses the active
+        // provider. A null result (pinned provider not installed, or no active
+        // provider) is recorded as a failed run so the admin sees why it didn't
+        // fire — the run is already claimed, so this never double-fires.
+        const provider = resolveProvider(p.providerId);
+        if (!provider) {
+            const reason = p.providerId
+                ? `AI provider "${p.providerId}" is not installed or enabled`
+                : 'No active AI provider is installed';
+            logger.warn({ promptId: p.id, name: p.name, providerId: p.providerId }, `Scheduled prompt skipped: ${reason}`);
+            try {
+                const { disabled } = await savedPrompts.recordRunFailure(p.id, claimedAt, reason);
+                if (disabled) {
+                    logger.error({ promptId: p.id, name: p.name }, 'Scheduled prompt auto-paused after consecutive failures');
+                }
+            } catch (writeErr) {
+                logger.warn({ err: writeErr, promptId: p.id, name: p.name }, 'Failed to persist scheduled-prompt provider-unavailable error');
+            }
+            continue;
+        }
+
         try {
             logger.info(
-                { promptId: p.id, name: p.name, cron: p.cron },
+                { promptId: p.id, name: p.name, cron: p.cron, providerId: p.providerId, model: p.model },
                 'Running scheduled prompt'
             );
             // Autonomous run → programmatic mode. The provider derives
             // triggerPath: 'programmatic' / actor: system from this, so the
             // governor's external-tool default-deny applies (no human present).
-            await provider.query({ prompt: p.prompt, mode: 'programmatic' });
+            // `model` is the optional per-query override (undefined → provider's
+            // configured default).
+            await provider.query({ prompt: p.prompt, model: p.model, mode: 'programmatic' });
             // Success ends any failure streak so intermittent errors never
             // accumulate toward the auto-pause threshold. Best-effort.
             try {

--- a/src/backend/modules/ai-tools/services/tool-audit-store.ts
+++ b/src/backend/modules/ai-tools/services/tool-audit-store.ts
@@ -43,6 +43,21 @@ export interface IToolInvocationPage {
 }
 
 /**
+ * Per-tool usage tally derived from the persistent audit trail. Matches the
+ * shape the Policy tab renders. `rateLimited` is not separable from the audit
+ * (a rate-limit denial is recorded with `status: 'denied'`, not its own status),
+ * so it is always 0 here — kept for shape compatibility with the live
+ * policy-engine counters.
+ */
+export interface IToolUsageTally {
+    invocations: number;
+    allowed: number;
+    denied: number;
+    rateLimited: number;
+    needsApproval: number;
+}
+
+/**
  * Persists and queries {@link IToolInvocationRecord} documents.
  */
 export class ToolAuditStore {
@@ -136,6 +151,53 @@ export class ToolAuditStore {
      */
     async getById(id: string): Promise<IToolInvocationRecord | null> {
         return this.database.findOne<IToolInvocationRecord>(COLLECTION, { id });
+    }
+
+    /**
+     * Aggregate per-tool usage tallies from the persistent invocation trail.
+     *
+     * The Policy tab's "Usage" column previously read the policy engine's
+     * in-memory counters, which reset to empty on every server restart — so a
+     * freshly-restarted process showed "no activity" for every tool regardless
+     * of history. This counts the durable audit records instead, grouped by tool
+     * and status, so the column reflects real cumulative activity across the
+     * retention window (90 days) and survives restarts. A single grouped
+     * aggregation keeps it to one round-trip regardless of tool count.
+     *
+     * @returns Tally per tool name; tools with no recorded calls are absent.
+     */
+    async aggregateUsage(): Promise<Record<string, IToolUsageTally>> {
+        const collection = this.database.getCollection<IToolInvocationRecord>(COLLECTION);
+        const rows = await collection
+            .aggregate<{ _id: { tool: string; status: ToolInvocationStatus }; count: number }>([
+                { $group: { _id: { tool: '$toolName', status: '$status' }, count: { $sum: 1 } } }
+            ])
+            .toArray();
+
+        const out: Record<string, IToolUsageTally> = {};
+        for (const row of rows) {
+            const tool = row._id?.tool;
+            if (!tool) {
+                continue;
+            }
+            const tally = (out[tool] ??= { invocations: 0, allowed: 0, denied: 0, rateLimited: 0, needsApproval: 0 });
+            tally.invocations += row.count;
+            switch (row._id.status) {
+                case 'ok':
+                    tally.allowed += row.count;
+                    break;
+                case 'denied':
+                    tally.denied += row.count;
+                    break;
+                case 'pending-approval':
+                    tally.needsApproval += row.count;
+                    break;
+                default:
+                    // 'error' contributes to the invocation total only.
+                    break;
+            }
+        }
+        return out;
     }
 
     /**

--- a/src/frontend/app/(core)/system/ai-tools/page.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/page.module.scss
@@ -102,6 +102,17 @@
     flex-wrap: wrap;
 }
 
+/* Spinner for inline busy icon buttons (e.g. saving a policy override). */
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.spin {
+    animation: spin 1s linear infinite;
+}
+
 /* Empty / loading placeholder text. */
 .placeholder {
     padding: var(--padding-lg);

--- a/src/frontend/app/(core)/system/ai-tools/tabs/ActivityTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/ActivityTab.tsx
@@ -12,6 +12,7 @@ import { RefreshCw } from 'lucide-react';
 import type { IToolInvocationRecord, ToolInvocationStatus, ToolTriggerPath } from '@/types';
 import { Stack } from '../../../../../components/layout';
 import { Button } from '../../../../../components/ui/Button';
+import { Select } from '../../../../../components/ui/Select';
 import { Badge } from '../../../../../components/ui/Badge';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
@@ -74,19 +75,19 @@ export function ActivityTab() {
     return (
         <Stack gap="md">
             <div className={styles.filters}>
-                <select className={styles.filter_select} value={status} onChange={(e) => setStatus(e.target.value as ToolInvocationStatus | '')} aria-label="Filter by status">
+                <Select value={status} onChange={(e) => setStatus(e.target.value as ToolInvocationStatus | '')} aria-label="Filter by status">
                     <option value="">All statuses</option>
                     <option value="ok">ok</option>
                     <option value="denied">denied</option>
                     <option value="pending-approval">pending-approval</option>
                     <option value="error">error</option>
-                </select>
-                <select className={styles.filter_select} value={triggerPath} onChange={(e) => setTriggerPath(e.target.value as ToolTriggerPath | '')} aria-label="Filter by trigger path">
+                </Select>
+                <Select value={triggerPath} onChange={(e) => setTriggerPath(e.target.value as ToolTriggerPath | '')} aria-label="Filter by trigger path">
                     <option value="">All triggers</option>
                     <option value="interactive">interactive</option>
                     <option value="scheduled">scheduled</option>
                     <option value="programmatic">programmatic</option>
-                </select>
+                </Select>
                 <Button variant="ghost" size="sm" onClick={() => { void load(); }}>
                     <RefreshCw size={16} /> Refresh
                 </Button>

--- a/src/frontend/app/(core)/system/ai-tools/tabs/PolicyTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/PolicyTab.tsx
@@ -9,10 +9,12 @@
  */
 
 import { useEffect, useState, useCallback } from 'react';
+import { Save, RotateCcw, Loader2 } from 'lucide-react';
 import type { IAiToolInfo, IToolPolicy } from '@/types';
 import { Stack } from '../../../../../components/layout';
-import { Button } from '../../../../../components/ui/Button';
 import { Input } from '../../../../../components/ui/Input';
+import { Select } from '../../../../../components/ui/Select';
+import { IconButton } from '../../../../../components/ui/IconButton';
 import { Badge } from '../../../../../components/ui/Badge';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
 import { useToast } from '../../../../../components/ui/ToastProvider';
@@ -93,6 +95,12 @@ function PolicyRow({ tool, override, usage, defaults, onSaved }: {
     // (from GET /policy), not a re-derivation here.
     const approvalDefaultLabel = defaults ? `Default (${defaults.requireApproval ? 'On' : 'Off'})` : 'Default';
     const unattendedDefaultLabel = defaults ? `Default (${defaults.allowUnattended ? 'On' : 'Off'})` : 'Default';
+    // Curation has no per-tool entry in GET /policy `defaults` because the
+    // governor's derived default for any curation-capable tool is always
+    // `require`. Label the inherited option with that resolved value so the
+    // curation dropdown reads the same way as the approval/unattended ones,
+    // rather than the opaque bare "Default".
+    const curationDefaultLabel = 'Default (Require)';
 
     // Pending edits relative to the saved override. Save stays disabled until a
     // field actually changes, so a long tool list doesn't present a column of
@@ -163,8 +171,8 @@ function PolicyRow({ tool, override, usage, defaults, onSaved }: {
                 {usage ? `${usage.invocations} calls · ${usage.denied} denied · ${usage.needsApproval} held` : 'no activity'}
             </Td>
             <Td>
-                <select
-                    className={`${styles.filter_select} ${styles.cell_control}`}
+                <Select
+                    className={styles.cell_control}
                     value={requireApproval}
                     onChange={(e) => setRequireApproval(e.target.value as TriState)}
                     aria-label={`Require approval for ${tool.name}`}
@@ -172,11 +180,11 @@ function PolicyRow({ tool, override, usage, defaults, onSaved }: {
                     <option value="inherit">{approvalDefaultLabel}</option>
                     <option value="on">On</option>
                     <option value="off">Off</option>
-                </select>
+                </Select>
             </Td>
             <Td>
-                <select
-                    className={`${styles.filter_select} ${styles.cell_control}`}
+                <Select
+                    className={styles.cell_control}
                     value={allowUnattended}
                     onChange={(e) => setAllowUnattended(e.target.value as TriState)}
                     aria-label={`Allow unattended runs for ${tool.name}`}
@@ -184,20 +192,20 @@ function PolicyRow({ tool, override, usage, defaults, onSaved }: {
                     <option value="inherit">{unattendedDefaultLabel}</option>
                     <option value="on">On</option>
                     <option value="off">Off</option>
-                </select>
+                </Select>
             </Td>
             <Td>
                 {curationCapable ? (
-                    <select
-                        className={`${styles.filter_select} ${styles.cell_control}`}
+                    <Select
+                        className={styles.cell_control}
                         value={curation}
                         onChange={(e) => setCuration(e.target.value as CurationMode)}
                         aria-label={`Curation handling for ${tool.name}`}
                     >
-                        <option value="inherit">Default</option>
+                        <option value="inherit">{curationDefaultLabel}</option>
                         <option value="require">Require</option>
                         <option value="auto-approve">Auto-approve</option>
-                    </select>
+                    </Select>
                 ) : (
                     <span className="text-subtle">—</span>
                 )}
@@ -210,8 +218,26 @@ function PolicyRow({ tool, override, usage, defaults, onSaved }: {
             </Td>
             <Td>
                 <div className={styles.row_actions}>
-                    <Button variant="primary" size="sm" loading={busy} disabled={busy || !dirty} onClick={() => { void save(); }}>Save</Button>
-                    <Button variant="ghost" size="sm" disabled={busy || !hasOverride} onClick={() => { void clear(); }}>Clear</Button>
+                    <IconButton
+                        variant="success"
+                        size="sm"
+                        disabled={busy || !dirty}
+                        onClick={() => { void save(); }}
+                        aria-label={`Save override for ${tool.name}`}
+                        title="Save override"
+                    >
+                        {busy ? <Loader2 size={16} className={styles.spin} /> : <Save size={16} />}
+                    </IconButton>
+                    <IconButton
+                        variant="danger"
+                        size="sm"
+                        disabled={busy || !hasOverride}
+                        onClick={() => { void clear(); }}
+                        aria-label={`Clear override for ${tool.name}`}
+                        title="Clear override (revert to class defaults)"
+                    >
+                        <RotateCcw size={16} />
+                    </IconButton>
                 </div>
             </Td>
         </Tr>
@@ -276,11 +302,11 @@ export function PolicyTab() {
                 re-arms the lethal-trifecta banner for that tool. Tools that don&apos;t self-curate show “—”.
             </p>
             <div className="table-scroll">
-                <Table stickyHeader>
+                <Table>
                     <Thead>
                         <Tr>
                             <Th width="shrink" title="Registered tool name; the “override” badge marks a custom policy.">Tool</Th>
-                            <Th width="shrink" title="Calls, denials, and held counts since the last server start.">Usage</Th>
+                            <Th width="shrink" title="Calls, denials, and held counts from the audit trail over the last 90 days.">Usage</Th>
                             <Th title="Hold every call for human approval before it runs. On = held; Off = runs without approval.">Require approval</Th>
                             <Th title="Whether the tool may run on autonomous (scheduled / programmatic) paths. On = allowed; Off = blocked.">Allow unattended</Th>
                             <Th title="How a self-curating tool releases effects: require review, or auto-approve.">Curation</Th>

--- a/src/frontend/app/(core)/system/ai-tools/tabs/PromptEditModal.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/PromptEditModal.tsx
@@ -16,8 +16,9 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { Save, Clock, AlertCircle, CheckCircle } from 'lucide-react';
 import type { ISavedPrompt } from '@/types';
 import { Button } from '../../../../../components/ui/Button';
+import { Select } from '../../../../../components/ui/Select';
 import { Switch } from '../../../../../components/ui/Switch';
-import { saveSavedPrompt } from '../../../../../modules/ai-tools';
+import { saveSavedPrompt, getQueryProviders, type IAiProviderModels } from '../../../../../modules/ai-tools';
 import {
     CRON_PRESETS,
     describeCron,
@@ -50,12 +51,38 @@ interface PromptEditModalProps {
 export function PromptEditModal({ prompt, onSaved, onError }: PromptEditModalProps) {
     const [nameDraft, setNameDraft] = useState(prompt.name);
     const [bodyDraft, setBodyDraft] = useState(prompt.prompt);
+    // The model pin encodes both provider and model as `providerId|model` so a
+    // single picker value carries which transport to route a scheduled run to —
+    // models span providers, so the model id alone is ambiguous. Empty means
+    // "active provider, default model".
+    const [modelDraft, setModelDraft] = useState<string>(
+        prompt.providerId && prompt.model ? `${prompt.providerId}|${prompt.model}` : ''
+    );
+    const [providers, setProviders] = useState<IAiProviderModels[]>([]);
     const [scheduleDraft, setScheduleDraft] = useState<{ cron: string; enabled: boolean }>({
         cron: prompt.cron ?? '',
         enabled: prompt.scheduleEnabled !== false
     });
     const [bodySaving, setBodySaving] = useState(false);
     const [scheduleSaving, setScheduleSaving] = useState(false);
+
+    // Load the model catalog across every registered provider for the picker.
+    // Secondary data on a click-mounted surface, so a loading gap and a quiet
+    // failure (picker shows only "Default") are both acceptable.
+    useEffect(() => {
+        let cancelled = false;
+        void (async () => {
+            try {
+                const list = await getQueryProviders();
+                if (!cancelled) {
+                    setProviders(list);
+                }
+            } catch {
+                /* picker falls back to the Default option only */
+            }
+        })();
+        return () => { cancelled = true; };
+    }, []);
 
     // Per-30s tick drives the "next run in Xm" countdown without a manual
     // refresh: fast enough to feel live, slow enough to stay jank-free.
@@ -87,15 +114,22 @@ export function PromptEditModal({ prompt, onSaved, onError }: PromptEditModalPro
         if (!trimmedName || !trimmedBody) {
             return;
         }
+        // Split the encoded picker value back into provider + model. Empty draft
+        // sends `null` for both, clearing any existing pin (revert to the active
+        // provider's default model). The model lives in this section, so it is
+        // saved with name + body.
+        const sep = modelDraft.indexOf('|');
+        const providerId = sep >= 0 ? modelDraft.slice(0, sep) : null;
+        const model = sep >= 0 ? modelDraft.slice(sep + 1) : null;
         setBodySaving(true);
         try {
-            onSaved(await saveSavedPrompt({ id: prompt.id, name: trimmedName, prompt: trimmedBody }));
+            onSaved(await saveSavedPrompt({ id: prompt.id, name: trimmedName, prompt: trimmedBody, providerId, model }));
         } catch (err) {
             onError(err instanceof Error ? err.message : 'Failed to update prompt');
         } finally {
             setBodySaving(false);
         }
-    }, [prompt.id, nameDraft, bodyDraft, onSaved, onError]);
+    }, [prompt.id, nameDraft, bodyDraft, modelDraft, onSaved, onError]);
 
     /**
      * Persist schedule edits. Name/body fields are omitted so a schedule save
@@ -138,6 +172,29 @@ export function PromptEditModal({ prompt, onSaved, onError }: PromptEditModalPro
                     rows={8}
                     aria-label="Prompt body"
                 />
+                <label className={styles.field_label} htmlFor={`prompt-model-${prompt.id}`}>Model</label>
+                <Select
+                    id={`prompt-model-${prompt.id}`}
+                    className={styles.model_select}
+                    value={modelDraft}
+                    onChange={(e) => setModelDraft(e.target.value)}
+                    aria-label="Model for this prompt"
+                >
+                    <option value="">Default — active provider, default model</option>
+                    {providers.map(provider => (
+                        <optgroup key={provider.id} label={provider.active ? `${provider.label} (active)` : provider.label}>
+                            {provider.models.map(model => (
+                                <option key={`${provider.id}|${model.id}`} value={`${provider.id}|${model.id}`}>
+                                    {model.display_name}
+                                </option>
+                            ))}
+                        </optgroup>
+                    ))}
+                </Select>
+                <p className={styles.field_hint}>
+                    Used when this prompt runs on a schedule. Pinning a model also pins its provider, so the
+                    scheduled run uses that provider even if another is active.
+                </p>
                 <div className={styles.edit_actions}>
                     <Button
                         variant="primary"

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
@@ -103,6 +103,13 @@
     gap: var(--gap-sm);
 }
 
+/* Running conversation cost estimate beside the "Conversation" label. */
+.conversation_cost {
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-muted);
+}
+
 .streaming_indicator {
     display: flex;
     align-items: center;
@@ -231,6 +238,12 @@
     gap: var(--gap-xs);
     font-size: var(--font-size-caption);
     color: var(--color-text-muted);
+}
+
+/* Per-turn estimated cost — slightly emphasized within the muted usage line. */
+.turn_cost {
+    color: var(--color-text);
+    font-weight: var(--font-weight-medium);
 }
 
 .turn_error {
@@ -442,24 +455,11 @@
     }
 }
 
-/* Per-query model override dropdown, matched to the dashboard filter selects. */
+/* Per-query model override dropdown. Theming comes from the shared <Select>
+ * primitive; this only caps the width in the composer toolbar (the class lands
+ * on the Select wrapper). */
 .model_select {
-    background: var(--input-background);
-    color: var(--color-text);
-    border: var(--input-border);
-    border-radius: var(--input-border-radius);
-    padding: var(--input-padding-sm);
-    font-size: var(--font-size-body-sm);
     max-width: var(--max-width-xs);
-
-    &:focus-visible {
-        @include focus-outline;
-    }
-
-    option {
-        background: var(--color-surface-accent);
-        color: var(--color-text);
-    }
 }
 
 /*

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
@@ -25,6 +25,7 @@ import type { IAiConversationMessage, IAiQueryRecord, IAiStreamChunk, IModelInfo
 import { Stack } from '../../../../../components/layout';
 import { Card } from '../../../../../components/ui/Card';
 import { Button } from '../../../../../components/ui/Button';
+import { Select } from '../../../../../components/ui/Select';
 import { Badge } from '../../../../../components/ui/Badge';
 import { IconButton } from '../../../../../components/ui/IconButton';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
@@ -78,6 +79,13 @@ interface ChatTurn {
     error?: string | null;
     model?: string;
     usage?: IAiStreamChunk['usage'] | null;
+    /**
+     * Provider-estimated USD cost of this turn, captured from the terminal
+     * `done` chunk (or a reopened history record). `null`/absent when the
+     * provider could not price it; the provider owns the rate card, so core
+     * only displays the number it is handed.
+     */
+    costUsd?: number | null;
 }
 
 /** A run of consecutive history records sharing one `conversationId`. */
@@ -166,6 +174,32 @@ function groupConversations(records: IAiQueryRecord[]): ConversationGroup[] {
         }
     }
     return order.map(id => byId.get(id) as ConversationGroup);
+}
+
+/**
+ * Format a provider-estimated USD cost for display, with precision that stays
+ * useful at the sub-cent scale of a single turn while staying readable at the
+ * dollar scale of a whole conversation. Mirrors the provider's own formatting so
+ * the core Query tab reads identically to the plugin's query tool. The provider
+ * computes the figure (it owns the rate card); core only renders it.
+ *
+ * @param amount - Cost in USD, or null/undefined when the turn was not priced.
+ * @returns A display string (e.g. '$0.0042', '<$0.0001', '$1.27'), or '—'.
+ */
+function formatUsd(amount: number | null | undefined): string {
+    if (amount === null || amount === undefined || Number.isNaN(amount)) {
+        return '—';
+    }
+    if (amount <= 0) {
+        return '$0.00';
+    }
+    if (amount < 0.0001) {
+        return '<$0.0001';
+    }
+    if (amount < 1) {
+        return `$${amount.toFixed(4)}`;
+    }
+    return `$${amount.toFixed(2)}`;
 }
 
 /**
@@ -272,7 +306,7 @@ export function QueryTab() {
             updateTurn(turnId, turn => ({ content: turn.content + text }));
         } else if (chunk.type === 'done') {
             setStreaming(false);
-            updateTurn(turnId, { pending: false, usage: chunk.usage ?? null });
+            updateTurn(turnId, { pending: false, usage: chunk.usage ?? null, costUsd: chunk.costUsd ?? null });
             streamingTurnIdRef.current = null;
             activeQueryIdRef.current = null;
         } else if (chunk.type === 'error') {
@@ -498,6 +532,7 @@ export function QueryTab() {
                     content: record.responseText ?? '',
                     model: record.model,
                     usage: record.usage,
+                    costUsd: record.costUsd ?? null,
                     error: record.responseText ? null : (record.errorMessage ?? 'No response recorded')
                 });
             }
@@ -532,6 +567,20 @@ export function QueryTab() {
         () => new Map(models.map(model => [model.id, model.display_name])),
         [models]
     );
+    // Running conversation cost: sum every priced turn. `null` when not a single
+    // turn could be priced, so the header hides the figure rather than showing
+    // a misleading $0.00 (mirrors the provider's own sum-or-hide behavior).
+    const conversationCost = useMemo(() => {
+        let total = 0;
+        let priced = false;
+        for (const turn of messages) {
+            if (typeof turn.costUsd === 'number') {
+                total += turn.costUsd;
+                priced = true;
+            }
+        }
+        return priced ? total : null;
+    }, [messages]);
 
     return (
         <div className={styles.query}>
@@ -576,6 +625,14 @@ export function QueryTab() {
                     <div className={styles.chat_header}>
                         <Bot size={16} className={styles.chat_header_icon} />
                         <span className={styles.chat_header_label}>Conversation</span>
+                        {conversationCost != null && (
+                            <span
+                                className={styles.conversation_cost}
+                                title="Estimated total cost of this conversation, summed across turns at the provider's per-model rates."
+                            >
+                                ≈ {formatUsd(conversationCost)}
+                            </span>
+                        )}
                         {streaming && (
                             <span className={styles.streaming_indicator}>
                                 <span className={styles.streaming_dot} aria-hidden="true" />
@@ -660,6 +717,9 @@ export function QueryTab() {
                                                     {turn.model && (
                                                         <span> · {modelLabel.get(turn.model) ?? turn.model}</span>
                                                     )}
+                                                    {turn.costUsd != null && (
+                                                        <span className={styles.turn_cost}> · ≈ {formatUsd(turn.costUsd)}</span>
+                                                    )}
                                                 </div>
                                             )}
                                         </div>
@@ -690,7 +750,7 @@ export function QueryTab() {
                         />
                         <div className={styles.composer_toolbar}>
                             {models.length > 0 && (
-                                <select
+                                <Select
                                     value={modelOverride}
                                     onChange={(e) => setModelOverride(e.target.value)}
                                     className={styles.model_select}
@@ -701,7 +761,7 @@ export function QueryTab() {
                                     {models.map(model => (
                                         <option key={model.id} value={model.id}>{model.display_name}</option>
                                     ))}
-                                </select>
+                                </Select>
                             )}
                             <div className={styles.composer_send}>
                                 {streaming ? (

--- a/src/frontend/app/(core)/system/ai-tools/tabs/SavedPromptsPanel.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/SavedPromptsPanel.module.scss
@@ -274,6 +274,18 @@
     color: var(--color-text-muted);
 }
 
+/* Model picker fills the field column (class lands on the <Select> wrapper). */
+.model_select {
+    width: 100%;
+}
+
+/* Helper text under a field, explaining when/why it applies. */
+.field_hint {
+    margin: 0;
+    font-size: var(--font-size-caption);
+    color: var(--color-text-subtle);
+}
+
 .text_input,
 .cron_input,
 .textarea {

--- a/src/frontend/app/(core)/system/ai-tools/tabs/VariablesSection.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/VariablesSection.tsx
@@ -19,6 +19,7 @@ import type { AiToolSensitivity, IPromptVariableInfo } from '@/types';
 import { Stack } from '../../../../../components/layout';
 import { Badge } from '../../../../../components/ui/Badge';
 import { Button } from '../../../../../components/ui/Button';
+import { Select } from '../../../../../components/ui/Select';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
 import { useToast } from '../../../../../components/ui/ToastProvider';
 import {
@@ -205,14 +206,13 @@ export function VariablesSection({ onChanged }: { onChanged: () => void }) {
                                         aria-label="Variable content"
                                         rows={4}
                                     />
-                                    <select
-                                        className={styles.filter_select}
+                                    <Select
                                         value={form.sensitivity}
                                         onChange={e => setForm({ ...form, sensitivity: e.target.value as AiToolSensitivity })}
                                         aria-label="Variable sensitivity"
                                     >
                                         {SENSITIVITIES.map(s => <option key={s} value={s}>{s}</option>)}
-                                    </select>
+                                    </Select>
                                     <Stack gap="sm" direction="horizontal">
                                         <Button variant="primary" size="sm" onClick={() => void handleSubmit()} disabled={saving}>
                                             {saving ? 'Saving…' : editingName ? 'Save changes' : 'Create variable'}
@@ -259,15 +259,14 @@ export function VariablesSection({ onChanged }: { onChanged: () => void }) {
                                                 </Badge>
                                             </Td>
                                             <Td>
-                                                <select
-                                                    className={styles.filter_select}
+                                                <Select
                                                     value={variable.sensitivity}
                                                     onChange={e => void handleClassify(variable.name, e.target.value as AiToolSensitivity)}
                                                     disabled={busyName === variable.name}
                                                     aria-label={`Classify ${variable.name}`}
                                                 >
                                                     {SENSITIVITIES.map(s => <option key={s} value={s}>{s}</option>)}
-                                                </select>
+                                                </Select>
                                             </Td>
                                             <Td>
                                                 {variable.editable && (

--- a/src/frontend/components/ui/Select/Select.module.css
+++ b/src/frontend/components/ui/Select/Select.module.css
@@ -1,0 +1,72 @@
+/**
+ * Select Component CSS Module
+ *
+ * Scoped styles for the Select component. Restyles the native `<select>` with
+ * the shared input tokens and a chevron overlay so dropdowns match the Input
+ * primitive instead of rendering as the browser default. `appearance: none`
+ * drops the native arrow; the chevron is a non-interactive overlay.
+ */
+
+.wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    /* Intrinsic by default (filter bars); consumers pass width:100% for cells. */
+    width: auto;
+    max-width: 100%;
+}
+
+.select {
+    width: 100%;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    border-radius: var(--input-border-radius);
+    background: var(--input-background);
+    border: var(--input-border);
+    color: var(--color-text);
+    /* Comfortable padding matching Input; extra right room clears the chevron. */
+    padding: var(--input-padding);
+    padding-right: var(--padding-xl);
+    font-size: var(--input-font-size);
+    line-height: var(--line-height-normal);
+    transition: var(--input-transition);
+    cursor: pointer;
+}
+
+/* Keyboard-only focus ring (mouse clicks should not leave a lingering ring). */
+.select:focus-visible {
+    outline: none;
+    border-color: var(--input-border-focus);
+    box-shadow: var(--input-shadow-focus);
+}
+
+.select:disabled {
+    opacity: var(--opacity-55);
+    cursor: not-allowed;
+}
+
+/*
+ * The option list is OS-rendered; color-scheme: dark (set globally in
+ * primitives.scss) already paints it dark. These keep the values legible in
+ * browsers that honor option styling without fighting the native popup.
+ */
+.select option,
+.select optgroup {
+    color: var(--color-text);
+    background: var(--color-surface-accent);
+}
+
+/* Chevron overlay — non-interactive so clicks fall through to the select. */
+.chevron {
+    position: absolute;
+    right: var(--gap-md);
+    pointer-events: none;
+    color: var(--color-text-muted);
+}
+
+/* Variant: Ghost — transparent for darker surfaces / inline contexts. */
+.select--ghost {
+    background: var(--input-ghost-background);
+    border-color: var(--input-ghost-border);
+}

--- a/src/frontend/components/ui/Select/Select.tsx
+++ b/src/frontend/components/ui/Select/Select.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import type { SelectHTMLAttributes } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { cn } from '../../../lib/cn';
+import styles from './Select.module.css';
+
+/**
+ * SelectProps defines the properties available for the Select component.
+ *
+ * Extends standard select attributes with a visual variant, mirroring the
+ * Input primitive so dropdowns and text inputs stay visually consistent.
+ */
+export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+    /**
+     * Visual style variant.
+     * @default 'default'
+     */
+    variant?: 'default' | 'ghost';
+}
+
+/**
+ * Select Component
+ *
+ * A themed dropdown that replaces the bare native `<select>` used ad-hoc across
+ * admin surfaces. The native control renders inconsistently and too small for
+ * the rest of the design system; this wraps it with the shared input tokens
+ * (`--input-padding`, `--input-background`, `--input-border`, focus ring) and a
+ * Lucide chevron so every dropdown matches Input, Button, and Badge. The native
+ * `<select>` is preserved underneath for full keyboard, accessibility, and
+ * mobile-picker behavior — only its appearance is restyled.
+ *
+ * Pass `<option>` / `<optgroup>` children as usual. The default width is
+ * intrinsic (sized to the selected option), suiting inline filter bars. To make
+ * it fill its container — e.g. a table cell — pass a `width: 100%` class via
+ * `className`, which forwards to the wrapper (the layout-controlling element).
+ *
+ * @example
+ * ```tsx
+ * <Select value={mode} onChange={(e) => setMode(e.target.value)} aria-label="Mode">
+ *     <option value="a">Option A</option>
+ *     <option value="b">Option B</option>
+ * </Select>
+ * ```
+ *
+ * @param props - Select properties including variant and standard select attributes.
+ * @returns A styled select element wrapped with a chevron affordance.
+ */
+export function Select({ className, variant = 'default', children, ...props }: SelectProps) {
+    return (
+        <span className={cn(styles.wrapper, className)}>
+            <select
+                className={cn(styles.select, variant === 'ghost' && styles['select--ghost'])}
+                {...props}
+            >
+                {children}
+            </select>
+            <ChevronDown className={styles.chevron} size={16} aria-hidden="true" />
+        </span>
+    );
+}

--- a/src/frontend/components/ui/Select/index.ts
+++ b/src/frontend/components/ui/Select/index.ts
@@ -1,0 +1,2 @@
+export { Select } from './Select';
+export type { SelectProps } from './Select';

--- a/src/frontend/modules/ai-tools/api/client.ts
+++ b/src/frontend/modules/ai-tools/api/client.ts
@@ -506,6 +506,34 @@ export async function getQueryModels(): Promise<IModelInfo[]> {
     return data.models;
 }
 
+/** One registered AI provider plus its model catalog, for the model picker. */
+export interface IAiProviderModels {
+    /** Provider plugin id (stored on a saved prompt's `providerId`). */
+    id: string;
+    /** Human-readable provider/vendor name for the picker's group label. */
+    label: string;
+    /** Whether this is the active transport. */
+    active: boolean;
+    /** Models this provider exposes; empty when its catalog could not be loaded. */
+    models: IModelInfo[];
+}
+
+/**
+ * List every registered AI provider with its model catalog, for the
+ * cross-provider saved-prompt model picker. Unlike {@link getQueryModels} (active
+ * provider only), this spans all providers so a prompt can pin a model on a
+ * non-active provider. Resolves to an empty array when none are installed.
+ *
+ * @returns Each provider with its models.
+ */
+export async function getQueryProviders(): Promise<IAiProviderModels[]> {
+    const data = await parse<{ providers: IAiProviderModels[] }>(
+        await fetch(`${BASE}/query/providers`),
+        'load query providers'
+    );
+    return data.providers;
+}
+
 /** Body for {@link saveSavedPrompt}. Omit `id` to create; supply it to update. */
 export interface ISavePromptRequest {
     id?: string;
@@ -514,6 +542,10 @@ export interface ISavePromptRequest {
     /** Cron expression; `''`/`null` clears the schedule. Omit to leave unchanged. */
     cron?: string | null;
     scheduleEnabled?: boolean;
+    /** Provider plugin id the prompt targets; `''`/`null` clears the pin. Omit to leave unchanged. */
+    providerId?: string | null;
+    /** Model id the prompt runs on; `''`/`null` clears the pin. Omit to leave unchanged. */
+    model?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Three related enhancements to the AI tools module.

**Provider/model pinning for saved prompts.** `ISavedPrompt` gains optional `providerId` and `model` fields. A scheduled run resolves the pinned provider from the core `'ai-providers'` registry by id and executes against it, rather than whatever transport happens to be active at run time — so a prompt pinned to a model keeps running on that model's provider even after the active transport changes. Backed by a new `IAiProviderRegistry.getProvider(id)` (resolves any registered provider by id, returns `null` for unknown rather than falling back to active) and a `GET /query/providers` admin endpoint.

**Per-query USD cost.** The provider prices each turn from its own per-model rate card and core forwards the figure vendor-neutrally as `costUsd` on the stream `done` chunk, the query result, and the persisted query record. A reopened conversation shows the same cost the live stream did instead of re-deriving against rates that may have changed.

**Shared `Select` primitive.** New `components/ui/Select` restyles the native `<select>` with the shared input design tokens and a Lucide chevron, replacing the bare native controls used ad-hoc across admin surfaces while preserving full keyboard/accessibility/mobile-picker behavior.

Frontend Query, Policy, and Prompt-edit surfaces updated to use the new provider/model picker, cost display, and Select primitive.