### PR TITLE
feat(ai-tools): lift send-toast into core as a provider-neutral built-in

### DIFF
--- a/src/backend/modules/ai-tools/AiToolsModule.ts
+++ b/src/backend/modules/ai-tools/AiToolsModule.ts
@@ -17,6 +17,7 @@
 import type { Express } from 'express';
 import type {
     IAccountDirectoryService,
+    IAiTool,
     IBlockchainObserverService,
     IBlockchainService,
     ICacheService,
@@ -254,6 +255,12 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
             cache: this.cacheService
         });
 
+        // Register the core-owned built-in tools. `send-toast` was lifted out of
+        // the trp-ai-assistant plugin so the site-wide announcement capability is
+        // provider-neutral — it exists for whichever AI provider is installed, or
+        // none, and survives a provider swap.
+        this.registerBuiltinTools();
+
         // Resolve a Better Auth user id to a live end-user principal via the
         // identity module's 'accounts' service, read lazily so the boot-order
         // race (identity registers 'accounts' in its own run()) and operator
@@ -266,6 +273,82 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
         this.controller = new AiToolsController(this.registry, this.policy, this.audit, this.approvals, this.governor, this.providerRegistry, this.curation, this.queryHistory, this.savedPrompts, this.promptVariables, this.systemPrompts, this.resolveEndUser);
 
         this.logger.info('ai-tools module initialized');
