### PR TITLE
feat(ai-tools): own built-in prompt variables in core; refine admin UI

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -456,6 +456,15 @@ async function initializeCoreServices(coreDatabase: IDatabaseService): Promise<v
     BlockchainObserverService.initialize(logger.child({ module: 'blockchain-observer' }));
     SystemConfigService.initialize(logger.child({ module: 'system-config' }), coreDatabase);
 
+    // Inject the database before any BlockchainService.getInstance(). The ai-tools
+    // module resolves the singleton during bootstrapInit() to back its built-in
+    // blockchain prompt variables — earlier than the scheduler core-jobs and plugin
+    // loader that otherwise perform this injection. The constructor calls
+    // getDatabase() immediately, so without this the first getInstance() throws and
+    // the app never boots. setDependencies is idempotent (registerModel is a
+    // Map.set), so the later calls remain harmless.
+    BlockchainService.setDependencies(coreDatabase);
+
     // Chain parameters: inject database, fetch from TronGrid first (populates DB), then warm cache
     ChainParametersService.setDependencies(coreDatabase);
     const chainParamsFetcher = new ChainParametersFetcher(axios, logger, coreDatabase);

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -41,6 +41,7 @@ import { SystemConfigService } from './services/system-config/index.js';
 import { CacheService } from './services/cache.service.js';
 import { ChainParametersFetcher } from './modules/chain-parameters/chain-parameters-fetcher.js';
 import { ChainParametersService } from './modules/chain-parameters/chain-parameters.service.js';
+import { BlockchainService } from './modules/blockchain/blockchain.service.js';
 import { TransactionDetailService } from './modules/blockchain/transaction-detail.service.js';
 import { registerTransactionAiTools } from './modules/blockchain/transaction-ai-tools.js';
 import { TronGridClient } from './modules/blockchain/tron-grid.client.js';
@@ -342,7 +343,19 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     await identityModule.init(sharedDeps);
     await trafficModule.init({ ...sharedDeps, scheduler: schedulerService, clickhouse });
     await toolsModule.init(sharedDeps);
