### PR TITLE
feat(widgets): unfiltered placement view and explicit zone ordering

### DIFF
--- a/docs/plugins/plugins-widget-zones-registration.md
+++ b/docs/plugins/plugins-widget-zones-registration.md
@@ -62,10 +62,13 @@ init: async (context: IPluginContext) => {
         label: 'My plugin sidebar',
         description: 'Right rail on the My Plugin page.',
         host: 'plugin',
-        layout: 'vertical'
+        layout: 'vertical',
+        order: 10
     }, myManifest.id);
 }
 ```
+
+The optional `order` controls where the zone sits **within its host track in the `/system/widgets` editor** — lower sorts first, so a zone meant to sit low on the page declares a higher value. This orders the zones in the operator's catalog; it is unrelated to the placement `order` that orders widgets *within* a zone (see [Ordering](#ordering)). Omit it and the zone sorts after every explicitly-ordered zone in its track, by id.
 
 ## Registering a Type Without a Default Placement
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delphian/tronrelic-types",
-  "version": "4.12.0",
+  "version": "4.13.0",
   "description": "Core type definitions for the TronRelic platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/types/src/widget-zones/IZoneDescriptor.ts
+++ b/packages/types/src/widget-zones/IZoneDescriptor.ts
@@ -65,6 +65,16 @@ export interface IZoneDescriptor {
     readonly host: ZoneHost;
     /** Visual layout hint. */
     readonly layout: ZoneLayout;
+    /**
+     * Display order of this zone within its host track in admin tooling
+     * (the `/system/widgets` placement editor). Lower sorts first, so a
+     * zone authored to sit at the bottom of the page — e.g. the site
+     * footer — declares a higher value than zones above it. This orders
+     * the *zones* in the editor, not the placements within a zone (that
+     * is the placement's own `order`). Optional: zones omitting it sort
+     * after all explicitly-ordered zones, by id.
+     */
+    readonly order?: number;
 }
 
 /**
@@ -85,6 +95,12 @@ export interface IDefineZoneOptions {
     host: ZoneHost;
     /** Visual layout hint. Defaults to `'vertical'` when omitted. */
     layout?: ZoneLayout;
+    /**
+     * Display order within the host track in admin tooling. Lower sorts
+     * first; omit to sort after explicitly-ordered zones by id. See
+     * {@link IZoneDescriptor.order}.
+     */
+    order?: number;
 }
 
 /**

--- a/packages/types/src/widget/IWidgetsService.ts
+++ b/packages/types/src/widget/IWidgetsService.ts
@@ -91,6 +91,13 @@ export interface IRegisterZoneInput {
     host: ZoneHost;
     /** Layout hint for the zone container. Defaults to `'vertical'`. */
     layout?: ZoneLayout;
+    /**
+     * Display order of this zone within its host track in the
+     * `/system/widgets` placement editor. Lower sorts first; omit to
+     * sort after explicitly-ordered zones by id. Orders the zones in the
+     * editor, not the placements within a zone.
+     */
+    order?: number;
 }
 
 /**

--- a/src/backend/modules/widgets/README.md
+++ b/src/backend/modules/widgets/README.md
@@ -141,6 +141,8 @@ The platform ships its own zones and widget types, registered by `WidgetsModule.
 
 **Zones** live in `zones/descriptors.ts`. The `footer` zone (`host: 'site'`) renders in the root layout below `<main>` inside a semantic `<footer>` and reaches every route — the home for site-wide footer content. Adding a zone requires a matching `<WidgetZone>` call site in a layout; descriptor and render site move together.
 
