### PR TITLE
fix(widgets): mark RawHtmlWidget as a client component

### DIFF
--- a/src/frontend/components/widgets/RawHtmlWidget.tsx
+++ b/src/frontend/components/widgets/RawHtmlWidget.tsx
@@ -16,13 +16,24 @@
  *
  * SSR + Live Updates: this is a pure presentational component whose
  * entire output derives from the SSR `data` prop — no client fetch, no
- * local state, no loading flash — so it renders fully on the server and
- * needs no `'use client'` directive or hydration guard. The content is
- * route-independent and never changes after render, so there is no live
- * update to subscribe to.
+ * local state, no loading flash. The content is route-independent and
+ * never changes after render, so there is no live update to subscribe to.
+ *
+ * The `'use client'` directive is mandatory despite that — not optional.
+ * Every widget is rendered through `WidgetWithContext`, a client component
+ * that receives the resolved component as a `Component` prop. React can
+ * only serialize a *client component reference* across that server→client
+ * boundary; a plain (non-`'use client'`) function is unserializable and
+ * throws "Functions cannot be passed directly to Client Components",
+ * crashing the SSR render of whatever zone the widget sits in (fatal for
+ * the root-layout `footer` zone, which renders on every route). Marking it
+ * a client component still SSRs the markup — App Router renders client
+ * components on the server — so the no-flash behavior is preserved.
  *
  * @module frontend/components/widgets/RawHtmlWidget
  */
+
+'use client';
 
 import type { IWidgetComponentProps } from '@/types';
 


### PR DESCRIPTION
## Summary

`RawHtmlWidget` was the only widget component missing the `'use client'` directive. Every widget is rendered by passing its component as a prop into `WidgetWithContext` — a client component. React can only serialize a *client component reference* across the server→client boundary; a plain non-`'use client'` function is unserializable and throws *"Functions cannot be passed directly to Client Components"*, which surfaces in production as the generic *"An error occurred in the Server Components render."*

Because the `footer` zone renders in the root layout (`app/layout.tsx`), placing a raw-html widget there crashed **every** route, not just one page.

## Fix

Add `'use client';` to `RawHtmlWidget.tsx`, making it a serializable client reference like every other widget. The component still server-renders its markup (App Router SSRs client components), so there is no loading flash and the raw HTML still appears in SSR output. This matches the documented widget-authoring standard (`plugins-widget-zones-ssr.md`), which `RawHtmlWidget` was the lone violator of. JSDoc updated to explain why the directive is mandatory.