-    await aiToolsModule.init({ ...sharedDeps, scheduler: schedulerService });
+    // The ai-tools module owns the built-in dynamic prompt variables (lifted out
+    // of trp-ai-assistant), so it needs the core services those resolvers read.
+    // All are singletons wired by initializeCoreServices() above; the resolvers
+    // call them lazily at variable-expansion time.
+    await aiToolsModule.init({
+        ...sharedDeps,
+        scheduler: schedulerService,
+        blockchainService: BlockchainService.getInstance(),
+        observerRegistry: BlockchainObserverService.getInstance(),
+        chainParameters: ChainParametersService.getInstance(),
+        usdtParameters: UsdtParametersService.getInstance(),
+        systemConfig: SystemConfigService.getInstance()
+    });
 
     return {
         app,

--- a/src/backend/modules/ai-tools/AiToolsModule.ts
+++ b/src/backend/modules/ai-tools/AiToolsModule.ts
@@ -16,13 +16,19 @@
 
 import type { Express } from 'express';
 import type {
+    IBlockchainObserverService,
+    IBlockchainService,
+    ICacheService,
+    IChainParametersService,
     IDatabaseService,
     IHookRegistry,
     IMenuService,
     IModule,
     IModuleMetadata,
     ISchedulerService,
-    IServiceRegistry
+    IServiceRegistry,
+    ISystemConfigService,
+    IUsdtParametersService
 } from '@/types';
 import { logger } from '../../lib/logger.js';
 import { getRedisClient } from '../../loaders/redis.js';
@@ -39,6 +45,7 @@ import { CurationQueue } from './services/curation-queue.js';
 import { CurationService } from './services/curation-service.js';
 import { SavedPromptsService } from './services/saved-prompts.service.js';
 import { PromptVariableRegistry } from './services/prompt-variable-registry.js';
+import { registerBuiltinVariables } from './variables/index.js';
 import { runScheduledPrompts } from './services/scheduled-prompts-runner.js';
 import { AiToolsController } from './api/ai-tools.controller.js';
 import { createAiToolsAdminRouter } from './api/ai-tools.router.js';
@@ -85,8 +92,23 @@ export interface IAiToolsModuleDependencies {
     serviceRegistry: IServiceRegistry;
     /** Hook registry the governor invokes the `ai.toolInvoke`/`ai.toolInvoked` seams through. */
     hookRegistry: IHookRegistry;
-    /** Menu service for registering the `/system/ai-tools` admin nav item. */
+    /**
+     * Menu service for registering the `/system/ai-tools` admin nav item, and the
+     * data source for the built-in `site-info` prompt variable.
+     */
     menuService: IMenuService;
+    /** Redis-backed cache; data source for the built-in `cache-keys` prompt variable. */
+    cacheService: ICacheService;
+    /** Block sync reads for the built-in blockchain prompt variables. */
+    blockchainService: IBlockchainService;
+    /** Observer processing stats for the built-in `observer-stats` prompt variable. */
+    observerRegistry: IBlockchainObserverService;
+    /** TRON chain parameters for the built-in `chain-params` prompt variable. */
+    chainParameters: IChainParametersService;
+    /** USDT transfer energy costs for the built-in `chain-params` prompt variable. */
+    usdtParameters: IUsdtParametersService;
+    /** Runtime site config for the built-in `site-info` prompt variable. */
+    systemConfig: ISystemConfigService;
     /** Express app the admin router mounts onto. */
     app: Express;
     /**
@@ -112,6 +134,12 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
     private serviceRegistry!: IServiceRegistry;
     private hookRegistry!: IHookRegistry;
     private menuService!: IMenuService;
+    private cacheService!: ICacheService;
+    private blockchainService!: IBlockchainService;
+    private observerRegistry!: IBlockchainObserverService;
+    private chainParameters!: IChainParametersService;
+    private usdtParameters!: IUsdtParametersService;
+    private systemConfig!: ISystemConfigService;
     private app!: Express;
     private scheduler: ISchedulerService | null = null;
 
@@ -143,6 +171,12 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
         this.serviceRegistry = dependencies.serviceRegistry;
         this.hookRegistry = dependencies.hookRegistry;
         this.menuService = dependencies.menuService;
+        this.cacheService = dependencies.cacheService;
+        this.blockchainService = dependencies.blockchainService;
+        this.observerRegistry = dependencies.observerRegistry;
+        this.chainParameters = dependencies.chainParameters;
+        this.usdtParameters = dependencies.usdtParameters;
+        this.systemConfig = dependencies.systemConfig;
         this.app = dependencies.app;
         this.scheduler = dependencies.scheduler ?? null;
 
@@ -190,6 +224,21 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
 
         this.promptVariables = new PromptVariableRegistry(this.logger, this.database);
         await this.promptVariables.load();
+
+        // Register the core-owned built-in dynamic variables. Lifted out of the
+        // trp-ai-assistant plugin so the variables exist for whichever AI provider
+        // is installed (or none) and the lethal-trifecta detector always sees them.
+        // The resolvers read these injected services lazily at expansion time.
+        registerBuiltinVariables(this.promptVariables, {
+            blockchainService: this.blockchainService,
+            chainParameters: this.chainParameters,
+            usdtParameters: this.usdtParameters,
+            observerRegistry: this.observerRegistry,
+            systemLog: this.logger,
+            systemConfig: this.systemConfig,
+            menuService: this.menuService,
+            cache: this.cacheService
+        });
 
         this.controller = new AiToolsController(this.registry, this.policy, this.audit, this.approvals, this.governor, this.providerRegistry, this.curation, this.queryHistory, this.savedPrompts, this.promptVariables);
 

--- a/src/backend/modules/ai-tools/README.md
+++ b/src/backend/modules/ai-tools/README.md
@@ -39,6 +39,7 @@ The AI *provider* is a swappable plugin (`trp-ai-assistant` for Anthropic today;
 | `services/curation-service.ts` | `'curation'` → `ICurationService`: type registry + hold/approve/reject/edit orchestration |
 | `services/ai-provider-registry.ts` | `'ai-providers'` → `IAiProviderRegistry`: provider metadata + executable instance; `getActive()` |
 | `services/prompt-variable-registry.ts` | `'prompt-variables'` → `IPromptVariableRegistry`: code-registered dynamic variables + DB-persisted static variables (`module_ai-tools_variables`), classification, `{%name%}` expansion, secret-name feed for the trifecta detector |
+| `variables/` | Core-owned built-in `dynamic` variables (Blockchain & Network, System Health, Site & Content, Database Access), registered into the registry at module init. Resolvers read injected core services; `types.ts` declares that dependency surface |
 | `services/ai-query-history.service.ts` | `module_ai-tools_query_history` writes/queries for the Query tab (`IAiQueryRecord`) |
 | `services/saved-prompts.service.ts` | `module_ai-tools_prompts` CRUD + cron validation + scheduler bookkeeping (`ISavedPrompt`); atomic field-level writes; failure-streak auto-pause |
 | `services/scheduled-prompts-runner.ts` | Per-tick cron evaluator: fires due prompts via `getActive().query({ mode: 'programmatic' })`, claim-before-fire to avoid double-firing |
@@ -92,7 +93,14 @@ The central queue of effects held for human review across content types. Provide
 
 ### `'prompt-variables'` → `IPromptVariableRegistry`
 
-The single registry of prompt variables — the `{%name%}` tokens an AI provider expands into a prompt. Holds two kinds behind one service (the Menu module's dual-backing pattern): `dynamic` variables a provider plugin or core module registers in code (`registerVariable`, classify-only) and `static` variables an admin authors and persists (`createStatic`/`updateStatic`/`deleteStatic`, full CRUD). The AI provider consumes `expandAll`/`expandWithMetadata` at request-build time, so a prompt expands admin-authored statics alongside built-ins. `classify()` sets a variable's sensitivity — a static stores it on the document, a dynamic persists an admin override over its code-declared default. `getSecretVariableNames()` feeds the trifecta detector. A new static defaults to `secret` (fail-safe), and a static that shadows a registered dynamic name is rejected. The `trp-ai-assistant` plugin registers its built-in dynamic variables here via the service watch and was the prior owner of this registry.
+The single registry of prompt variables — the `{%name%}` tokens an AI provider expands into a prompt. Holds two kinds behind one service (the Menu module's dual-backing pattern): `dynamic` variables a provider plugin or core module registers in code (`registerVariable`, classify-only) and `static` variables an admin authors and persists (`createStatic`/`updateStatic`/`deleteStatic`, full CRUD). The AI provider consumes `expandAll`/`expandWithMetadata` at request-build time, so a prompt expands admin-authored statics alongside built-ins. `classify()` sets a variable's sensitivity — a static stores it on the document, a dynamic persists an admin override over its code-declared default. `getSecretVariableNames()` feeds the trifecta detector. A new static defaults to `secret` (fail-safe), and a static that shadows a registered dynamic name is rejected. This module registers a core-owned set of **built-in dynamic variables** (`variables/`) at init; the installed AI provider and other plugins register their own the same way through the service watch. The module owns the registry — it and the built-in set were lifted out of the `trp-ai-assistant` plugin.
+
+| Category | Built-in dynamic variables |
+|---|---|
+| Blockchain & Network | `system-status`, `chain-params`, `tx-activity`, `tx-types`, `tx-week` |
+| System Health | `observer-stats`, `log-summary`, `server-info` |
+| Site & Content | `site-info` |
+| Database Access | `cache-keys` |
 
 ## Admin REST API
 
@@ -149,7 +157,7 @@ Declared in `src/backend/hooks/registry.ts`. `ai.toolInvoke` (series, `IAiToolIn
 
 ## Lifecycle Obligations
 
-`init()` constructs the registry, policy engine, audit store, approval queue, curation queue + service, governor, provider registry, query-history service, saved-prompts service, and prompt-variable registry; loads persisted tool-states, policy overrides, and prompt-variable statics + classifications; ensures every collection's indexes (the collections are new, so index creation here is correct rather than a migration — including `module_ai-tools_query_history`, `module_ai-tools_prompts`, and `module_ai-tools_variables`); and injects the curation binding resolver into the policy engine (`policy.setCurationResolver(curation.hasType)`). `run()` mounts the admin router, registers `'ai-tools'` / `'ai-tool-governor'` / `'ai-providers'` / `'curation'` / `'prompt-variables'`, wires the governor's and curation service's broadcast sinks to `WebSocketService`, registers the daily `ai-tools:prune-audit` retention job and the 2-minute `ai-tools:run-scheduled-prompts` job (both only when a scheduler is injected), and registers the `/system/ai-tools` admin nav item under the System container. Errors in either phase fail the boot — there is no degraded mode.
+`init()` constructs the registry, policy engine, audit store, approval queue, curation queue + service, governor, provider registry, query-history service, saved-prompts service, and prompt-variable registry (into which it registers the core-owned built-in dynamic variables); loads persisted tool-states, policy overrides, and prompt-variable statics + classifications; ensures every collection's indexes (the collections are new, so index creation here is correct rather than a migration — including `module_ai-tools_query_history`, `module_ai-tools_prompts`, and `module_ai-tools_variables`); and injects the curation binding resolver into the policy engine (`policy.setCurationResolver(curation.hasType)`). `run()` mounts the admin router, registers `'ai-tools'` / `'ai-tool-governor'` / `'ai-providers'` / `'curation'` / `'prompt-variables'`, wires the governor's and curation service's broadcast sinks to `WebSocketService`, registers the daily `ai-tools:prune-audit` retention job and the 2-minute `ai-tools:run-scheduled-prompts` job (both only when a scheduler is injected), and registers the `/system/ai-tools` admin nav item under the System container. Errors in either phase fail the boot — there is no degraded mode.
 
 ## Related
 

--- a/src/backend/modules/ai-tools/__tests__/ai-tools-module.test.ts
+++ b/src/backend/modules/ai-tools/__tests__/ai-tools-module.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { HookAbortError, UNTRUSTED_CONTENT_NOTICE } from '@/types';
-import type { IAiTool, IAiToolCapability, IAiToolInfo, ICurationType, IHookRegistry, IMenuService, ISchedulerService, ISystemLogService, IToolInvocationContext } from '@/types';
+import type { IAiTool, IAiToolCapability, IAiToolInfo, IBlockchainObserverService, IBlockchainService, ICacheService, IChainParametersService, ICurationType, IHookRegistry, IMenuService, ISchedulerService, ISystemConfigService, ISystemLogService, IToolInvocationContext, IUsdtParametersService } from '@/types';
 import { AiToolsModule, AUDIT_PRUNE_JOB, CurationQueue, CurationService, ToolApprovalQueue, detectTrifecta, lintToolCapability } from '../index.js';
 import { ToolPolicyEngine } from '../services/tool-policy-engine.js';
 import { runWithCurationAutoApprove, shouldAutoApproveCuration } from '../services/curation-auto-approve-context.js';
@@ -46,6 +46,26 @@ function createMockHookRegistry(): IHookRegistry {
         snapshot: vi.fn(() => ({ tracks: [] })),
         invoke: vi.fn(async () => undefined)
     } as unknown as IHookRegistry;
+}
+
+/**
+ * Stub the core services the module injects solely to back the built-in prompt
+ * variables. Those resolvers run lazily at variable-expansion time, never during
+ * the module lifecycle these tests exercise, so empty typed stubs satisfy the
+ * dependency surface without being invoked.
+ */
+function builtinVariableDeps(): Pick<
+    Parameters<AiToolsModule['init']>[0],
+    'cacheService' | 'blockchainService' | 'observerRegistry' | 'chainParameters' | 'usdtParameters' | 'systemConfig'
+> {
+    return {
+        cacheService: { keys: vi.fn(async () => [] as string[]) } as unknown as ICacheService,
+        blockchainService: {} as unknown as IBlockchainService,
+        observerRegistry: {} as unknown as IBlockchainObserverService,
+        chainParameters: {} as unknown as IChainParametersService,
+        usdtParameters: {} as unknown as IUsdtParametersService,
+        systemConfig: {} as unknown as ISystemConfigService
+    };
 }
 
 /** A strictly read-only tool with a spy handler. */
@@ -171,7 +191,8 @@ describe('AiToolsModule', () => {
             serviceRegistry: mockRegistry,
             hookRegistry: mockHooks,
             menuService: createMockMenuService(),
-            app: mockApp as never
+            app: mockApp as never,
+            ...builtinVariableDeps()
         });
     });
 