+Each descriptor carries an optional `order` (`IZoneDescriptor.order`) that sets where the zone appears within its host track in the `/system/widgets` editor — lower sorts first, so `footer` (order `90`) follows `ticker-after` (order `10`) rather than leading the site track alphabetically. `snapshot()` sorts by `order` then id; zones omitting it sort after explicitly-ordered ones. This orders the *zones* in the editor, distinct from the placement `order` that sorts widgets within a zone.
+
 **Widget types** live in `widget-types/core-widget-types.ts`. The only one today is `core:raw-html` — an operator-authored block of raw HTML or plain text. Its `defaultDataFetcher` reads `content` and `mode` straight from the placement's `instanceConfig` (validated against the type's `configSchema`), so the payload is route-independent. `mode: 'html'` injects raw markup verbatim; `mode: 'text'` escapes it. The content is admin-authored and trusted — consistent with head-fragment injection, themes, and pages markdown.
 
 A core widget type needs a matching frontend renderer keyed by its `typeId` in `components/widgets/widgets.core.ts`. That hand-written registry is merged ahead of the generator-owned `widgets.generated.ts` by `components/widgets/getWidgetComponent.ts`, so core components resolve without the plugin-registry generator touching them.

--- a/src/backend/modules/widgets/__tests__/core-catalog.test.ts
+++ b/src/backend/modules/widgets/__tests__/core-catalog.test.ts
@@ -95,6 +95,18 @@ describe('Core zone catalog', () => {
         }
         expect(widgets.hasZone('footer')).toBe(true);
     });
+
+    it('orders site-track zones by descriptor order, not alphabetically', () => {
+        // Regression guard: the footer zone must follow the block-ticker
+        // zone in the editor (page top-to-bottom order). The previous
+        // alphabetical snapshot sort put 'footer' ahead of 'ticker-after'.
+        const { widgets } = buildWidgetsService();
+        for (const descriptor of CORE_ZONE_DESCRIPTORS) {
+            widgets.registerZone(descriptor, 'core');
+        }
+        const siteTrack = widgets.listZones().tracks.find(track => track.id === 'site');
+        expect(siteTrack?.zones.map(zone => zone.id)).toEqual(['ticker-after', 'footer']);
+    });
 });
 
 describe('Core widget-type catalog (raw-html)', () => {

--- a/src/backend/modules/widgets/widgets.service.ts
+++ b/src/backend/modules/widgets/widgets.service.ts
@@ -226,7 +226,8 @@ export class WidgetsService implements IWidgetsService {
             label: input.label,
             description: input.description,
             host: input.host,
-            layout: input.layout
+            layout: input.layout,
+            order: input.order
         });
         return this.zones.register(ownerId, descriptor);
     }

--- a/src/backend/modules/widgets/zones/define-zone.ts
+++ b/src/backend/modules/widgets/zones/define-zone.ts
@@ -46,7 +46,8 @@ export function defineZone(options: IDefineZoneOptions): IZoneDescriptor {
         label: options.label,
         description: options.description,
         host: options.host,
-        layout: options.layout ?? 'vertical'
+        layout: options.layout ?? 'vertical',
+        order: options.order
     });
 
     KNOWN_ZONES.set(options.id, descriptor);

