### PR TITLE
Refine AI tools dashboard: collapsible trifecta, conversation cost column

### DIFF
--- a/src/frontend/app/(core)/system/ai-tools/components/TrifectaPanel.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/TrifectaPanel.tsx
@@ -84,6 +84,7 @@ export function TrifectaPanel({ status }: { status: ITrifectaStatus }) {
                     className={styles.trifecta_toggle}
                     onClick={() => setExpanded(current => !current)}
                     aria-expanded={expanded}
+                    aria-controls="trifecta-panel-details"
                 >
                     <Icon size={18} style={{ color: accent.color }} />
                     <strong style={{ color: accent.text }}>
@@ -91,29 +92,31 @@ export function TrifectaPanel({ status }: { status: ITrifectaStatus }) {
                     </strong>
                     <Chevron size={18} className={styles.trifecta_toggle_chevron} />
                 </button>
-                {expanded && (
-                    <>
-                        <p className="text-muted" style={{ margin: 0, fontSize: 'var(--font-size-body-sm)' }}>
-                            {supervised
-                                ? 'All three capabilities are enabled, but every off-platform channel forces curator review — injected text cannot exfiltrate autonomously, since a human releases each outbound effect. Residual risk remains: a reviewer must read the raw payload to catch a disguised one, so keep the review queue focused enough that approvals stay meaningful.'
-                                : 'The enabled tools combine all three legs with an open off-platform channel, so prompt-injected text could read a secret and exfiltrate it in one turn. Disable one leg below to break the chain.'}
-                        </p>
-                        <div className={styles.trifecta_legs}>
-                            <Leg label="Private data" tools={[...status.privateData, ...status.privateDataVariables]} tone={accent.tone} />
-                            <Leg label="Untrusted content" tools={status.untrustedContent} tone={accent.tone} />
-                            {(status.exfiltrationOpen.length > 0 || status.exfiltrationGated.length > 0) && (
-                                <Stack gap="sm">
-                                    {status.exfiltrationOpen.length > 0 && (
-                                        <Leg label="Exfiltration (open)" tools={status.exfiltrationOpen} tone="danger" />
-                                    )}
-                                    {status.exfiltrationGated.length > 0 && (
-                                        <Leg label="Exfiltration (curator-gated)" tools={status.exfiltrationGated} tone="warning" />
-                                    )}
-                                </Stack>
-                            )}
-                        </div>
-                    </>
-                )}
+                <div id="trifecta-panel-details">
+                    {expanded && (
+                        <Stack gap="sm">
+                            <p className="text-muted" style={{ margin: 0, fontSize: 'var(--font-size-body-sm)' }}>
+                                {supervised
+                                    ? 'All three capabilities are enabled, but every off-platform channel forces curator review — injected text cannot exfiltrate autonomously, since a human releases each outbound effect. Residual risk remains: a reviewer must read the raw payload to catch a disguised one, so keep the review queue focused enough that approvals stay meaningful.'
+                                    : 'The enabled tools combine all three legs with an open off-platform channel, so prompt-injected text could read a secret and exfiltrate it in one turn. Disable one leg below to break the chain.'}
+                            </p>
+                            <div className={styles.trifecta_legs}>
+                                <Leg label="Private data" tools={[...status.privateData, ...status.privateDataVariables]} tone={accent.tone} />
+                                <Leg label="Untrusted content" tools={status.untrustedContent} tone={accent.tone} />
+                                {(status.exfiltrationOpen.length > 0 || status.exfiltrationGated.length > 0) && (
+                                    <Stack gap="sm">
+                                        {status.exfiltrationOpen.length > 0 && (
+                                            <Leg label="Exfiltration (open)" tools={status.exfiltrationOpen} tone="danger" />
+                                        )}
+                                        {status.exfiltrationGated.length > 0 && (
+                                            <Leg label="Exfiltration (curator-gated)" tools={status.exfiltrationGated} tone="warning" />
+                                        )}
+                                    </Stack>
+                                )}
+                            </div>
+                        </Stack>
+                    )}
+                </div>
             </Stack>
         </Card>
     );

--- a/src/frontend/app/(core)/system/ai-tools/components/TrifectaPanel.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/TrifectaPanel.tsx
@@ -10,9 +10,15 @@
  * — a caution, not an all-clear), and `lethal` (all three present with an open,
  * autonomously closable channel). It names the contributing tools so an operator
  * can break the chain by disabling one leg.
+ *
+ * The amber/red states open collapsed — only the severity icon and headline show
+ * until an operator expands the card — so the dashboard stays scannable and the
+ * full explanation plus contributing-tool list appear on demand rather than
+ * dominating the page whenever a trifecta is present.
  */
 