@@ -206,7 +227,8 @@ describe('AiToolsModule', () => {
                 hookRegistry: createMockHookRegistry(),
                 menuService: createMockMenuService(),
                 app: { use: vi.fn() } as never,
-                scheduler
+                scheduler,
+                ...builtinVariableDeps()
             });
             await scheduledModule.run();
 

--- a/src/backend/modules/ai-tools/variables/blockchain.ts
+++ b/src/backend/modules/ai-tools/variables/blockchain.ts
@@ -1,0 +1,212 @@
+/**
+ * @file variables/blockchain.ts
+ *
+ * Built-in dynamic prompt variables in the "Blockchain & Network" category.
+ * Registered by {@link registerBuiltinVariables} via registerBlockchainVariables.
+ *
+ * Lifted from the trp-ai-assistant plugin to core unchanged in behaviour; the
+ * resolvers now read injected core services (`deps`) instead of `IPluginContext`.
+ */
+
+import type { IPromptVariableRegistry } from '@/types';
+import type { IBuiltinVariableDeps } from './types.js';
+
+/**
+ * Major TRON transaction contract types for the tx-types breakdown. Each entry
+ * maps an internal contract type name to a human-readable label.
+ */
+export const MAJOR_TX_TYPES: Array<{ type: string; label: string }> = [
+    { type: 'TransferContract', label: 'TRX Transfers' },
+    { type: 'TriggerSmartContract', label: 'Smart Contract Calls (incl. USDT)' },
+    { type: 'TransferAssetContract', label: 'TRC-10 Token Transfers' },
+    { type: 'FreezeBalanceV2Contract', label: 'TRX Staking (Freeze)' },
+    { type: 'UnfreezeBalanceV2Contract', label: 'TRX Unstaking (Unfreeze)' },
+    { type: 'DelegateResourceContract', label: 'Energy Delegations' },
+    { type: 'UnDelegateResourceContract', label: 'Energy Undelegations' },
+    { type: 'VoteWitnessContract', label: 'SR Votes' }
+];
+
+/**
+ * Register all "Blockchain & Network" built-in variables on the given registry.
+ *
+ * @param registry - The core prompt-variable registry.
+ * @param deps - Injected core services the resolvers read at expansion time.
+ */
+export function registerBlockchainVariables(
+    registry: IPromptVariableRegistry,
+    deps: IBuiltinVariableDeps
+): void {
+    registry.registerVariable({
+        name: 'system-status',
+        category: 'Blockchain & Network',
+        description: 'Blockchain sync status: current block, timestamp, and transaction count',
+        resolve: async () => {
+            const block = await deps.blockchainService.getLatestBlock();
+
+            if (!block) {
+                return 'Blockchain Sync Status: No blocks processed yet.';
+            }
+
+            const lines = [
+                'Blockchain Sync Status:',
+                `  Latest Block: ${block.blockNumber}`,
+                `  Block ID: ${block.blockId}`,
+                `  Timestamp: ${block.timestamp.toISOString()}`,
+                `  Transactions in Block: ${block.transactionCount}`,
+                `  Processed At: ${block.processedAt.toISOString()}`
+            ];
+
+            return lines.join('\n');
+        }
+    });
+
+    registry.registerVariable({
+        name: 'chain-params',
+        category: 'Blockchain & Network',
+        description: 'TRON network parameters: energy fee, bandwidth, conversion rates, USDT costs',
+        resolve: async () => {
+            const params = await deps.chainParameters.getParameters();
+            const energyFee = deps.chainParameters.getEnergyFee();
+            const energyPer1TRX = deps.chainParameters.getEnergyFromTRX(1);
+
+            let usdtStandard = 'N/A';
+            let usdtFirstTime = 'N/A';
+
+            try {
+                usdtStandard = String(await deps.usdtParameters.getStandardTransferEnergy());
+                usdtFirstTime = String(await deps.usdtParameters.getFirstTimeTransferEnergy());
+            } catch {
+                // USDT parameters may not be loaded yet
+            }
+
+            const lines = [
+                'TRON Chain Parameters:',
+                `  Network: ${params.network}`,
+                `  Energy Fee: ${energyFee} SUN per unit`,
+                `  Energy from 1 TRX: ${energyPer1TRX}`,
+                `  Total Energy Limit: ${params.parameters.totalEnergyCurrentLimit.toLocaleString()}`,
+                `  Total Frozen for Energy: ${params.parameters.totalFrozenForEnergy.toLocaleString()}`,
+                `  Bandwidth Per TRX: ${params.parameters.bandwidthPerTrx}`,
+                `  Standard USDT Transfer Energy: ${usdtStandard}`,
+                `  First-time USDT Transfer Energy: ${usdtFirstTime}`,
+                `  Fetched At: ${params.fetchedAt.toISOString()}`
+            ];
+
+            return lines.join('\n');
+        }
+    });
+
+    registry.registerVariable({
+        name: 'tx-activity',
+        category: 'Blockchain & Network',
+        description: 'Transaction volume summary for the last 24 hours with peak and averages',
+        resolve: async () => {
+            const timeseries = await deps.blockchainService.getTransactionTimeseries(1);
+
+            if (!timeseries || timeseries.length === 0) {
+                return 'Transaction Activity (24h): No data available.';
+            }
+
+            const totalTx = timeseries.reduce((sum, point) => sum + point.transactions, 0);
+            const avgPerPeriod = Math.round(totalTx / timeseries.length);
+            const peak = timeseries.reduce((max, point) => Math.max(max, point.transactions), 0);
+            const avgPerBlock = timeseries.reduce((sum, point) => sum + point.avgPerBlock, 0) / timeseries.length;
+
+            const lines = [
+                'Transaction Activity (Last 24 Hours):',
+                `  Total Transactions: ${totalTx.toLocaleString()}`,
+                `  Data Points: ${timeseries.length}`,
+                `  Average per Period: ${avgPerPeriod.toLocaleString()}`,
+                `  Peak Period: ${peak.toLocaleString()} transactions`,
+                `  Average per Block: ${avgPerBlock.toFixed(1)}`
+            ];
+
+            return lines.join('\n');
+        }
+    });
+
+    registry.registerVariable({
+        name: 'tx-types',
+        category: 'Blockchain & Network',
+        description: 'Transaction breakdown by contract type over the last 24 hours',
+        resolve: async () => {
+            const now = new Date();
+            const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+            const counts = await Promise.all(
+                MAJOR_TX_TYPES.map(async ({ type, label }) => {
+                    const count = await deps.blockchainService.countTransactionsByType(type, dayAgo, now);
+                    return { label, count };
+                })
+            );
+
+            const total = counts.reduce((sum, c) => sum + c.count, 0);
+
+            const lines = [
+                'Transaction Breakdown by Type (Last 24 Hours):',
+                `  Total Counted: ${total.toLocaleString()}`,
+                ''
+            ];
+
+            for (const { label, count } of counts) {
+                const pct = total > 0 ? ((count / total) * 100).toFixed(1) : '0.0';
+                lines.push(`  ${label}: ${count.toLocaleString()} (${pct}%)`);
+            }
+
+            return lines.join('\n');
+        }
+    });
+
+    registry.registerVariable({
+        name: 'tx-week',
+        category: 'Blockchain & Network',
+        description: '7-day transaction trend with daily totals and direction',
+        resolve: async () => {
+            const timeseries = await deps.blockchainService.getTransactionTimeseries(7);
+
+            if (!timeseries || timeseries.length === 0) {
+                return 'Transaction Trend (7 Days): No data available.';
+            }
+
+            // Group hourly data into daily buckets
+            const dailyMap = new Map<string, { total: number; count: number }>();
+
+            for (const point of timeseries) {
+                const day = point.date.split('T')[0];
+                const entry = dailyMap.get(day) || { total: 0, count: 0 };
+                entry.total += point.transactions;
+                entry.count += 1;
+                dailyMap.set(day, entry);
+            }
+
+            const days = [...dailyMap.entries()].sort(([a], [b]) => a.localeCompare(b));
+            const weekTotal = days.reduce((sum, [, d]) => sum + d.total, 0);
+
+            // Trend: compare last day to first day
+            let trend = 'stable';
+            if (days.length >= 2) {
+                const firstDay = days[0][1].total;
+                const lastDay = days[days.length - 1][1].total;
+                const changePct = firstDay > 0 ? ((lastDay - firstDay) / firstDay) * 100 : 0;
+
+                if (changePct > 10) trend = `up ${changePct.toFixed(0)}%`;
+                else if (changePct < -10) trend = `down ${Math.abs(changePct).toFixed(0)}%`;
+                else trend = `flat (${changePct > 0 ? '+' : ''}${changePct.toFixed(0)}%)`;
+            }
+
+            const lines = [
+                'Transaction Trend (Last 7 Days):',
+                `  Week Total: ${weekTotal.toLocaleString()}`,
+                `  Daily Average: ${Math.round(weekTotal / Math.max(days.length, 1)).toLocaleString()}`,
+                `  Trend: ${trend}`,
+                ''
+            ];
+
+            for (const [date, data] of days) {
+                lines.push(`  ${date}: ${data.total.toLocaleString()} transactions`);
+            }
+
+            return lines.join('\n');
+        }
+    });
+}