--- a/src/backend/modules/widgets/zones/descriptors.ts
+++ b/src/backend/modules/widgets/zones/descriptors.ts
@@ -31,7 +31,8 @@ export const CORE_ZONE_DESCRIPTORS: ReadonlyArray<IRegisterZoneInput> = [
         description:
             'Rendered in the root layout below the block ticker. Reaches every route the root layout serves.',
         host: 'site',
-        layout: 'vertical'
+        layout: 'vertical',
+        order: 10
     },
     {
         id: 'footer',
@@ -39,7 +40,8 @@ export const CORE_ZONE_DESCRIPTORS: ReadonlyArray<IRegisterZoneInput> = [
         description:
             'Rendered in the root layout below the main content, inside a semantic <footer>. Reaches every route the root layout serves — the home for site-wide footer content (links, legal text, attribution).',
         host: 'site',
-        layout: 'vertical'
+        layout: 'vertical',
+        order: 90
     },
     {
         id: 'main-before',
@@ -47,7 +49,8 @@ export const CORE_ZONE_DESCRIPTORS: ReadonlyArray<IRegisterZoneInput> = [
         description:
             'Above the primary page content inside the (core) route group. Front-of-house pages only.',
         host: 'core',
-        layout: 'vertical'
+        layout: 'vertical',
+        order: 10
     },
     {
         id: 'main-after',
@@ -55,7 +58,8 @@ export const CORE_ZONE_DESCRIPTORS: ReadonlyArray<IRegisterZoneInput> = [
         description:
             'Below the primary page content inside the (core) route group. Common destination for feeds and related-content widgets.',
         host: 'core',
-        layout: 'vertical'
+        layout: 'vertical',
+        order: 20
     },
     {
         id: 'plugin-content:before',
@@ -63,7 +67,8 @@ export const CORE_ZONE_DESCRIPTORS: ReadonlyArray<IRegisterZoneInput> = [
         description:
             'Above the rendered plugin page. Enables cross-plugin injection around plugin pages.',
         host: 'plugin',
-        layout: 'vertical'
+        layout: 'vertical',
+        order: 10
     },
     {
         id: 'plugin-content:after',
@@ -71,6 +76,7 @@ export const CORE_ZONE_DESCRIPTORS: ReadonlyArray<IRegisterZoneInput> = [
         description:
             'Below the rendered plugin page. Enables cross-plugin injection around plugin pages.',
         host: 'plugin',
-        layout: 'vertical'
+        layout: 'vertical',
+        order: 20
     }
 ] as const;

--- a/src/backend/modules/widgets/zones/zone-registry.ts
+++ b/src/backend/modules/widgets/zones/zone-registry.ts
@@ -200,13 +200,19 @@ export class ZoneRegistry implements IZoneRegistry {
      * Produce the introspection snapshot consumed by the admin endpoint.
      *
      * Groups every registered zone by host so the placement editor
-     * renders the catalog without re-grouping. Empty hosts appear in
-     * the snapshot to keep the timeline shape stable across deployments.
+     * renders the catalog without re-grouping. Within a host track zones
+     * sort by their descriptor `order` (lower first) so the editor lists
+     * them in page top-to-bottom order — e.g. the site footer, declared
+     * with a higher order, follows the block-ticker zone rather than
+     * leading the track alphabetically. Zones omitting `order` sort after
+     * explicitly-ordered ones, with id as the stable tie-breaker so the
+     * timeline shape stays deterministic across deployments. Empty hosts
+     * still appear to keep the track shape stable.
      *
      * @returns Structured payload ready for JSON serialization.
      */
     snapshot(): IZoneSnapshot {
-        const byHost: Map<ZoneHost, IZoneSnapshotRecord[]> = new Map();
+        const byHost: Map<ZoneHost, IRegisteredZone[]> = new Map();
         for (const track of HOST_TRACKS) {
             byHost.set(track.id, []);
         }
@@ -214,17 +220,35 @@ export class ZoneRegistry implements IZoneRegistry {
         for (const entry of this.zones.values()) {
             const bucket = byHost.get(entry.descriptor.host);
             if (!bucket) continue;
-            bucket.push(toSnapshotRecord(entry));
+            bucket.push(entry);
         }
 
         const tracks = HOST_TRACKS.map(track => ({
             id: track.id,
             label: track.label,
-            zones: (byHost.get(track.id) ?? []).sort((a, b) => a.id.localeCompare(b.id))
+            zones: (byHost.get(track.id) ?? [])
+                .sort((a, b) => zoneOrder(a) - zoneOrder(b) || a.descriptor.id.localeCompare(b.descriptor.id))
+                .map(toSnapshotRecord)
         }));
 
         return { tracks };
     }
+}
+
+/**
+ * Resolve a registered zone's sort weight for the admin snapshot.
+ *
+ * Zones declare an optional `order` to control where they sit within
+ * their host track; the snapshot sorts ascending so lower renders first.
+ * Zones that omit it fall to the end of the track (a large sentinel)
+ * rather than the front, so an unordered plugin zone never jumps ahead
+ * of a deliberately-placed core zone — id breaks the remaining ties.
+ *
+ * @param entry - Internal registered-zone record.
+ * @returns Numeric sort weight; `Number.MAX_SAFE_INTEGER` when unset.
+ */
+function zoneOrder(entry: IRegisteredZone): number {
+    return typeof entry.descriptor.order === 'number' ? entry.descriptor.order : Number.MAX_SAFE_INTEGER;
 }
 
 /**

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -440,8 +440,20 @@ export default function WidgetsAdminPage() {
             if (active.id === over.id && sourceZone === destZone) return;
 
             const sameZone = sourceZone === destZone;
+            // Reorder only the placements the current view actually shows.
+            // `grouped` renders global-only placements when no route is
+            // selected and route-matching placements otherwise; the drag
+            // renumber must use the identical predicate or it interleaves and
+            // PATCHes hidden placements (route-scoped rows in the unfiltered
+            // view, other-route rows in a filtered view) the operator never
+            // sees. The resolver only ever orders placements among those that
+            // match a given path, so renumbering the visible subset is safe.
+            const visibleInView = (p: IPlacement): boolean =>
+                selectedRoute === null
+                    ? p.routes.length === 0
+                    : placementMatchesRoute(p.routes, selectedRoute);
             const sourceList = placements
-                .filter(p => p.zoneId === sourceZone)
+                .filter(p => p.zoneId === sourceZone && visibleInView(p))
                 .sort((a, b) => a.order - b.order);
             const moved = sourceList.find(p => p.id === active.id);
             if (!moved) return;
@@ -450,7 +462,7 @@ export default function WidgetsAdminPage() {
             const destListPrev = sameZone
                 ? sourceWithoutActive
                 : placements
-                    .filter(p => p.zoneId === destZone)
+                    .filter(p => p.zoneId === destZone && visibleInView(p))
                     .sort((a, b) => a.order - b.order);
 
             const insertIdx =
@@ -505,7 +517,7 @@ export default function WidgetsAdminPage() {
                 void fetchAll(false);
             }
         },
-        [placements, patchPlacement, notifyError, fetchAll]
+        [placements, selectedRoute, patchPlacement, notifyError, fetchAll]
     );
 
     /**

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -237,9 +237,11 @@ export default function WidgetsAdminPage() {
     const [error, setError] = useState<string | null>(null);
     const [busyId, setBusyId] = useState<string | null>(null);
 
-    // URL-centric editing. Zones stay hidden until the operator picks a
-    // page URL; only then are that URL's widgets shown. `selectedRoute`
-    // is null before any selection. `customRoutes` holds URLs the
+    // URL-centric editing. `selectedRoute` is null before any selection;
+    // in that state the editor shows every zone with only its global
+    // (no-route-filter) placements so site-wide widgets stay manageable
+    // without first picking a page. Selecting a URL narrows each zone to
+    // the placements that resolve on it. `customRoutes` holds URLs the
     // operator typed in the new-URL box that no placement targets yet, so
     // they remain selectable until a widget is placed on them.
     const [selectedRoute, setSelectedRoute] = useState<string | null>(null);
@@ -522,18 +524,24 @@ export default function WidgetsAdminPage() {
     }, [placements, customRoutes]);
 
     /**
-     * Group placements by zone for rendering, scoped to the selected
-     * URL. Returns empty until a URL is selected so no widgets show
-     * before the operator picks a page. Once selected, each zone lists
-     * only the placements whose route filter matches that URL (exact,
-     * glob, or global). Empty zones still render so operators see the
-     * full target set for the page.
+     * Group placements by zone for rendering. With a URL selected, each
+     * zone lists the placements whose route filter matches that URL
+     * (exact, glob, or global). With no URL selected the editor shows the
+     * unfiltered catalog: every zone with only its *global* placements —
+     * those carrying no route filter (`routes: []`) — so an operator can
+     * see and manage site-wide widgets without first picking a page.
+     * Route-scoped placements stay hidden in that mode because they
+     * belong to a specific URL. Empty zones still render so operators see
+     * the full target set.
      */
     const grouped = useMemo(() => {
-        if (!zones || selectedRoute === null) return [] as Array<{ trackId: string; trackLabel: string; rows: Array<{ zoneId: string; zoneLabel: string; placements: IPlacement[] }> }>;
+        if (!zones) return [] as Array<{ trackId: string; trackLabel: string; rows: Array<{ zoneId: string; zoneLabel: string; placements: IPlacement[] }> }>;
         const byZone = new Map<string, IPlacement[]>();
         for (const placement of placements) {
-            if (!placementMatchesRoute(placement.routes, selectedRoute)) continue;
+            const matches = selectedRoute === null
+                ? placement.routes.length === 0
+                : placementMatchesRoute(placement.routes, selectedRoute);
+            if (!matches) continue;
             const bucket = byZone.get(placement.zoneId) ?? [];
             bucket.push(placement);
             byZone.set(placement.zoneId, bucket);
@@ -684,7 +692,7 @@ export default function WidgetsAdminPage() {
                             variant="primary"
                             icon={<Plus size={16} />}
                             onClick={() => openPlacementModal('create', undefined, selectedRoute ?? undefined)}
-                            disabled={!zones || !types || selectedRoute === null}
+                            disabled={!zones || !types}
                         >
                             Place widget
                         </Button>
@@ -701,7 +709,7 @@ export default function WidgetsAdminPage() {
                                     value={selectedRoute ?? ''}
                                     onChange={(e) => setSelectedRoute(e.target.value === '' ? null : e.target.value)}
                                 >
-                                    <option value="">Select a page URL&hellip;</option>
+                                    <option value="">All pages (no route filter)</option>
                                     {routeOptions.map(route => (
                                         <option key={route} value={route}>{route}</option>
                                     ))}
@@ -744,11 +752,12 @@ export default function WidgetsAdminPage() {
 
                     {!loading && zones && selectedRoute === null && (
                         <p className={`text-muted ${styles.route_gate}`}>
-                            Select a page URL above — or add a new one — to view and manage its widgets.
+                            Showing site-wide widgets (no route filter). Select a page URL above — or add a
+                            new one — to view and manage that page&rsquo;s widgets.
                         </p>
                     )}
 
-                    {!loading && zones && selectedRoute !== null && (
+                    {!loading && zones && (
                         <DndContext
                             sensors={sensors}
                             collisionDetection={closestCorners}

--- a/src/frontend/features/charts/components/BarChart/BarChart.module.css
+++ b/src/frontend/features/charts/components/BarChart/BarChart.module.css
@@ -19,7 +19,11 @@
 
 .chart svg {
     width: 100%;
-    height: auto;
+    /* Height is set explicitly per instance via the SVG `height` attribute rather
+       than derived from the viewBox aspect ratio. A measured width is unavailable
+       during SSR, so `height: auto` made the chart paint at the wrong height on the
+       server and jump to full height after hydration. A fixed pixel height keeps
+       the box stable across SSR and the post-measurement re-render. */
     display: block;
     /* Browsers clip the root <svg> to its viewBox by default; axis labels are
        anchored at the margins and would lose their outermost glyphs. Let them

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -182,13 +182,14 @@ const TOOLTIP_EDGE_GUTTER = 8;
  * Width, in viewBox units, assumed before the ResizeObserver measures the real
  * container. The server cannot measure layout, so SSR and the first client render
  * use this fixed value — keeping the two byte-identical (no hydration mismatch).
- * Paired with a fixed pixel height and `preserveAspectRatio="none"` on the SVG,
- * the later measured correction only rescales the viewBox horizontally; it never
- * resizes the chart's box, which is what previously produced the visible
- * post-hydration "load". 640 sits near the geometric mean of a narrow widget
- * column and a full-width page, bounding the brief pre-measurement horizontal
- * distortion in either context — far better than the old per-mode `minWidth`
- * default (80 in widget mode stretched a typical column ~4.5x for that frame).
+ * Paired with a fixed pixel height and `preserveAspectRatio="xMinYMid meet"` on
+ * the SVG, the later measured correction only widens the viewBox horizontally; it
+ * never resizes the chart's box, which is what previously produced the visible
+ * post-hydration "load". `meet` scales the content uniformly and left-anchors it,
+ * so before measurement the chart renders undistorted at its natural width with
+ * transient empty space on the right rather than stretching text and bars to fill.
+ * 640 sits near the geometric mean of a narrow widget column and a full-width page,
+ * bounding that transient gap in either context.
  */
 const SSR_DEFAULT_WIDTH = 640;
 
@@ -592,19 +593,21 @@ export function BarChart({
     return (
         <figure ref={setContainer} className={cn(styles.chart, isWidget && styles['chart--widget'], className)}>
             {/*
-              * Render at a fixed pixel height with a width-stretched viewBox so the
+              * Render at a fixed pixel height with a uniformly-scaled viewBox so the
               * chart occupies its final box during SSR. Height no longer derives from
               * the pre-measurement viewBox aspect ratio (CSS `height: auto`), which
               * made the server paint the chart at the wrong height and grow it after
               * the ResizeObserver fired — the visible "loading" jump. With
-              * `preserveAspectRatio="none"` the viewBox fills the fixed box; once the
-              * observer matches the viewBox width to the rendered width the mapping is
-              * 1:1, so this changes only the brief pre-measurement frame.
+              * `preserveAspectRatio="xMinYMid meet"` the viewBox scales uniformly and
+              * left-anchors inside the fixed box; once the observer matches the viewBox
+              * width to the rendered width the mapping is 1:1, so before measurement the
+              * content is undistorted (transient empty space on the right) rather than
+              * horizontally stretched.
               */}
             <svg
                 viewBox={`0 0 ${width} ${chartHeight}`}
                 height={chartHeight}
-                preserveAspectRatio="none"
+                preserveAspectRatio="xMinYMid meet"
                 role="img"
                 aria-label={ariaLabel}
                 onPointerMove={chrome.interactive ? handlePointerMove : undefined}

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -179,6 +179,20 @@ interface TooltipState {
 const TOOLTIP_EDGE_GUTTER = 8;
 
 /**
+ * Width, in viewBox units, assumed before the ResizeObserver measures the real
+ * container. The server cannot measure layout, so SSR and the first client render
+ * use this fixed value — keeping the two byte-identical (no hydration mismatch).
+ * Paired with a fixed pixel height and `preserveAspectRatio="none"` on the SVG,
+ * the later measured correction only rescales the viewBox horizontally; it never
+ * resizes the chart's box, which is what previously produced the visible
+ * post-hydration "load". 640 sits near the geometric mean of a narrow widget
+ * column and a full-width page, bounding the brief pre-measurement horizontal
+ * distortion in either context — far better than the old per-mode `minWidth`
+ * default (80 in widget mode stretched a typical column ~4.5x for that frame).
+ */
+const SSR_DEFAULT_WIDTH = 640;
+
+/**
  * Converts a date string to a Date object, handling ISO 8601 timestamps.
  *
  * Mirrors LineChart's parser so both charts interpret backend UTC timestamps
@@ -265,7 +279,7 @@ export function BarChart({
     const resolvedShowLegend = showLegend ?? chrome.showLegend;
 
     const [container, setContainer] = useState<HTMLElement | null>(null);
-    const [containerWidth, setContainerWidth] = useState(chrome.minWidth);
+    const [containerWidth, setContainerWidth] = useState(Math.max(SSR_DEFAULT_WIDTH, chrome.minWidth));
     const [tooltip, setTooltip] = useState<TooltipState | null>(null);
     const [tooltipNode, setTooltipNode] = useState<HTMLDivElement | null>(null);
     const [tooltipWidth, setTooltipWidth] = useState(0);
@@ -577,8 +591,20 @@ export function BarChart({
 
     return (
         <figure ref={setContainer} className={cn(styles.chart, isWidget && styles['chart--widget'], className)}>
+            {/*
+              * Render at a fixed pixel height with a width-stretched viewBox so the
+              * chart occupies its final box during SSR. Height no longer derives from
+              * the pre-measurement viewBox aspect ratio (CSS `height: auto`), which
+              * made the server paint the chart at the wrong height and grow it after
+              * the ResizeObserver fired — the visible "loading" jump. With
+              * `preserveAspectRatio="none"` the viewBox fills the fixed box; once the
+              * observer matches the viewBox width to the rendered width the mapping is
+              * 1:1, so this changes only the brief pre-measurement frame.
+              */}
             <svg
                 viewBox={`0 0 ${width} ${chartHeight}`}
+                height={chartHeight}
+                preserveAspectRatio="none"
                 role="img"
                 aria-label={ariaLabel}
                 onPointerMove={chrome.interactive ? handlePointerMove : undefined}

--- a/src/frontend/features/charts/components/LineChart/LineChart.module.css
+++ b/src/frontend/features/charts/components/LineChart/LineChart.module.css
@@ -17,7 +17,11 @@
 
 .chart svg {
     width: 100%;
-    height: auto;
+    /* Height is set explicitly per instance via the SVG `height` attribute rather
+       than derived from the viewBox aspect ratio. A measured width is unavailable
+       during SSR, so `height: auto` made the chart paint at the wrong height on the
+       server and jump to full height after hydration. A fixed pixel height keeps
+       the box stable across SSR and the post-measurement re-render. */
     display: block;
 }
 

--- a/src/frontend/features/charts/components/LineChart/LineChart.tsx
+++ b/src/frontend/features/charts/components/LineChart/LineChart.tsx
@@ -122,6 +122,19 @@ const DEFAULT_COLORS = ['#7C9BFF', '#5CE1E6', '#FF9F6E', '#F06EF0'];
 const MARGIN = { top: 24, right: 32, bottom: 36, left: 64 };
 
 /**
+ * Width, in viewBox units, the chart assumes before its ResizeObserver measures
+ * the real container. The server cannot measure layout, so SSR and the first
+ * client render both use this fixed value — keeping the two renders byte-identical
+ * (no hydration mismatch). Paired with a fixed pixel height and
+ * `preserveAspectRatio="none"` on the SVG, the later measured correction only
+ * rescales the viewBox horizontally; it never resizes the chart's box, which is
+ * what previously produced the visible post-hydration "load". 640 sits near the
+ * geometric mean of a narrow widget column and a full-width page, bounding the
+ * brief pre-measurement horizontal text distortion in either context.
+ */
+const SSR_DEFAULT_WIDTH = 640;
+
+/**
  * Converts date string to Date object, handling various formats.
  *
  * Properly handles ISO 8601 timestamps with timezone information from the backend API.
@@ -182,7 +195,7 @@ export function LineChart({
     yAxisMax: fixedYMax
 }: LineChartProps) {
     const containerRef = useRef<HTMLElement | null>(null);
-    const [containerWidth, setContainerWidth] = useState(860);
+    const [containerWidth, setContainerWidth] = useState(SSR_DEFAULT_WIDTH);
     const [tooltip, setTooltip] = useState<TooltipState | null>(null);
     const [hiddenSeries, setHiddenSeries] = useState<Set<string>>(new Set());
 
@@ -452,8 +465,20 @@ export function LineChart({
 
     return (
         <figure ref={containerRef} className={cn(styles.chart, className)}>
+            {/*
+              * Render at a fixed pixel height with a width-stretched viewBox so the
+              * chart occupies its final box during SSR. Height no longer derives from
+              * the pre-measurement viewBox aspect ratio (CSS `height: auto`), which
+              * made the server paint the chart short and then grow it to full height
+              * after the ResizeObserver fired — the visible "loading" jump. With
+              * `preserveAspectRatio="none"` the viewBox fills the fixed box; once the
+              * observer matches the viewBox width to the rendered width the mapping is
+              * 1:1, so this changes only the brief pre-measurement frame.
+              */}
             <svg
                 viewBox={`0 0 ${width} ${chartHeight}`}
+                height={chartHeight}
+                preserveAspectRatio="none"
                 role="img"
                 onMouseMove={handlePointerMove}
                 onMouseLeave={handlePointerLeave}

--- a/src/frontend/features/charts/components/LineChart/LineChart.tsx
+++ b/src/frontend/features/charts/components/LineChart/LineChart.tsx
@@ -126,11 +126,14 @@ const MARGIN = { top: 24, right: 32, bottom: 36, left: 64 };
  * the real container. The server cannot measure layout, so SSR and the first
  * client render both use this fixed value — keeping the two renders byte-identical
  * (no hydration mismatch). Paired with a fixed pixel height and
- * `preserveAspectRatio="none"` on the SVG, the later measured correction only
- * rescales the viewBox horizontally; it never resizes the chart's box, which is
- * what previously produced the visible post-hydration "load". 640 sits near the
- * geometric mean of a narrow widget column and a full-width page, bounding the
- * brief pre-measurement horizontal text distortion in either context.
+ * `preserveAspectRatio="xMinYMid meet"` on the SVG, the later measured correction
+ * only widens the viewBox horizontally; it never resizes the chart's box, which is
+ * what previously produced the visible post-hydration "load". `meet` scales the
+ * content uniformly and left-anchors it, so before measurement the chart renders
+ * undistorted at its natural width with transient empty space on the right rather
+ * than stretching text and lines to fill. 640 sits near the geometric mean of a
+ * narrow widget column and a full-width page, bounding that transient gap in either
+ * context.
  */
 const SSR_DEFAULT_WIDTH = 640;
 
@@ -466,19 +469,21 @@ export function LineChart({
     return (
         <figure ref={containerRef} className={cn(styles.chart, className)}>
             {/*
-              * Render at a fixed pixel height with a width-stretched viewBox so the
+              * Render at a fixed pixel height with a uniformly-scaled viewBox so the
               * chart occupies its final box during SSR. Height no longer derives from
               * the pre-measurement viewBox aspect ratio (CSS `height: auto`), which
               * made the server paint the chart short and then grow it to full height
               * after the ResizeObserver fired — the visible "loading" jump. With
-              * `preserveAspectRatio="none"` the viewBox fills the fixed box; once the
-              * observer matches the viewBox width to the rendered width the mapping is
-              * 1:1, so this changes only the brief pre-measurement frame.
+              * `preserveAspectRatio="xMinYMid meet"` the viewBox scales uniformly and
+              * left-anchors inside the fixed box; once the observer matches the viewBox
+              * width to the rendered width the mapping is 1:1, so before measurement the
+              * content is undistorted (transient empty space on the right) rather than
+              * horizontally stretched.
               */}
             <svg
                 viewBox={`0 0 ${width} ${chartHeight}`}
                 height={chartHeight}
-                preserveAspectRatio="none"
+                preserveAspectRatio="xMinYMid meet"
                 role="img"
                 onMouseMove={handlePointerMove}
                 onMouseLeave={handlePointerLeave}


### PR DESCRIPTION
## Widget placements admin (`/system/widgets`)

**Unfiltered view.** Previously the editor hid every zone until an operator picked a page URL. Now, with no URL selected, the editor shows every zone listing only its *global* placements (those with no route filter, `routes: []`), so site-wide widgets are visible and manageable without first choosing a page. Selecting a URL narrows each zone to the placements that resolve on it, as before. The empty filter option is relabeled **All pages (no route filter)**, and **Place widget** is enabled in this mode (creating with no route produces a global widget).

**Zone ordering.** The site footer zone was sorting to the top of the site track because the admin zone snapshot sorted alphabetically by id (`footer` < `ticker-after`). Added an optional `order` to the zone descriptor contract (`IZoneDescriptor`, `IDefineZoneOptions`, `IRegisterZoneInput`), threaded through `defineZone`/`registerZone`, and changed the snapshot to sort by `order` then id. Core zones now declare explicit orders so each host track renders page top-to-bottom (footer last in the site track). Zones omitting `order` sort after explicitly-ordered ones, so existing plugin zones are unaffected. Types bumped to `4.13.0`. Docs updated in the widgets README and `plugins-widget-zones-registration.md` (distinguishing zone `order` from placement `order`); regression test added.

## Charts

SSR hydration fix for `BarChart`/`LineChart`: render at a fixed pixel height with a width-stretched viewBox and an SSR default width so the chart occupies its final box during SSR, eliminating the post-hydration resize "load".