### PR TITLE
feat(widgets): per-zone flexbox layout config and block-ticker widget

### DIFF
--- a/docs/system/system-api-widgets.md
+++ b/docs/system/system-api-widgets.md
@@ -1,6 +1,6 @@
 # Widget Admin API
 
-Endpoints powering the `/system/widgets` operator UI. Three parallel namespaces under `/api/admin/system/` cover read-only zone and widget-type introspection plus full placement CRUD.
+Endpoints powering the `/system/widgets` operator UI. Three parallel namespaces under `/api/admin/system/` cover zone introspection plus per-zone flexbox layout, read-only widget-type introspection, and full placement CRUD.
 
 ## Why This Matters
 
@@ -14,13 +14,14 @@ The placements controller validates inputs against the live `IZoneRegistry` and 
 
 ## Endpoints
 
-### Zones — read-only introspection
+### Zones — introspection + layout
 
-| Method | Path | Returns |
-|---|---|---|
-| GET | `/api/admin/system/zones` | `IZoneSnapshot` |
+| Method | Path | Body | Returns |
+|---|---|---|---|
+| GET | `/api/admin/system/zones` | — | `IZoneSnapshot` |
+| PATCH | `/api/admin/system/zones/:zoneId/layout` | `IZoneLayoutConfig` | `{ success, layoutConfig }` |
 
-Tracks-grouped catalogue of every registered zone with host (`site` / `core` / `plugin` / `admin`) and registration metadata.
+GET is the tracks-grouped catalogue of every registered zone with host (`site` / `core` / `plugin` / `admin`), registration metadata, and each zone's effective `layoutConfig` (the operator override, else a default derived from the descriptor's coarse `layout` hint). PATCH persists an operator's flexbox layout for a zone — `404` on an unknown zone, `400` on an off-enum flex value — and fires `widgets:placements-update` so admin UIs refetch.
 
 ### Widget Types — read-only introspection
 

--- a/docs/system/system.md
+++ b/docs/system/system.md
@@ -44,7 +44,7 @@ Navigation service that aggregates menu nodes from core and plugins. Supports DB
 
 ### Widgets
 