--- a/src/backend/modules/ai-tools/variables/database-access.ts
+++ b/src/backend/modules/ai-tools/variables/database-access.ts
@@ -1,0 +1,65 @@
+/**
+ * @file variables/database-access.ts
+ *
+ * Built-in dynamic prompt variables in the "Database Access" category.
+ * Registered by {@link registerBuiltinVariables} via registerDatabaseAccessVariables.
+ *
+ * Lifted from the trp-ai-assistant plugin to core unchanged in behaviour; the
+ * resolvers now read injected core services (`deps`) instead of `IPluginContext`.
+ */
+
+import type { IPromptVariableRegistry } from '@/types';
+import type { IBuiltinVariableDeps } from './types.js';
+
+/**
+ * Register all "Database Access" built-in variables on the given registry.
+ *
+ * @param registry - The core prompt-variable registry.
+ * @param deps - Injected core services the resolvers read at expansion time.
+ */
+export function registerDatabaseAccessVariables(
+    registry: IPromptVariableRegistry,
+    deps: IBuiltinVariableDeps
+): void {
+    registry.registerVariable({
+        name: 'cache-keys',
+        category: 'Database Access',
+        description: 'All Redis cache keys currently stored, grouped by prefix',
+        resolve: async () => {
+            const keys = await deps.cache.keys('*');
+
+            if (keys.length === 0) {
+                return 'Cache: Empty - no keys stored.';
+            }
+
+            // Group by prefix (first segment before colon)
+            const groups = new Map<string, string[]>();
+
+            for (const key of keys) {
+                const prefix = key.split(':')[0] || 'other';
+                const group = groups.get(prefix) || [];
+                group.push(key);
+                groups.set(prefix, group);
+            }
+
+            const lines = [
+                `Cache Keys (${keys.length} total):`,
+                ''
+            ];
+
+            const sortedGroups = [...groups.entries()].sort(([, a], [, b]) => b.length - a.length);
+            for (const [prefix, groupKeys] of sortedGroups) {
+                lines.push(`  ${prefix}/ (${groupKeys.length} keys):`);
+                // Show up to 10 keys per group
+                for (const key of groupKeys.slice(0, 10)) {
+                    lines.push(`    ${key}`);
+                }
+                if (groupKeys.length > 10) {
+                    lines.push(`    ... and ${groupKeys.length - 10} more`);
+                }
+            }
+
+            return lines.join('\n');
+        }
+    });
+}