+    }
+
+    /**
+     * Register the core-owned built-in AI tools on the registry.
+     *
+     * Today this is `send-toast`: a site-wide UI announcement broadcast. It is
+     * classified external / reversible / public, so the registry's
+     * capability-driven default-deny ships it disabled until an operator opts in,
+     * and the governor rate-governs it like any other external tool. Lifted from
+     * the trp-ai-assistant plugin so the capability is provider-neutral — it does
+     * not vanish when the Anthropic transport is swapped for another provider.
+     * The handler broadcasts on the global `'toast'` WebSocket event, surfaced in
+     * every browser by the core `CoreToastHandler` component; `WebSocketService`
+     * is resolved lazily at call time and its emit is a no-op when WebSockets are
+     * disabled, so registration never depends on socket availability.
+     */
+    private registerBuiltinTools(): void {
+        const sendToast: IAiTool = {
+            name: 'send-toast',
+            description:
+                'Broadcast a system-wide toast notification to EVERY connected browser session — all users, ' +
+                'not just the person who sent this query. This is a public site-wide announcement mechanism. ' +
+                'Never use this to answer the user\'s question, relay query findings, or communicate normal responses — ' +
+                'write those as regular text in the conversation instead. ' +
+                'Appropriate uses: site restarts, maintenance windows, critical system alerts, or global status changes ' +
+                'that every visitor should see regardless of who they are or what page they are on. ' +
+                'Toasts appear as small pop-ups in the bottom-right corner and auto-dismiss after a few seconds. ' +
+                'Keep title under 60 characters and description under 120. ' +
+                'Do NOT call this tool multiple times in rapid succession.',
+            inputSchema: {
+                type: 'object',
+                description: 'Toast notification content and presentation options',
+                properties: {
+                    title: { type: 'string', description: 'Short toast title, under 60 characters (required)' },
+                    description: { type: 'string', description: 'Optional longer description, under 120 characters' },
+                    tone: { type: 'string', enum: ['info', 'success', 'warning', 'danger'], description: 'Visual tone. Use info for neutral, success for confirmations, warning for caution, danger for errors. Defaults to info.' },
+                    duration: { type: 'number', description: 'Auto-dismiss duration in milliseconds. Defaults to 6000. Use 0 for persistent toasts that require manual dismissal.' }
+                },
+                required: ['title'],
+                additionalProperties: false
+            },
+            capability: { sideEffect: 'external', reversible: true, sensitivity: 'public' },
+            handler: async (input) => {
+                // Re-validate model input: the schema is a hint, not a guarantee.
+                const payload = input as {
+                    tone?: 'info' | 'success' | 'warning' | 'danger';
+                    title?: unknown;
+                    description?: unknown;
+                    duration?: unknown;
+                };
+                const title = typeof payload.title === 'string' ? payload.title.trim() : '';
+                if (!title) {
+                    return { success: false, error: 'title is required and must be a non-empty string' };
+                }
+                const tone = payload.tone && ['info', 'success', 'warning', 'danger'].includes(payload.tone)
+                    ? payload.tone
+                    : 'info';
+                const duration = typeof payload.duration === 'number' && Number.isFinite(payload.duration) && payload.duration >= 0
+                    ? payload.duration
+                    : 6000;
+
+                WebSocketService.getInstance().emit({
+                    event: 'toast',
+                    payload: {
+                        tone,
+                        title,
+                        description: typeof payload.description === 'string' ? payload.description : undefined,
+                        duration
+                    }
+                });
+
+                return { success: true, sent: true };
+            }
+        };
+
+        this.registry.registerTool(sendToast, 'core');
     }
 
     /**

--- a/src/backend/modules/ai-tools/AiToolsModule.ts
+++ b/src/backend/modules/ai-tools/AiToolsModule.ts
@@ -339,7 +339,7 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
                     payload: {
                         tone,
                         title,
-                        description: typeof payload.description === 'string' ? payload.description : undefined,
+                        description: typeof payload.description === 'string' ? payload.description.trim() || undefined : undefined,
                         duration
                     }
                 });

--- a/src/backend/modules/ai-tools/README.md
+++ b/src/backend/modules/ai-tools/README.md
@@ -28,7 +28,7 @@ The AI *provider* is a swappable plugin (`trp-ai-assistant` for Anthropic today;
 
 | File | Responsibility |
 |------|----------------|
-| `AiToolsModule.ts` | Two-phase lifecycle; constructs services, mounts the admin router, publishes `'ai-tools'` + `'ai-tool-governor'` |
+| `AiToolsModule.ts` | Two-phase lifecycle; constructs services, mounts the admin router, publishes `'ai-tools'` + `'ai-tool-governor'`; registers the core built-in `send-toast` tool (external/reversible/public, ships disabled) via `registerBuiltinTools()` — a site-wide UI announcement broadcast on the global `'toast'` WebSocket event, provider-neutral so it survives a provider swap |
 | `services/ai-tool-registry.ts` | `IAiToolRegistry`: registration, enabled-state (capability-driven default-deny), declarations for a provider |
 | `services/ai-tool-governor.ts` | `IAiToolGovernor`: the invoke pipeline + approve/reject |
 | `services/tool-policy-engine.ts` | Capability-classed defaults, admin overrides, fixed-window rate limiter, autonomous default-deny, curation mode (`require`/`auto-approve`) + egress-gating predicate |

--- a/src/backend/services/websocket.service.ts
+++ b/src/backend/services/websocket.service.ts
@@ -335,6 +335,13 @@ export class WebSocketService implements IWebSocketService {
         // carry only a timestamp or count, never governed data.
         this.io.emit(event.event, event.payload);
         break;
+      case 'toast':
+        // Site-wide toast broadcast from the core `send-toast` AI tool. Every
+        // connected browser surfaces it via CoreToastHandler. The payload
+        // carries only display fields (tone/title/description/duration) — never
+        // governed data — so a global broadcast is safe.
+        this.io.emit(event.event, event.payload);
+        break;
       default:
         logger.warn({ event }, 'Unknown socket event');
     }

--- a/src/frontend/app/providers.tsx
+++ b/src/frontend/app/providers.tsx
@@ -4,6 +4,7 @@ import { useMemo, type ReactNode } from 'react';
 import { Provider } from 'react-redux';
 import { createStore } from '../store';
 import { SocketBridge } from '../components/socket/SocketBridge';
+import { CoreToastHandler } from '../components/socket/CoreToastHandler';
 import { ToastProvider } from '../components/ui/ToastProvider';
 import { ModalProvider } from '../components/ui/ModalProvider';
 import { PluginLoader } from '../components/plugins/PluginLoader';
@@ -39,6 +40,7 @@ export function Providers({ children, ssrSession }: ProvidersProps) {
                 <ModalProvider>
                     <FrontendPluginContextProvider>
                         <SocketBridge />
+                        <CoreToastHandler />
                         <SessionProvider initialSession={ssrSession ?? null}>
                             <PluginLoader />
                             <PageViewTracker />

--- a/src/frontend/components/socket/CoreToastHandler.tsx
+++ b/src/frontend/components/socket/CoreToastHandler.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect } from 'react';
+import { getSocket } from '../../lib/socketClient';
+import { useToast, type ToastTone } from '../ui/ToastProvider';
+
+/**
+ * Shape of the payload carried by the global `'toast'` WebSocket event. Emitted
+ * by the core `send-toast` AI tool through `WebSocketService` and broadcast to
+ * every connected session. Only display fields travel — never governed data.
+ */
+interface ICoreToastPayload {
+    tone?: ToastTone;
+    title: string;
+    description?: string;
+    duration?: number;
+}
+
+/**
+ * Surfaces site-wide toast broadcasts in every browser.
+ *
+ * The core `send-toast` AI tool emits a raw (non-plugin-namespaced) `'toast'`
+ * event on the shared Socket.IO connection; this listener forwards it to the
+ * toast provider so a single announcement reaches all sessions. It lived in the
+ * trp-ai-assistant plugin until the tool moved to core — keeping the listener in
+ * core makes the capability survive a provider swap. Renders no visible UI; it
+ * only wires the subscription.
+ *
+ * @returns Always null — this is a side-effect-only component.
+ */
+export function CoreToastHandler(): null {
+    const { push } = useToast();
+
+    useEffect(() => {
+        const socket = getSocket();
+
+        /**
+         * Forward an incoming toast broadcast to the toast provider, defaulting
+         * tone and dismiss duration so a minimal payload still renders sensibly.
+         *
+         * @param payload - Display fields from the backend broadcast.
+         */
+        const handleToast = (payload: ICoreToastPayload): void => {
+            if (!payload?.title) {
+                return;
+            }
+            push({
+                tone: payload.tone ?? 'info',
+                title: payload.title,
+                description: payload.description,
+                duration: payload.duration ?? 6000
+            });
+        };
+
+        socket.on('toast', handleToast);
+
+        return () => {
+            socket.off('toast', handleToast);
+        };
+    }, [push]);
+
+    return null;
+}


### PR DESCRIPTION
## Summary

Moves the site-wide toast announcement capability out of the `trp-ai-assistant` plugin and into core's `ai-tools` module, making it provider-neutral. The capability now exists for whichever AI provider is installed — or none — and survives a provider swap.

## Changes

- **`AiToolsModule.registerBuiltinTools()`** registers `send-toast` on the AI tool registry. It is classified external / reversible / public, so the registry's capability-driven default-deny ships it **disabled** until an operator opts in, and the governor rate-governs it like any other external tool. The handler re-validates model input (title required, tone/duration defaulted) and broadcasts on the global `'toast'` WebSocket event.
- **`WebSocketService`** gains a `'toast'` emit case so the global event is not dropped by the emit switch. Payload carries only display fields (tone/title/description/duration) — never governed data — so a global broadcast is safe.
- **`CoreToastHandler`** (new core frontend component) subscribes to the raw `'toast'` event and forwards it to the toast provider, surfacing announcements in every connected session. Composed in `providers.tsx` alongside `SocketBridge`.
- **README** updated to document the built-in tool.