-Owns the widget subsystem behind one public service — `IWidgetsService`, registry name `'widgets'` — covering zone definitions, placement persistence, widget-type registration, and the `/system/widgets` admin UI. Plugins, modules, admin controllers, and the SSR router reach widgets only through this service; there is no other entry point. See [Widgets Module README](../../src/backend/modules/widgets/README.md) and [system-api-widgets.md](./system-api-widgets.md).
+Owns the widget subsystem behind one public service — `IWidgetsService`, registry name `'widgets'` — covering zone definitions, per-zone flexbox layout, placement persistence, widget-type registration (including the core `core:block-ticker`, `core:world-clocks`, and `core:raw-html` types), and the `/system/widgets` admin UI. Plugins, modules, admin controllers, and the SSR router reach widgets only through this service; there is no other entry point. See [Widgets Module README](../../src/backend/modules/widgets/README.md) and [system-api-widgets.md](./system-api-widgets.md).
 
 ### Migrations
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -164,6 +164,13 @@ export type {
     ZoneLayout,
     IZoneSnapshot,
     IZoneSnapshotRecord,
+    IZoneLayoutConfig,
+    ZoneFlexDirection,
+    ZoneJustifyContent,
+    ZoneAlignItems,
+    ZoneFlexWrap,
+    ZoneGapSize,
+    ZoneLayoutPreset,
     // Internal — used only by widgets-module implementation. Consumers
     // (plugins, other modules) reach zone state through IWidgetsService.
     IZoneRegistry,

--- a/packages/types/src/widget-zones/IZoneLayoutConfig.ts
+++ b/packages/types/src/widget-zones/IZoneLayoutConfig.ts
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Operator-configurable flexbox layout for a widget zone.
+ *
+ * A zone renders its placed widgets as a CSS flex container; this config
+ * is the operator's choice of how that container arranges its items. It
+ * is distinct from {@link IZoneDescriptor.layout} — the coarse,
+ * code-declared `'vertical' | 'horizontal' | 'grid'` hint — which seeds
+ * the *default* when no operator override exists. The override is
+ * persisted per zone id and applied at SSR by the `WidgetZone` renderer.
+ *
+ * The shape mirrors the flexbox properties an operator actually tunes
+ * (direction, main- and cross-axis alignment, wrapping, gap) rather than
+ * exposing raw CSS, so the admin UI can offer a preset dropdown plus
+ * granular selects and the renderer can map each value to a design-token
+ * gap without parsing arbitrary CSS.
+ *
+ * @module types/widget-zones/IZoneLayoutConfig
+ */
+
+/** `flex-direction` — main-axis orientation of the zone's items. */
+export type ZoneFlexDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
+
+/** `justify-content` — distribution of items along the main axis. */
+export type ZoneJustifyContent =
+    | 'flex-start'
+    | 'center'
+    | 'flex-end'
+    | 'space-between'
+    | 'space-around'
+    | 'space-evenly';
+
+/** `align-items` — alignment of items along the cross axis. */
+export type ZoneAlignItems = 'stretch' | 'flex-start' | 'center' | 'flex-end' | 'baseline';
+
+/** `flex-wrap` — whether items wrap onto multiple lines. */
+export type ZoneFlexWrap = 'nowrap' | 'wrap';
+
+/**
+ * Gap between items, expressed as a design-token t-shirt size rather than
+ * a raw length so the renderer maps it to `--gap-*` (and `none` to `0`),
+ * keeping zone spacing on the token scale.
+ */
+export type ZoneGapSize = 'none' | 'sm' | 'md' | 'lg';
+
+/**
+ * Named popular layout the admin UI offers as a one-click preset. Each
+ * preset sets the four flex properties; `'custom'` marks a config the
+ * operator hand-tuned past any preset so the UI shows the granular
+ * controls as the source of truth.
+ */
+export type ZoneLayoutPreset =
+    | 'row-left'
+    | 'row-center'
+    | 'row-between'
+    | 'row-right'
+    | 'row-wrap'
+    | 'column'
+    | 'custom';
+
+/**
+ * Effective flexbox layout for a zone container. The `WidgetZone`
+ * renderer reads these to set the container's flex properties (gap via a
+ * token), and the admin editor reads/writes them through the zone-layout
+ * admin endpoint. `preset` is UI sugar — the renderer ignores it and
+ * applies only the explicit flex fields.
+ */
+export interface IZoneLayoutConfig {
+    /** Preset the operator last selected, or `'custom'` when hand-tuned. */
+    preset?: ZoneLayoutPreset;
+    /** Main-axis orientation. */
+    flexDirection: ZoneFlexDirection;
+    /** Main-axis distribution. */
+    justifyContent: ZoneJustifyContent;
+    /** Cross-axis alignment. */
+    alignItems: ZoneAlignItems;
+    /** Whether items wrap onto multiple lines. */
+    flexWrap: ZoneFlexWrap;
+    /** Inter-item gap as a token size. */
+    gap: ZoneGapSize;
+}

--- a/packages/types/src/widget-zones/IZoneRegistry.ts
+++ b/packages/types/src/widget-zones/IZoneRegistry.ts
@@ -16,6 +16,7 @@
  */
 
 import type { IZoneDescriptor, IDefineZoneOptions, ZoneRegisterDisposer, ZoneHost } from './IZoneDescriptor.js';
+import type { IZoneLayoutConfig } from './IZoneLayoutConfig.js';
 
 /**
  * Introspection record for a single registered zone. Surfaced through
@@ -31,8 +32,16 @@ export interface IZoneSnapshotRecord {
     readonly description: string;
     /** Layout context. */
     readonly host: ZoneHost;
-    /** Visual layout hint. */
+    /** Visual layout hint (the coarse, code-declared default). */
     readonly layout: 'vertical' | 'horizontal' | 'grid';
+    /**
+     * Effective flexbox layout the zone container renders with. Always
+     * present: the operator's persisted override when one exists, else a
+     * default derived from {@link layout}. The SSR renderer and the admin
+     * editor both consume this; the renderer applies it to the flex
+     * container, the editor seeds its dropdowns from it.
+     */
+    readonly layoutConfig: IZoneLayoutConfig;
     /** Plugin id that declared the zone, or `'core'`. */
     readonly pluginId: string;
     /** ISO-8601 timestamp the zone was registered with the runtime. */

--- a/packages/types/src/widget-zones/index.ts
+++ b/packages/types/src/widget-zones/index.ts
@@ -24,3 +24,13 @@ export type {
     IZoneSnapshot,
     IZoneSnapshotRecord
 } from './IZoneRegistry.js';
+
+export type {
+    IZoneLayoutConfig,
+    ZoneFlexDirection,
+    ZoneJustifyContent,
+    ZoneAlignItems,
+    ZoneFlexWrap,
+    ZoneGapSize,
+    ZoneLayoutPreset
+} from './IZoneLayoutConfig.js';

--- a/packages/types/src/widget/IWidgetsService.ts
+++ b/packages/types/src/widget/IWidgetsService.ts
@@ -19,6 +19,7 @@
 import type { JSONSchema7 } from 'json-schema';
 import type { WidgetDataFetcher } from '../widget-types/IWidgetType.js';
 import type { IZoneSnapshot } from '../widget-zones/IZoneRegistry.js';
+import type { IZoneLayoutConfig } from '../widget-zones/IZoneLayoutConfig.js';
 import type { IWidgetTypeSnapshot } from '../widget-types/IWidgetTypeRegistry.js';
 import type { ZoneHost, ZoneLayout } from '../widget-zones/IZoneDescriptor.js';
 import type {
@@ -129,7 +130,13 @@ export interface IWidgetsService {
     // Discovery
     // ------------------------------------------------------------
 
-    /** Snapshot of every registered zone, grouped by host. */
+    /**
+     * Snapshot of every registered zone, grouped by host. Each zone
+     * record carries its effective `layoutConfig` — the operator's
+     * persisted flexbox override merged over the descriptor default — so
+     * the SSR router and the admin editor read layout from the same
+     * snapshot they already consume for zone discovery.
+     */
     listZones(): IZoneSnapshot;
 
     /** Snapshot of every registered widget type, grouped by owning plugin. */
@@ -235,6 +242,22 @@ export interface IWidgetsService {
      * never disposed, the call is a no-op.
      */
     unregisterAllForOwner(ownerId: string): Promise<void>;
+
+    // ------------------------------------------------------------
+    // Zone layout (operator surface)
+    // ------------------------------------------------------------
+
+    /**
+     * Persist an operator's flexbox layout override for a zone and return
+     * the stored config. The override survives restarts and is merged
+     * into {@link listZones} as the zone's effective `layoutConfig`. The
+     * zone must be registered.
+     *
+     * @param zoneId - Target zone id.
+     * @param config - Full flexbox layout to persist for the zone.
+     * @throws Error when `zoneId` is not a registered zone.
+     */
+    setZoneLayout(zoneId: string, config: IZoneLayoutConfig): Promise<IZoneLayoutConfig>;
 
     // ------------------------------------------------------------
     // Placement CRUD (operator surface)

--- a/src/backend/api/routes/widget.router.ts
+++ b/src/backend/api/routes/widget.router.ts
@@ -1,4 +1,5 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
+import type { IZoneLayoutConfig } from '@/types';
 import { WidgetsService } from '../../modules/widgets/widgets.service.js';
 import { logger } from '../../lib/logger.js';
 
@@ -36,7 +37,10 @@ export function widgetRouter(): Router {
      *       title: 'Widget Title',
      *       data: { ... }
      *     }
-     *   ]
+     *   ],
+     *   // Effective flexbox layout per zone id, so the SSR renderer can
+     *   // arrange each zone's widgets as flex items without a second call.
+     *   zones: { 'main-after': { flexDirection: 'column', ... } }
      * }
      */
     router.get('/', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
@@ -72,9 +76,20 @@ export function widgetRouter(): Router {
             // Lazy lookup — the service singleton is configured by
             // `WidgetsModule.init()`, which runs before the HTTP server
             // accepts connections.
-            const widgets = await WidgetsService.getInstance().fetchWidgetsForRoute(route, params);
+            const service = WidgetsService.getInstance();
+            const widgets = await service.fetchWidgetsForRoute(route, params);
 
-            res.json({ widgets });
+            // Flatten the zone snapshot to a zoneId → layoutConfig map so
+            // the frontend can apply each zone's flexbox layout to its
+            // container without resolving the full snapshot client-side.
+            const zones: Record<string, IZoneLayoutConfig> = {};
+            for (const track of service.listZones().tracks) {
+                for (const zone of track.zones) {
+                    zones[zone.id] = zone.layoutConfig;
+                }
+            }
+
+            res.json({ widgets, zones });
         } catch (error) {
             logger.error('Error fetching widgets', {
                 error: error instanceof Error ? error.message : String(error),

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -308,6 +308,12 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     // concrete classes.
     serviceRegistry.register('chain-parameters', ChainParametersService.getInstance());
 
+    // Publish the blockchain service so late-binding consumers can read
+    // the latest processed block without importing the concrete singleton.
+    // The core block-ticker widget's SSR data fetcher resolves this lazily
+    // per request; setDependencies already ran in initializeCoreServices.
+    serviceRegistry.register('blockchain', BlockchainService.getInstance());
+
     // Central content-type registry: one shared, process-lifetime home where
     // providers publish content types and pipelines (curation today,
     // notifications next) discover them. Constructed here as core infrastructure

--- a/src/backend/modules/widgets/README.md
+++ b/src/backend/modules/widgets/README.md
@@ -9,11 +9,11 @@ Owns every concern of the widget subsystem behind a single public surface: `IWid
 | Module id | `widgets` |
 | Admin UI | `/system/widgets` |
 | Public service | `'widgets'` on the service registry (`IWidgetsService`) |
-| Backend API base | `/api/admin/system/widgets/placements`, `/api/admin/system/widget-types`, `/api/admin/system/zones`, plus SSR fetch at `/api/widgets` |
-| WebSocket event | `widgets:placements-update` |
-| Types package | `@delphian/tronrelic-types` — `IWidgetsService`, `IRegisterWidgetTypeInput`, `IRegisterZoneInput`, `IRegisterWidgetInput`, `IWidgetPlacement`, `IPlacementInput`, `IPlacementPatch`, `IPlacementListFilter`, `IWidgetType`, `IWidgetPlacementContext`, `IZoneDescriptor`, `IZoneSnapshot`, `IWidgetTypeSnapshot` |
-| Storage | `module_widgets_placements` (MongoDB) |
-| Migration | `module:widgets:001_create_placements_collection` (creates collection + 4 indexes) |
+| Backend API base | `/api/admin/system/widgets/placements`, `/api/admin/system/widget-types`, `/api/admin/system/zones` (now also `PATCH /:zoneId/layout`), plus SSR fetch at `/api/widgets` |
+| WebSocket event | `widgets:placements-update` (also fired on zone-layout change — no separate event) |
+| Types package | `@delphian/tronrelic-types` — `IWidgetsService`, `IRegisterWidgetTypeInput`, `IRegisterZoneInput`, `IRegisterWidgetInput`, `IWidgetPlacement`, `IPlacementInput`, `IPlacementPatch`, `IPlacementListFilter`, `IWidgetType`, `IWidgetPlacementContext`, `IZoneDescriptor`, `IZoneSnapshot`, `IZoneLayoutConfig`, `IWidgetTypeSnapshot` |
+| Storage | `module_widgets_placements`, `module_widgets_zone_layouts` (MongoDB) |
+| Migration | `module:widgets:001_create_widget_placements` (placements collection + 4 indexes). The zone-layouts collection needs no migration — `ZoneLayoutService.load()` creates its unique index idempotently at boot. |
 | System menu node | "Widgets" under the System container — seeded by `WidgetsModule.run()` |
 
 ## Source Map
@@ -27,10 +27,12 @@ Owns every concern of the widget subsystem behind a single public surface: `IWid
 | `placements/route-matcher.ts` | `routeMatches` predicate, `normaliseRoutePattern` validator, `partitionRoutePatterns` for the admin path |
 | `widget-types/widget-type-registry.ts` | Internal widget-type registry — instantiated by `WidgetsModule.init()` |
 | `widget-types/define-widget-type.ts` | Descriptor mint — runtime registry refuses unminted descriptors |
-| `zones/zone-registry.ts` | Internal zone registry — instantiated by `WidgetsModule.init()` |
+| `zones/zone-registry.ts` | Internal zone registry — instantiated by `WidgetsModule.init()`; each snapshot record carries a descriptor-derived `layoutConfig` default |
+| `zones/zone-layout.service.ts` | Internal singleton storing operator flexbox overrides (`module_widgets_zone_layouts`); in-memory cache + `defaultLayoutConfigFor(hint)` |
 | `zones/define-zone.ts` | Zone descriptor mint |
-| `zones/descriptors.ts` | Core zone descriptors as plain `IRegisterZoneInput[]` (includes the `footer` zone); `WidgetsModule.run()` iterates and registers them via the public service |
-| `widget-types/core-widget-types.ts` | Core widget-type catalog as plain `IRegisterWidgetTypeInput[]` (the `core:raw-html` block); `WidgetsModule.run()` registers each as `'core'`-owned. Frontend renderer lives in `components/widgets/widgets.core.ts` |
+| `zones/descriptors.ts` | Core zone descriptors as plain `IRegisterZoneInput[]` (the `Site Header` zone — id `ticker-after` — and `footer`); `WidgetsModule.run()` iterates and registers them via the public service |
+| `widget-types/core-widget-types.ts` | Core widget-type catalog, built by `buildCoreWidgetTypeDescriptors(deps)` (`core:raw-html`, `core:world-clocks`, `core:block-ticker`); `WidgetsModule.run()` registers each as `'core'`-owned. Frontend renderers live in `components/widgets/widgets.core.ts` |
+| `database/IZoneLayoutDocument.ts` | `module_widgets_zone_layouts` document shape + collection constant |
 | `api/zones.controller.ts` / `zones.routes.ts` | Read-only zone snapshot adapter over `IWidgetsService.listZones()` |
 | `api/widget-types.controller.ts` / `widget-types.routes.ts` | Read-only widget-type snapshot adapter over `IWidgetsService.listTypes()` |
 | `api/placements.controller.ts` / `placements.routes.ts` | Placement CRUD + restore-defaults adapter over `IWidgetsService` |
@@ -53,11 +55,12 @@ Internal types (`IZoneRegistry`, `IWidgetTypeRegistry`, `IPlacementService`, `IP
 
 All endpoints require admin auth (cookie path: verified wallet + admin group; service-token path: `ADMIN_API_TOKEN` via `x-admin-token` or `Authorization: Bearer`). All three routers chain `createAdminRateLimiter` before `requireAdmin`.
 
-### Zones — read-only
+### Zones
 
-| Method | Path | Returns |
-|---|---|---|
-| GET | `/api/admin/system/zones` | `IZoneSnapshot` — tracks (one per host) → zones |
+| Method | Path | Body | Returns | Notes |
+|---|---|---|---|---|
+| GET | `/api/admin/system/zones` | — | `IZoneSnapshot` — tracks (one per host) → zones, each carrying its effective `layoutConfig` | |
+| PATCH | `/api/admin/system/zones/:zoneId/layout` | `IZoneLayoutConfig` | `{ success, layoutConfig }` | 404 unknown zone; 400 off-enum flex value. Persists the operator's flexbox override |
 
 ### Widget Types — read-only
 
@@ -80,7 +83,7 @@ All endpoints require admin auth (cookie path: verified wallet + admin group; se
 
 | Method | Path | Returns |
 |---|---|---|
-| GET | `/api/widgets?route=<path>&params=<json>` | `{ widgets: IWidgetData[] }` — pre-fetched data ready for SSR embedding |
+| GET | `/api/widgets?route=<path>&params=<json>` | `{ widgets: IWidgetData[], zones: Record<string, IZoneLayoutConfig> }` — pre-fetched data plus each zone's effective flexbox layout, ready for SSR embedding |
 
 The pre-split admin read endpoints (`/api/widgets/all`, `/api/widgets/zones/:zone`) have been deleted. Admin reads happen on the admin namespace above.
 
@@ -102,7 +105,7 @@ Empty `routes: []` matches every route. Glob markers are only valid at the trail
 |---|---|---|---|
 | `widgets:placements-update` | server → all | `{ event: 'placement:created' \| 'placement:updated' \| 'placement:deleted' \| 'placement:restored', placementId, zoneId?, timestamp }` | All connected sockets — public pages must refetch widget data to pick up operator changes |
 
-The placement service emits via a callback `WidgetsModule.init()` wires to `WebSocketService.getInstance().emit(...)`. Broadcast failures are logged but do not roll back the mutation.
+The placement service emits via a callback `WidgetsModule.init()` wires to `WebSocketService.getInstance().emit(...)`. The zone-layout store reuses this same event (`placementId: ''`, `zoneId` set) on a layout write rather than introducing a new event — the admin editor refetches zones and placements together. Broadcast failures are logged but do not roll back the mutation.
 
 ## Storage Schema
 
@@ -125,6 +128,17 @@ The placement service emits via a callback `WidgetsModule.init()` wires to `WebS
 
 Indexes (migration 001): `(typeId, pluginId)` sparse unique for plugin-row atomicity; `(enabled, zoneId, order)` for SSR queries; `routes` multikey; `source`.
 
+`module_widgets_zone_layouts` collection (one row per zone with an operator override; zones with no row fall back to a descriptor-derived default):
+
+| Field | Type | Notes |
+|---|---|---|
+| `_id` | ObjectId | |
+| `zoneId` | string | Zone the override applies to. Unique index (created at boot by `ZoneLayoutService.load()`). |
+| `preset` | string? | Last-selected named preset, or `custom` when hand-tuned |
+| `flexDirection` / `justifyContent` / `alignItems` / `flexWrap` | string | Flex container properties |
+| `gap` | string | Token gap size (`none`/`sm`/`md`/`lg` → `--gap-*`) |
+| `updatedAt` | Date | |
+
 ## Lifecycle Semantics
 
 **Plugin enable** — Plugin code calls `widgets.registerWidget(input, pluginId)` during `init()`. The service caches the original args under `${pluginId}::${typeId}` (for restore-defaults), mints a type descriptor via `defineWidgetType` and stores it in the type registry, then calls `placementService.ensurePluginPlacement(...)` which upserts the row with `enabled: true` while preserving operator customisations on existing rows via `$setOnInsert`.
@@ -139,13 +153,15 @@ Indexes (migration 001): `(typeId, pluginId)` sparse unique for plugin-row atomi
 
 The platform ships its own zones and widget types, registered by `WidgetsModule.run()` as `'core'`-owned through the same public service plugins use — `registerZone` for zones, `registerType` for types. Core types use `registerType` (not `registerWidget`, which is plugin-only and creates a plugin-source placement); operators then place them from `/system/widgets` as `operator`-source rows.
 
-**Zones** live in `zones/descriptors.ts`. The `footer` zone (`host: 'site'`) renders in the root layout below `<main>` inside a semantic `<footer>` and reaches every route — the home for site-wide footer content. Adding a zone requires a matching `<WidgetZone>` call site in a layout; descriptor and render site move together.
+**Zones** live in `zones/descriptors.ts`. The `Site Header` zone (id `ticker-after`, `host: 'site'`) renders directly below the main nav and is where the block ticker now lives; the `footer` zone (`host: 'site'`) renders below `<main>` inside a semantic `<footer>`. Both reach every route. Adding a zone requires a matching `<WidgetZone>` call site in a layout; descriptor and render site move together.
 
 Each descriptor carries an optional `order` (`IZoneDescriptor.order`) that sets where the zone appears within its host track in the `/system/widgets` editor — lower sorts first, so `footer` (order `90`) follows `ticker-after` (order `10`) rather than leading the site track alphabetically. `snapshot()` sorts by `order` then id; zones omitting it sort after explicitly-ordered ones. This orders the *zones* in the editor, distinct from the placement `order` that sorts widgets within a zone.
 
-**Widget types** live in `widget-types/core-widget-types.ts`. The only one today is `core:raw-html` — an operator-authored block of raw HTML or plain text. Its `defaultDataFetcher` reads `content` and `mode` straight from the placement's `instanceConfig` (validated against the type's `configSchema`), so the payload is route-independent. `mode: 'html'` injects raw markup verbatim; `mode: 'text'` escapes it. The content is admin-authored and trusted — consistent with head-fragment injection, themes, and pages markdown.
+**Widget types** are built by `buildCoreWidgetTypeDescriptors(deps)` in `widget-types/core-widget-types.ts` — a factory, not a static array, because one fetcher needs a runtime dependency. Three ship today: `core:raw-html` (operator-authored HTML/text block, read from `instanceConfig`), `core:world-clocks` (configured time-zone row), and `core:block-ticker` (the real-time blockchain status row). The ticker fetcher resolves the `'blockchain'` service from the registry at fetch time and returns `{ block }` — the latest processed block, or `null` when none is indexed (wrapped, never bare-null, so the resolver keeps the placement and the component still mounts to receive live `block:new` updates). raw-html and world-clocks ignore `deps`.
 
 A core widget type needs a matching frontend renderer keyed by its `typeId` in `components/widgets/widgets.core.ts`. That hand-written registry is merged ahead of the generator-owned `widgets.generated.ts` by `components/widgets/getWidgetComponent.ts`, so core components resolve without the plugin-registry generator touching them.
+
+**Per-zone flexbox layout.** Every zone renders as a CSS flex container; placed widgets are flex items. The arrangement (direction, justify, align, wrap, gap) is an `IZoneLayoutConfig` an operator sets per zone from `/system/widgets` and the `WidgetZone` renderer applies via inline CSS custom properties (gap maps to `--gap-*` tokens). Overrides persist in `module_widgets_zone_layouts`; a zone with no row uses a default derived from its descriptor's coarse `layout` hint (`vertical` → stacked column, so untouched zones look unchanged). `WidgetsService.listZones()` merges the override (else the default) into each zone's `layoutConfig`, and `/api/widgets` returns a `zoneId → layoutConfig` map so SSR applies layout without a second call.
 
 ## SSR Resolution
 

--- a/src/backend/modules/widgets/README.md
+++ b/src/backend/modules/widgets/README.md
@@ -13,7 +13,7 @@ Owns every concern of the widget subsystem behind a single public surface: `IWid
 | WebSocket event | `widgets:placements-update` (also fired on zone-layout change — no separate event) |
 | Types package | `@delphian/tronrelic-types` — `IWidgetsService`, `IRegisterWidgetTypeInput`, `IRegisterZoneInput`, `IRegisterWidgetInput`, `IWidgetPlacement`, `IPlacementInput`, `IPlacementPatch`, `IPlacementListFilter`, `IWidgetType`, `IWidgetPlacementContext`, `IZoneDescriptor`, `IZoneSnapshot`, `IZoneLayoutConfig`, `IWidgetTypeSnapshot` |
 | Storage | `module_widgets_placements`, `module_widgets_zone_layouts` (MongoDB) |
-| Migration | `module:widgets:001_create_widget_placements` (placements collection + 4 indexes). The zone-layouts collection needs no migration — `ZoneLayoutService.load()` creates its unique index idempotently at boot. |
+| Migration | `module:widgets:001_create_widget_placements` (placements collection + 4 indexes); `module:widgets:002_seed_block_ticker_placement` (idempotent seed of one operator-source `core:block-ticker` placement in `ticker-after`, guarded on absence so it runs once and never fights an operator edit). The zone-layouts collection needs no migration — `ZoneLayoutService.load()` creates its unique index idempotently at boot. |
 | System menu node | "Widgets" under the System container — seeded by `WidgetsModule.run()` |
 
 ## Source Map
@@ -151,7 +151,7 @@ Indexes (migration 001): `(typeId, pluginId)` sparse unique for plugin-row atomi
 
 ## Core Catalog
 
-The platform ships its own zones and widget types, registered by `WidgetsModule.run()` as `'core'`-owned through the same public service plugins use — `registerZone` for zones, `registerType` for types. Core types use `registerType` (not `registerWidget`, which is plugin-only and creates a plugin-source placement); operators then place them from `/system/widgets` as `operator`-source rows.
+The platform ships its own zones and widget types, registered by `WidgetsModule.run()` as `'core'`-owned through the same public service plugins use — `registerZone` for zones, `registerType` for types. Core types use `registerType` (not `registerWidget`, which is plugin-only and creates a plugin-source placement); operators then place them from `/system/widgets` as `operator`-source rows. The one exception is `core:block-ticker`: because it was historically rendered unconditionally in the root layout, migration `002_seed_block_ticker_placement` seeds one operator-source placement in `ticker-after` so the site-wide ticker renders by default — operators remain free to move, reconfigure, or delete it.
 
 **Zones** live in `zones/descriptors.ts`. The `Site Header` zone (id `ticker-after`, `host: 'site'`) renders directly below the main nav and is where the block ticker now lives; the `footer` zone (`host: 'site'`) renders below `<main>` inside a semantic `<footer>`. Both reach every route. Adding a zone requires a matching `<WidgetZone>` call site in a layout; descriptor and render site move together.
 

--- a/src/backend/modules/widgets/WidgetsModule.ts
+++ b/src/backend/modules/widgets/WidgetsModule.ts
@@ -43,10 +43,11 @@ import { createWidgetTypesAdminRouter } from './api/widget-types.routes.js';
 import { PlacementService } from './placements/placement.service.js';
 import { PlacementResolver } from './placements/placement-resolver.js';
 import { ZoneRegistry } from './zones/zone-registry.js';
+import { ZoneLayoutService } from './zones/zone-layout.service.js';
 import { WidgetTypeRegistry } from './widget-types/widget-type-registry.js';
 import { WidgetsService } from './widgets.service.js';
 import { CORE_ZONE_DESCRIPTORS } from './zones/descriptors.js';
-import { CORE_WIDGET_TYPE_DESCRIPTORS } from './widget-types/core-widget-types.js';
+import { buildCoreWidgetTypeDescriptors } from './widget-types/core-widget-types.js';
 import { WebSocketService } from '../../services/websocket.service.js';
 import { MAIN_SYSTEM_CONTAINER_ID } from '../menu/index.js';
 
@@ -96,6 +97,7 @@ export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
     private menuService!: IMenuService;
     private app!: Express;
     private zoneRegistry!: ZoneRegistry;
+    private zoneLayoutService!: ZoneLayoutService;
     private widgetTypeRegistry!: WidgetTypeRegistry;
     private placementService!: PlacementService;
     private placementResolver!: PlacementResolver;
@@ -170,13 +172,36 @@ export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
             });
         });
 
-        // Singleton-backed unified widgets service. Composes the four
-        // internal collaborators behind one IWidgetsService surface.
+        // Zone-layout store: owns operator flexbox overrides per zone.
+        // Load warms the in-memory cache (and creates the unique index on
+        // first boot) so `WidgetsService.listZones()` can merge layout
+        // synchronously. Reuses the existing `widgets:placements-update`
+        // refetch signal so connected admin clients re-pull zones — no new
+        // WebSocket event is introduced.
+        ZoneLayoutService.setDependencies(this.database, this.logger);
+        this.zoneLayoutService = ZoneLayoutService.getInstance();
+        await this.zoneLayoutService.load();
+        this.zoneLayoutService.setBroadcast((zoneId) => {
+            const wsService = WebSocketService.getInstance();
+            wsService.emit({
+                event: 'widgets:placements-update',
+                payload: {
+                    event: 'placement:updated',
+                    placementId: '',
+                    zoneId,
+                    timestamp: new Date().toISOString()
+                }
+            });
+        });
+
+        // Singleton-backed unified widgets service. Composes the internal
+        // collaborators behind one IWidgetsService surface.
         WidgetsService.setDependencies(
             this.zoneRegistry,
             this.widgetTypeRegistry,
             this.placementService,
             this.placementResolver,
+            this.zoneLayoutService,
             this.logger
         );
         this.widgetsService = WidgetsService.getInstance();
@@ -220,15 +245,20 @@ export class WidgetsModule implements IModule<IWidgetsModuleDependencies> {
             'Core zone catalog registered'
         );
 
-        // Register the core widget-type catalog (e.g. the raw text/HTML
-        // block). Routed through the public service as 'core'-owned so
-        // operators can place these types from /system/widgets exactly
-        // like plugin-declared types.
-        for (const descriptor of CORE_WIDGET_TYPE_DESCRIPTORS) {
+        // Register the core widget-type catalog (raw text/HTML, world
+        // clocks, block ticker). Built via factory so the block-ticker
+        // fetcher can resolve the `'blockchain'` service from the registry
+        // at fetch time. Routed through the public service as 'core'-owned
+        // so operators place these types from /system/widgets exactly like
+        // plugin-declared types.
+        const coreWidgetTypeDescriptors = buildCoreWidgetTypeDescriptors({
+            serviceRegistry: this.serviceRegistry
+        });
+        for (const descriptor of coreWidgetTypeDescriptors) {
             this.widgetsService.registerType(descriptor, 'core');
         }
         this.logger.info(
-            { coreWidgetTypeCount: CORE_WIDGET_TYPE_DESCRIPTORS.length },
+            { coreWidgetTypeCount: coreWidgetTypeDescriptors.length },
             'Core widget-type catalog registered'
         );
 

--- a/src/backend/modules/widgets/__tests__/core-catalog.test.ts
+++ b/src/backend/modules/widgets/__tests__/core-catalog.test.ts
@@ -17,18 +17,31 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { ISystemLogService } from '@/types';
 import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+import { createMockServiceRegistry } from '../../../tests/vitest/mocks/service-registry.js';
 import { WidgetsService } from '../widgets.service.js';
 import { ZoneRegistry } from '../zones/zone-registry.js';
 import { WidgetTypeRegistry } from '../widget-types/widget-type-registry.js';
 import { PlacementService } from '../placements/placement.service.js';
 import { PlacementResolver } from '../placements/placement-resolver.js';
+import { ZoneLayoutService } from '../zones/zone-layout.service.js';
 import { __resetKnownZonesForTests } from '../zones/define-zone.js';
 import { __resetKnownWidgetTypesForTests } from '../widget-types/define-widget-type.js';
 import { CORE_ZONE_DESCRIPTORS } from '../zones/descriptors.js';
 import {
-    CORE_WIDGET_TYPE_DESCRIPTORS,
+    buildCoreWidgetTypeDescriptors,
     RAW_HTML_TYPE_ID
 } from '../widget-types/core-widget-types.js';
+
+/**
+ * Core widget-type descriptors built over a mock service registry. The
+ * block-ticker fetcher resolves `'blockchain'` from the registry at fetch
+ * time; an empty mock registry returns undefined, which the fetcher
+ * handles by yielding `{ block: null }`. The raw-html assertions below
+ * never exercise the ticker, so the empty registry is sufficient.
+ */
+const coreWidgetTypeDescriptors = buildCoreWidgetTypeDescriptors({
+    serviceRegistry: createMockServiceRegistry()
+});
 
 /**
  * Minimal `ISystemLogService` stub — every method is a spy/no-op so the
@@ -71,8 +84,11 @@ function buildWidgetsService(): { widgets: WidgetsService } {
     const zones = new ZoneRegistry(logger);
     const types = new WidgetTypeRegistry(logger);
     const resolver = new PlacementResolver(placements, types, logger);
+    ZoneLayoutService.__resetForTests();
+    ZoneLayoutService.setDependencies(db, logger);
+    const zoneLayouts = ZoneLayoutService.getInstance();
     WidgetsService.__resetForTests();
-    WidgetsService.setDependencies(zones, types, placements, resolver, logger);
+    WidgetsService.setDependencies(zones, types, placements, resolver, zoneLayouts, logger);
     return { widgets: WidgetsService.getInstance() };
 }
 
@@ -112,7 +128,7 @@ describe('Core zone catalog', () => {
 describe('Core widget-type catalog (raw-html)', () => {
     it('registers as core-owned and exposes its config schema', () => {
         const { widgets } = buildWidgetsService();
-        for (const descriptor of CORE_WIDGET_TYPE_DESCRIPTORS) {
+        for (const descriptor of coreWidgetTypeDescriptors) {
             widgets.registerType(descriptor, 'core');
         }
 
@@ -132,7 +148,7 @@ describe('Core widget-type catalog (raw-html)', () => {
             CORE_ZONE_DESCRIPTORS.find(z => z.id === 'footer')!,
             'core'
         );
-        for (const descriptor of CORE_WIDGET_TYPE_DESCRIPTORS) {
+        for (const descriptor of coreWidgetTypeDescriptors) {
             widgets.registerType(descriptor, 'core');
         }
 

--- a/src/backend/modules/widgets/__tests__/widgets.service.test.ts
+++ b/src/backend/modules/widgets/__tests__/widgets.service.test.ts
@@ -20,6 +20,7 @@ import { ZoneRegistry } from '../zones/zone-registry.js';
 import { WidgetTypeRegistry } from '../widget-types/widget-type-registry.js';
 import { PlacementService } from '../placements/placement.service.js';
 import { PlacementResolver } from '../placements/placement-resolver.js';
+import { ZoneLayoutService } from '../zones/zone-layout.service.js';
 import { __resetKnownZonesForTests } from '../zones/define-zone.js';
 import { __resetKnownWidgetTypesForTests } from '../widget-types/define-widget-type.js';
 
@@ -67,8 +68,11 @@ function buildWidgetsService(): {
     const zones = new ZoneRegistry(logger);
     const types = new WidgetTypeRegistry(logger);
     const resolver = new PlacementResolver(placements, types, logger);
+    ZoneLayoutService.__resetForTests();
+    ZoneLayoutService.setDependencies(db, logger);
+    const zoneLayouts = ZoneLayoutService.getInstance();
     WidgetsService.__resetForTests();
-    WidgetsService.setDependencies(zones, types, placements, resolver, logger);
+    WidgetsService.setDependencies(zones, types, placements, resolver, zoneLayouts, logger);
     return { widgets: WidgetsService.getInstance(), zones, types, placements, logger };
 }
 
@@ -584,5 +588,65 @@ describe('WidgetsService.fetchWidgetsForRoute', () => {
 
         const markets = await widgets.fetchWidgetsForRoute('/markets');
         expect(markets.map(w => w.id)).toEqual(['p:markets']);
+    });
+});
+
+describe('WidgetsService zone layout', () => {
+    /**
+     * Resolve a single zone record from the snapshot by id, across all
+     * host tracks — the snapshot groups zones by host so a flat find is
+     * the cleanest way to assert on one zone's merged layout.
+     */
+    function findZone(widgets: WidgetsService, zoneId: string) {
+        return widgets.listZones().tracks.flatMap(t => t.zones).find(z => z.id === zoneId);
+    }
+
+    it('defaults a vertical zone to a stacked column layout when no override exists', () => {
+        const { widgets } = buildWidgetsService();
+        widgets.registerZone(
+            { id: 'main-after', label: 'After', description: 'd', host: 'core', layout: 'vertical' },
+            'core'
+        );
+
+        const zone = findZone(widgets, 'main-after');
+        expect(zone?.layoutConfig.flexDirection).toBe('column');
+        expect(zone?.layoutConfig.preset).toBe('column');
+    });
+
+    it('persists an operator override and merges it into the snapshot', async () => {
+        const { widgets } = buildWidgetsService();
+        widgets.registerZone(
+            { id: 'main-after', label: 'After', description: 'd', host: 'core', layout: 'vertical' },
+            'core'
+        );
+
+        const stored = await widgets.setZoneLayout('main-after', {
+            preset: 'row-center',
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'center',
+            flexWrap: 'nowrap',
+            gap: 'lg'
+        });
+        expect(stored.flexDirection).toBe('row');
+
+        const zone = findZone(widgets, 'main-after');
+        expect(zone?.layoutConfig.flexDirection).toBe('row');
+        expect(zone?.layoutConfig.justifyContent).toBe('center');
+        expect(zone?.layoutConfig.gap).toBe('lg');
+        expect(zone?.layoutConfig.preset).toBe('row-center');
+    });
+
+    it('rejects a layout write for an unregistered zone', async () => {
+        const { widgets } = buildWidgetsService();
+        await expect(
+            widgets.setZoneLayout('no-such-zone', {
+                flexDirection: 'row',
+                justifyContent: 'flex-start',
+                alignItems: 'center',
+                flexWrap: 'nowrap',
+                gap: 'md'
+            })
+        ).rejects.toThrow();
     });
 });

--- a/src/backend/modules/widgets/api/zones.controller.ts
+++ b/src/backend/modules/widgets/api/zones.controller.ts
@@ -9,10 +9,60 @@
  */
 
 import type { Request, Response } from 'express';
-import type { IWidgetsService, ISystemLogService } from '@/types';
+import type { IWidgetsService, ISystemLogService, IZoneLayoutConfig } from '@/types';
+import { UnknownZoneError } from '../widgets.errors.js';
+
+/** Allowed values per flex field — the body is operator input, never trusted. */
+const FLEX_DIRECTIONS = ['row', 'row-reverse', 'column', 'column-reverse'] as const;
+const JUSTIFY_CONTENTS = ['flex-start', 'center', 'flex-end', 'space-between', 'space-around', 'space-evenly'] as const;
+const ALIGN_ITEMS = ['stretch', 'flex-start', 'center', 'flex-end', 'baseline'] as const;
+const FLEX_WRAPS = ['nowrap', 'wrap'] as const;
+const GAP_SIZES = ['none', 'sm', 'md', 'lg'] as const;
+const LAYOUT_PRESETS = ['row-left', 'row-center', 'row-between', 'row-right', 'row-wrap', 'column', 'custom'] as const;
 
 /**
- * Admin endpoint controller for widget-zone introspection.
+ * Validate and coerce an operator-supplied layout body into a typed
+ * {@link IZoneLayoutConfig}. Returns the config, or an error string the
+ * controller surfaces as a 400 — the admin UI sends typed values, but the
+ * endpoint must reject anything off-enum since it persists to storage and
+ * feeds inline CSS at SSR.
+ *
+ * @param body - Raw request body.
+ * @returns The validated config, or `{ error }` describing the first failure.
+ */
+function validateLayoutBody(body: unknown): { config?: IZoneLayoutConfig; error?: string } {
+    if (typeof body !== 'object' || body === null) {
+        return { error: 'Body must be a layout config object.' };
+    }
+    const b = body as Record<string, unknown>;
+    const check = <T extends string>(field: string, allowed: ReadonlyArray<T>): T | null =>
+        typeof b[field] === 'string' && (allowed as ReadonlyArray<string>).includes(b[field] as string)
+            ? (b[field] as T)
+            : null;
+
+    const flexDirection = check('flexDirection', FLEX_DIRECTIONS);
+    const justifyContent = check('justifyContent', JUSTIFY_CONTENTS);
+    const alignItems = check('alignItems', ALIGN_ITEMS);
+    const flexWrap = check('flexWrap', FLEX_WRAPS);
+    const gap = check('gap', GAP_SIZES);
+    if (!flexDirection) return { error: 'Invalid or missing flexDirection.' };
+    if (!justifyContent) return { error: 'Invalid or missing justifyContent.' };
+    if (!alignItems) return { error: 'Invalid or missing alignItems.' };
+    if (!flexWrap) return { error: 'Invalid or missing flexWrap.' };
+    if (!gap) return { error: 'Invalid or missing gap.' };
+
+    const config: IZoneLayoutConfig = { flexDirection, justifyContent, alignItems, flexWrap, gap };
+    // preset is optional UI sugar; accept only a known value, else omit.
+    if (b.preset !== undefined) {
+        const preset = check('preset', LAYOUT_PRESETS);
+        if (preset) config.preset = preset;
+    }
+    return { config };
+}
+
+/**
+ * Admin endpoint controller for widget-zone introspection and the
+ * operator-editable per-zone flexbox layout.
  */
 export class ZonesController {
     constructor(
@@ -21,7 +71,8 @@ export class ZonesController {
     ) {}
 
     /**
-     * Return the current zone snapshot.
+     * Return the current zone snapshot (each zone carries its effective
+     * `layoutConfig`).
      */
     getSnapshot = (_req: Request, res: Response): void => {
         try {
@@ -29,6 +80,36 @@ export class ZonesController {
         } catch (err) {
             this.logger.error({ err }, 'Failed to read zone snapshot');
             res.status(500).json({ success: false, error: 'Failed to read zone snapshot' });
+        }
+    };
+
+    /**
+     * Persist an operator's flexbox layout override for a zone. Validates
+     * the body against the allowed flex value sets, then writes through
+     * the widgets service. 404 when the zone is unknown, 400 on a malformed
+     * body.
+     */
+    setLayout = async (req: Request, res: Response): Promise<void> => {
+        const zoneId = req.params.zoneId;
+        if (typeof zoneId !== 'string' || zoneId.length === 0) {
+            res.status(400).json({ success: false, error: 'A zoneId path parameter is required.' });
+            return;
+        }
+        const { config, error } = validateLayoutBody(req.body);
+        if (!config) {
+            res.status(400).json({ success: false, error });
+            return;
+        }
+        try {
+            const stored = await this.widgets.setZoneLayout(zoneId, config);
+            res.json({ success: true, layoutConfig: stored });
+        } catch (err) {
+            if (err instanceof UnknownZoneError) {
+                res.status(404).json({ success: false, error: err.message });
+                return;
+            }
+            this.logger.error({ err, zoneId }, 'Failed to persist zone layout');
+            res.status(500).json({ success: false, error: 'Failed to persist zone layout' });
         }
     };
 }

--- a/src/backend/modules/widgets/api/zones.controller.ts
+++ b/src/backend/modules/widgets/api/zones.controller.ts
@@ -31,7 +31,7 @@ const LAYOUT_PRESETS = ['row-left', 'row-center', 'row-between', 'row-right', 'r
  * @returns The validated config, or `{ error }` describing the first failure.
  */
 function validateLayoutBody(body: unknown): { config?: IZoneLayoutConfig; error?: string } {
-    if (typeof body !== 'object' || body === null) {
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
         return { error: 'Body must be a layout config object.' };
     }
     const b = body as Record<string, unknown>;

--- a/src/backend/modules/widgets/api/zones.routes.ts
+++ b/src/backend/modules/widgets/api/zones.routes.ts
@@ -1,11 +1,11 @@
 /**
- * @fileoverview Router factory for the zone-introspection admin
- * endpoint.
+ * @fileoverview Router factory for the zone admin endpoints.
  *
- * Single read-only `GET /` route returning the registry snapshot.
- * Caller mounts the router under `/api/admin/system/zones` with the
- * `requireAdmin` middleware applied at mount time, so the router
- * itself stays unauthenticated.
+ * `GET /` returns the registry snapshot; `PATCH /:zoneId/layout` persists
+ * an operator's flexbox layout override for a zone. Caller mounts the
+ * router under `/api/admin/system/zones` with the `requireAdmin`
+ * middleware applied at mount time, so the router itself stays
+ * unauthenticated.
  *
  * @module backend/modules/widgets/api/zones.routes
  */
@@ -22,6 +22,7 @@ import type { ZonesController } from './zones.controller.js';
 export function createZonesAdminRouter(controller: ZonesController): Router {
     const router = Router();
     router.get('/', controller.getSnapshot);
+    router.patch('/:zoneId/layout', controller.setLayout);
 
     return router;
 }

--- a/src/backend/modules/widgets/database/IZoneLayoutDocument.ts
+++ b/src/backend/modules/widgets/database/IZoneLayoutDocument.ts
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Mongo document interface for per-zone layout overrides.
+ *
+ * Zones are code-declared and rebuilt in memory every boot, so an
+ * operator's choice of how a zone arranges its widgets has nowhere to
+ * live on the descriptor. This collection is that home: one row per zone
+ * id holding the flexbox config the `WidgetZone` renderer applies. Absent
+ * a row, the zone falls back to a default derived from its descriptor's
+ * coarse `layout` hint, so this collection only ever holds genuine
+ * operator overrides.
+ *
+ * @see {@link ../../../../docs/system/system-database.md} for the manual
+ *   `module_*_*` collection-prefix convention.
+ * @module backend/modules/widgets/database/IZoneLayoutDocument
+ */
+
+import type { ObjectId } from 'mongodb';
+import type {
+    ZoneFlexDirection,
+    ZoneJustifyContent,
+    ZoneAlignItems,
+    ZoneFlexWrap,
+    ZoneGapSize,
+    ZoneLayoutPreset
+} from '@/types';
+
+/**
+ * Zone layout override as stored in MongoDB. The flex fields mirror
+ * `IZoneLayoutConfig`; `zoneId` is the stable identity (unique) so a
+ * zone never carries two override rows.
+ */
+export interface IZoneLayoutDocument {
+    _id: ObjectId;
+    /** Zone id this override applies to. Unique. */
+    zoneId: string;
+    /** Preset the operator last selected, or `'custom'` when hand-tuned. */
+    preset?: ZoneLayoutPreset;
+    /** Main-axis orientation. */
+    flexDirection: ZoneFlexDirection;
+    /** Main-axis distribution. */
+    justifyContent: ZoneJustifyContent;
+    /** Cross-axis alignment. */
+    alignItems: ZoneAlignItems;
+    /** Whether items wrap onto multiple lines. */
+    flexWrap: ZoneFlexWrap;
+    /** Inter-item gap as a token size. */
+    gap: ZoneGapSize;
+    updatedAt: Date;
+}
+
+/**
+ * Logical collection name. `IDatabaseService` maps it to the physical
+ * `module_widgets_zone_layouts` via the module-prefix convention; the
+ * service supplies this prefixed name to `getCollection(...)`.
+ */
+export const ZONE_LAYOUT_COLLECTION = 'module_widgets_zone_layouts';

--- a/src/backend/modules/widgets/migrations/002_seed_block_ticker_placement.ts
+++ b/src/backend/modules/widgets/migrations/002_seed_block_ticker_placement.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview Seed the core block-ticker placement into the site header.
+ *
+ * Before the widget subsystem owned the ticker, the root layout rendered
+ * `<BlockTicker>` unconditionally on every page. Making the ticker a
+ * placeable `core:block-ticker` widget removed that hardcoded element, so
+ * the site-wide live ticker now renders only when a persisted placement
+ * exists. `WidgetsModule.run()` registers the widget *type* but never a
+ * placement, and migration 001 inserts no rows — so without this seed a
+ * fresh or freshly-migrated deployment would show no ticker under the nav
+ * until an operator created one by hand. This migration restores the
+ * historical default by seeding one operator-source placement.
+ *
+ * The placement is `source: 'operator'` (not `plugin`) on purpose: it
+ * belongs to no plugin lifecycle, and operator rows are freely
+ * editable and deletable from `/system/widgets`. Because migrations run
+ * exactly once per environment, an operator who later deletes or
+ * reconfigures the ticker is never overridden on the next boot — the
+ * completed migration does not re-run.
+ *
+ * Idempotent — guarded on the absence of any `core:block-ticker`
+ * placement, so a retried run after a partial failure inserts nothing
+ * the second time, and an environment that somehow already carries a
+ * ticker placement is left untouched.
+ *
+ * @module backend/modules/widgets/migrations/002_seed_block_ticker_placement
+ */
+
+import type { IMigration, IMigrationContext } from '@/types';
+
+export const migration: IMigration = {
+    id: '002_seed_block_ticker_placement',
+    description:
+        'Seed one operator-source core:block-ticker placement into the ticker-after zone so the ' +
+        'site-wide live ticker renders by default after it became a placeable widget.',
+    dependencies: ['module:widgets:001_create_widget_placements'],
+
+    async up(context: IMigrationContext): Promise<void> {
+        const collection = 'module_widgets_placements';
+
+        // String literals, never imported constants: a migration is a
+        // point-in-time snapshot and must keep rendering the same effect
+        // even if these ids are later renamed in code. These match
+        // `BLOCK_TICKER_TYPE_ID` and the `ticker-after` zone descriptor
+        // at the time of writing.
+        const typeId = 'core:block-ticker';
+        const zoneId = 'ticker-after';
+
+        // Guard on any existing block-ticker placement so the seed runs
+        // at most once and never fights an operator who relocated or
+        // removed it. The (typeId, pluginId) unique index is sparse and
+        // excludes operator rows, so it cannot enforce this for us.
+        const existing = await context.database.findOne(collection, { typeId });
+        if (existing) {
+            return;
+        }
+
+        const now = new Date();
+        await context.database.insertOne(collection, {
+            typeId,
+            zoneId,
+            // Empty routes match every route — the ticker is global, as the
+            // unconditional `<BlockTicker>` was before this PR.
+            routes: [],
+            // Lowest order keeps the ticker at the top of the site header,
+            // directly below the nav, mirroring its historical position.
+            order: 0,
+            enabled: true,
+            source: 'operator',
+            createdAt: now,
+            updatedAt: now
+        });
+    }
+};

--- a/src/backend/modules/widgets/widget-types/core-widget-types.ts
+++ b/src/backend/modules/widgets/widget-types/core-widget-types.ts
@@ -14,7 +14,17 @@
  * live time for a set of operator-configured time zones. Both read their
  * SSR payload straight from the placement's operator-editable
  * `instanceConfig`; their matching frontend components (`RawHtmlWidget`,
- * `WorldClocksWidget`) render it.
+ * `WorldClocksWidget`) render it. `core:block-ticker` is the real-time
+ * blockchain status row: its SSR payload is the latest processed block,
+ * read at fetch time from the `'blockchain'` service, after which the
+ * `BlockTickerWidget` component takes over live updates over WebSocket.
+ *
+ * Because the block-ticker fetcher needs a runtime dependency the other
+ * two do not, the catalog is a *factory* — `buildCoreWidgetTypeDescriptors`
+ * — rather than a static array. `WidgetsModule.run()` calls it with the
+ * service registry so the ticker fetcher can resolve `'blockchain'`
+ * lazily per request (sidestepping module init-order). raw-html and
+ * world-clocks ignore the dependency.
  *
  * Adding a new core type requires editing this file *and* registering a
  * matching frontend component in `widgets.core.ts` — the descriptor and
@@ -26,7 +36,13 @@
  */
 
 import type { JSONSchema7 } from 'json-schema';
-import type { IRegisterWidgetTypeInput, IWidgetPlacementContext } from '@/types';
+import type {
+    IRegisterWidgetTypeInput,
+    IWidgetPlacementContext,
+    IServiceRegistry,
+    IBlockchainService,
+    WidgetDataFetcher
+} from '@/types';
 
 /**
  * Widget-type id for the raw text/HTML block. Namespaced under `core:`
@@ -244,27 +260,158 @@ export const WORLD_CLOCKS_CONFIG_SCHEMA: JSONSchema7 = {
 };
 
 /**
- * Declared core widget types. Bundle of plain registration inputs —
- * descriptor minting happens inside `WidgetsService.registerType` when
- * `WidgetsModule.run()` iterates this list at bootstrap.
+ * Widget-type id for the real-time blockchain status ticker. Namespaced
+ * under `core:` so it never collides with a plugin-declared id; the
+ * frontend component registry (`widgets.core.ts`) keys its renderer on
+ * this same string.
  */
-export const CORE_WIDGET_TYPE_DESCRIPTORS: ReadonlyArray<IRegisterWidgetTypeInput> = [
-    {
-        id: RAW_HTML_TYPE_ID,
-        label: 'Raw text / HTML',
-        description:
-            'Operator-authored block of raw HTML or plain text. Drop links, legal text, attribution, or embeds into any zone without a plugin.',
-        category: 'Content',
-        defaultDataFetcher: fetchRawHtmlData,
-        configSchema: RAW_HTML_CONFIG_SCHEMA
-    },
-    {
-        id: WORLD_CLOCKS_TYPE_ID,
-        label: 'World clocks',
-        description:
-            'Compact row of country flags with live local time for a set of configured time zones.',
-        category: 'Content',
-        defaultDataFetcher: fetchWorldClocksData,
-        configSchema: WORLD_CLOCKS_CONFIG_SCHEMA
-    }
-] as const;
+export const BLOCK_TICKER_TYPE_ID = 'core:block-ticker';
+
+/**
+ * One block's stats in the ticker SSR payload. Mirrors the frontend
+ * `BlockStatSnapshot` so the payload casts cleanly into the
+ * `BlockTicker` component's `initialBlock` prop without a second shape.
+ */
+interface IBlockTickerStats {
+    transactions: number;
+    transfers: number;
+    contractCalls: number;
+    delegations: number;
+    stakes: number;
+    tokenCreations: number;
+    internalTransactions: number;
+    totalEnergyUsed: number;
+    totalEnergyCost: number;
+    totalBandwidthUsed: number;
+}
+
+/**
+ * SSR payload the block-ticker data fetcher returns and the frontend
+ * `BlockTickerWidget` consumes. The `block` is the latest processed block
+ * (or `null` when none has been indexed yet) — wrapped in an object,
+ * never returned bare, so the resolver always keeps the placement (a bare
+ * `null` would make the resolver drop the widget, and the component would
+ * never mount to receive the live `block:new` updates that fill an empty
+ * initial state).
+ */
+export interface IBlockTickerWidgetData {
+    /** Latest processed block summary, or null when none indexed yet. */
+    block: {
+        blockNumber: number;
+        timestamp: string;
+        transactionCount: number;
+        stats: IBlockTickerStats;
+    } | null;
+}
+
+/**
+ * Dependencies the core widget-type catalog needs to build its fetchers.
+ *
+ * Only the block-ticker fetcher consumes anything here — it resolves the
+ * blockchain service from the registry at fetch time. Passing the
+ * registry (rather than the service itself) keeps resolution lazy so the
+ * catalog builds regardless of module init order; `'blockchain'` is
+ * published during bootstrap and is always present by the time a page
+ * renders.
+ */
+export interface ICoreWidgetTypeDeps {
+    /** Service registry used to resolve `'blockchain'` lazily per request. */
+    serviceRegistry: IServiceRegistry;
+}
+
+/**
+ * Build the block-ticker SSR data fetcher bound to the service registry.
+ *
+ * Resolves `'blockchain'` and reads the latest processed block, mapping
+ * it to the serialisable {@link IBlockTickerWidgetData} the frontend
+ * component renders. Never throws and never returns bare null: on a
+ * missing service, an empty database, or any error it yields
+ * `{ block: null }` so the widget still mounts and hydrates to live
+ * updates. The fetcher ignores route/params — the ticker is global.
+ *
+ * @param deps - Carries the service registry for lazy `'blockchain'` lookup.
+ * @returns A {@link WidgetDataFetcher} producing the ticker's SSR payload.
+ */
+function buildBlockTickerFetcher(deps: ICoreWidgetTypeDeps): WidgetDataFetcher {
+    return async (): Promise<IBlockTickerWidgetData> => {
+        try {
+            const blockchain = deps.serviceRegistry.get<IBlockchainService>('blockchain');
+            const block = blockchain ? await blockchain.getLatestBlock() : null;
+            if (!block) {
+                return { block: null };
+            }
+
+            const timestamp =
+                block.timestamp instanceof Date
+                    ? block.timestamp.toISOString()
+                    : new Date(block.timestamp).toISOString();
+
+            return {
+                block: {
+                    blockNumber: block.blockNumber,
+                    timestamp,
+                    transactionCount: block.transactionCount,
+                    stats: {
+                        transactions: block.transactionCount,
+                        transfers: block.stats.transfers,
+                        contractCalls: block.stats.contractCalls,
+                        delegations: block.stats.delegations,
+                        stakes: block.stats.stakes,
+                        tokenCreations: block.stats.tokenCreations,
+                        internalTransactions: block.stats.internalTransactions,
+                        totalEnergyUsed: block.stats.totalEnergyUsed,
+                        totalEnergyCost: block.stats.totalEnergyCost,
+                        totalBandwidthUsed: block.stats.totalBandwidthUsed
+                    }
+                }
+            };
+        } catch {
+            return { block: null };
+        }
+    };
+}
+
+/**
+ * Build the core widget-type catalog as plain registration inputs.
+ *
+ * A factory rather than a constant because the block-ticker fetcher needs
+ * the service registry to read the latest block; raw-html and
+ * world-clocks ignore `deps`. Descriptor minting happens inside
+ * `WidgetsService.registerType` when `WidgetsModule.run()` iterates the
+ * returned list at bootstrap.
+ *
+ * @param deps - Runtime dependencies forwarded to fetchers that need them.
+ * @returns The ordered list of core widget-type registration inputs.
+ */
+export function buildCoreWidgetTypeDescriptors(
+    deps: ICoreWidgetTypeDeps
+): ReadonlyArray<IRegisterWidgetTypeInput> {
+    return [
+        {
+            id: RAW_HTML_TYPE_ID,
+            label: 'Raw text / HTML',
+            description:
+                'Operator-authored block of raw HTML or plain text. Drop links, legal text, attribution, or embeds into any zone without a plugin.',
+            category: 'Content',
+            defaultDataFetcher: fetchRawHtmlData,
+            configSchema: RAW_HTML_CONFIG_SCHEMA
+        },
+        {
+            id: WORLD_CLOCKS_TYPE_ID,
+            label: 'World clocks',
+            description:
+                'Compact row of country flags with live local time for a set of configured time zones.',
+            category: 'Content',
+            defaultDataFetcher: fetchWorldClocksData,
+            configSchema: WORLD_CLOCKS_CONFIG_SCHEMA
+        },
+        {
+            id: BLOCK_TICKER_TYPE_ID,
+            label: 'Block ticker',
+            description:
+                'Compact real-time row of latest-block metrics — block number, transactions, transfers, contracts, delegations, stakes, tokens, energy.',
+            category: 'Blockchain',
+            defaultDataFetcher: buildBlockTickerFetcher(deps)
+        }
+    ];
+}

--- a/src/backend/modules/widgets/widgets.service.ts
+++ b/src/backend/modules/widgets/widgets.service.ts
@@ -43,9 +43,11 @@ import type {
     IPlacementPatch,
     IZoneRegistry,
     IWidgetTypeRegistry,
-    IPlacementService
+    IPlacementService,
+    IZoneLayoutConfig
 } from '@/types';
 import type { PlacementResolver } from './placements/placement-resolver.js';
+import { ZoneLayoutService } from './zones/zone-layout.service.js';
 import { defineZone } from './zones/define-zone.js';
 import { defineWidgetType } from './widget-types/define-widget-type.js';
 import {
@@ -103,6 +105,7 @@ export class WidgetsService implements IWidgetsService {
         private readonly widgetTypes: IWidgetTypeRegistry,
         private readonly placements: IPlacementService,
         private readonly resolver: PlacementResolver,
+        private readonly zoneLayouts: ZoneLayoutService,
         private readonly logger: ISystemLogService
     ) {}
 
@@ -115,6 +118,7 @@ export class WidgetsService implements IWidgetsService {
         widgetTypes: IWidgetTypeRegistry,
         placements: IPlacementService,
         resolver: PlacementResolver,
+        zoneLayouts: ZoneLayoutService,
         logger: ISystemLogService
     ): void {
         if (!WidgetsService.instance) {
@@ -123,6 +127,7 @@ export class WidgetsService implements IWidgetsService {
                 widgetTypes,
                 placements,
                 resolver,
+                zoneLayouts,
                 logger
             );
         }
@@ -153,7 +158,24 @@ export class WidgetsService implements IWidgetsService {
     // ------------------------------------------------------------
 
     listZones(): IZoneSnapshot {
-        return this.zones.snapshot();
+        // Merge each zone's effective layout into the registry snapshot:
+        // the operator override when one is persisted, else a default
+        // derived from the descriptor's coarse `layout` hint. Both the
+        // SSR router and the admin editor read layout from this one
+        // snapshot rather than a parallel lookup.
+        const snapshot = this.zones.snapshot();
+        return {
+            tracks: snapshot.tracks.map(track => ({
+                id: track.id,
+                label: track.label,
+                zones: track.zones.map(zone => ({
+                    ...zone,
+                    // Operator override when persisted, else the
+                    // descriptor-derived default the registry already set.
+                    layoutConfig: this.zoneLayouts.get(zone.id) ?? zone.layoutConfig
+                }))
+            }))
+        };
     }
 
     listTypes(): IWidgetTypeSnapshot {
@@ -364,6 +386,17 @@ export class WidgetsService implements IWidgetsService {
                 'Widget registrations disposed for owner'
             );
         }
+    }
+
+    // ------------------------------------------------------------
+    // Zone layout
+    // ------------------------------------------------------------
+
+    async setZoneLayout(zoneId: string, config: IZoneLayoutConfig): Promise<IZoneLayoutConfig> {
+        if (!this.zones.has(zoneId)) {
+            throw new UnknownZoneError(zoneId);
+        }
+        return this.zoneLayouts.set(zoneId, config);
     }
 
     // ------------------------------------------------------------

--- a/src/backend/modules/widgets/zones/descriptors.ts
+++ b/src/backend/modules/widgets/zones/descriptors.ts
@@ -27,9 +27,9 @@ import type { IRegisterZoneInput } from '@/types';
 export const CORE_ZONE_DESCRIPTORS: ReadonlyArray<IRegisterZoneInput> = [
     {
         id: 'ticker-after',
-        label: 'Below the block ticker',
+        label: 'Site Header',
         description:
-            'Rendered in the root layout below the block ticker. Reaches every route the root layout serves.',
+            'Rendered in the root layout directly below the main navigation, across every route the root layout serves. Home for the block ticker and other site-wide header widgets. (Zone id stays "ticker-after" so existing placements survive the rename.)',
         host: 'site',
         layout: 'vertical',
         order: 10

--- a/src/backend/modules/widgets/zones/zone-layout.service.ts
+++ b/src/backend/modules/widgets/zones/zone-layout.service.ts
@@ -1,0 +1,249 @@
+/**
+ * @fileoverview Per-zone flexbox layout store.
+ *
+ * Internal collaborator (no public exposure — reached only through
+ * `WidgetsService`) that owns the `module_widgets_zone_layouts`
+ * collection. It keeps every operator override in an in-memory cache so
+ * `WidgetsService.listZones()` stays synchronous: the cache is loaded
+ * once at `init()` and updated on every `set()`, mirroring how the zone
+ * registry holds descriptors in memory.
+ *
+ * Zones with no override are not stored here; the default they fall back
+ * to is derived from the descriptor's coarse `layout` hint by
+ * {@link defaultLayoutConfigFor}, so the collection stays small and a
+ * fresh deploy carries no rows.
+ *
+ * @module backend/modules/widgets/zones/zone-layout.service
+ */
+
+import type {
+    IDatabaseService,
+    ISystemLogService,
+    IZoneLayoutConfig,
+    ZoneLayout
+} from '@/types';
+import type { IZoneLayoutDocument } from '../database/IZoneLayoutDocument.js';
+import { ZONE_LAYOUT_COLLECTION } from '../database/IZoneLayoutDocument.js';
+
+/**
+ * Callback fired after a successful layout write so `WidgetsModule` can
+ * broadcast a refetch signal. Errors thrown by it are swallowed by the
+ * caller so a broadcast failure never rolls back the persisted change.
+ *
+ * @param zoneId - Zone whose layout changed.
+ */
+export type ZoneLayoutBroadcastCallback = (zoneId: string) => void;
+
+/**
+ * Derive the default flexbox config for a zone from its coarse `layout`
+ * hint. This is what a zone renders with before any operator override:
+ * `'vertical'` reproduces the historical stacked column (so untouched
+ * zones look identical to the pre-flex renderer), `'horizontal'` is a
+ * centered row, and `'grid'` approximates a dashboard with a wrapping
+ * row. Centralised here so the renderer default and the admin editor's
+ * seed agree.
+ *
+ * @param hint - The descriptor's coarse layout hint.
+ * @returns A full {@link IZoneLayoutConfig} default for the hint.
+ */
+export function defaultLayoutConfigFor(hint: ZoneLayout): IZoneLayoutConfig {
+    switch (hint) {
+        case 'horizontal':
+            return {
+                preset: 'row-left',
+                flexDirection: 'row',
+                justifyContent: 'flex-start',
+                alignItems: 'center',
+                flexWrap: 'nowrap',
+                gap: 'md'
+            };
+        case 'grid':
+            return {
+                preset: 'row-wrap',
+                flexDirection: 'row',
+                justifyContent: 'flex-start',
+                alignItems: 'stretch',
+                flexWrap: 'wrap',
+                gap: 'md'
+            };
+        case 'vertical':
+        default:
+            return {
+                preset: 'column',
+                flexDirection: 'column',
+                justifyContent: 'flex-start',
+                alignItems: 'stretch',
+                flexWrap: 'nowrap',
+                gap: 'md'
+            };
+    }
+}
+
+/**
+ * Singleton zone-layout store. Configured once during
+ * `WidgetsModule.init()` via {@link setDependencies}, loaded via
+ * {@link load}, and consumed by `WidgetsService` for both reads (merged
+ * into the zone snapshot) and writes (the admin layout endpoint).
+ */
+export class ZoneLayoutService {
+    private static instance: ZoneLayoutService;
+    private readonly database: IDatabaseService;
+    private readonly logger: ISystemLogService;
+    /** zoneId → persisted override. Absent key means "use the default". */
+    private readonly cache: Map<string, IZoneLayoutConfig> = new Map();
+    private broadcast: ZoneLayoutBroadcastCallback | null = null;
+
+    private constructor(database: IDatabaseService, logger: ISystemLogService) {
+        this.database = database;
+        this.logger = logger;
+    }
+
+    /**
+     * Configure the singleton's injected dependencies. Idempotent —
+     * called once during `WidgetsModule.init()`.
+     */
+    public static setDependencies(database: IDatabaseService, logger: ISystemLogService): void {
+        if (!ZoneLayoutService.instance) {
+            ZoneLayoutService.instance = new ZoneLayoutService(database, logger);
+        }
+    }
+
+    /**
+     * Retrieve the configured singleton.
+     *
+     * @throws Error if `setDependencies` has not been called yet.
+     */
+    public static getInstance(): ZoneLayoutService {
+        if (!ZoneLayoutService.instance) {
+            throw new Error('ZoneLayoutService.setDependencies() must be called first');
+        }
+        return ZoneLayoutService.instance;
+    }
+
+    /**
+     * Test-only reset so a fresh injection can occur between unit tests.
+     */
+    public static __resetForTests(): void {
+        // @ts-expect-error — clearing the private static for tests
+        ZoneLayoutService.instance = undefined;
+    }
+
+    /**
+     * Wire the broadcast callback fired after every successful write.
+     *
+     * @param callback - Function invoked post-write, or null to disable.
+     */
+    public setBroadcast(callback: ZoneLayoutBroadcastCallback | null): void {
+        this.broadcast = callback;
+    }
+
+    /**
+     * Ensure the unique index exists and warm the in-memory cache from
+     * MongoDB. Called once during `WidgetsModule.init()`. `createIndex`
+     * is idempotent so this doubles as first-boot schema creation — the
+     * collection needs no migration because it is brand new.
+     */
+    async load(): Promise<void> {
+        await this.database.createIndex(ZONE_LAYOUT_COLLECTION, { zoneId: 1 }, { unique: true });
+
+        const collection = this.database.getCollection<IZoneLayoutDocument>(ZONE_LAYOUT_COLLECTION);
+        const docs = await collection.find({}).toArray();
+        this.cache.clear();
+        for (const doc of docs) {
+            this.cache.set(doc.zoneId, toConfig(doc));
+        }
+        this.logger.debug({ zoneLayoutCount: this.cache.size }, 'Zone layout overrides loaded');
+    }
+
+    /**
+     * Read a zone's persisted override, or `undefined` when none exists
+     * (the caller then falls back to {@link defaultLayoutConfigFor}).
+     * Synchronous — served from the in-memory cache.
+     *
+     * @param zoneId - Zone id to look up.
+     * @returns The override config, or `undefined`.
+     */
+    get(zoneId: string): IZoneLayoutConfig | undefined {
+        return this.cache.get(zoneId);
+    }
+
+    /**
+     * Persist a zone's layout override (upsert), refresh the cache, and
+     * fire the broadcast. Returns the stored config.
+     *
+     * @param zoneId - Zone id to write.
+     * @param config - Full flexbox config to persist.
+     * @returns The persisted config.
+     */
+    async set(zoneId: string, config: IZoneLayoutConfig): Promise<IZoneLayoutConfig> {
+        const collection = this.database.getCollection<IZoneLayoutDocument>(ZONE_LAYOUT_COLLECTION);
+        const now = new Date();
+        const setOps: Partial<IZoneLayoutDocument> = {
+            flexDirection: config.flexDirection,
+            justifyContent: config.justifyContent,
+            alignItems: config.alignItems,
+            flexWrap: config.flexWrap,
+            gap: config.gap,
+            updatedAt: now
+        };
+        if (config.preset !== undefined) {
+            setOps.preset = config.preset;
+        }
+
+        await collection.updateOne(
+            { zoneId },
+            { $set: setOps, $setOnInsert: { zoneId } },
+            { upsert: true }
+        );
+
+        const stored: IZoneLayoutConfig = {
+            preset: config.preset,
+            flexDirection: config.flexDirection,
+            justifyContent: config.justifyContent,
+            alignItems: config.alignItems,
+            flexWrap: config.flexWrap,
+            gap: config.gap
+        };
+        this.cache.set(zoneId, stored);
+
+        this.fireBroadcast(zoneId);
+        this.logger.debug({ zoneId, preset: config.preset }, 'Zone layout override persisted');
+        return stored;
+    }
+
+    /**
+     * Invoke the broadcast callback if wired, swallowing any error so a
+     * notification failure never surfaces as a write failure.
+     *
+     * @param zoneId - Zone whose layout changed.
+     */
+    private fireBroadcast(zoneId: string): void {
+        if (!this.broadcast) return;
+        try {
+            this.broadcast(zoneId);
+        } catch (err) {
+            this.logger.warn(
+                { err: err instanceof Error ? err.message : String(err), zoneId },
+                'Zone layout broadcast callback threw — write succeeded but the notification was not delivered'
+            );
+        }
+    }
+}
+
+/**
+ * Map a stored document to the public {@link IZoneLayoutConfig} shape,
+ * dropping Mongo-only fields (`_id`, `zoneId`, `updatedAt`).
+ *
+ * @param doc - Stored zone-layout document.
+ * @returns The flexbox config the renderer and editor consume.
+ */
+function toConfig(doc: IZoneLayoutDocument): IZoneLayoutConfig {
+    return {
+        preset: doc.preset,
+        flexDirection: doc.flexDirection,
+        justifyContent: doc.justifyContent,
+        alignItems: doc.alignItems,
+        flexWrap: doc.flexWrap,
+        gap: doc.gap
+    };
+}

--- a/src/backend/modules/widgets/zones/zone-registry.ts
+++ b/src/backend/modules/widgets/zones/zone-registry.ts
@@ -26,6 +26,7 @@ import type {
     ISystemLogService
 } from '@/types';
 import { forgetZone, isKnownZone, listKnownZones } from './define-zone.js';
+import { defaultLayoutConfigFor } from './zone-layout.service.js';
 
 const RESERVED_PLUGIN_ID = 'core';
 
@@ -265,6 +266,11 @@ function toSnapshotRecord(entry: IRegisteredZone): IZoneSnapshotRecord {
         description: entry.descriptor.description,
         host: entry.descriptor.host,
         layout: entry.descriptor.layout,
+        // The descriptor-derived default. `WidgetsService.listZones()`
+        // replaces this with a persisted operator override when one
+        // exists, so the registry record carries the effective layout
+        // even before the layout store is consulted.
+        layoutConfig: defaultLayoutConfigFor(entry.descriptor.layout),
         pluginId: entry.pluginId,
         registeredAt: new Date(entry.registeredAt).toISOString(),
         source: entry.source

--- a/src/frontend/app/(core)/layout.tsx
+++ b/src/frontend/app/(core)/layout.tsx
@@ -26,13 +26,13 @@ export default async function CoreLayout({ children }: { children: ReactNode }) 
     // have their own layouts that provide context-specific params
     const params: Record<string, string> = {};
 
-    const widgets = await fetchWidgetsForRoute(pathname, params);
+    const { widgets, zones } = await fetchWidgetsForRoute(pathname, params);
 
     return (
         <div className="core-layout">
-            <WidgetZone name="main-before" widgets={widgets} route={pathname} params={params} />
+            <WidgetZone name="main-before" widgets={widgets} layout={zones['main-before']} route={pathname} params={params} />
             {children}
-            <WidgetZone name="main-after" widgets={widgets} route={pathname} params={params} />
+            <WidgetZone name="main-after" widgets={widgets} layout={zones['main-after']} route={pathname} params={params} />
         </div>
     );
 }

--- a/src/frontend/app/(core)/system/widgets/page.module.scss
+++ b/src/frontend/app/(core)/system/widgets/page.module.scss
@@ -108,6 +108,28 @@
     flex-wrap: wrap;
 }
 
+/* Per-zone flexbox layout controls — a wrapping row of compact labeled
+   selects (preset + granular). Each field stays narrow so the whole row
+   fits several controls before wrapping on tight containers. */
+.zone_layout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-sm);
+    align-items: flex-end;
+    padding: var(--padding-xs) 0;
+    border-bottom: var(--border-width-thin) solid var(--color-border);
+}
+
+.zone_layout_field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+    // Share the row and wrap as space runs out; min-width:0 lets the
+    // selects shrink below content width instead of forcing overflow.
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
 .zone_label {
     margin: 0;
     font-size: var(--font-size-body-lg);

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -49,7 +49,12 @@ import {
     verticalListSortingStrategy
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import type { IZoneSnapshot, IWidgetTypeSnapshot } from '@/types';
+import type {
+    IZoneSnapshot,
+    IWidgetTypeSnapshot,
+    IZoneLayoutConfig,
+    ZoneLayoutPreset
+} from '@/types';
 import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 
 import { Page, PageHeader, Stack } from '../../../../components/layout';
@@ -221,6 +226,167 @@ function normaliseRouteInput(value: string): string | null {
     if (!trimmed.startsWith('/')) return null;
     if (/\s/.test(trimmed)) return null;
     return trimmed;
+}
+
+/* ------------------------------------------------------------------ */
+/* Zone flexbox layout controls                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Named popular layouts the preset dropdown offers, each mapping to the
+ * four flex properties (gap is chosen separately, so presets leave it
+ * untouched). `'custom'` is not in this map — it is the marker the UI
+ * shows when the operator hand-tunes a granular control past any preset.
+ */
+const LAYOUT_PRESETS: Record<Exclude<ZoneLayoutPreset, 'custom'>, Omit<IZoneLayoutConfig, 'gap' | 'preset'>> = {
+    'row-left': { flexDirection: 'row', justifyContent: 'flex-start', alignItems: 'center', flexWrap: 'nowrap' },
+    'row-center': { flexDirection: 'row', justifyContent: 'center', alignItems: 'center', flexWrap: 'nowrap' },
+    'row-between': { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'nowrap' },
+    'row-right': { flexDirection: 'row', justifyContent: 'flex-end', alignItems: 'center', flexWrap: 'nowrap' },
+    'row-wrap': { flexDirection: 'row', justifyContent: 'flex-start', alignItems: 'stretch', flexWrap: 'wrap' },
+    'column': { flexDirection: 'column', justifyContent: 'flex-start', alignItems: 'stretch', flexWrap: 'nowrap' }
+};
+
+/** Preset dropdown options, in display order. */
+const PRESET_OPTIONS: ReadonlyArray<{ value: ZoneLayoutPreset; label: string }> = [
+    { value: 'row-left', label: 'Row — left' },
+    { value: 'row-center', label: 'Row — centered' },
+    { value: 'row-between', label: 'Row — space between' },
+    { value: 'row-right', label: 'Row — right' },
+    { value: 'row-wrap', label: 'Row — wrap' },
+    { value: 'column', label: 'Column (stacked)' },
+    { value: 'custom', label: 'Custom' }
+];
+
+/** Granular dropdown option lists, label → CSS value. */
+const DIRECTION_OPTIONS = ['row', 'row-reverse', 'column', 'column-reverse'] as const;
+const JUSTIFY_OPTIONS = ['flex-start', 'center', 'flex-end', 'space-between', 'space-around', 'space-evenly'] as const;
+const ALIGN_OPTIONS = ['stretch', 'flex-start', 'center', 'flex-end', 'baseline'] as const;
+const WRAP_OPTIONS = ['nowrap', 'wrap'] as const;
+const GAP_OPTIONS = ['none', 'sm', 'md', 'lg'] as const;
+
+/**
+ * Per-zone flexbox controls: a preset dropdown that sets the common
+ * arrangements in one click, plus granular dropdowns (direction,
+ * justify, align, wrap, gap) for fine-tuning. Selecting a preset applies
+ * its four flex fields and keeps the chosen gap; touching any granular
+ * flex field re-tags the config as `'custom'` so the preset dropdown
+ * reflects that the layout no longer matches a named preset. Gap is
+ * preset-independent, so changing it preserves the current preset label.
+ *
+ * @param props.zoneId - Zone these controls edit.
+ * @param props.layout - The zone's current effective layout.
+ * @param props.disabled - Whether the controls are inert (busy write).
+ * @param props.onChange - Persists the new config for the zone.
+ */
+function ZoneLayoutControls({
+    zoneId,
+    layout,
+    disabled,
+    onChange
+}: {
+    zoneId: string;
+    layout: IZoneLayoutConfig;
+    disabled: boolean;
+    onChange: (zoneId: string, config: IZoneLayoutConfig) => void;
+}) {
+    /**
+     * Apply a preset: spread its flex fields over the current config,
+     * keep the operator's gap, and stamp the preset name.
+     *
+     * @param preset - Selected preset value from the dropdown.
+     */
+    const applyPreset = (preset: ZoneLayoutPreset) => {
+        if (preset === 'custom') {
+            onChange(zoneId, { ...layout, preset: 'custom' });
+            return;
+        }
+        onChange(zoneId, { ...LAYOUT_PRESETS[preset], gap: layout.gap, preset });
+    };
+
+    /**
+     * Apply a granular flex change. Any granular edit re-tags the config
+     * as `'custom'` (the layout no longer matches a named preset). Gap is
+     * excluded — it does not belong to a preset — so a gap change keeps
+     * the current preset label.
+     *
+     * @param patch - The single field being changed.
+     * @param keepPreset - True only for the gap control.
+     */
+    const applyGranular = (patch: Partial<IZoneLayoutConfig>, keepPreset: boolean) => {
+        onChange(zoneId, { ...layout, ...patch, preset: keepPreset ? layout.preset : 'custom' });
+    };
+
+    return (
+        <div className={styles.zone_layout}>
+            <div className={styles.zone_layout_field}>
+                <label className={styles.filter_label} htmlFor={`zl-preset-${zoneId}`}>Layout</label>
+                <Select
+                    id={`zl-preset-${zoneId}`}
+                    value={layout.preset ?? 'custom'}
+                    onChange={(e) => applyPreset(e.target.value as ZoneLayoutPreset)}
+                    disabled={disabled}
+                >
+                    {PRESET_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </Select>
+            </div>
+            <div className={styles.zone_layout_field}>
+                <label className={styles.filter_label} htmlFor={`zl-dir-${zoneId}`}>Direction</label>
+                <Select
+                    id={`zl-dir-${zoneId}`}
+                    value={layout.flexDirection}
+                    onChange={(e) => applyGranular({ flexDirection: e.target.value as IZoneLayoutConfig['flexDirection'] }, false)}
+                    disabled={disabled}
+                >
+                    {DIRECTION_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
+                </Select>
+            </div>
+            <div className={styles.zone_layout_field}>
+                <label className={styles.filter_label} htmlFor={`zl-justify-${zoneId}`}>Justify</label>
+                <Select
+                    id={`zl-justify-${zoneId}`}
+                    value={layout.justifyContent}
+                    onChange={(e) => applyGranular({ justifyContent: e.target.value as IZoneLayoutConfig['justifyContent'] }, false)}
+                    disabled={disabled}
+                >
+                    {JUSTIFY_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
+                </Select>
+            </div>
+            <div className={styles.zone_layout_field}>
+                <label className={styles.filter_label} htmlFor={`zl-align-${zoneId}`}>Align</label>
+                <Select
+                    id={`zl-align-${zoneId}`}
+                    value={layout.alignItems}
+                    onChange={(e) => applyGranular({ alignItems: e.target.value as IZoneLayoutConfig['alignItems'] }, false)}
+                    disabled={disabled}
+                >
+                    {ALIGN_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
+                </Select>
+            </div>
+            <div className={styles.zone_layout_field}>
+                <label className={styles.filter_label} htmlFor={`zl-wrap-${zoneId}`}>Wrap</label>
+                <Select
+                    id={`zl-wrap-${zoneId}`}
+                    value={layout.flexWrap}
+                    onChange={(e) => applyGranular({ flexWrap: e.target.value as IZoneLayoutConfig['flexWrap'] }, false)}
+                    disabled={disabled}
+                >
+                    {WRAP_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
+                </Select>
+            </div>
+            <div className={styles.zone_layout_field}>
+                <label className={styles.filter_label} htmlFor={`zl-gap-${zoneId}`}>Gap</label>
+                <Select
+                    id={`zl-gap-${zoneId}`}
+                    value={layout.gap}
+                    onChange={(e) => applyGranular({ gap: e.target.value as IZoneLayoutConfig['gap'] }, true)}
+                    disabled={disabled}
+                >
+                    {GAP_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
+                </Select>
+            </div>
+        </div>
+    );
 }
 
 /**
@@ -416,6 +582,45 @@ export default function WidgetsAdminPage() {
         [notifyError, notifySuccess]
     );
 
+    /**
+     * Persist a zone's flexbox layout. Updates the local zone snapshot
+     * optimistically so the editor (and the live preview a refetch would
+     * bring) reflects the change immediately, then PATCHes the zone-layout
+     * endpoint. A failed write reverts by refetching the server truth.
+     */
+    const setZoneLayout = useCallback(
+        async (zoneId: string, config: IZoneLayoutConfig): Promise<void> => {
+            setZones(prev =>
+                prev
+                    ? {
+                        tracks: prev.tracks.map(track => ({
+                            ...track,
+                            zones: track.zones.map(zone =>
+                                zone.id === zoneId ? { ...zone, layoutConfig: config } : zone
+                            )
+                        }))
+                    }
+                    : prev
+            );
+            try {
+                const res = await fetch(`/api/admin/system/zones/${encodeURIComponent(zoneId)}/layout`, {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(config)
+                });
+                if (!res.ok) {
+                    const body = await res.json().catch(() => ({}));
+                    throw new Error(body.error || `Layout update failed (${res.status})`);
+                }
+                notifySuccess('Zone layout updated');
+            } catch (err) {
+                notifyError('Could not update zone layout', err);
+                void fetchAll(false);
+            }
+        },
+        [notifyError, notifySuccess, fetchAll]
+    );
+
     const sensors = useSensors(
         useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
         useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
@@ -547,7 +752,7 @@ export default function WidgetsAdminPage() {
      * the full target set.
      */
     const grouped = useMemo(() => {
-        if (!zones) return [] as Array<{ trackId: string; trackLabel: string; rows: Array<{ zoneId: string; zoneLabel: string; placements: IPlacement[] }> }>;
+        if (!zones) return [] as Array<{ trackId: string; trackLabel: string; rows: Array<{ zoneId: string; zoneLabel: string; layoutConfig: IZoneLayoutConfig; placements: IPlacement[] }> }>;
         const byZone = new Map<string, IPlacement[]>();
         for (const placement of placements) {
             const matches = selectedRoute === null
@@ -567,6 +772,7 @@ export default function WidgetsAdminPage() {
             rows: track.zones.map(zone => ({
                 zoneId: zone.id,
                 zoneLabel: zone.label,
+                layoutConfig: zone.layoutConfig,
                 placements: byZone.get(zone.id) ?? []
             }))
         }));
@@ -784,6 +990,7 @@ export default function WidgetsAdminPage() {
                                                 key={zone.zoneId}
                                                 zoneId={zone.zoneId}
                                                 zoneLabel={zone.zoneLabel}
+                                                layoutConfig={zone.layoutConfig}
                                                 placements={zone.placements}
                                                 types={types}
                                                 zones={zones}
@@ -792,6 +999,7 @@ export default function WidgetsAdminPage() {
                                                 onEdit={(p) => openPlacementModal('edit', p)}
                                                 onDelete={openDeleteModal}
                                                 onRestore={(p) => restoreDefaults(p.id)}
+                                                onLayoutChange={setZoneLayout}
                                             />
                                         ))}
                                     </div>
@@ -812,6 +1020,7 @@ export default function WidgetsAdminPage() {
 interface ZoneSectionProps {
     zoneId: string;
     zoneLabel: string;
+    layoutConfig: IZoneLayoutConfig;
     placements: IPlacement[];
     types: IWidgetTypeSnapshot | null;
     zones: IZoneSnapshot | null;
@@ -820,11 +1029,13 @@ interface ZoneSectionProps {
     onEdit: (placement: IPlacement) => void;
     onDelete: (placement: IPlacement) => void;
     onRestore: (placement: IPlacement) => void;
+    onLayoutChange: (zoneId: string, config: IZoneLayoutConfig) => void;
 }
 
 function ZoneSection({
     zoneId,
     zoneLabel,
+    layoutConfig,
     placements,
     types,
     zones,
@@ -832,7 +1043,8 @@ function ZoneSection({
     onToggleEnabled,
     onEdit,
     onDelete,
-    onRestore
+    onRestore,
+    onLayoutChange
 }: ZoneSectionProps) {
     const zoneInfo = lookupZone(zones, zoneId);
     const { setNodeRef, isOver } = useDroppable({ id: zoneId, data: { zoneId } });
@@ -850,6 +1062,13 @@ function ZoneSection({
                     {placements.length} {placements.length === 1 ? 'placement' : 'placements'}
                 </span>
             </header>
+
+            <ZoneLayoutControls
+                zoneId={zoneId}
+                layout={layoutConfig}
+                disabled={busyId !== null}
+                onChange={onLayoutChange}
+            />
 
             <SortableContext id={zoneId} items={itemIds} strategy={verticalListSortingStrategy}>
                 <div ref={setNodeRef} className={styles.bubbles}>

--- a/src/frontend/app/layout.tsx
+++ b/src/frontend/app/layout.tsx
@@ -7,10 +7,8 @@ import { buildMetadata, SITE_NAME } from '../lib/seo';
 import './globals.scss';
 import { Providers } from './providers';
 import { MainHeader } from '../components/layout/MainHeader';
-import { BlockTicker } from '../components/layout/BlockTicker';
 import { WidgetZone, fetchWidgetsForRoute } from '../components/widgets';
 import { getServerSession, type ISSRSession } from '../modules/user/lib/session-server';
-import type { BlockSummary } from '../features/blockchain/slice';
 
 /**
  * Head fragment shape served by the backend `ssr.headFragments` hook.
@@ -246,39 +244,6 @@ function renderHeadFragment(fragment: IHeadFragmentResponse): ReactElement {
 }
 
 /**
- * Fetch latest block for SSR to enable immediate ticker rendering.
- *
- * Fetches the most recent indexed block from the backend API. This data
- * is passed to BlockTicker to render immediately during SSR instead of
- * waiting for WebSocket connection after hydration.
- *
- * IMPORTANT: Uses internal Docker URL (SITE_BACKEND) for container-to-container
- * communication during SSR.
- *
- * @returns Block summary data or null if fetch fails
- */
-async function fetchInitialBlock(): Promise<BlockSummary | null> {
-    try {
-        const backendUrl = getServerSideApiUrl();
-        const response = await fetch(`${backendUrl}/api/blockchain/latest`, {
-            cache: 'no-store',
-            signal: AbortSignal.timeout(3000) // 3 second timeout
-        });
-
-        if (!response.ok) {
-            console.error('Failed to fetch initial block:', response.status);
-            return null;
-        }
-
-        const data = await response.json();
-        return (data.block as BlockSummary) || null;
-    } catch (error) {
-        console.error('Error fetching initial block:', error);
-        return null;
-    }
-}
-
-/**
  * Fetch the Better Auth session for SSR.
  *
  * Resolves the session by forwarding the inbound cookies to BA's
@@ -314,12 +279,11 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   // via ssr.headFragments and stamps data-theme="active" via
   // ssr.htmlAttributes, so no separate fetchActiveThemes call or cookie
   // branch is needed in this layout.
-  const [runtimeConfig, headFragments, htmlAttributes, ssrSession, initialBlock, tickerWidgets] = await Promise.all([
+  const [runtimeConfig, headFragments, htmlAttributes, ssrSession, widgetBundle] = await Promise.all([
     getServerConfig(),
     fetchHeadFragments(pathname, cookieMap),
     fetchHtmlAttributes(pathname, cookieMap),
     fetchSSRSession(),
-    fetchInitialBlock(),
     fetchWidgetsForRoute(pathname, {})
   ]);
 
@@ -347,13 +311,12 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
       <body>
         <Providers ssrSession={ssrSession}>
           <MainHeader />
-          <BlockTicker initialBlock={initialBlock} />
-          <WidgetZone name="ticker-after" widgets={tickerWidgets} route={pathname} params={{}} />
+          <WidgetZone name="ticker-after" widgets={widgetBundle.widgets} layout={widgetBundle.zones['ticker-after']} route={pathname} params={{}} />
           <main>
             {children}
           </main>
           <footer>
-            <WidgetZone name="footer" widgets={tickerWidgets} route={pathname} params={{}} />
+            <WidgetZone name="footer" widgets={widgetBundle.widgets} layout={widgetBundle.zones['footer']} route={pathname} params={{}} />
           </footer>
         </Providers>
       </body>

--- a/src/frontend/app/page.tsx
+++ b/src/frontend/app/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function HomePage(): Promise<JSX.Element> {
   // Fetch widgets for homepage - enables plugin widgets to render on the homepage
-  const widgets = await fetchWidgetsForRoute('/', {});
+  const { widgets, zones } = await fetchWidgetsForRoute('/', {});
 
   const faqSchema = {
     '@context': 'https://schema.org',
@@ -81,7 +81,7 @@ export default async function HomePage(): Promise<JSX.Element> {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
       {/* Widget zone for plugin-injected content below main homepage content */}
-      <WidgetZone name="main-after" widgets={widgets} route="/" params={{}} />
+      <WidgetZone name="main-after" widgets={widgets} layout={zones['main-after']} route="/" params={{}} />
     </Page>
   );
 }

--- a/src/frontend/components/PluginPageWithZones.tsx
+++ b/src/frontend/components/PluginPageWithZones.tsx
@@ -73,7 +73,7 @@ export async function PluginPageWithZones({ slug, initialData }: PluginPageWithZ
     const route = slug;
     const params: Record<string, string> = {};
 
-    const widgets = await fetchWidgetsForRoute(route, params);
+    const { widgets, zones } = await fetchWidgetsForRoute(route, params);
     const isResourceMarkets = slug === '/resource-markets';
 
     let seoContent: JSX.Element | null = null;
@@ -153,9 +153,9 @@ export async function PluginPageWithZones({ slug, initialData }: PluginPageWithZ
 
     return (
         <>
-            <WidgetZone name="plugin-content:before" widgets={widgets} route={route} params={params} />
+            <WidgetZone name="plugin-content:before" widgets={widgets} layout={zones['plugin-content:before']} route={route} params={params} />
             <PluginPageHandler slug={slug} initialData={initialData} />
-            <WidgetZone name="plugin-content:after" widgets={widgets} route={route} params={params} />
+            <WidgetZone name="plugin-content:after" widgets={widgets} layout={zones['plugin-content:after']} route={route} params={params} />
             {seoContent}
         </>
     );

--- a/src/frontend/components/widgets/BlockTickerWidget.tsx
+++ b/src/frontend/components/widgets/BlockTickerWidget.tsx
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Core "block ticker" widget renderer.
+ *
+ * Renders the real-time blockchain status row as a placeable widget. The
+ * ticker used to be hardcoded into the root layout; making it a core
+ * widget type lets operators position it (and sit it beside other
+ * widgets) from /system/widgets like any other widget.
+ *
+ * SSR + Live Updates: the `core:block-ticker` data fetcher ships the
+ * latest processed block as `data.block`, which this wrapper hands to the
+ * existing {@link BlockTicker} as `initialBlock`. `BlockTicker` already
+ * owns the pattern — it renders the SSR block immediately, then prefers
+ * live Redux state fed by the `block:new` WebSocket event after
+ * hydration. This component adds no state of its own; it is the thin seam
+ * between the widget data envelope and the ticker's prop.
+ *
+ * @module frontend/components/widgets/BlockTickerWidget
+ */
+
+'use client';
+
+import type { IWidgetComponentProps } from '@/types';
+import { BlockTicker } from '../layout/BlockTicker';
+import type { BlockSummary } from '../../features/blockchain/slice';
+
+/**
+ * SSR payload shape produced by the `core:block-ticker` data fetcher.
+ * Mirrors `IBlockTickerWidgetData` on the backend; `block` is the latest
+ * processed block or null when none has been indexed yet.
+ */
+interface IBlockTickerData {
+    /** Latest processed block summary, or null when none indexed yet. */
+    block?: BlockSummary | null;
+}
+
+/**
+ * Block-ticker widget: the real-time blockchain status row.
+ *
+ * @param props - Widget component props; only the SSR `data` is consumed.
+ *   The ticker needs no plugin context, route, or instance config.
+ * @returns The ticker bar (which itself returns null until a block exists).
+ */
+export function BlockTickerWidget({ data }: IWidgetComponentProps) {
+    const { block = null } = (data ?? {}) as IBlockTickerData;
+
+    return <BlockTicker initialBlock={block} />;
+}

--- a/src/frontend/components/widgets/WidgetZone.module.scss
+++ b/src/frontend/components/widgets/WidgetZone.module.scss
@@ -1,0 +1,33 @@
+/**
+ * Widget zone container styling.
+ *
+ * A zone is a flex container whose arrangement is operator-configured at
+ * runtime: the component injects the flex properties as `--zone-*` custom
+ * properties (see WidgetZone.tsx) and these rules consume them with
+ * token-backed fallbacks. Keeping the values in custom properties lets the
+ * same static rule render a stacked column, a centered row, or a wrapping
+ * grid depending on the operator's choice — no per-layout class needed.
+ */
+
+.zone {
+    display: flex;
+    flex-direction: var(--zone-flex-direction, column);
+    justify-content: var(--zone-justify-content, flex-start);
+    align-items: var(--zone-align-items, stretch);
+    flex-wrap: var(--zone-flex-wrap, nowrap);
+    gap: var(--zone-gap, var(--gap-md));
+}
+
+.item {
+    // Allow flex items to shrink below their content width so a wide
+    // widget (e.g. the block ticker) in a row layout reflows instead of
+    // forcing the container to overflow.
+    min-width: 0;
+}
+
+.item_title {
+    margin: 0 0 var(--gap-sm);
+    font-size: var(--font-size-heading-md);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+}

--- a/src/frontend/components/widgets/WidgetZone.tsx
+++ b/src/frontend/components/widgets/WidgetZone.tsx
@@ -1,8 +1,68 @@
-import type { ComponentType } from 'react';
+import type { ComponentType, CSSProperties } from 'react';
 import Link from 'next/link';
+import type { IZoneLayoutConfig, ZoneGapSize } from '@/types';
 import type { WidgetData } from './types';
 import { getWidgetComponent } from './getWidgetComponent';
 import { WidgetWithContext } from './WidgetWithContext';
+import styles from './WidgetZone.module.scss';
+
+/**
+ * Default flexbox layout when a zone carries no resolved config (e.g. the
+ * SSR fetch failed and the zones map is empty). Reproduces the historical
+ * stacked column so an unconfigured zone looks exactly as it did before
+ * zones became flex containers.
+ */
+const DEFAULT_LAYOUT: IZoneLayoutConfig = {
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    alignItems: 'stretch',
+    flexWrap: 'nowrap',
+    gap: 'md'
+};
+
+/**
+ * Map a token gap size to the CSS value the container's `gap` resolves
+ * to. Sizes map to the `--gap-*` design tokens (never a raw length) so
+ * zone spacing stays on the token scale; `none` is a literal `0`.
+ *
+ * @param gap - The zone's configured gap size.
+ * @returns A CSS length string referencing a gap token, or `0`.
+ */
+function gapToCss(gap: ZoneGapSize): string {
+    switch (gap) {
+        case 'none':
+            return '0';
+        case 'sm':
+            return 'var(--gap-sm)';
+        case 'lg':
+            return 'var(--gap-lg)';
+        case 'md':
+        default:
+            return 'var(--gap-md)';
+    }
+}
+
+/**
+ * Build the inline custom-property style that drives the flex container.
+ *
+ * The flex values are operator-chosen, so they cannot live in the static
+ * stylesheet; they ride as CSS custom properties the colocated module
+ * reads with token-backed fallbacks. Keeping them as variables (rather
+ * than direct inline `flex-*` props) lets the `.zone` rule own the
+ * cascade and the `.item` rule react to wrap state.
+ *
+ * @param layout - The zone's effective layout config.
+ * @returns A style object of `--zone-*` custom properties.
+ */
+function zoneStyle(layout: IZoneLayoutConfig): CSSProperties {
+    return {
+        '--zone-flex-direction': layout.flexDirection,
+        '--zone-justify-content': layout.justifyContent,
+        '--zone-align-items': layout.alignItems,
+        '--zone-flex-wrap': layout.flexWrap,
+        '--zone-gap': gapToCss(layout.gap)
+    } as CSSProperties;
+}
 
 /**
  * Props for WidgetRenderer component.
@@ -77,29 +137,39 @@ function WidgetRenderer({ widget, route, params }: WidgetRendererProps) {
  * 3. SSR: WidgetZone renders components with fresh data
  * 4. Hydration: Widget components become interactive, can subscribe to WebSocket
  *
+ * The zone renders as a CSS flex container; each placed widget is a flex
+ * item. The arrangement (direction, alignment, wrap, gap) comes from the
+ * operator-configured `layout` — resolved server-side and passed in — so
+ * the same zone can stack widgets, lay them in a centered row, or wrap
+ * them into a grid without code changes. Falls back to a stacked column
+ * when `layout` is omitted.
+ *
  * @param name - Zone identifier (e.g., 'main-after', 'sidebar-top')
  * @param widgets - Array of widget data from SSR fetch
  * @param route - Current URL path for context-aware widgets
  * @param params - Route parameters extracted from the URL path
+ * @param layout - Effective flexbox layout for this zone (from the SSR bundle)
  *
  * @example
  * ```tsx
  * // In layout.tsx (Server Component)
- * const widgets = await fetchWidgetsForRoute(pathname, params);
+ * const { widgets, zones } = await fetchWidgetsForRoute(pathname, params);
  *
- * <WidgetZone name="main-after" widgets={widgets} route={pathname} params={params} />
+ * <WidgetZone name="main-after" widgets={widgets} layout={zones['main-after']} route={pathname} params={params} />
  * ```
  */
 export function WidgetZone({
     name,
     widgets,
     route,
-    params
+    params,
+    layout
 }: {
     name: string;
     widgets: WidgetData[];
     route: string;
     params: Record<string, string>;
+    layout?: IZoneLayoutConfig;
 }) {
     // Filter widgets for this zone and sort by order
     const zoneWidgets = widgets
@@ -111,17 +181,23 @@ export function WidgetZone({
         return null;
     }
 
+    const effectiveLayout = layout ?? DEFAULT_LAYOUT;
+
     return (
-        <div className="widget-zone" data-zone={name}>
+        <div
+            className={styles.zone}
+            data-zone={name}
+            style={zoneStyle(effectiveLayout)}
+        >
             {zoneWidgets.map(widget => (
                 <div
                     key={widget.id}
-                    className="widget-container mb-6"
+                    className={styles.item}
                     data-widget-id={widget.id}
                     data-plugin-id={widget.pluginId}
                 >
                     {widget.title && (
-                        <h2 className="text-xl font-semibold mb-4">
+                        <h2 className={styles.item_title}>
                             {widget.titleUrl ? (
                                 <Link href={widget.titleUrl}>{widget.title}</Link>
                             ) : (

--- a/src/frontend/components/widgets/fetchWidgetsForRoute.ts
+++ b/src/frontend/components/widgets/fetchWidgetsForRoute.ts
@@ -1,5 +1,18 @@
+import type { IZoneLayoutConfig } from '@/types';
 import type { WidgetData } from './types';
 import { getServerSideApiUrl } from '../../lib/api-url';
+
+/**
+ * SSR widget bundle: the resolved widgets for a route plus the effective
+ * flexbox layout for every zone, keyed by zone id. The layout map lets a
+ * `<WidgetZone>` arrange its widgets as flex items without a second
+ * request. Empty objects on fetch failure so callers render an empty,
+ * default-laid-out page rather than crashing.
+ */
+export interface IWidgetBundle {
+    widgets: WidgetData[];
+    zones: Record<string, IZoneLayoutConfig>;
+}
 
 /**
  * Fetch widgets for a specific route during SSR.
@@ -13,7 +26,7 @@ import { getServerSideApiUrl } from '../../lib/api-url';
  *
  * @param route - URL path to fetch widgets for (e.g., '/', '/u/TXyz...')
  * @param params - Optional route parameters (e.g., { address: 'TXyz...' })
- * @returns Array of widget data with pre-fetched content
+ * @returns The widget bundle: pre-fetched widgets plus each zone's layout
  *
  * @example
  * ```tsx
@@ -49,7 +62,7 @@ import { getServerSideApiUrl } from '../../lib/api-url';
 export async function fetchWidgetsForRoute(
     route: string,
     params: Record<string, string> = {}
-): Promise<WidgetData[]> {
+): Promise<IWidgetBundle> {
     try {
         const backendUrl = getServerSideApiUrl();
         let url = `${backendUrl}/api/widgets?route=${encodeURIComponent(route)}`;
@@ -67,13 +80,16 @@ export async function fetchWidgetsForRoute(
 
         if (!response.ok) {
             console.error('Failed to fetch widgets:', response.status);
-            return [];
+            return { widgets: [], zones: {} };
         }
 
         const data = await response.json();
-        return data.widgets || [];
+        return {
+            widgets: data.widgets || [],
+            zones: data.zones || {}
+        };
     } catch (error) {
         console.error('Error fetching widgets:', error);
-        return [];
+        return { widgets: [], zones: {} };
     }
 }

--- a/src/frontend/components/widgets/index.ts
+++ b/src/frontend/components/widgets/index.ts
@@ -12,6 +12,7 @@
 
 export { WidgetZone } from './WidgetZone';
 export { fetchWidgetsForRoute } from './fetchWidgetsForRoute';
+export type { IWidgetBundle } from './fetchWidgetsForRoute';
 export { getWidgetComponent } from './getWidgetComponent';
 export { widgetComponentRegistry } from './widgets.generated';
 export { coreWidgetComponents } from './widgets.core';

--- a/src/frontend/components/widgets/widgets.core.ts
+++ b/src/frontend/components/widgets/widgets.core.ts
@@ -19,6 +19,7 @@
 import type { WidgetComponent } from '@/types';
 import { RawHtmlWidget } from './RawHtmlWidget';
 import { WorldClocksWidget } from './WorldClocksWidget';
+import { BlockTickerWidget } from './BlockTickerWidget';
 
 /**
  * Core widget components keyed by backend widget-type id. Mirrors the
@@ -28,5 +29,6 @@ import { WorldClocksWidget } from './WorldClocksWidget';
  */
 export const coreWidgetComponents: Record<string, WidgetComponent> = {
     'core:raw-html': RawHtmlWidget,
-    'core:world-clocks': WorldClocksWidget
+    'core:world-clocks': WorldClocksWidget,
+    'core:block-ticker': BlockTickerWidget
 };


### PR DESCRIPTION
Adds operator-editable per-zone flexbox layout to the widgets subsystem and a new core block-ticker widget type.

## Backend
- New `IZoneLayoutConfig` type and `IZoneLayoutDocument` persistence.
- `zone-layout.service.ts` resolves a zone's effective layout: operator override, else a default derived from the descriptor's coarse `layout` hint.
- `PATCH /api/admin/system/zones/:zoneId/layout` persists an override (`404` unknown zone, `400` off-enum flex value) and fires `widgets:placements-update` so admin UIs refetch.
- Zone snapshots now carry each zone's effective `layoutConfig`.
- Registers the `core:block-ticker` widget type alongside `core:world-clocks` and `core:raw-html`.

## Frontend
- `BlockTickerWidget` component with scoped `WidgetZone.module.scss`.
- `/system/widgets` admin UI extended to edit per-zone flexbox layout.
- `WidgetZone` applies the resolved layout config.

## Docs
- Updated `system-api-widgets.md` and `system.md` to document the layout endpoint and the expanded widget-type catalogue.