--- a/src/backend/modules/ai-tools/variables/index.ts
+++ b/src/backend/modules/ai-tools/variables/index.ts
@@ -1,0 +1,43 @@
+/**
+ * @file variables/index.ts
+ *
+ * Registers the core-owned built-in dynamic prompt variables into the
+ * `'prompt-variables'` registry. These were previously registered by the
+ * trp-ai-assistant plugin through `IPluginContext`; ownership moved to the
+ * ai-tools module so the variables exist for whichever AI provider is installed
+ * (or none) and so the lethal-trifecta detector sees them regardless of which
+ * provider plugin is enabled.
+ *
+ * Plugins keep the ability to register their own dynamic variables the same way —
+ * by watching the `'prompt-variables'` service and calling `registerVariable` —
+ * this module simply owns the built-in set.
+ */
+
+import type { IPromptVariableRegistry } from '@/types';
+import type { IBuiltinVariableDeps } from './types.js';
+import { registerBlockchainVariables } from './blockchain.js';
+import { registerSystemHealthVariables } from './system-health.js';
+import { registerSiteContentVariables } from './site-content.js';
+import { registerDatabaseAccessVariables } from './database-access.js';
+
+export type { IBuiltinVariableDeps } from './types.js';
+
+/**
+ * Register every built-in dynamic variable on the registry. Idempotent —
+ * `registerVariable` replaces by name — so it is safe to call once at module
+ * `init()`. The resolvers close over `deps` and read them lazily at expansion
+ * time, so the services need only exist (be constructed), not be fully warmed,
+ * when this runs.
+ *
+ * @param registry - The core prompt-variable registry.
+ * @param deps - Injected core services the resolvers read at expansion time.
+ */
+export function registerBuiltinVariables(
+    registry: IPromptVariableRegistry,
+    deps: IBuiltinVariableDeps
+): void {
+    registerBlockchainVariables(registry, deps);
+    registerSystemHealthVariables(registry, deps);
+    registerSiteContentVariables(registry, deps);
+    registerDatabaseAccessVariables(registry, deps);
+}