-import { AlertTriangle, ShieldAlert, ShieldCheck } from 'lucide-react';
+import { useState } from 'react';
+import { AlertTriangle, ChevronDown, ChevronRight, ShieldAlert, ShieldCheck } from 'lucide-react';
 import type { ITrifectaStatus } from '@/types';
 import { Card } from '../../../../../components/ui/Card';
 import { Badge } from '../../../../../components/ui/Badge';
@@ -42,10 +48,18 @@ function Leg({ label, tools, tone }: { label: string; tools: string[]; tone: Leg
  * with the exfiltration leg split into open (danger) and curator-gated (warning)
  * channels so the operator sees why a state is amber rather than red.
  *
+ * The amber/red card opens collapsed: a single toggle button shows only the
+ * severity icon and headline, keeping the dashboard scannable, and the full
+ * explanation plus contributing-tool legs render only once the operator expands
+ * it. Disclosure is client-only UI state, so no SSR hydration is involved and
+ * the deterministic collapsed default produces matching server/client markup.
+ *
  * @param props.status - The current trifecta status over the enabled set.
  * @returns The banner.
  */
 export function TrifectaPanel({ status }: { status: ITrifectaStatus }) {
+    const [expanded, setExpanded] = useState(false);
+
     if (status.severity === 'safe') {
         return (
             <div className="text-muted" style={{ display: 'flex', alignItems: 'center', gap: 'var(--gap-sm)', fontSize: 'var(--font-size-body-sm)' }}>
@@ -60,35 +74,46 @@ export function TrifectaPanel({ status }: { status: ITrifectaStatus }) {
         ? { color: 'var(--color-warning)', text: 'var(--color-warning-text)', border: 'var(--color-warning-alpha-40)', tone: 'warning' as const }
         : { color: 'var(--color-danger)', text: 'var(--color-danger-text)', border: 'var(--color-danger-alpha-50)', tone: 'danger' as const };
     const Icon = supervised ? ShieldAlert : AlertTriangle;
+    const Chevron = expanded ? ChevronDown : ChevronRight;
 
     return (
         <Card tone="accent" style={{ borderColor: accent.border }}>
             <Stack gap="sm">
-                <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--gap-sm)' }}>
+                <button
+                    type="button"
+                    className={styles.trifecta_toggle}
+                    onClick={() => setExpanded(current => !current)}
+                    aria-expanded={expanded}
+                >
                     <Icon size={18} style={{ color: accent.color }} />
                     <strong style={{ color: accent.text }}>
                         {supervised ? 'Trifecta present — exfiltration is curator-gated' : 'Lethal trifecta present'}
                     </strong>
-                </div>
-                <p className="text-muted" style={{ margin: 0, fontSize: 'var(--font-size-body-sm)' }}>
-                    {supervised
-                        ? 'All three capabilities are enabled, but every off-platform channel forces curator review — injected text cannot exfiltrate autonomously, since a human releases each outbound effect. Residual risk remains: a reviewer must read the raw payload to catch a disguised one, so keep the review queue focused enough that approvals stay meaningful.'
-                        : 'The enabled tools combine all three legs with an open off-platform channel, so prompt-injected text could read a secret and exfiltrate it in one turn. Disable one leg below to break the chain.'}
-                </p>
-                <div className={styles.trifecta_legs}>
-                    <Leg label="Private data" tools={[...status.privateData, ...status.privateDataVariables]} tone={accent.tone} />
-                    <Leg label="Untrusted content" tools={status.untrustedContent} tone={accent.tone} />
-                    {(status.exfiltrationOpen.length > 0 || status.exfiltrationGated.length > 0) && (
-                        <Stack gap="sm">
-                            {status.exfiltrationOpen.length > 0 && (
-                                <Leg label="Exfiltration (open)" tools={status.exfiltrationOpen} tone="danger" />
+                    <Chevron size={18} className={styles.trifecta_toggle_chevron} />
+                </button>
+                {expanded && (
+                    <>
+                        <p className="text-muted" style={{ margin: 0, fontSize: 'var(--font-size-body-sm)' }}>
+                            {supervised
+                                ? 'All three capabilities are enabled, but every off-platform channel forces curator review — injected text cannot exfiltrate autonomously, since a human releases each outbound effect. Residual risk remains: a reviewer must read the raw payload to catch a disguised one, so keep the review queue focused enough that approvals stay meaningful.'
+                                : 'The enabled tools combine all three legs with an open off-platform channel, so prompt-injected text could read a secret and exfiltrate it in one turn. Disable one leg below to break the chain.'}
+                        </p>
+                        <div className={styles.trifecta_legs}>
+                            <Leg label="Private data" tools={[...status.privateData, ...status.privateDataVariables]} tone={accent.tone} />
+                            <Leg label="Untrusted content" tools={status.untrustedContent} tone={accent.tone} />
+                            {(status.exfiltrationOpen.length > 0 || status.exfiltrationGated.length > 0) && (
+                                <Stack gap="sm">
+                                    {status.exfiltrationOpen.length > 0 && (
+                                        <Leg label="Exfiltration (open)" tools={status.exfiltrationOpen} tone="danger" />
+                                    )}
+                                    {status.exfiltrationGated.length > 0 && (
+                                        <Leg label="Exfiltration (curator-gated)" tools={status.exfiltrationGated} tone="warning" />
+                                    )}
+                                </Stack>
                             )}
-                            {status.exfiltrationGated.length > 0 && (
-                                <Leg label="Exfiltration (curator-gated)" tools={status.exfiltrationGated} tone="warning" />
-                            )}
-                        </Stack>
-                    )}
-                </div>
+                        </div>
+                    </>
+                )}
             </Stack>
         </Card>
     );

--- a/src/frontend/app/(core)/system/ai-tools/page.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/page.module.scss
@@ -126,6 +126,27 @@
     font-size: var(--font-size-body-sm);
 }
 
+/* Trifecta banner disclosure toggle: the icon + headline row doubles as the
+   expand/collapse control, so it resets the button chrome and lets the trailing
+   chevron drift to the right edge to signal the row is interactive. */
+.trifecta_toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    width: 100%;
+    padding: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    color: var(--color-text);
+}
+
+.trifecta_toggle_chevron {
+    margin-left: auto;
+    color: var(--color-text-muted);
+}
+
 /* Trifecta banner contributing-tool lists. */
 .trifecta_legs {
     display: grid;

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
@@ -131,11 +131,15 @@
     50% { opacity: var(--opacity-35); }
 }
 
-/* Scrolling transcript region. Keeps a min-height floor so dragging the
-   composer taller shrinks it only to that floor, then grows the card — the
-   transcript never collapses to zero. */
+/* Scrolling transcript region. Flex-basis is 0 (not auto) so the transcript's
+   intrinsic contribution to the card height is only its min-height floor, not
+   the conversation's content height — the card holds at its resting height and
+   the transcript scrolls as turns accumulate. (With basis auto, content height
+   drives the card taller and overflow never engages.) The min-height floor also
+   bounds the shrink: dragging the composer taller reduces the transcript only
+   to that floor, then grows the card. */
 .transcript {
-    flex: 1 1 auto;
+    flex: 1 1 0;
     min-height: var(--query-transcript-min-height);
     overflow-y: auto;
     display: flex;
@@ -468,9 +472,14 @@
     color: var(--color-text-muted);
 }
 
+/* The list is a three-track grid — prompt (flexible) | cost | action — so the
+ * cost and "Open in chat" columns align across every row like a table while
+ * each takes only the width its content needs. Each row is a subgrid spanning
+ * all three tracks, which keeps the per-row card border/background while
+ * inheriting the shared column edges. */
 .history_list {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr auto auto;
     gap: var(--gap-sm);
     list-style: none;
     margin: 0;
@@ -478,22 +487,39 @@
 }
 
 .history_item {
-    display: flex;
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: subgrid;
     align-items: center;
     gap: var(--gap-sm);
     padding: var(--padding-sm);
     border: var(--border-width-thin) solid var(--color-border);
     border-radius: var(--radius-sm);
     background: var(--color-surface-muted);
-    flex-wrap: wrap;
 }
 
 .history_item_main {
-    flex: 1 1 auto;
     min-width: 0;
     display: flex;
     flex-direction: column;
     gap: var(--gap-2xs);
+}
+
+/* Cost column — right-aligned and nowrap so figures form a clean rule against
+ * the action column; tabular numerals keep digits in vertical register. */
+.history_item_cost {
+    justify-self: end;
+    white-space: nowrap;
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-medium);
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text-muted);
+}
+
+/* Action column — hold the button at its intrinsic width so it never stretches. */
+.history_item_action {
+    justify-self: end;
+    white-space: nowrap;
 }
 
 .history_item_prompt {

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
@@ -95,6 +95,13 @@ interface ConversationGroup {
     turns: number;
     firstPrompt: string;
     lastAt: string;
+    /**
+     * Estimated total USD cost of the conversation, summed across every priced
+     * turn at the rates captured when each turn ran. `null` when not a single
+     * turn could be priced, so the row shows a dash rather than a misleading
+     * $0.00 — mirrors the live transcript's sum-or-hide behavior.
+     */
+    costUsd: number | null;
 }
 
 /**
@@ -163,15 +170,22 @@ function groupConversations(records: IAiQueryRecord[]): ConversationGroup[] {
         if (!id) {
             continue;
         }
+        // Add this turn's priced cost, treating an unpriced turn as a no-op so
+        // a partially-priced conversation still surfaces the sum of what could
+        // be priced rather than collapsing to null.
+        const turnCost = typeof record.costUsd === 'number' ? record.costUsd : null;
         const existing = byId.get(id);
         if (existing) {
             existing.turns += 1;
+            if (turnCost !== null) {
+                existing.costUsd = (existing.costUsd ?? 0) + turnCost;
+            }
             // Records arrive newest-first, so an earlier record carries the
             // older prompt — keep it as the conversation's opening line.
             existing.firstPrompt = record.prompt;
         } else {
             order.push(id);
-            byId.set(id, { conversationId: id, turns: 1, firstPrompt: record.prompt, lastAt: record.createdAt });
+            byId.set(id, { conversationId: id, turns: 1, firstPrompt: record.prompt, lastAt: record.createdAt, costUsd: turnCost });
         }
     }
     return order.map(id => byId.get(id) as ConversationGroup);
@@ -819,9 +833,16 @@ export function QueryTab() {
                                                 <span>· {group.turns} turn{group.turns === 1 ? '' : 's'}</span>
                                             </span>
                                         </div>
+                                        <span
+                                            className={styles.history_item_cost}
+                                            title="Estimated total cost of this conversation, summed across turns at the provider's per-model rates."
+                                        >
+                                            {formatUsd(group.costUsd)}
+                                        </span>
                                         <Button
                                             variant="secondary"
                                             size="sm"
+                                            className={styles.history_item_action}
                                             onClick={() => { void openConversation(group.conversationId); }}
                                             aria-label={`Open conversation starting "${group.firstPrompt}" in chat`}
                                         >

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
@@ -835,7 +835,8 @@ export function QueryTab() {
                                         </div>
                                         <span
                                             className={styles.history_item_cost}
-                                            title="Estimated total cost of this conversation, summed across turns at the provider's per-model rates."
+                                            title="Estimated cost across this conversation's recently-loaded turns, at the provider's per-model rates. Open the conversation to see every turn."
+                                            aria-label={group.costUsd !== null ? `Estimated cost across loaded turns: ${formatUsd(group.costUsd)}` : 'Cost not available'}
                                         >
                                             {formatUsd(group.costUsd)}
                                         </span>

--- a/src/frontend/app/(core)/system/ai-tools/tabs/SavedPromptsPanel.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/SavedPromptsPanel.tsx
@@ -260,12 +260,14 @@ export function SavedPromptsPanel({
                             >
                                 {sp.name}
                             </button>
-                            <div className={styles.row_meta}>
-                                {renderScheduleChip(sp)}
-                                {sp.lastRunAt && <span>Last run {formatRelativeTime(sp.lastRunAt)}</span>}
-                            </div>
+                            {sp.lastRunAt && (
+                                <div className={styles.row_meta}>
+                                    <span>Last run {formatRelativeTime(sp.lastRunAt)}</span>
+                                </div>
+                            )}
                         </div>
                         <div className={styles.row_actions}>
+                            {renderScheduleChip(sp)}
                             <IconButton
                                 variant="primary"
                                 size="sm"

--- a/src/frontend/app/(core)/system/ai-tools/tabs/ScreenSettingsSection.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/ScreenSettingsSection.module.scss
@@ -6,7 +6,7 @@
  * slideout/modal contexts), not the viewport.
  */
 
-@use '../../../breakpoints' as *;
+@use '../../../../breakpoints' as *;
 
 /* The wrapper declares the query container; the inner grid responds to it. A
  * container query (not a media query) so the layout answers to the section's


### PR DESCRIPTION
Refines the `/system/ai-tools` dashboard UI.

- **Collapsible trifecta banner.** The amber/red trifecta panel now opens collapsed to just the severity icon and headline behind a toggle button, keeping the dashboard scannable; the full explanation and contributing-tool legs render on demand. Disclosure is client-only state with a deterministic collapsed default, so server/client markup match and no hydration is involved.
- **Conversation cost column.** Query history rows now show an estimated total USD cost per conversation, summed across priced turns at each turn's captured rates. Unpriced conversations show a dash rather than a misleading $0.00. The history list moves to a three-track subgrid so cost and action columns align across rows.
- **Saved-prompt schedule chip** relocated into the row actions area.
- **Transcript sizing fix.** `flex: 1 1 0` so the card holds at its resting height and the transcript scrolls as turns accumulate, instead of content height growing the card.
- **Breakpoints import fix** in `ScreenSettingsSection.module.scss` (`@use` path depth).