### PR TITLE
feat(ai-tools): curation history view in admin Curation tab

### DIFF
--- a/docs/system/system-curation.md
+++ b/docs/system/system-curation.md
@@ -12,6 +12,8 @@ Core owns only the **decision** (held → approved / rejected) and the **envelop
 
 A provider registers an `ICurationType` and producers call `hold()`; the admin surface lists and decides. Core records the decision first (the queue's atomic gate), then invokes the type's callback — so a callback failure leaves the item decided rather than re-opening a half-committed effect. A type whose plugin is disabled is unregistered, so its held items **block** on decision until the plugin returns; this is intentional, not data loss.
 
+A decision mutates an item in place rather than deleting it, so the queue doubles as an audit trail. The admin tab's **Pending** view is the live queue (`GET /curations`); its **History** view reads the decided items back (`GET /curations/history`), newest decision first, rendered read-only from each item's frozen `preview` snapshot — re-deriving a live `describe()` could misrepresent a past decision, so history keeps the snapshot it was decided on.
+
 ### The Type Contract
 
 A provider gives core the content-specific operations it cannot infer. Core stays payload-agnostic — it only ever sees the generic `ICurationPreview` (`title` / `body` / `media` / `fields` / `editable`).
@@ -55,7 +57,7 @@ The admin edits the neutral `body` text in a core modal; the write routes core �
 | Admin tab | `/system/ai-tools` → Curation |
 | WebSocket signal | `ai-tools:curations-changed` (refetch cue) |
 | Review bypass | `IToolPolicy.curation: 'require'` (default) \| `'auto-approve'` (interactive-only admin bypass) |
-| REST | `GET /curations`, `GET /curations/count`, `PATCH /curations/:id`, `POST /curations/:id/{approve,reject}` under `/api/admin/system/ai-tools` |
+| REST | `GET /curations`, `GET /curations/count`, `GET /curations/history` (decided audit), `PATCH /curations/:id`, `POST /curations/:id/{approve,reject}` under `/api/admin/system/ai-tools` |
 | Types | `@delphian/tronrelic-types` → `ICurationType`, `ICurationItem`, `ICurationPreview`, `ICurationService`, `ICurationEditPatch` |
 
 ## Example

--- a/src/backend/modules/ai-tools/README.md
+++ b/src/backend/modules/ai-tools/README.md
@@ -139,6 +139,7 @@ All under `/api/admin/system/ai-tools` (rate-limited + `requireAdmin`).
 | GET | `/policy` | Per-tool overrides + usage tallies |
 | PUT/DELETE | `/policy/:name` | Set / clear a per-tool override |
 | GET | `/curations` · `/curations/count` | Pending curation queue + count (Curation tab + badge) |
+| GET | `/curations/history` | Decided items (approved/rejected), newest decision first (Curation tab → History) |
 | PATCH | `/curations/:id` | Apply an operator inline edit (`{ body }`) via the type's `applyEdit` |
 | POST | `/curations/:id/approve` · `/curations/:id/reject` | Decide a held item (404 not-pending · 409 owner-unavailable) |
 

--- a/src/backend/modules/ai-tools/api/ai-tools.controller.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.controller.ts
@@ -885,6 +885,12 @@ export class AiToolsController {
         res.json({ count: await this.curation.countPending() });
     };
 
+    /** GET /curations/history — decided items (approved/rejected), most recent decision first. */
+    listCurationHistory = async (_req: Request, res: Response): Promise<void> => {
+        const items = await this.curation.listHistory();
+        res.json({ curations: items.map(serializeCurationItem) });
+    };
+
     /** POST /curations/:id/approve — approve a held item and commit it via its type. */
     approveCuration = async (req: Request, res: Response): Promise<void> => {
         await this.decideCuration(req, res, 'approve');

--- a/src/backend/modules/ai-tools/api/ai-tools.router.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.router.ts
@@ -66,6 +66,7 @@ export function createAiToolsAdminRouter(controller: AiToolsController): Router 
 
     router.get('/curations', controller.listCurations);
     router.get('/curations/count', controller.getCurationsCount);
+    router.get('/curations/history', controller.listCurationHistory);
     router.patch('/curations/:id', controller.editCuration);
     router.post('/curations/:id/approve', controller.approveCuration);
     router.post('/curations/:id/reject', controller.rejectCuration);

--- a/src/backend/modules/ai-tools/services/curation-queue.ts
+++ b/src/backend/modules/ai-tools/services/curation-queue.ts
@@ -139,7 +139,8 @@ export class CurationQueue {
     async resolve(
         id: string,
         status: Exclude<CurationItemStatus, 'pending'>,
-        decidedBy?: string
+        decidedBy?: string,
+        preview?: ICurationPreview
     ): Promise<ICurationItem | null> {
         const existing = await this.database.findOne<ICurationItem>(COLLECTION, { id, status: 'pending' });
         let resolved: ICurationItem | null = null;
@@ -149,9 +150,16 @@ export class CurationQueue {
             if (decidedBy !== undefined) {
                 setFields.decidedBy = decidedBy;
             }
+            // Freeze the decision-time preview into the same atomic update as the
+            // status transition, so history shows exactly what the curator decided
+            // on and only the winning transition persists it. The service supplies
+            // it (the queue has no type registry); absent, the cached snapshot stands.
+            if (preview !== undefined) {
+                setFields.preview = preview;
+            }
             const modified = await this.database.updateMany(COLLECTION, { id, status: 'pending' }, { $set: setFields });
             if (modified > 0) {
-                resolved = { ...existing, status, decidedAt, decidedBy };
+                resolved = { ...existing, status, decidedAt, decidedBy, preview: preview ?? existing.preview };
                 this.logger.info({ id, status, decidedBy }, `Curation item ${status}: ${existing.typeId}`);
             }
         }

--- a/src/backend/modules/ai-tools/services/curation-queue.ts
+++ b/src/backend/modules/ai-tools/services/curation-queue.ts
@@ -42,6 +42,7 @@ export class CurationQueue {
         await this.database.createIndex(COLLECTION, { id: 1 }, { unique: true });
         await this.database.createIndex(COLLECTION, { status: 1, createdAt: -1 });
         await this.database.createIndex(COLLECTION, { typeId: 1, status: 1 });
+        await this.database.createIndex(COLLECTION, { status: 1, decidedAt: -1 });
     }
 
     /**
@@ -89,6 +90,26 @@ export class CurationQueue {
      */
     async countPending(): Promise<number> {
         return this.database.count(COLLECTION, { status: 'pending' });
+    }
+
+    /**
+     * List decided envelopes (approved or rejected), most-recently-decided first,
+     * for the curation history view. The records were never discarded — a decision
+     * mutates an item in place rather than deleting it (see `resolve`) — so this is
+     * the audit half of the queue: who decided what, and when. Sorted by `decidedAt`
+     * so the freshest decisions lead, backed by the `{ status, decidedAt }` index.
+     *
+     * @param limit - Maximum envelopes to return (default 100, capped at 500).
+     * @returns The decided envelopes, newest decision first.
+     */
+    async listHistory(limit = 100): Promise<ICurationItem[]> {
+        const capped = Math.min(Math.max(1, limit), 500);
+        const collection = this.database.getCollection<ICurationItem>(COLLECTION);
+        return collection
+            .find({ status: { $in: ['approved', 'rejected'] } })
+            .sort({ decidedAt: -1 })
+            .limit(capped)
+            .toArray();
     }
 
     /**

--- a/src/backend/modules/ai-tools/services/curation-service.ts
+++ b/src/backend/modules/ai-tools/services/curation-service.ts
@@ -196,6 +196,20 @@ export class CurationService implements ICurationService {
     }
 
     /**
+     * List decided envelopes (approved/rejected) newest-first for the history view.
+     * Unlike `listPending`, these are returned with their cached preview rather than
+     * a live `describe()`: history records what was decided at decision time, so the
+     * snapshot frozen into the envelope is the faithful view — re-deriving from the
+     * owner's current record could misrepresent a past decision.
+     *
+     * @param limit - Maximum envelopes to return.
+     * @returns The decided envelopes.
+     */
+    async listHistory(limit?: number): Promise<ICurationItem[]> {
+        return this.queue.listHistory(limit);
+    }
+
+    /**
      * Fetch one envelope by id, resolving a live preview while it is pending and
      * its owner is registered.
      *

--- a/src/backend/modules/ai-tools/services/curation-service.ts
+++ b/src/backend/modules/ai-tools/services/curation-service.ts
@@ -354,7 +354,21 @@ export class CurationService implements ICurationService {
                 );
                 result = null;
             } else {
-                const resolved = await this.queue.resolve(id, status, decidedBy);
+                // Snapshot what the curator actually saw. The pending queue shows
+                // a live `describe()` (withLivePreview), but the cached preview on
+                // the envelope is the hold-time value unless an inline edit
+                // refreshed it. Re-derive here so the terminal write freezes the
+                // decision-time view as faithful audit history; fall back to the
+                // cached snapshot if `describe()` fails. Passing it into `resolve()`
+                // keeps the preview inside the same atomic status gate, so only the
+                // winning transition persists it.
+                let decisionPreview = existing.preview;
+                try {
+                    decisionPreview = await entry.type.describe(existing.ref);
+                } catch (error) {
+                    this.logger.warn({ error, id }, 'Decision-time preview resolution failed; recording cached snapshot in history');
+                }
+                const resolved = await this.queue.resolve(id, status, decidedBy, decisionPreview);
                 if (resolved) {
                     // The decision is recorded; broadcast it before committing so
                     // the queue badge updates regardless of the commit outcome.

--- a/src/frontend/app/(core)/system/ai-tools/tabs/CurationTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/CurationTab.tsx
@@ -6,6 +6,9 @@
  * preview (title, body, media, fields); approving commits the effect through its
  * owning plugin, rejecting discards it. An item whose owning plugin is disabled
  * returns a 409 the toast surfaces, since it cannot be decided until re-enabled.
+ * A Pending/History toggle switches between the live queue and the read-only
+ * audit of past decisions — decisions never delete a record, so history is just
+ * the decided items, rendered from their frozen snapshot with no actions.
  * Refetches on the `ai-tools:curations-changed` signal and reports the new count
  * up via `onChanged` so the header badge stays live. Like the sibling tabs this
  * is an admin client surface, not an SSR-first public component.
@@ -22,7 +25,7 @@ import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { useToast } from '../../../../../components/ui/ToastProvider';
 import { useModal } from '../../../../../components/ui/ModalProvider';
 import { getSocket } from '../../../../../lib/socketClient';
-import { listCurations, approveCuration, rejectCuration, editCuration, type ICurationItemView } from '../../../../../modules/ai-tools';
+import { listCurations, listCurationHistory, approveCuration, rejectCuration, editCuration, type ICurationItemView } from '../../../../../modules/ai-tools';
 import styles from '../page.module.scss';
 
 /** Truncate body text for the inline preview cell. */
@@ -109,6 +112,27 @@ function CurationPreview({ preview }: { preview: ICurationItemView['preview'] })
 }
 
 /**
+ * Render a decided item's outcome for the history view: the terminal status as a
+ * toned badge, when it was decided, and the deciding curator's Better Auth id.
+ * Read-only by design — a history row offers no actions because its effect already
+ * committed or was discarded, and the record exists only as an audit trail.
+ *
+ * @param props.item - The decided curation envelope (status is approved/rejected).
+ * @returns The decision cell content.
+ */
+function CurationDecision({ item }: { item: ICurationItemView }) {
+    return (
+        <div className={styles.curation_preview}>
+            <Badge tone={item.status === 'approved' ? 'success' : 'danger'}>{item.status}</Badge>
+            {item.decidedAt && (
+                <div className={styles.tool_desc}><ClientTime date={item.decidedAt} format="datetime" /></div>
+            )}
+            {item.decidedBy && <div className={styles.tool_desc}>by {item.decidedBy}</div>}
+        </div>
+    );
+}
+
+/**
  * Curation tab content.
  *
  * @param props.onChanged - Called after load/approve/reject so the page header
@@ -116,6 +140,7 @@ function CurationPreview({ preview }: { preview: ICurationItemView['preview'] })
  * @returns The tab.
  */
 export function CurationTab({ onChanged }: { onChanged: () => void }) {
+    const [view, setView] = useState<'pending' | 'history'>('pending');
     const [items, setItems] = useState<ICurationItemView[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -125,16 +150,19 @@ export function CurationTab({ onChanged }: { onChanged: () => void }) {
 
     const load = useCallback(async () => {
         try {
-            setItems(await listCurations());
+            setItems(await (view === 'pending' ? listCurations() : listCurationHistory()));
             setError(null);
         } catch (err) {
-            setError(err instanceof Error ? err.message : 'Failed to load curation queue');
+            setError(err instanceof Error ? err.message : `Failed to load curation ${view}`);
         } finally {
             setLoading(false);
         }
-    }, []);
+    }, [view]);
 
-    useEffect(() => { void load(); }, [load]);
+    // Switching views is a user action, so a brief loading state is acceptable here
+    // (admin surface, not SSR-first primary content); reset it so the prior view's
+    // rows don't linger under the new view's header while the fetch is in flight.
+    useEffect(() => { setLoading(true); void load(); }, [load]);
 
     useEffect(() => {
         const socket = getSocket();
@@ -185,63 +213,71 @@ export function CurationTab({ onChanged }: { onChanged: () => void }) {
         });
     }, [open, close, load, onChanged, push]);
 
-    if (loading) {
-        return <div className={styles.placeholder}>Loading curation queue…</div>;
-    }
+    const isHistory = view === 'history';
 
     return (
         <Stack gap="md">
+            <div className={styles.row_actions} role="group" aria-label="Curation view">
+                <Button variant={isHistory ? 'ghost' : 'primary'} size="sm" onClick={() => setView('pending')}>Pending</Button>
+                <Button variant={isHistory ? 'primary' : 'ghost'} size="sm" onClick={() => setView('history')}>History</Button>
+            </div>
             {error && <div className="alert" role="alert">{error}</div>}
             <p className="text-muted" style={{ margin: 0, fontSize: 'var(--font-size-body-sm)' }}>
-                Effects held for human review across every content type. Approving commits the effect through its owning
-                plugin; rejecting discards it. An item whose owning plugin is disabled cannot be decided until it is
-                re-enabled.
+                {isHistory
+                    ? 'Past curation decisions, most recent first. Records persist after a decision; each row shows its frozen preview, the outcome, and who decided.'
+                    : 'Effects held for human review across every content type. Approving commits the effect through its owning plugin; rejecting discards it. An item whose owning plugin is disabled cannot be decided until it is re-enabled.'}
             </p>
-            {items.length === 0
-                ? <div className={styles.placeholder}>Nothing is awaiting curation.</div>
-                : (
-                    <div className="table-scroll">
-                        <Table>
-                            <Thead>
-                                <Tr>
-                                    <Th width="shrink">Held</Th>
-                                    <Th width="shrink">Type</Th>
-                                    <Th>Preview</Th>
-                                    <Th width="shrink">Decision</Th>
-                                </Tr>
-                            </Thead>
-                            <Tbody>
-                                {items.map(item => (
-                                    <Tr key={item.id}>
-                                        <Td muted><ClientTime date={item.createdAt} format="datetime" /></Td>
-                                        <Td>
-                                            <div className={styles.tool_name}>{item.preview.title ?? item.typeId}</div>
-                                            <div className={styles.tool_desc}>
-                                                {item.providerId}{item.source ? ` · ${item.source}` : ''}
-                                            </div>
-                                        </Td>
-                                        <Td><CurationPreview preview={item.preview} /></Td>
-                                        <Td>
-                                            <div className={styles.row_actions}>
-                                                <Button variant="primary" size="sm" loading={busyId === item.id} disabled={busyId !== null && busyId !== item.id} onClick={() => { void resolve(item.id, 'approve'); }}>
-                                                    <Check size={16} /> Approve
-                                                </Button>
-                                                {item.preview.editable && (
-                                                    <Button variant="secondary" size="sm" disabled={busyId !== null} onClick={() => openEditor(item)}>
-                                                        <Pencil size={16} /> Edit
-                                                    </Button>
-                                                )}
-                                                <Button variant="danger" size="sm" disabled={busyId !== null && busyId !== item.id} onClick={() => { void resolve(item.id, 'reject'); }}>
-                                                    <X size={16} /> Reject
-                                                </Button>
-                                            </div>
-                                        </Td>
+            {loading
+                ? <div className={styles.placeholder}>Loading…</div>
+                : items.length === 0
+                    ? <div className={styles.placeholder}>{isHistory ? 'No curation decisions yet.' : 'Nothing is awaiting curation.'}</div>
+                    : (
+                        <div className="table-scroll">
+                            <Table>
+                                <Thead>
+                                    <Tr>
+                                        <Th width="shrink">Held</Th>
+                                        <Th width="shrink">Type</Th>
+                                        <Th>Preview</Th>
+                                        <Th width="shrink">Decision</Th>
                                     </Tr>
-                                ))}
-                            </Tbody>
-                        </Table>
-                    </div>
-                )}
+                                </Thead>
+                                <Tbody>
+                                    {items.map(item => (
+                                        <Tr key={item.id}>
+                                            <Td muted><ClientTime date={item.createdAt} format="datetime" /></Td>
+                                            <Td>
+                                                <div className={styles.tool_name}>{item.preview.title ?? item.typeId}</div>
+                                                <div className={styles.tool_desc}>
+                                                    {item.providerId}{item.source ? ` · ${item.source}` : ''}
+                                                </div>
+                                            </Td>
+                                            <Td><CurationPreview preview={item.preview} /></Td>
+                                            <Td>
+                                                {isHistory
+                                                    ? <CurationDecision item={item} />
+                                                    : (
+                                                        <div className={styles.row_actions}>
+                                                            <Button variant="primary" size="sm" loading={busyId === item.id} disabled={busyId !== null && busyId !== item.id} onClick={() => { void resolve(item.id, 'approve'); }}>
+                                                                <Check size={16} /> Approve
+                                                            </Button>
+                                                            {item.preview.editable && (
+                                                                <Button variant="secondary" size="sm" disabled={busyId !== null} onClick={() => openEditor(item)}>
+                                                                    <Pencil size={16} /> Edit
+                                                                </Button>
+                                                            )}
+                                                            <Button variant="danger" size="sm" disabled={busyId !== null && busyId !== item.id} onClick={() => { void resolve(item.id, 'reject'); }}>
+                                                                <X size={16} /> Reject
+                                                            </Button>
+                                                        </div>
+                                                    )}
+                                            </Td>
+                                        </Tr>
+                                    ))}
+                                </Tbody>
+                            </Table>
+                        </div>
+                    )}
         </Stack>
     );
 }

--- a/src/frontend/app/(core)/system/ai-tools/tabs/CurationTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/CurationTab.tsx
@@ -162,7 +162,26 @@ export function CurationTab({ onChanged }: { onChanged: () => void }) {
     // Switching views is a user action, so a brief loading state is acceptable here
     // (admin surface, not SSR-first primary content); reset it so the prior view's
     // rows don't linger under the new view's header while the fetch is in flight.
-    useEffect(() => { setLoading(true); void load(); }, [load]);
+    // A `cancelled` flag discards a slower earlier fetch that resolves after the
+    // user has already toggled to the other view, so its stale rows can't overwrite
+    // the current view's state (matches the menu/page.tsx load guard).
+    useEffect(() => {
+        let cancelled = false;
+        setLoading(true);
+        (async () => {
+            try {
+                const next = await (view === 'pending' ? listCurations() : listCurationHistory());
+                if (cancelled) return;
+                setItems(next);
+                setError(null);
+            } catch (err) {
+                if (!cancelled) setError(err instanceof Error ? err.message : `Failed to load curation ${view}`);
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [view]);
 
     useEffect(() => {
         const socket = getSocket();

--- a/src/frontend/modules/ai-tools/api/client.ts
+++ b/src/frontend/modules/ai-tools/api/client.ts
@@ -321,6 +321,18 @@ export async function listCurations(): Promise<ICurationItemView[]> {
 }
 
 /**
+ * List decided curation items (approved/rejected), most-recently-decided first.
+ * The pending queue answers "what needs me now?"; this answers "what was decided,
+ * when, and by whom?" — the records persist after a decision, this surfaces them.
+ *
+ * @returns The decided curation envelopes, newest decision first.
+ */
+export async function listCurationHistory(): Promise<ICurationItemView[]> {
+    const data = await parse<{ curations: ICurationItemView[] }>(await fetch(`${BASE}/curations/history`), 'load curation history');
+    return data.curations;
+}
+
+/**
  * Fetch the count of pending curation items, for the header badge.
  *
  * @returns The pending count.


### PR DESCRIPTION
## What

Adds a **History** view to the AI Tools → Curation admin tab, surfacing past curation decisions (approved/rejected) alongside the existing live **Pending** queue.

## Why

Curation decisions already persist in `module_ai-tools_curations` — approving or rejecting mutates an item in place (`decidedAt`/`decidedBy` recorded), it never deletes the record. But the only reader was `listPending()`, so the audit trail was invisible from the UI. This exposes it.

## Changes

- **`CurationQueue.listHistory(limit)`** — queries decided items, newest decision first, backed by a new `{ status, decidedAt }` index.
- **`CurationService.listHistory()`** — returns the **cached** preview snapshot rather than a live `describe()`, so history faithfully reflects what was decided rather than the owner's current record.
- **`GET /curations/history`** — admin-gated endpoint; serialized through the existing `serializeCurationItem`.
- **Frontend** — `listCurationHistory()` client fn; `CurationTab` gains a Pending/History toggle and a read-only decision cell (outcome badge + `<ClientTime>` + curator id).
- **Docs** — `system-curation.md` and the ai-tools module README document the new audit surface.

## Verification

`typecheck:backend` and `typecheck:frontend` clean; ai-tools module suite passes (79/79).

## Note

No retention/pruning exists for `module_ai-tools_curations` (unlike the 90-day prune on invocations), so history grows unbounded; the new index keeps the query fast.