--- a/src/backend/modules/ai-tools/variables/site-content.ts
+++ b/src/backend/modules/ai-tools/variables/site-content.ts
@@ -1,0 +1,67 @@
+/**
+ * @file variables/site-content.ts
+ *
+ * Built-in dynamic prompt variables in the "Site & Content" category.
+ * Registered by {@link registerBuiltinVariables} via registerSiteContentVariables.
+ *
+ * Lifted from the trp-ai-assistant plugin to core unchanged in behaviour; the
+ * resolvers now read injected core services (`deps`) instead of `IPluginContext`.
+ */
+
+import type { IPromptVariableRegistry } from '@/types';
+import type { IBuiltinVariableDeps } from './types.js';
+
+/**
+ * Register all "Site & Content" built-in variables on the given registry.
+ *
+ * @param registry - The core prompt-variable registry.
+ * @param deps - Injected core services the resolvers read at expansion time.
+ */
+export function registerSiteContentVariables(
+    registry: IPromptVariableRegistry,
+    deps: IBuiltinVariableDeps
+): void {
+    registry.registerVariable({
+        name: 'site-info',
+        category: 'Site & Content',
+        description: 'TronRelic site URL, platform identity, and navigation structure',
+        resolve: async () => {
+            const siteUrl = await deps.systemConfig.getSiteUrl();
+            const namespaces = deps.menuService.getNamespaces();
+
+            const lines = [
+                'Site Information:',
+                `  URL: ${siteUrl}`,
+                `  Platform: TronRelic - TRON Blockchain Analytics`,
+                `  Menu Namespaces: ${namespaces.join(', ')}`,
+                ''
+            ];
+
+            // Include main navigation structure
+            const mainTree = deps.menuService.getTree('main');
+            if (mainTree.roots.length > 0) {
+                lines.push('  Main Navigation:');
+                for (const node of mainTree.roots) {
+                    const icon = node.icon ? `[${node.icon}] ` : '';
+                    lines.push(`    ${icon}${node.label} → ${node.url}`);
+                    const children = deps.menuService.getChildren(node._id!, 'main');
+                    for (const child of children) {
+                        lines.push(`      ${child.label} → ${child.url}`);
+                    }
+                }
+                lines.push('');
+            }
+
+            // System navigation
+            const systemTree = deps.menuService.getTree('system');
+            if (systemTree.roots.length > 0) {
+                lines.push('  System Navigation:');
+                for (const node of systemTree.roots) {
+                    lines.push(`    ${node.label} → ${node.url}`);
+                }
+            }
+
+            return lines.join('\n');
+        }
+    });
+}

--- a/src/backend/modules/ai-tools/variables/system-health.ts
+++ b/src/backend/modules/ai-tools/variables/system-health.ts
@@ -1,0 +1,207 @@
+/**
+ * @file variables/system-health.ts
+ *
+ * Built-in dynamic prompt variables in the "System Health" category.
+ * Registered by {@link registerBuiltinVariables} via registerSystemHealthVariables.
+ *
+ * Lifted from the trp-ai-assistant plugin to core unchanged in behaviour; the
+ * resolvers now read injected core services (`deps`) instead of `IPluginContext`.
+ */
+
+import os from 'node:os';
+import { readFileSync, statfsSync } from 'node:fs';
+import { resolve as pathResolve } from 'node:path';
+import type { IPromptVariableRegistry } from '@/types';
+import type { IBuiltinVariableDeps } from './types.js';
+
+/**
+ * Register all "System Health" built-in variables on the given registry.
+ *
+ * @param registry - The core prompt-variable registry.
+ * @param deps - Injected core services the resolvers read at expansion time.
+ */
+export function registerSystemHealthVariables(
+    registry: IPromptVariableRegistry,
+    deps: IBuiltinVariableDeps
+): void {
+    registry.registerVariable({
+        name: 'observer-stats',
+        category: 'System Health',
+        description: 'Blockchain observer processing stats: throughput, errors, queue depth per observer',
+        resolve: async () => {
+            const aggregate = deps.observerRegistry.getAggregateStats();
+            const observers = deps.observerRegistry.getAllObserverStats();
+            const subscriptions = deps.observerRegistry.getSubscriptionStats();
+
+            const lines = [
+                'Observer Processing Statistics:',
+                `  Total Observers: ${aggregate.totalObservers}`,
+                `  Total Processed: ${aggregate.totalProcessed.toLocaleString()}`,
+                `  Total Errors: ${aggregate.totalErrors.toLocaleString()}`,
+                `  Total Dropped: ${aggregate.totalDropped.toLocaleString()}`,
+                `  Queue Depth: ${aggregate.totalQueueDepth}`,
+                `  Avg Processing Time: ${aggregate.avgProcessingTimeMs.toFixed(1)}ms`,
+                `  Highest Error Rate: ${(aggregate.highestErrorRate * 100).toFixed(2)}%`,
+                `  Observers with Errors: ${aggregate.observersWithErrors}`,
+                ''
+            ];
+
+            // Subscription counts by tx type
+            const subEntries = Object.entries(subscriptions);
+            if (subEntries.length > 0) {
+                lines.push('  Subscriptions by Transaction Type:');
+                for (const [type, count] of subEntries) {
+                    lines.push(`    ${type}: ${count} observer(s)`);
+                }
+                lines.push('');
+            }
+
+            // Per-observer breakdown
+            if (observers.length > 0) {
+                lines.push('  Per-Observer Detail:');
+                for (const obs of observers) {
+                    const errorRate = obs.totalProcessed > 0
+                        ? ((obs.totalErrors / obs.totalProcessed) * 100).toFixed(1)
+                        : '0.0';
+                    lines.push(`    ${obs.name}:`);
+                    lines.push(`      Processed: ${obs.totalProcessed.toLocaleString()} | Errors: ${obs.totalErrors} (${errorRate}%) | Queue: ${obs.queueDepth} | Avg: ${obs.avgProcessingTimeMs.toFixed(1)}ms`);
+                }
+            }
+
+            return lines.join('\n');
+        }
+    });
+
+    registry.registerVariable({
+        name: 'log-summary',
+        category: 'System Health',
+        description: 'System log statistics: counts by level, by service, and unresolved issues',
+        resolve: async () => {
+            const stats = await deps.systemLog.getStatistics();
+
+            const lines = [
+                'System Log Summary:',
+                `  Total Entries: ${stats.total.toLocaleString()}`,
+                `  Unresolved: ${stats.unresolved}`,
+                '',
+                '  By Level:'
+            ];
+
+            for (const [level, count] of Object.entries(stats.byLevel)) {
+                if (count > 0) {
+                    lines.push(`    ${level}: ${count.toLocaleString()}`);
+                }
+            }
+
+            const serviceEntries = Object.entries(stats.byService);
+            if (serviceEntries.length > 0) {
+                lines.push('');
+                lines.push('  By Service:');
+                // Sort by count descending, show top 15
+                serviceEntries.sort(([, a], [, b]) => (b as number) - (a as number));
+                for (const [service, count] of serviceEntries.slice(0, 15)) {
+                    lines.push(`    ${service}: ${(count as number).toLocaleString()}`);
+                }
+                if (serviceEntries.length > 15) {
+                    lines.push(`    ... and ${serviceEntries.length - 15} more services`);
+                }
+            }
+
+            return lines.join('\n');
+        }
+    });
+
+    let cachedAppVersion = 'unknown';
+    try {
+        const pkg = JSON.parse(readFileSync(pathResolve(process.cwd(), 'package.json'), 'utf-8'));
+        cachedAppVersion = pkg.version ?? 'unknown';
+    } catch {
+        /* fallback */
+    }
+
+    registry.registerVariable({
+        name: 'server-info',
+        category: 'System Health',
+        description: 'Server runtime environment: current time with UTC offset, Node.js version, uptime, memory, OS, hostname, CPU count, app version',
+        resolve: async () => {
+            const now = new Date();
+            const offsetMin = now.getTimezoneOffset();
+            const offsetSign = offsetMin <= 0 ? '+' : '-';
+            const absOffset = Math.abs(offsetMin);
+            const offsetHours = String(Math.floor(absOffset / 60)).padStart(2, '0');
+            const offsetMins = String(absOffset % 60).padStart(2, '0');
+            const utcOffset = `${offsetSign}${offsetHours}:${offsetMins}`;
+
+            let tzName = 'Unknown';
+            try {
+                tzName = Intl.DateTimeFormat().resolvedOptions().timeZone;
+            } catch {
+                /* fallback */
+            }
+
+            const mem = process.memoryUsage();
+            const formatMb = (bytes: number): string => `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+            const formatGb = (bytes: number): string => `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+
+            const uptimeSec = process.uptime();
+            const days = Math.floor(uptimeSec / 86400);
+            const hours = Math.floor((uptimeSec % 86400) / 3600);
+            const minutes = Math.floor((uptimeSec % 3600) / 60);
+            const uptimeStr = days > 0
+                ? `${days}d ${hours}h ${minutes}m`
+                : `${hours}h ${minutes}m`;
+
+            const lines = [
+                'Server Information:',
+                '',
+                '  Time & Locale:',
+                `    Current Time (UTC): ${now.toISOString()}`,
+                `    Server Timezone: ${tzName} (UTC${utcOffset})`,
+                `    Process Uptime: ${uptimeStr}`,
+                '',
+                '  Runtime:',
+                `    Node.js: ${process.version}`,
+                `    NODE_ENV: ${process.env.NODE_ENV ?? 'not set'}`,
+                `    PID: ${process.pid}`,
+                `    Heap Used: ${formatMb(mem.heapUsed)} / ${formatMb(mem.heapTotal)}`,
+                `    RSS: ${formatMb(mem.rss)}`,
+                '',
+                '  Platform:',
+                `    OS: ${os.platform()} ${os.arch()}`,
+                `    OS Release: ${os.release()}`,
+                `    Hostname: ${os.hostname()}`,
+                `    CPU Count: ${os.cpus().length}`,
+                `    Load Average (1/5/15m): ${os.loadavg().map(v => v.toFixed(2)).join(' / ')}`,
+                '',
+                '  System Memory:',
+                `    Total: ${formatGb(os.totalmem())}`,
+                `    Free: ${formatGb(os.freemem())}`,
+                `    Used: ${formatGb(os.totalmem() - os.freemem())}`,
+            ];
+
+            try {
+                const diskStats = statfsSync('/');
+                const diskTotal = diskStats.blocks * diskStats.bsize;
+                const diskFree = diskStats.bavail * diskStats.bsize;
+                lines.push(
+                    '',
+                    '  Disk (/):',
+                    `    Total: ${formatGb(diskTotal)}`,
+                    `    Free: ${formatGb(diskFree)}`,
+                    `    Used: ${formatGb(diskTotal - diskFree)}`
+                );
+            } catch {
+                /* statfsSync unavailable or permission denied */
+            }
+
+            lines.push(
+                '',
+                '  Application:',
+                `    TronRelic Version: ${cachedAppVersion}`,
+                `    Backend Port: ${process.env.PORT ?? '4000'}`
+            );
+
+            return lines.join('\n');
+        }
+    });
+}

--- a/src/backend/modules/ai-tools/variables/types.ts
+++ b/src/backend/modules/ai-tools/variables/types.ts
@@ -1,0 +1,49 @@
+/**
+ * @file variables/types.ts
+ *
+ * Dependency surface the built-in dynamic prompt-variable resolvers close over.
+ *
+ * These resolvers were lifted out of the trp-ai-assistant plugin so the core
+ * ai-tools module owns every built-in variable: the plugin used to register them
+ * into the core `'prompt-variables'` registry through `IPluginContext`, which
+ * coupled "what variables exist" to whether the Anthropic provider happened to be
+ * enabled. Core registers them now, so the variables exist for whichever AI
+ * provider is installed (or none). The resolvers reference the same core
+ * singletons the plugin context exposed — declared here as interfaces so the
+ * module injects them rather than importing concrete classes.
+ */
+
+import type {
+    IBlockchainService,
+    IBlockchainObserverService,
+    ICacheService,
+    IChainParametersService,
+    IMenuService,
+    ISystemConfigService,
+    ISystemLogService,
+    IUsdtParametersService
+} from '@/types';
+
+/**
+ * Core services the built-in variable resolvers read at expansion time. Captured
+ * once at module init; each resolver calls into them lazily when a prompt that
+ * references its `{%name%}` is expanded, long after bootstrap.
+ */
+export interface IBuiltinVariableDeps {
+    /** Block sync reads: latest block, transaction timeseries, per-type counts. */
+    blockchainService: IBlockchainService;
+    /** TRON chain parameters: energy fee, conversions, network limits. */
+    chainParameters: IChainParametersService;
+    /** USDT transfer energy costs (standard / first-time). */
+    usdtParameters: IUsdtParametersService;
+    /** Observer processing stats: throughput, errors, queue depth, subscriptions. */
+    observerRegistry: IBlockchainObserverService;
+    /** System log statistics for the log-summary variable. */
+    systemLog: ISystemLogService;
+    /** Runtime site URL for the site-info variable. */
+    systemConfig: ISystemConfigService;
+    /** Menu trees and namespaces for the site-info variable. */
+    menuService: IMenuService;
+    /** Redis key enumeration for the cache-keys variable. */
+    cache: ICacheService;
+}

--- a/src/frontend/app/(core)/system/ai-tools/components/TrifectaPanel.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/TrifectaPanel.tsx
@@ -25,9 +25,9 @@ type LegTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger';
 /** One trifecta leg: its label and the enabled tools that contribute it. */
 function Leg({ label, tools, tone }: { label: string; tools: string[]; tone: LegTone }) {
     return (
-        <div>
+        <div className={styles.trifecta_leg}>
             <div className={styles.trifecta_leg_label}>{label}</div>
-            <span className={styles.badges}>
+            <span className={styles.trifecta_leg_badges}>
                 {tools.length === 0
                     ? <span className="text-subtle">none</span>
                     : tools.map(name => <Badge key={name} tone={tone}>{name}</Badge>)}

--- a/src/frontend/app/(core)/system/ai-tools/page.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/page.module.scss
@@ -77,6 +77,20 @@
     gap: var(--gap-xs);
 }
 
+/* Activity feed Time column: keep a full datetime on one line so it never wraps
+   mid-value. Below the dashboard's mobile breakpoint, allow wrapping so the
+   narrow table can reclaim the width. Scoped here rather than on the shared
+   Table `.th_shrink` so only this column widens. */
+.col_time {
+    white-space: nowrap;
+}
+
+@container ai-tools-dashboard (max-width: #{$breakpoint-mobile-lg}) {
+    .col_time {
+        white-space: normal;
+    }
+}
+
 /* Filter bar above the activity feed. */
 .filters {
     display: flex;
@@ -129,11 +143,31 @@
     margin-top: var(--gap-sm);
 }
 
+/* One leg: the category label stacked above its contributing-tool chips, with a
+   small vertical gap separating the label from the listing beneath it. */
+.trifecta_leg {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+}
+
 .trifecta_leg_label {
     font-size: var(--font-size-caption);
     text-transform: uppercase;
     letter-spacing: var(--letter-spacing-wide);
     color: var(--color-text-subtle);
+}
+
+/* Contributing-tool chips under a leg. The badge font already sits at the
+   smallest label token, so the listing reads as secondary detail by shrinking
+   the bubble — tighter padding, gap, and radius than a default Badge. */
+.trifecta_leg_badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-2xs);
+    --badge-padding: var(--padding-2xs) var(--padding-xs);
+    --badge-gap: var(--gap-2xs);
+    --badge-border-radius: var(--radius-sm);
 }
 
 /* Provider panel rows. */

--- a/src/frontend/app/(core)/system/ai-tools/tabs/ActivityTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/ActivityTab.tsx
@@ -105,7 +105,7 @@ export function ActivityTab() {
                         <Table>
                             <Thead>
                                 <Tr>
-                                    <Th width="shrink">Time</Th>
+                                    <Th width="shrink" className={styles.col_time}>Time</Th>
                                     <Th>Tool</Th>
                                     <Th width="shrink">AI Provider</Th>
                                     <Th width="shrink">Actor</Th>
@@ -117,7 +117,7 @@ export function ActivityTab() {
                             <Tbody>
                                 {items.map(record => (
                                     <Tr key={record.id} hasError={record.status === 'error'}>
-                                        <Td muted><ClientTime date={record.createdAt} format="datetime" /></Td>
+                                        <Td muted className={styles.col_time}><ClientTime date={record.createdAt} format="datetime" /></Td>
                                         <Td>
                                             <div className={styles.tool_name}>{record.toolName}</div>
                                             {record.error && <div className={styles.mono}>{record.error}</div>}

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
@@ -65,10 +65,10 @@
     /* Resting height so the panel does not grow as the conversation fills — the
        transcript scrolls within. It is a min-height, not a fixed height, so
        dragging the composer textarea taller grows the card to contain it rather
-       than collapsing the transcript or clipping the toolbar. resize: vertical
-       additionally lets the admin drag the whole card taller. */
+       than collapsing the transcript or clipping the toolbar. The card itself is
+       not user-resizable: only the embedded textarea carries `resize`, and the
+       card expands to follow it. */
     min-height: var(--query-chat-height-sm);
-    resize: vertical;
 }
 
 @container ai-query (min-width: #{$breakpoint-mobile-md}) {

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
@@ -614,13 +614,6 @@ export function QueryTab() {
 
             {view === 'chat' ? (
                 <>
-                <SavedPromptsPanel
-                    prompts={savedPrompts}
-                    onPromptsChange={setSavedPrompts}
-                    currentPromptText={input}
-                    onLoadPromptText={(text) => { setInput(text); textareaRef.current?.focus(); }}
-                    onError={setError}
-                />
                 <Card className={styles.chat_card}>
                     <div className={styles.chat_header}>
                         <Bot size={16} className={styles.chat_header_icon} />
@@ -788,6 +781,13 @@ export function QueryTab() {
                         </div>
                     </div>
                 </Card>
+                <SavedPromptsPanel
+                    prompts={savedPrompts}
+                    onPromptsChange={setSavedPrompts}
+                    currentPromptText={input}
+                    onLoadPromptText={(text) => { setInput(text); textareaRef.current?.focus(); }}
+                    onError={setError}
+                />
                 </>
             ) : (
                 <Stack gap="md">


### PR DESCRIPTION
## Built-in prompt variables → core

Lifts the built-in dynamic prompt-variable resolvers out of the `trp-ai-assistant` plugin into the core `ai-tools` module's new `variables/` directory. The module registers them at `init()` from injected core services (`blockchainService`, `chainParameters`, `usdtParameters`, `observerRegistry`, system log, `systemConfig`, `menuService`, `cache`), so the variables exist for whichever AI provider is installed — or none — and the lethal-trifecta detector always accounts for them.

The plugin keeps only the `TemplateVariableRegistry` expander and a watch to cache the core registry reference; it no longer registers or unregisters any variables. Plugins retain the ability to register their own via the `prompt-variables` service.

Variables moved: `system-status`, `chain-params`, `tx-activity`, `tx-types`, `tx-week`, `observer-stats`, `log-summary`, `server-info`, `site-info`, `cache-keys`.

## Admin UI refinements (/system/ai-tools)

- Trifecta legs stack the category label above the tool chips with a gap; chips use a compact bubble.
- Activity "Time" column no longer wraps a datetime (wraps only below the mobile breakpoint), scoped without touching the shared Table component.
- Query tab: saved-prompts panel moved below the conversation card.
- Conversation card is no longer user-resizable but still grows to follow its textarea.

## Notes

- The companion `trp-ai-assistant` cleanup lives in that plugin's own repo and ships separately.
- Verified: core `tsc` clean, ai-tools module suite 79/79 passing.