### PR TITLE
feat(widgets): single-level layout-group containers with drag nesting

### DIFF
--- a/packages/types/src/widget-placements/IPlacementService.ts
+++ b/packages/types/src/widget-placements/IPlacementService.ts
@@ -48,6 +48,15 @@ export interface IPlacementListFilter {
  */
 export interface IPlacementPatch {
     zoneId?: string;
+    /**
+     * Reparent the placement. A string attaches it to that
+     * `core:layout-group` container (forcing its `zoneId` to the parent's
+     * zone and clearing `routes`); `null` detaches it back to the zone
+     * (`$unset`); omission leaves the current parent unchanged. Mirrors
+     * the three-state convention used by `title`/`titleUrl`. See
+     * {@link IWidgetPlacement.parentId} for the one-level nesting rule.
+     */
+    parentId?: string | null;
     routes?: string[];
     order?: number;
     title?: string | null;
@@ -172,4 +181,16 @@ export interface IPlacementService {
             title?: string;
         }
     ): Promise<IWidgetPlacement | null>;
+
+    /**
+     * Detach every child of a container placement, clearing their
+     * `parentId` so they fall back to direct children of the zone. Used
+     * when a `core:layout-group` container is deleted: rather than
+     * cascade-deleting its children (and losing operator config), the
+     * service relocates them to the zone at their existing order.
+     *
+     * @param parentId - The container placement id whose children detach.
+     * @returns Count of child placements detached.
+     */
+    detachChildrenOf(parentId: string): Promise<number>;
 }

--- a/packages/types/src/widget-placements/IWidgetPlacement.ts
+++ b/packages/types/src/widget-placements/IWidgetPlacement.ts
@@ -42,6 +42,15 @@ export interface IWidgetPlacement {
     readonly typeId: string;
     /** Zone id this placement targets. */
     readonly zoneId: string;
+    /**
+     * Optional parent placement id. When set, this placement is a child
+     * of a `core:layout-group` container in the same zone rather than a
+     * direct child of the zone, and the resolver nests it under that
+     * container at SSR. Nesting is capped at one level: a container never
+     * carries a `parentId`, and a child's parent is always a top-level
+     * layout group. Absent for ordinary, directly-zoned placements.
+     */
+    readonly parentId?: string;
     /** Route filter — empty array matches every route. */
     readonly routes: ReadonlyArray<string>;
     /** Sort order within the zone (lower renders first). */
@@ -82,6 +91,14 @@ export interface IWidgetPlacement {
 export interface IPlacementInput {
     typeId: string;
     zoneId: string;
+    /**
+     * Optional parent placement id. When set, the placement is created
+     * as a child of the named `core:layout-group` container; the service
+     * forces its `zoneId` to the parent's zone and clears its `routes`
+     * (the container governs route visibility). See
+     * {@link IWidgetPlacement.parentId} for the one-level nesting rule.
+     */
+    parentId?: string;
     routes: string[];
     order?: number;
     title?: string;

--- a/packages/types/src/widget/IWidgetData.ts
+++ b/packages/types/src/widget/IWidgetData.ts
@@ -60,4 +60,15 @@ export interface IWidgetData {
      * overrides) and the frontend renderer defaults it to `{}` on read.
      */
     instanceConfig?: Record<string, unknown>;
+
+    /**
+     * Child widgets nested inside this item, present only when `id` is a
+     * `core:layout-group` container. The resolver assembles them from
+     * placements whose `parentId` points at this container, sorted by
+     * their own `order`. The `WidgetZone` renderer draws them inside a
+     * nested flex container driven by this group's instance config.
+     * Nesting is one level deep, so a child never carries its own
+     * `children`. Absent for ordinary leaf widgets.
+     */
+    children?: IWidgetData[];
 }

--- a/src/backend/modules/widgets/README.md
+++ b/src/backend/modules/widgets/README.md
@@ -13,7 +13,7 @@ Owns every concern of the widget subsystem behind a single public surface: `IWid
 | WebSocket event | `widgets:placements-update` (also fired on zone-layout change — no separate event) |
 | Types package | `@delphian/tronrelic-types` — `IWidgetsService`, `IRegisterWidgetTypeInput`, `IRegisterZoneInput`, `IRegisterWidgetInput`, `IWidgetPlacement`, `IPlacementInput`, `IPlacementPatch`, `IPlacementListFilter`, `IWidgetType`, `IWidgetPlacementContext`, `IZoneDescriptor`, `IZoneSnapshot`, `IZoneLayoutConfig`, `IWidgetTypeSnapshot` |
 | Storage | `module_widgets_placements`, `module_widgets_zone_layouts` (MongoDB) |
-| Migration | `module:widgets:001_create_widget_placements` (placements collection + 4 indexes); `module:widgets:002_seed_block_ticker_placement` (idempotent seed of one operator-source `core:block-ticker` placement in `ticker-after`, guarded on absence so it runs once and never fights an operator edit). The zone-layouts collection needs no migration — `ZoneLayoutService.load()` creates its unique index idempotently at boot. |
+| Migration | `module:widgets:001_create_widget_placements` (placements collection + 4 indexes); `module:widgets:002_seed_block_ticker_placement` (idempotent seed of one operator-source `core:block-ticker` placement in `ticker-after`, guarded on absence so it runs once and never fights an operator edit); `module:widgets:003_add_parent_id_index` (sparse `parentId` index for child grouping). The zone-layouts collection needs no migration — `ZoneLayoutService.load()` creates its unique index idempotently at boot. |
 | System menu node | "Widgets" under the System container — seeded by `WidgetsModule.run()` |
 
 ## Source Map
@@ -22,7 +22,7 @@ Owns every concern of the widget subsystem behind a single public surface: `IWid
 |------|---------|
 | `WidgetsModule.ts` | `IModule` impl: wires registries, placement service, resolver, widgets service, mounts three admin routers, seeds menu entry |
 | `widgets.service.ts` | `WidgetsService` singleton implementing `IWidgetsService`. Composes the three internal collaborators behind one surface; published on the service registry |
-| `placements/placement.service.ts` | `IPlacementService` singleton (internal): CRUD, `ensurePluginPlacement`, `softDisableForPlugin`, `findByRoute`, `restoreToPluginDefaults`, broadcast hook |
+| `placements/placement.service.ts` | `IPlacementService` singleton (internal): CRUD, `ensurePluginPlacement`, `softDisableForPlugin`, `findByRoute`, `restoreToPluginDefaults`, `detachChildrenOf` (container-delete child relocation), broadcast hook |
 | `placements/placement-resolver.ts` | SSR-time join of placements ↔ widget-type descriptors with 5s timeout and JSON serialisability check |
 | `placements/route-matcher.ts` | `routeMatches` predicate, `normaliseRoutePattern` validator, `partitionRoutePatterns` for the admin path |
 | `widget-types/widget-type-registry.ts` | Internal widget-type registry — instantiated by `WidgetsModule.init()` |
@@ -74,9 +74,9 @@ All endpoints require admin auth (cookie path: verified wallet + admin group; se
 |---|---|---|---|---|
 | GET | `/api/admin/system/widgets/placements` | — | `{ success, placements: IWidgetPlacement[] }` | Query: `zoneId?`, `pluginId?`, `source?` (`plugin`\|`operator`), `enabledOnly?` |
 | GET | `/api/admin/system/widgets/placements/:id` | — | `{ success, placement }` or 404 | |
-| POST | `/api/admin/system/widgets/placements` | `IPlacementInput` | `{ success, placement }` 201 | Always `source: 'operator'`; rejects unknown `typeId`/`zoneId` |
-| PATCH | `/api/admin/system/widgets/placements/:id` | `IPlacementPatch` | `{ success, placement }` or 404 | Operator-editable on every row, including plugin-source. `title: null` / `titleUrl: null` clears that field; `titleUrl` must be a root-relative internal path |
-| DELETE | `/api/admin/system/widgets/placements/:id` | — | 204 / 400 / 404 | 400 on plugin-source rows (use disable or restore-defaults) |
+| POST | `/api/admin/system/widgets/placements` | `IPlacementInput` | `{ success, placement }` 201 | Always `source: 'operator'`; rejects unknown `typeId`/`zoneId`. Optional `parentId` nests the row in a layout group (400 if the parent isn't a top-level `core:layout-group`); a nested row's `zoneId` is forced to the parent's zone and its `routes` cleared |
+| PATCH | `/api/admin/system/widgets/placements/:id` | `IPlacementPatch` | `{ success, placement }` or 404 | Operator-editable on every row, including plugin-source. `title: null` / `titleUrl: null` clears that field; `titleUrl` must be a root-relative internal path. `parentId` is three-state like `title` — a 24-hex id attaches (forcing zone + clearing routes), `null` detaches to the zone, omission leaves nesting unchanged |
+| DELETE | `/api/admin/system/widgets/placements/:id` | — | 204 / 400 / 404 | 400 on plugin-source rows (use disable or restore-defaults). Deleting a `core:layout-group` container detaches its children back to the zone (clears their `parentId`) rather than cascade-deleting them |
 | POST | `/api/admin/system/widgets/placements/:id/restore-defaults` | — | `{ success, placement }` | 400 on operator rows; 409 when plugin has not registered in this process |
 
 ### SSR Fetch
@@ -116,6 +116,7 @@ The placement service emits via a callback `WidgetsModule.init()` wires to `WebS
 | `_id` | ObjectId | |
 | `typeId` | string | Widget-type id this placement renders |
 | `zoneId` | string | Zone id this placement targets |
+| `parentId` | ObjectId? | Set only on a child nested in a `core:layout-group`; references the container row's `_id`. Exposed publicly as the hex string `parentId`. Sparse-indexed (migration 003) |
 | `routes` | string[] | Route filter — empty matches every route |
 | `order` | number | Sort key within zone (lower renders first); plugin default `100` |
 | `title` | string? | Operator override of widget heading |
@@ -157,9 +158,17 @@ The platform ships its own zones and widget types, registered by `WidgetsModule.
 
 Each descriptor carries an optional `order` (`IZoneDescriptor.order`) that sets where the zone appears within its host track in the `/system/widgets` editor — lower sorts first, so `footer` (order `90`) follows `ticker-after` (order `10`) rather than leading the site track alphabetically. `snapshot()` sorts by `order` then id; zones omitting it sort after explicitly-ordered ones. This orders the *zones* in the editor, distinct from the placement `order` that sorts widgets within a zone.
 
-**Widget types** are built by `buildCoreWidgetTypeDescriptors(deps)` in `widget-types/core-widget-types.ts` — a factory, not a static array, because one fetcher needs a runtime dependency. Three ship today: `core:raw-html` (operator-authored HTML/text block, read from `instanceConfig`), `core:world-clocks` (configured time-zone row), and `core:block-ticker` (the real-time blockchain status row). The ticker fetcher resolves the `'blockchain'` service from the registry at fetch time and returns `{ block }` — the latest processed block, or `null` when none is indexed (wrapped, never bare-null, so the resolver keeps the placement and the component still mounts to receive live `block:new` updates). raw-html and world-clocks ignore `deps`.
+**Widget types** are built by `buildCoreWidgetTypeDescriptors(deps)` in `widget-types/core-widget-types.ts` — a factory, not a static array, because one fetcher needs a runtime dependency. Four ship today: `core:raw-html` (operator-authored HTML/text block, read from `instanceConfig`), `core:world-clocks` (configured time-zone row), `core:layout-group` (the structural container — see [Single-level grouping](#single-level-grouping)), and `core:block-ticker` (the real-time blockchain status row). The ticker fetcher resolves the `'blockchain'` service from the registry at fetch time and returns `{ block }` — the latest processed block, or `null` when none is indexed (wrapped, never bare-null, so the resolver keeps the placement and the component still mounts to receive live `block:new` updates). raw-html, world-clocks, and layout-group ignore `deps`.
 
-A core widget type needs a matching frontend renderer keyed by its `typeId` in `components/widgets/widgets.core.ts`. That hand-written registry is merged ahead of the generator-owned `widgets.generated.ts` by `components/widgets/getWidgetComponent.ts`, so core components resolve without the plugin-registry generator touching them.
+A core widget type needs a matching frontend renderer keyed by its `typeId` in `components/widgets/widgets.core.ts`. That hand-written registry is merged ahead of the generator-owned `widgets.generated.ts` by `components/widgets/getWidgetComponent.ts`, so core components resolve without the plugin-registry generator touching them. **`core:layout-group` is the one exception** — it has no registry entry because it has no UI of its own; `WidgetZone` special-cases its `typeId`, drawing its children inside a nested flex container.
+
+## Single-level grouping
+
+An operator can group widgets inside a zone by placing a `core:layout-group` container and nesting other widgets in it, giving that subset its own flexbox arrangement (a row of widgets inside a column zone, say) without a new zone or render site. Nesting is intentionally **one level deep**: a container is always top-level, and a child is always a leaf.
+
+A child points at its container through the placement `parentId`. `WidgetsService` enforces the contract on create/attach — the parent must exist, be a `core:layout-group`, and be top-level; a layout group can never itself be nested — and forces the child into the parent's zone with an empty route filter so the container alone governs where the group renders (`InvalidParentPlacementError` → HTTP 400 otherwise). Deleting a container calls `IPlacementService.detachChildrenOf`, relocating its children back to the zone (`$unset parentId`) so operator-configured widgets survive.
+
+The container's `instanceConfig` *is* an `IZoneLayoutConfig`; its data fetcher echoes the normalized config as the widget `data`, and `WidgetZone` styles the nested flex container from it. At SSR, `PlacementResolver` fetches placements flat, then assembles a two-level tree: each child is nested under its container's `IWidgetData.children` (sorted by the child's `order`), only top-level items are returned, and a child whose container did not resolve (disabled / route-filtered / failed) is dropped as an orphan — the same silent-skip discipline as an unregistered type.
 
 **Per-zone flexbox layout.** Every zone renders as a CSS flex container; placed widgets are flex items. The arrangement (direction, justify, align, wrap, gap) is an `IZoneLayoutConfig` an operator sets per zone from `/system/widgets` and the `WidgetZone` renderer applies via inline CSS custom properties (gap maps to `--gap-*` tokens). Overrides persist in `module_widgets_zone_layouts`; a zone with no row uses a default derived from its descriptor's coarse `layout` hint (`vertical` → stacked column, so untouched zones look unchanged). `WidgetsService.listZones()` merges the override (else the default) into each zone's `layoutConfig`, and `/api/widgets` returns a `zoneId → layoutConfig` map so SSR applies layout without a second call.
 

--- a/src/backend/modules/widgets/__tests__/placements.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.test.ts
@@ -444,6 +444,7 @@ describe('PlacementResolver', () => {
         id: overrides.id ?? 'placement-1',
         typeId: overrides.typeId ?? 'plugin:type',
         zoneId: overrides.zoneId ?? 'main-after',
+        parentId: overrides.parentId,
         routes: overrides.routes ?? [],
         order: overrides.order ?? 10,
         title: overrides.title,
@@ -476,7 +477,8 @@ describe('PlacementResolver', () => {
             delete: vi.fn(),
             findById: vi.fn(),
             list: vi.fn(),
-            restoreToPluginDefaults: vi.fn()
+            restoreToPluginDefaults: vi.fn(),
+            detachChildrenOf: vi.fn(async () => 0)
         };
         resolver = new PlacementResolver(placementService, typeRegistry, logger);
     });
@@ -630,6 +632,38 @@ describe('PlacementResolver', () => {
         expect(result.map(r => r.id)).toEqual(['t2', 't3', 't1']);
         expect(result.map(r => r.zone)).toEqual(['main-after', 'main-after', 'main-before']);
         expect(result.map(r => r.order)).toEqual([5, 100, 50]);
+    });
+
+    it('nests children under their layout-group container, sorted by child order', async () => {
+        (typeRegistry as any).__types.set('core:layout-group', buildType('core:layout-group', async () => ({ flexDirection: 'row' })));
+        (typeRegistry as any).__types.set('child:type', buildType('child:type', async () => 'kid'));
+        (placementService.findByRoute as ReturnType<typeof vi.fn>).mockResolvedValue([
+            buildPlacement({ id: 'group-1', typeId: 'core:layout-group', source: 'operator', order: 10 }),
+            buildPlacement({ id: 'child-b', typeId: 'child:type', source: 'operator', parentId: 'group-1', order: 20 }),
+            buildPlacement({ id: 'child-a', typeId: 'child:type', source: 'operator', parentId: 'group-1', order: 5 })
+        ]);
+
+        const result = await resolver.resolveForRoute('/', {});
+
+        // Only the container is top-level; its children are nested and
+        // ordered by their own `order`, not their fetch order.
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('core:layout-group');
+        expect(result[0].children?.map(c => c.order)).toEqual([5, 20]);
+        expect(result[0].data).toEqual({ flexDirection: 'row' });
+    });
+
+    it('drops an orphan child whose container did not resolve', async () => {
+        // The container's type is unregistered, so it is skipped; its
+        // child must be dropped rather than promoted to top-level.
+        (typeRegistry as any).__types.set('child:type', buildType('child:type', async () => 'kid'));
+        (placementService.findByRoute as ReturnType<typeof vi.fn>).mockResolvedValue([
+            buildPlacement({ id: 'group-gone', typeId: 'core:layout-group', source: 'operator' }),
+            buildPlacement({ id: 'child-x', typeId: 'child:type', source: 'operator', parentId: 'group-gone' })
+        ]);
+
+        const result = await resolver.resolveForRoute('/', {});
+        expect(result).toEqual([]);
     });
 });
 

--- a/src/backend/modules/widgets/__tests__/widgets.service.test.ts
+++ b/src/backend/modules/widgets/__tests__/widgets.service.test.ts
@@ -562,6 +562,80 @@ describe('WidgetsService.deletePlacement', () => {
     });
 });
 
+describe('WidgetsService nesting (layout groups)', () => {
+    /**
+     * Wire a service with two zones, the layout-group container type, a
+     * leaf widget type, and one container placement so child tests have a
+     * valid parent to nest under.
+     */
+    async function setupWithContainer() {
+        const ctx = buildWidgetsService();
+        ctx.widgets.registerZone({ id: 'main-after', label: 'm', description: 'm', host: 'core' }, 'core');
+        ctx.widgets.registerZone({ id: 'footer', label: 'f', description: 'f', host: 'core' }, 'core');
+        ctx.widgets.registerType({
+            id: 'core:layout-group', label: 'LG', description: 'LG', defaultDataFetcher: async () => ({})
+        }, 'core');
+        ctx.widgets.registerType({
+            id: 't', label: 'T', description: 'T', defaultDataFetcher: async () => ({})
+        }, 'p');
+        const container = await ctx.widgets.createPlacement({
+            typeId: 'core:layout-group', zoneId: 'main-after', routes: []
+        });
+        return { ...ctx, container };
+    }
+
+    it('forces a child into the parent zone and clears its routes', async () => {
+        const { widgets, container } = await setupWithContainer();
+        const child = await widgets.createPlacement({
+            typeId: 't', zoneId: 'footer', parentId: container.id, routes: ['/markets']
+        });
+        expect(child.parentId).toBe(container.id);
+        // Parent's zone wins over the operator-sent zone…
+        expect(child.zoneId).toBe('main-after');
+        // …and the container governs route visibility, so the child's own
+        // route filter is cleared.
+        expect(child.routes).toEqual([]);
+    });
+
+    it('rejects a parent that is not a layout group', async () => {
+        const { widgets } = await setupWithContainer();
+        const plain = await widgets.createPlacement({ typeId: 't', zoneId: 'main-after', routes: [] });
+        await expect(widgets.createPlacement({
+            typeId: 't', zoneId: 'main-after', parentId: plain.id, routes: []
+        })).rejects.toThrow(/not a layout group/);
+    });
+
+    it('rejects a non-existent parent', async () => {
+        const { widgets } = await setupWithContainer();
+        await expect(widgets.createPlacement({
+            typeId: 't', zoneId: 'main-after', parentId: '507f1f77bcf86cd799439011', routes: []
+        })).rejects.toThrow(/does not exist/);
+    });
+
+    it('refuses to nest a layout group inside another container', async () => {
+        const { widgets, container } = await setupWithContainer();
+        await expect(widgets.createPlacement({
+            typeId: 'core:layout-group', zoneId: 'main-after', parentId: container.id, routes: []
+        })).rejects.toThrow(/cannot be nested/);
+    });
+
+    it('detaches children back to the zone when their container is deleted', async () => {
+        const { widgets, container } = await setupWithContainer();
+        const child = await widgets.createPlacement({
+            typeId: 't', zoneId: 'main-after', parentId: container.id, routes: []
+        });
+
+        const removed = await widgets.deletePlacement(container.id);
+        expect(removed).toBe(true);
+
+        // The child survives the container's deletion, relocated to the
+        // zone with its parent link cleared.
+        const survivor = await widgets.findPlacementById(child.id);
+        expect(survivor).not.toBeNull();
+        expect(survivor?.parentId).toBeUndefined();
+    });
+});
+
 describe('WidgetsService.fetchWidgetsForRoute', () => {
     it('resolves placements through the SSR resolver, applying route filters', async () => {
         const { widgets } = buildWidgetsService();

--- a/src/backend/modules/widgets/api/placements.controller.ts
+++ b/src/backend/modules/widgets/api/placements.controller.ts
@@ -27,6 +27,7 @@ import type {
 } from '@/types';
 import { normaliseRoutePattern } from '../placements/route-matcher.js';
 import {
+    InvalidParentPlacementError,
     MissingPluginDefaultsError,
     PluginPlacementDeletionForbiddenError,
     RestoreDefaultsOnOperatorRowError,
@@ -90,6 +91,14 @@ const INTERNAL_PATH_PATTERN = /^\/(?![/\\])(?!.*\/\/)(?!.*\.\.)[^\s\\]*$/;
  * reach the Mongo query.
  */
 const ZONE_ID_PATTERN = /^[a-z][a-z0-9_:-]{0,63}$/;
+
+/**
+ * Format gate for a placement id used as a `parentId`. Placement ids are
+ * stringified Mongo ObjectIds — exactly 24 hex characters. Rejecting any
+ * other shape at the boundary keeps malformed input out of the service's
+ * `ObjectId.isValid` path and out of the Mongo query.
+ */
+const OBJECT_ID_PATTERN = /^[a-f0-9]{24}$/;
 
 /**
  * Format gate for plugin ids. Same shape as a zone id minus the
@@ -273,7 +282,11 @@ export class PlacementsController {
             const placement = await this.widgets.createPlacement(parsed.input);
             res.status(201).json({ success: true, placement });
         } catch (err) {
-            if (err instanceof UnknownWidgetTypeError || err instanceof UnknownZoneError) {
+            if (
+                err instanceof UnknownWidgetTypeError ||
+                err instanceof UnknownZoneError ||
+                err instanceof InvalidParentPlacementError
+            ) {
                 res.status(400).json({ success: false, error: err.message });
                 return;
             }
@@ -326,7 +339,7 @@ export class PlacementsController {
             }
             res.json({ success: true, placement });
         } catch (err) {
-            if (err instanceof UnknownZoneError) {
+            if (err instanceof UnknownZoneError || err instanceof InvalidParentPlacementError) {
                 res.status(400).json({ success: false, error: err.message });
                 return;
             }
@@ -382,7 +395,7 @@ export class PlacementsController {
     };
 
     private parseCreateBody(body: unknown):
-        | { input: { typeId: string; zoneId: string; routes: string[]; order?: number; title?: string; titleUrl?: string; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
+        | { input: { typeId: string; zoneId: string; parentId?: string; routes: string[]; order?: number; title?: string; titleUrl?: string; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
         | { error: string } {
         if (!body || typeof body !== 'object') {
             return { error: 'Request body must be an object' };
@@ -402,6 +415,9 @@ export class PlacementsController {
         if (!this.widgets.hasZone(b.zoneId)) {
             return { error: `Unknown zone id: '${b.zoneId}'` };
         }
+
+        const parentIdResult = this.parseParentId(b.parentId);
+        if ('error' in parentIdResult) return parentIdResult;
 
         const routesResult = this.parseRoutes(b.routes);
         if ('error' in routesResult) return routesResult;
@@ -424,6 +440,7 @@ export class PlacementsController {
             input: {
                 typeId: b.typeId,
                 zoneId: b.zoneId,
+                parentId: parentIdResult.parentId,
                 routes: routesResult.routes,
                 order: orderResult.order,
                 title: titleResult.title,
@@ -441,7 +458,7 @@ export class PlacementsController {
             return { error: 'Request body must be an object' };
         }
         const b = body as Record<string, unknown>;
-        const patch: { zoneId?: string; routes?: string[]; order?: number; title?: string | null; titleUrl?: string | null; instanceConfig?: Record<string, unknown>; enabled?: boolean } = {};
+        const patch: { zoneId?: string; parentId?: string | null; routes?: string[]; order?: number; title?: string | null; titleUrl?: string | null; instanceConfig?: Record<string, unknown>; enabled?: boolean } = {};
 
         if (b.zoneId !== undefined) {
             if (typeof b.zoneId !== 'string' || b.zoneId.length === 0) {
@@ -451,6 +468,20 @@ export class PlacementsController {
                 return { error: `Unknown zone id: '${b.zoneId}'` };
             }
             patch.zoneId = b.zoneId;
+        }
+
+        if (b.parentId !== undefined) {
+            if (b.parentId === null) {
+                // Explicit detach.
+                patch.parentId = null;
+            } else {
+                const result = this.parseParentId(b.parentId);
+                if ('error' in result) return result;
+                if (result.parentId === undefined) {
+                    return { error: 'parentId must be a 24-character hex id or null' };
+                }
+                patch.parentId = result.parentId;
+            }
         }
 
         if (b.routes !== undefined) {
@@ -499,6 +530,25 @@ export class PlacementsController {
         }
 
         return { patch };
+    }
+
+    /**
+     * Validate an optional `parentId`. Accepts a 24-hex ObjectId string
+     * (nest under that container) or absence (no nesting). `null` is
+     * handled by the patch caller as an explicit detach and never reaches
+     * here. The deeper one-level-nesting contract (parent is a layout
+     * group, parent is top-level) is enforced by the service, which can
+     * read the parent row; the controller only gates the wire shape.
+     *
+     * @param value - Raw `parentId` from the request body.
+     * @returns The validated id (or undefined when absent), or an error.
+     */
+    private parseParentId(value: unknown): { parentId?: string } | { error: string } {
+        if (value === undefined) return { parentId: undefined };
+        if (typeof value !== 'string' || !OBJECT_ID_PATTERN.test(value)) {
+            return { error: 'parentId must be a 24-character hex placement id' };
+        }
+        return { parentId: value };
     }
 
     private parseRoutes(value: unknown): { routes: string[] } | { error: string } {

--- a/src/backend/modules/widgets/database/IWidgetPlacementDocument.ts
+++ b/src/backend/modules/widgets/database/IWidgetPlacementDocument.ts
@@ -32,6 +32,14 @@ export interface IWidgetPlacementDocument {
     typeId: string;
     /** Zone id this placement targets. */
     zoneId: string;
+    /**
+     * Parent container placement id when this row nests inside a
+     * `core:layout-group`. Stored as an `ObjectId` so it references
+     * another row's `_id` natively; `toPublic` exposes it as the hex
+     * string `parentId`. Absent for directly-zoned placements. Nesting is
+     * capped at one level — a container never carries a `parentId`.
+     */
+    parentId?: ObjectId;
     /** Route filter — empty array matches every route. */
     routes: string[];
     /** Sort order within the zone (lower renders first). */

--- a/src/backend/modules/widgets/migrations/003_add_parent_id_index.ts
+++ b/src/backend/modules/widgets/migrations/003_add_parent_id_index.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Add the `parentId` index to the widget-placement
+ * collection.
+ *
+ * Single-level widget grouping lets an operator nest placements inside a
+ * `core:layout-group` container by pointing each child's `parentId` at
+ * the container row. Two hot paths query that field: the SSR resolver
+ * groups children by `parentId` to assemble the render tree, and the
+ * admin "delete container" path detaches every child of a parent at
+ * once. A sparse index keeps both selective without scanning the (far
+ * more numerous) directly-zoned rows that omit `parentId` entirely.
+ *
+ * The collection already exists in production (migration 001), so the
+ * new index ships as its own forward migration rather than schema
+ * creation. `createIndex` is idempotent — re-running finds the index
+ * present and short-circuits.
+ *
+ * @module backend/modules/widgets/migrations/003_add_parent_id_index
+ */
+
+import type { IMigration, IMigrationContext } from '@/types';
+
+export const migration: IMigration = {
+    id: '003_add_parent_id_index',
+    description:
+        'Add a sparse index on module_widgets_placements.parentId for ' +
+        'SSR child grouping and container-delete detachment.',
+    dependencies: ['module:widgets:001_create_widget_placements'],
+
+    /**
+     * Create the sparse `parentId` index. Sparse so only the rows that
+     * actually nest (children of a layout group) are indexed; the bulk
+     * of placements carry no `parentId` and stay out of the index.
+     *
+     * @param context - Migration context exposing the database service.
+     */
+    async up(context: IMigrationContext): Promise<void> {
+        await context.database.createIndex(
+            'module_widgets_placements',
+            { parentId: 1 },
+            { name: 'placement_parent', sparse: true }
+        );
+
+        return;
+    }
+};

--- a/src/backend/modules/widgets/placements/placement-resolver.ts
+++ b/src/backend/modules/widgets/placements/placement-resolver.ts
@@ -78,11 +78,23 @@ export class PlacementResolver {
         const placements = await this.placementService.findByRoute(route);
         if (placements.length === 0) return [];
 
+        // A child whose container is not in the route result is an orphan
+        // the tree assembly below would drop anyway. Children are stored
+        // with `routes: []` (forced by WidgetsService), so a route-scoped
+        // container that is filtered out for this path still returns its
+        // children here. Skip those before fetching so an unrelated page
+        // never runs a hidden grouped widget's (possibly expensive or
+        // route-sensitive) data fetcher only to discard the result.
+        // Parents that ARE present but fail to resolve are still handled
+        // by the post-fetch orphan check below.
+        const presentIds = new Set(placements.map(p => p.id));
+        const fetchable = placements.filter(p => !p.parentId || presentIds.has(p.parentId));
+
         // Fetch every placement in parallel, pairing each successful
         // result with its source placement so the tree assembly below
         // can read `parentId` (which `IWidgetData` does not carry).
         const fetched = await Promise.all(
-            placements.map(async p => {
+            fetchable.map(async p => {
                 const widget = await this.fetchOne(p, route, params);
                 return widget ? { placement: p, widget } : null;
             })

--- a/src/backend/modules/widgets/placements/placement-resolver.ts
+++ b/src/backend/modules/widgets/placements/placement-resolver.ts
@@ -56,11 +56,20 @@ export class PlacementResolver {
      * whose `typeId` is not currently registered (e.g. plugin
      * disabled) are silently skipped.
      *
+     * Single-level grouping: a placement with a `parentId` is a child of
+     * a `core:layout-group` container. After the flat fetch this method
+     * assembles a two-level tree — each child is nested under its
+     * container's `IWidgetData.children` (sorted by the child's `order`)
+     * and only top-level items are returned. A child whose container did
+     * not resolve (disabled, route-filtered out, or failed) is dropped
+     * as an orphan, mirroring the silent-skip of an unregistered type.
+     *
      * @param route - Request path resolved by the host.
      * @param params - Route params extracted by the host (e.g.
      *   `{ address }` on `/u/[address]`). Forwarded to each widget
      *   type's data fetcher.
-     * @returns Widget data ready for the frontend, in render order.
+     * @returns Top-level widget data ready for the frontend, in render
+     *   order, with container children nested.
      */
     async resolveForRoute(
         route: string,
@@ -69,12 +78,56 @@ export class PlacementResolver {
         const placements = await this.placementService.findByRoute(route);
         if (placements.length === 0) return [];
 
-        const results = await Promise.all(
-            placements.map(p => this.fetchOne(p, route, params))
+        // Fetch every placement in parallel, pairing each successful
+        // result with its source placement so the tree assembly below
+        // can read `parentId` (which `IWidgetData` does not carry).
+        const fetched = await Promise.all(
+            placements.map(async p => {
+                const widget = await this.fetchOne(p, route, params);
+                return widget ? { placement: p, widget } : null;
+            })
+        );
+        const resolved = fetched.filter(
+            (r): r is { placement: IWidgetPlacement; widget: IWidgetData } => r !== null
         );
 
-        const filtered = results.filter((w): w is IWidgetData => w !== null);
-        filtered.sort((a, b) => {
+        // A child only renders when its container also resolved. Index
+        // by placement id so orphan children (parent disabled / filtered
+        // / failed) can be detected and dropped.
+        const resolvedIds = new Set(resolved.map(r => r.placement.id));
+        const childrenByParent = new Map<string, IWidgetData[]>();
+        const topLevel: IWidgetData[] = [];
+        let orphanCount = 0;
+
+        for (const { placement, widget } of resolved) {
+            const parentId = placement.parentId;
+            if (parentId) {
+                if (!resolvedIds.has(parentId)) {
+                    orphanCount += 1;
+                    continue;
+                }
+                const siblings = childrenByParent.get(parentId);
+                if (siblings) {
+                    siblings.push(widget);
+                } else {
+                    childrenByParent.set(parentId, [widget]);
+                }
+            } else {
+                topLevel.push(widget);
+            }
+        }
+
+        // Attach each container's children in their own `order`, then
+        // order the top-level items by `(zone, order)` as before.
+        for (const { placement, widget } of resolved) {
+            if (placement.parentId) continue;
+            const children = childrenByParent.get(placement.id);
+            if (children) {
+                children.sort((a, b) => a.order - b.order);
+                widget.children = children;
+            }
+        }
+        topLevel.sort((a, b) => {
             if (a.zone !== b.zone) return a.zone.localeCompare(b.zone);
             return a.order - b.order;
         });
@@ -83,13 +136,15 @@ export class PlacementResolver {
             {
                 route,
                 placementCount: placements.length,
-                successCount: filtered.length,
-                failedCount: placements.length - filtered.length
+                successCount: resolved.length,
+                topLevelCount: topLevel.length,
+                orphanCount,
+                failedCount: placements.length - resolved.length
             },
             'Resolved widgets for route'
         );
 
-        return filtered;
+        return topLevel;
     }
 
     /**

--- a/src/backend/modules/widgets/placements/placement.service.ts
+++ b/src/backend/modules/widgets/placements/placement.service.ts
@@ -420,10 +420,14 @@ export class PlacementService implements IPlacementService {
             updatedAt: now
         };
 
-        // `$unset` the optional title field when the plugin never set
-        // one so the restored row matches a fresh plugin registration
-        // exactly, not "plugin defaults plus operator title".
-        const unsetOps: Record<string, ''> = {};
+        // Plugin registration defaults never nest a widget, so a faithful
+        // restore must drop any operator-applied `parentId` — otherwise the
+        // UI reports "defaults restored" while the resolver still renders
+        // the widget inside the old container. Also `$unset` the optional
+        // title field when the plugin never set one so the restored row
+        // matches a fresh plugin registration exactly, not "plugin defaults
+        // plus operator title".
+        const unsetOps: Record<string, ''> = { parentId: '' };
         if (defaults.title !== undefined) {
             setOps.title = defaults.title;
         } else {

--- a/src/backend/modules/widgets/placements/placement.service.ts
+++ b/src/backend/modules/widgets/placements/placement.service.ts
@@ -294,6 +294,13 @@ export class PlacementService implements IPlacementService {
             createdAt: now,
             updatedAt: now
         };
+        // Nest under a container when a valid parent id is supplied. The
+        // service layer (WidgetsService) has already enforced that the
+        // parent is a top-level layout group in the same zone; here we
+        // only translate the hex string into the stored ObjectId.
+        if (input.parentId !== undefined && ObjectId.isValid(input.parentId)) {
+            doc.parentId = new ObjectId(input.parentId);
+        }
         if (input.title !== undefined) doc.title = input.title;
         if (input.titleUrl !== undefined) doc.titleUrl = input.titleUrl;
         if (input.instanceConfig !== undefined) doc.instanceConfig = input.instanceConfig;
@@ -317,6 +324,13 @@ export class PlacementService implements IPlacementService {
         const setOps: Partial<IWidgetPlacementDocument> = { updatedAt: new Date() };
         const unsetOps: Record<string, ''> = {};
         if (patch.zoneId !== undefined) setOps.zoneId = patch.zoneId;
+        if (patch.parentId === null) {
+            // Explicit detach — drop the parent link so the placement
+            // falls back to a direct child of its zone.
+            unsetOps.parentId = '';
+        } else if (patch.parentId !== undefined && ObjectId.isValid(patch.parentId)) {
+            setOps.parentId = new ObjectId(patch.parentId);
+        }
         if (patch.routes !== undefined) setOps.routes = [...patch.routes];
         if (patch.order !== undefined) setOps.order = patch.order;
         if (patch.title === null) {
@@ -432,6 +446,19 @@ export class PlacementService implements IPlacementService {
         return publicShape;
     }
 
+    async detachChildrenOf(parentId: string): Promise<number> {
+        if (!ObjectId.isValid(parentId)) return 0;
+        const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
+        // Relocate every child back to the zone by clearing its parent
+        // link. Used when a container is deleted so operator-configured
+        // children survive rather than cascade-deleting with the parent.
+        const result = await collection.updateMany(
+            { parentId: new ObjectId(parentId) },
+            { $unset: { parentId: '' }, $set: { updatedAt: new Date() } }
+        );
+        return result.modifiedCount ?? 0;
+    }
+
     async findById(id: string): Promise<IWidgetPlacement | null> {
         if (!ObjectId.isValid(id)) return null;
         const collection = this.database.getCollection<IWidgetPlacementDocument>(WIDGET_PLACEMENT_COLLECTION);
@@ -464,6 +491,7 @@ function toPublic(doc: IWidgetPlacementDocument): IWidgetPlacement {
         id: doc._id.toHexString(),
         typeId: doc.typeId,
         zoneId: doc.zoneId,
+        parentId: doc.parentId ? doc.parentId.toHexString() : undefined,
         routes: doc.routes,
         order: doc.order,
         title: doc.title,

--- a/src/backend/modules/widgets/widget-types/core-widget-types.ts
+++ b/src/backend/modules/widgets/widget-types/core-widget-types.ts
@@ -366,11 +366,13 @@ async function fetchLayoutGroupData(
     const flexDirection: ZoneFlexDirection =
         config.flexDirection === 'row' ||
         config.flexDirection === 'row-reverse' ||
+        config.flexDirection === 'column' ||
         config.flexDirection === 'column-reverse'
             ? config.flexDirection
             : DEFAULT_GROUP_LAYOUT.flexDirection;
 
     const justifyContent: ZoneJustifyContent =
+        config.justifyContent === 'flex-start' ||
         config.justifyContent === 'center' ||
         config.justifyContent === 'flex-end' ||
         config.justifyContent === 'space-between' ||
@@ -380,6 +382,7 @@ async function fetchLayoutGroupData(
             : DEFAULT_GROUP_LAYOUT.justifyContent;
 
     const alignItems: ZoneAlignItems =
+        config.alignItems === 'stretch' ||
         config.alignItems === 'flex-start' ||
         config.alignItems === 'center' ||
         config.alignItems === 'flex-end' ||
@@ -390,7 +393,7 @@ async function fetchLayoutGroupData(
     const flexWrap: ZoneFlexWrap = config.flexWrap === 'wrap' ? 'wrap' : 'nowrap';
 
     const gap: ZoneGapSize =
-        config.gap === 'none' || config.gap === 'sm' || config.gap === 'lg'
+        config.gap === 'none' || config.gap === 'sm' || config.gap === 'md' || config.gap === 'lg'
             ? config.gap
             : DEFAULT_GROUP_LAYOUT.gap;
 

--- a/src/backend/modules/widgets/widget-types/core-widget-types.ts
+++ b/src/backend/modules/widgets/widget-types/core-widget-types.ts
@@ -41,6 +41,12 @@ import type {
     IWidgetPlacementContext,
     IServiceRegistry,
     IBlockchainService,
+    IZoneLayoutConfig,
+    ZoneFlexDirection,
+    ZoneJustifyContent,
+    ZoneAlignItems,
+    ZoneFlexWrap,
+    ZoneGapSize,
     WidgetDataFetcher
 } from '@/types';
 
@@ -305,6 +311,152 @@ export const WORLD_CLOCKS_CONFIG_SCHEMA: JSONSchema7 = {
 };
 
 /**
+ * Widget-type id for the layout-group container. Namespaced under
+ * `core:` so it never collides with a plugin-declared id. Unlike every
+ * other widget type, this one has no frontend renderer in
+ * `widgets.core.ts`: a layout group has no UI of its own — it is a
+ * structural flex container the `WidgetZone` renderer special-cases,
+ * drawing its nested children rather than looking up a component. The
+ * backend still registers it as a normal type so operators can place it
+ * and so the placement admin API validates its `instanceConfig`.
+ */
+export const LAYOUT_GROUP_TYPE_ID = 'core:layout-group';
+
+/**
+ * Flexbox default a layout group renders with before any operator
+ * tuning — a stacked column, matching the historical look of an
+ * untouched zone. The group fetcher fills any unset field from this so a
+ * freshly-created container with empty config still has a complete,
+ * renderable layout.
+ */
+const DEFAULT_GROUP_LAYOUT: IZoneLayoutConfig = {
+    preset: 'column',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    alignItems: 'stretch',
+    flexWrap: 'nowrap',
+    gap: 'md'
+};
+
+/**
+ * Resolve the layout-group SSR payload from the placement's instance
+ * config.
+ *
+ * A layout group ships no data of its own — its `instanceConfig` *is* an
+ * {@link IZoneLayoutConfig}, and the fetcher's only job is to echo that
+ * config (normalized to enum-valid values) as the widget `data` the
+ * frontend reads to style the nested flex container. Normalizing here —
+ * rather than trusting the stored blob — means a legacy or hand-edited
+ * placement degrades to the column default instead of emitting an
+ * invalid `flex-direction`. The children themselves are attached by the
+ * resolver from `parentId`, not by this fetcher.
+ *
+ * @param _route - Unused; group layout is route-independent.
+ * @param _params - Unused; group layout is route-independent.
+ * @param placement - Placement context carrying the operator config.
+ * @returns The normalized flexbox layout for the frontend container.
+ */
+async function fetchLayoutGroupData(
+    _route: string,
+    _params: Record<string, string>,
+    placement?: IWidgetPlacementContext
+): Promise<IZoneLayoutConfig> {
+    const config = placement?.instanceConfig ?? {};
+
+    const flexDirection: ZoneFlexDirection =
+        config.flexDirection === 'row' ||
+        config.flexDirection === 'row-reverse' ||
+        config.flexDirection === 'column-reverse'
+            ? config.flexDirection
+            : DEFAULT_GROUP_LAYOUT.flexDirection;
+
+    const justifyContent: ZoneJustifyContent =
+        config.justifyContent === 'center' ||
+        config.justifyContent === 'flex-end' ||
+        config.justifyContent === 'space-between' ||
+        config.justifyContent === 'space-around' ||
+        config.justifyContent === 'space-evenly'
+            ? config.justifyContent
+            : DEFAULT_GROUP_LAYOUT.justifyContent;
+
+    const alignItems: ZoneAlignItems =
+        config.alignItems === 'flex-start' ||
+        config.alignItems === 'center' ||
+        config.alignItems === 'flex-end' ||
+        config.alignItems === 'baseline'
+            ? config.alignItems
+            : DEFAULT_GROUP_LAYOUT.alignItems;
+
+    const flexWrap: ZoneFlexWrap = config.flexWrap === 'wrap' ? 'wrap' : 'nowrap';
+
+    const gap: ZoneGapSize =
+        config.gap === 'none' || config.gap === 'sm' || config.gap === 'lg'
+            ? config.gap
+            : DEFAULT_GROUP_LAYOUT.gap;
+
+    return { flexDirection, justifyContent, alignItems, flexWrap, gap };
+}
+
+/**
+ * JSON Schema (Draft 7) for the layout-group placement's
+ * `instanceConfig`.
+ *
+ * Mirrors the `IZoneLayoutConfig` flex fields the per-zone layout editor
+ * already produces, so the admin UI can reuse that same control to edit
+ * a container. Every field is optional with an enum and default —
+ * `additionalProperties: false` keeps the shape tight while letting an
+ * operator save a bare container that falls back to the column default.
+ * `preset` is accepted (UI sugar) but the renderer ignores it.
+ */
+export const LAYOUT_GROUP_CONFIG_SCHEMA: JSONSchema7 = {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+        preset: {
+            type: 'string',
+            enum: ['row-left', 'row-center', 'row-between', 'row-right', 'row-wrap', 'column', 'custom'],
+            title: 'Layout preset',
+            description: 'One-click arrangement the editor last applied; the renderer ignores it and uses the explicit flex fields.'
+        },
+        flexDirection: {
+            type: 'string',
+            enum: ['row', 'row-reverse', 'column', 'column-reverse'],
+            default: 'column',
+            title: 'Direction',
+            description: 'Main-axis orientation of the grouped widgets.'
+        },
+        justifyContent: {
+            type: 'string',
+            enum: ['flex-start', 'center', 'flex-end', 'space-between', 'space-around', 'space-evenly'],
+            default: 'flex-start',
+            title: 'Justify',
+            description: 'Distribution of widgets along the main axis.'
+        },
+        alignItems: {
+            type: 'string',
+            enum: ['stretch', 'flex-start', 'center', 'flex-end', 'baseline'],
+            default: 'stretch',
+            title: 'Align',
+            description: 'Alignment of widgets along the cross axis.'
+        },
+        flexWrap: {
+            type: 'string',
+            enum: ['nowrap', 'wrap'],
+            default: 'nowrap',
+            title: 'Wrap',
+            description: "'wrap' lets the grouped widgets reflow onto multiple lines."
+        },
+        gap: {
+            type: 'string',
+            enum: ['none', 'sm', 'md', 'lg'],
+            default: 'md',
+            title: 'Gap',
+            description: 'Spacing between grouped widgets, mapped to the --gap-* tokens.'
+        }
+    }
+};
+
+/**
  * Widget-type id for the real-time blockchain status ticker. Namespaced
  * under `core:` so it never collides with a plugin-declared id; the
  * frontend component registry (`widgets.core.ts`) keys its renderer on
@@ -449,6 +601,15 @@ export function buildCoreWidgetTypeDescriptors(
             category: 'Content',
             defaultDataFetcher: fetchWorldClocksData,
             configSchema: WORLD_CLOCKS_CONFIG_SCHEMA
+        },
+        {
+            id: LAYOUT_GROUP_TYPE_ID,
+            label: 'Layout group',
+            description:
+                'Structural container that arranges the widgets dropped into it with their own flexbox layout — group a row of widgets inside a column zone, or vice versa.',
+            category: 'Layout',
+            defaultDataFetcher: fetchLayoutGroupData,
+            configSchema: LAYOUT_GROUP_CONFIG_SCHEMA
         },
         {
             id: BLOCK_TICKER_TYPE_ID,

--- a/src/backend/modules/widgets/widget-types/core-widget-types.ts
+++ b/src/backend/modules/widgets/widget-types/core-widget-types.ts
@@ -160,6 +160,17 @@ export interface IWorldClocksWidgetData {
     zones: IWorldClockZone[];
     /** Whether the client renders 12-hour (AM/PM) time; otherwise 24-hour. */
     hour12: boolean;
+    /**
+     * Row wrap behaviour. `nowrap` keeps a single horizontal row (the
+     * widget is a flex child of its zone, whose min-content width would
+     * otherwise collapse it to one clock and stack the rest vertically);
+     * `wrap` lets the row reflow onto multiple lines on narrow hosts.
+     */
+    wrap: 'nowrap' | 'wrap';
+    /** `justify-content` distributing the clocks across the widget width. */
+    justify: 'flex-start' | 'center' | 'flex-end' | 'space-between';
+    /** Token gap size between clocks (`sm`/`md`/`lg` → `--gap-*`). */
+    gap: 'sm' | 'md' | 'lg';
 }
 
 /**
@@ -173,12 +184,15 @@ export interface IWorldClocksWidgetData {
  * coercing each zone's fields and dropping any entry missing a time zone
  * — so a malformed legacy placement degrades to fewer clocks rather than
  * throwing inside the resolver's round-trip. No time is computed here;
- * the component ticks it client-side.
+ * the component ticks it client-side. The layout fields (`wrap`,
+ * `justify`, `gap`) are likewise normalized to their enum defaults so a
+ * legacy placement saved before they existed renders as a single
+ * left-aligned row rather than an undefined layout.
  *
  * @param _route - Unused; the clock row is route-independent.
  * @param _params - Unused; the clock row is route-independent.
  * @param placement - Placement context carrying the operator config.
- * @returns The normalized zone list and hour-format flag for the component.
+ * @returns The normalized zone list, hour-format flag, and layout settings for the component.
  */
 async function fetchWorldClocksData(
     _route: string,
@@ -202,8 +216,16 @@ async function fetchWorldClocksData(
         .filter((zone) => zone.timeZone !== '');
 
     const hour12 = config.hour12 === true;
+    const wrap = config.wrap === 'wrap' ? 'wrap' : 'nowrap';
+    const justify =
+        config.justify === 'center' ||
+        config.justify === 'flex-end' ||
+        config.justify === 'space-between'
+            ? config.justify
+            : 'flex-start';
+    const gap = config.gap === 'sm' || config.gap === 'lg' ? config.gap : 'md';
 
-    return { zones, hour12 };
+    return { zones, hour12, wrap, justify, gap };
 }
 
 /**
@@ -255,6 +277,29 @@ export const WORLD_CLOCKS_CONFIG_SCHEMA: JSONSchema7 = {
             default: false,
             title: '12-hour clock',
             description: 'Show AM/PM time instead of 24-hour.'
+        },
+        wrap: {
+            type: 'string',
+            enum: ['nowrap', 'wrap'],
+            default: 'nowrap',
+            title: 'Row wrapping',
+            description:
+                "'nowrap' keeps every clock on a single horizontal row; 'wrap' lets the row reflow onto multiple lines when it does not fit the host width."
+        },
+        justify: {
+            type: 'string',
+            enum: ['flex-start', 'center', 'flex-end', 'space-between'],
+            default: 'flex-start',
+            title: 'Horizontal alignment',
+            description:
+                'How the clocks distribute across the widget width: packed to the start, centred, packed to the end, or spread edge to edge.'
+        },
+        gap: {
+            type: 'string',
+            enum: ['sm', 'md', 'lg'],
+            default: 'md',
+            title: 'Spacing',
+            description: 'Gap between adjacent clocks — small, medium, or large.'
         }
     }
 };

--- a/src/backend/modules/widgets/widgets.errors.ts
+++ b/src/backend/modules/widgets/widgets.errors.ts
@@ -60,6 +60,20 @@ export class WidgetTypeOwnerConflictError extends WidgetsServiceError {
 }
 
 /**
+ * Thrown when a placement's `parentId` does not name a valid layout-group
+ * container. Covers every way the one-level nesting contract can be
+ * broken: the parent row does not exist, the parent is not a
+ * `core:layout-group`, the parent is itself nested (which would make the
+ * tree two levels deep), or the placement being nested is itself a layout
+ * group. HTTP maps this to 400.
+ */
+export class InvalidParentPlacementError extends WidgetsServiceError {
+    constructor(message: string) {
+        super(message);
+    }
+}
+
+/**
  * Thrown when the controller attempts to DELETE a plugin-source
  * placement. The supported reversals are disable and restore-defaults;
  * deletion would silently re-appear on the next plugin enable.

--- a/src/backend/modules/widgets/widgets.service.ts
+++ b/src/backend/modules/widgets/widgets.service.ts
@@ -50,7 +50,9 @@ import type { PlacementResolver } from './placements/placement-resolver.js';
 import { ZoneLayoutService } from './zones/zone-layout.service.js';
 import { defineZone } from './zones/define-zone.js';
 import { defineWidgetType } from './widget-types/define-widget-type.js';
+import { LAYOUT_GROUP_TYPE_ID } from './widget-types/core-widget-types.js';
 import {
+    InvalidParentPlacementError,
     MissingPluginDefaultsError,
     PluginPlacementDeletionForbiddenError,
     RestoreDefaultsOnOperatorRowError,
@@ -420,6 +422,19 @@ export class WidgetsService implements IWidgetsService {
         if (!this.zones.has(input.zoneId)) {
             throw new UnknownZoneError(input.zoneId);
         }
+
+        // Nesting: when a parent is named, validate the one-level
+        // contract and force the child into the parent's zone with no
+        // route filter of its own (the container governs visibility).
+        if (input.parentId !== undefined) {
+            const parent = await this.resolveContainerParent(input.typeId, null, input.parentId);
+            return this.placements.create({
+                ...input,
+                zoneId: parent.zoneId,
+                routes: []
+            });
+        }
+
         return this.placements.create(input);
     }
 
@@ -430,6 +445,23 @@ export class WidgetsService implements IWidgetsService {
         if (patch.zoneId !== undefined && !this.zones.has(patch.zoneId)) {
             throw new UnknownZoneError(patch.zoneId);
         }
+
+        // Attaching to a container (parentId is a string): validate the
+        // one-level contract against the row being moved and force it
+        // into the parent's zone with an empty route filter. Detaching
+        // (`parentId: null`) needs no validation — it just clears the
+        // link — and omission leaves nesting untouched.
+        if (typeof patch.parentId === 'string') {
+            const existing = await this.placements.findById(id);
+            if (!existing) return null;
+            const parent = await this.resolveContainerParent(existing.typeId, id, patch.parentId);
+            return this.placements.update(id, {
+                ...patch,
+                zoneId: parent.zoneId,
+                routes: []
+            });
+        }
+
         return this.placements.update(id, patch);
     }
 
@@ -439,7 +471,59 @@ export class WidgetsService implements IWidgetsService {
         if (existing.source === 'plugin') {
             throw new PluginPlacementDeletionForbiddenError();
         }
+        // Deleting a container relocates its children back to the zone
+        // rather than cascade-deleting them, so operator-configured
+        // widgets survive the container's removal.
+        if (existing.typeId === LAYOUT_GROUP_TYPE_ID) {
+            await this.placements.detachChildrenOf(id);
+        }
         return this.placements.delete(id);
+    }
+
+    /**
+     * Validate the one-level nesting contract and return the resolved
+     * container row so the caller can adopt its zone.
+     *
+     * Throws {@link InvalidParentPlacementError} when any rule is broken:
+     * a layout group cannot itself be nested; a placement cannot be its
+     * own parent; the parent must exist, must be a `core:layout-group`,
+     * and must be top-level (no `parentId` of its own) so the tree never
+     * exceeds one level of depth.
+     *
+     * @param childTypeId - Widget-type id of the placement being nested.
+     * @param childId - Id of the placement being moved, or `null` on
+     *   create; used to reject self-parenting on update.
+     * @param parentId - Candidate container placement id.
+     * @returns The validated parent placement.
+     */
+    private async resolveContainerParent(
+        childTypeId: string,
+        childId: string | null,
+        parentId: string
+    ): Promise<IWidgetPlacement> {
+        if (childTypeId === LAYOUT_GROUP_TYPE_ID) {
+            throw new InvalidParentPlacementError(
+                'A layout group cannot be nested inside another container.'
+            );
+        }
+        if (childId !== null && childId === parentId) {
+            throw new InvalidParentPlacementError('A placement cannot be its own parent.');
+        }
+        const parent = await this.placements.findById(parentId);
+        if (!parent) {
+            throw new InvalidParentPlacementError(`Parent placement '${parentId}' does not exist.`);
+        }
+        if (parent.typeId !== LAYOUT_GROUP_TYPE_ID) {
+            throw new InvalidParentPlacementError(
+                `Parent placement '${parentId}' is not a layout group; only layout groups can contain widgets.`
+            );
+        }
+        if (parent.parentId) {
+            throw new InvalidParentPlacementError(
+                `Parent placement '${parentId}' is itself nested; nesting is limited to one level.`
+            );
+        }
+        return parent;
     }
 
     async restorePluginDefaults(id: string): Promise<IWidgetPlacement | null> {

--- a/src/backend/tests/vitest/mocks/database-service.ts
+++ b/src/backend/tests/vitest/mocks/database-service.ts
@@ -331,10 +331,19 @@ export function createMockDatabaseService(): IDatabaseService & {
                     checkInjectedError(name, 'updateMany');
                     let modifiedCount = 0;
 
+                    const updateFields = (update as any).$set || {};
+                    const unsetFields = (update as any).$unset || {};
+
                     for (let i = 0; i < data.length; i++) {
                         if (matchesFilter(data[i], filter)) {
-                            const updateFields = (update as any).$set || {};
+                            // Apply $set, then $unset — mirror updateOne so a
+                            // bulk relocation that clears a field (e.g.
+                            // detaching widget children by $unset-ing
+                            // parentId) behaves the same as the single-doc path.
                             data[i] = { ...data[i], ...updateFields };
+                            for (const key of Object.keys(unsetFields)) {
+                                delete (data[i] as any)[key];
+                            }
                             modifiedCount++;
                         }
                     }

--- a/src/backend/tests/vitest/mocks/mongoose.ts
+++ b/src/backend/tests/vitest/mocks/mongoose.ts
@@ -82,6 +82,17 @@ export function matchesFilter(doc: any, filter: Filter<any>): boolean {
             return doc._id.equals(value);
         }
 
+        // Handle ObjectId equality on any other field (e.g. a `parentId`
+        // reference between documents). Two ObjectId instances with the
+        // same hex are not `===`, so the simple-equality path below would
+        // never match — compare by value via `.equals`, falling back to a
+        // hex-string compare when the stored value is a plain string.
+        if (value instanceof ObjectId) {
+            const docValue = key.includes('.') ? getNestedValue(doc, key) : doc[key];
+            if (docValue instanceof ObjectId) return docValue.equals(value);
+            return docValue != null && String(docValue) === value.toHexString();
+        }
+
         // Handle RegExp (for MongoDB regex queries like { mimeType: /^image\// })
         if (value instanceof RegExp) {
             const docValue = getNestedValue(doc, key);

--- a/src/frontend/app/(core)/system/widgets/page.module.scss
+++ b/src/frontend/app/(core)/system/widgets/page.module.scss
@@ -275,6 +275,24 @@
     gap: var(--gap-xs);
 }
 
+/* Children of a layout-group container, indented under its bubble with a
+ * left rule so the nesting reads at a glance. Non-draggable in this
+ * iteration — order and container assignment are edited from the modal. */
+.bubble_children {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+    margin: var(--gap-2xs) 0 var(--gap-xs) var(--gap-lg);
+    padding-left: var(--gap-md);
+    border-left: var(--border-width-medium) solid var(--color-border-strong);
+}
+
+.bubble_children_empty {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-caption);
+    font-style: italic;
+}
+
 /* ------------------------------------------------------------------ */
 /* Placement form                                                      */
 /* ------------------------------------------------------------------ */

--- a/src/frontend/app/(core)/system/widgets/page.module.scss
+++ b/src/frontend/app/(core)/system/widgets/page.module.scss
@@ -283,8 +283,18 @@
     flex-direction: column;
     gap: var(--gap-sm);
     margin: var(--gap-2xs) 0 var(--gap-xs) var(--gap-lg);
-    padding-left: var(--gap-md);
+    padding: var(--gap-2xs) 0 var(--gap-2xs) var(--gap-md);
     border-left: var(--border-width-medium) solid var(--color-border-strong);
+    border-radius: var(--radius-xs);
+    transition: background-color var(--transition-base), border-color var(--transition-base);
+}
+
+// Highlight the group region while a dragged widget hovers it, so the
+// operator can see they are about to nest into this container rather than
+// drop in the zone.
+.bubble_children--drop-target {
+    background: var(--color-primary-alpha-10);
+    border-left-color: var(--color-primary);
 }
 
 .bubble_children_empty {

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -24,6 +24,7 @@
  */
 
 import {
+    Fragment,
     useCallback,
     useEffect,
     useMemo,
@@ -82,6 +83,11 @@ interface IPlacement {
     id: string;
     typeId: string;
     zoneId: string;
+    /**
+     * Parent container placement id when this row is nested inside a
+     * `core:layout-group`. Absent for directly-zoned placements.
+     */
+    parentId?: string;
     routes: string[];
     order: number;
     title?: string;
@@ -101,6 +107,11 @@ interface IPlacement {
  */
 interface IPlacementPatch {
     zoneId?: string;
+    /**
+     * Reparent the placement: a container id nests it, `null` detaches it
+     * back to the zone, omission leaves it unchanged.
+     */
+    parentId?: string | null | undefined;
     routes?: string[];
     order?: number;
     title?: string | null | undefined;
@@ -116,6 +127,8 @@ interface IPlacementPatch {
 interface IPlacementCreate {
     typeId: string;
     zoneId: string;
+    /** Optional container placement id to nest the new widget inside. */
+    parentId?: string;
     routes: string[];
     order?: number;
     title?: string;
@@ -123,6 +136,14 @@ interface IPlacementCreate {
     instanceConfig?: Record<string, unknown>;
     enabled?: boolean;
 }
+
+/**
+ * Widget-type id of the structural layout-group container. Placements of
+ * this type hold other widgets (via their `parentId`) and are edited with
+ * the same flexbox config the per-zone layout control produces. Mirrors
+ * the backend `LAYOUT_GROUP_TYPE_ID`.
+ */
+const LAYOUT_GROUP_TYPE_ID = 'core:layout-group';
 
 /**
  * Translate a placement source into a Badge tone.
@@ -814,6 +835,7 @@ export default function WidgetsAdminPage() {
                         defaultRoutes={defaultRoute ? [defaultRoute] : undefined}
                         types={types}
                         zones={zones}
+                        placements={placements}
                         onCancel={() => closeModal(id)}
                         onSubmit={async (data) => {
                             try {
@@ -843,6 +865,7 @@ export default function WidgetsAdminPage() {
             notifySuccess,
             openModal,
             patchPlacement,
+            placements,
             types,
             zones
         ]
@@ -1048,7 +1071,26 @@ function ZoneSection({
 }: ZoneSectionProps) {
     const zoneInfo = lookupZone(zones, zoneId);
     const { setNodeRef, isOver } = useDroppable({ id: zoneId, data: { zoneId } });
-    const itemIds = useMemo(() => placements.map(p => p.id), [placements]);
+
+    // Split the zone's placements into the top-level rows (drawn in the
+    // sortable list) and the children nested inside layout-group
+    // containers. Only top-level rows participate in drag-reorder; a
+    // child's container and order are edited from the modal instead.
+    const topLevel = useMemo(() => placements.filter(p => !p.parentId), [placements]);
+    const childrenByParent = useMemo(() => {
+        const map = new Map<string, IPlacement[]>();
+        for (const p of placements) {
+            if (!p.parentId) continue;
+            const bucket = map.get(p.parentId) ?? [];
+            bucket.push(p);
+            map.set(p.parentId, bucket);
+        }
+        for (const bucket of map.values()) {
+            bucket.sort((a, b) => a.order - b.order);
+        }
+        return map;
+    }, [placements]);
+    const itemIds = useMemo(() => topLevel.map(p => p.id), [topLevel]);
 
     return (
         <section className={cn(styles.zone, isOver && styles['zone--drop-target'])}>
@@ -1072,23 +1114,52 @@ function ZoneSection({
 
             <SortableContext id={zoneId} items={itemIds} strategy={verticalListSortingStrategy}>
                 <div ref={setNodeRef} className={styles.bubbles}>
-                    {placements.length === 0 ? (
+                    {topLevel.length === 0 ? (
                         <p className={styles.zone_empty}>
                             No placements in this zone — drag a widget here to place it.
                         </p>
                     ) : (
-                        placements.map(placement => (
-                            <PlacementBubble
-                                key={placement.id}
-                                placement={placement}
-                                typeInfo={lookupType(types, placement.typeId)}
-                                busy={busyId === placement.id}
-                                onToggleEnabled={onToggleEnabled}
-                                onEdit={onEdit}
-                                onDelete={onDelete}
-                                onRestore={onRestore}
-                            />
-                        ))
+                        topLevel.map(placement => {
+                            const isContainer = placement.typeId === LAYOUT_GROUP_TYPE_ID;
+                            const kids = isContainer
+                                ? childrenByParent.get(placement.id) ?? []
+                                : [];
+                            return (
+                                <Fragment key={placement.id}>
+                                    <PlacementBubble
+                                        placement={placement}
+                                        typeInfo={lookupType(types, placement.typeId)}
+                                        busy={busyId === placement.id}
+                                        onToggleEnabled={onToggleEnabled}
+                                        onEdit={onEdit}
+                                        onDelete={onDelete}
+                                        onRestore={onRestore}
+                                    />
+                                    {isContainer && (
+                                        <div className={styles.bubble_children}>
+                                            {kids.length === 0 ? (
+                                                <span className={styles.bubble_children_empty}>
+                                                    Empty group — edit a widget and set its container to this group.
+                                                </span>
+                                            ) : (
+                                                kids.map(child => (
+                                                    <ChildPlacementRow
+                                                        key={child.id}
+                                                        placement={child}
+                                                        typeInfo={lookupType(types, child.typeId)}
+                                                        busy={busyId === child.id}
+                                                        onToggleEnabled={onToggleEnabled}
+                                                        onEdit={onEdit}
+                                                        onDelete={onDelete}
+                                                        onRestore={onRestore}
+                                                    />
+                                                ))
+                                            )}
+                                        </div>
+                                    )}
+                                </Fragment>
+                            );
+                        })
                     )}
                 </div>
             </SortableContext>
@@ -1173,6 +1244,89 @@ function PlacementBubble({
                             <code key={r} className={styles.route_chip}>{r}</code>
                         ))}
                 </div>
+            </div>
+            <div className={styles.bubble_actions}>
+                <Switch
+                    size="sm"
+                    on={placement.enabled}
+                    onChange={(next) => onToggleEnabled(placement, next)}
+                    disabled={busy}
+                    aria-label={`${placement.enabled ? 'Disable' : 'Enable'} placement ${label}`}
+                />
+                <IconButton
+                    size="sm"
+                    variant="primary"
+                    aria-label={`Edit ${label}`}
+                    onClick={() => onEdit(placement)}
+                >
+                    <Pencil size={14} />
+                </IconButton>
+                {placement.source === 'plugin' ? (
+                    <IconButton
+                        size="sm"
+                        variant="ghost"
+                        aria-label={`Restore plugin defaults for ${label}`}
+                        onClick={() => onRestore(placement)}
+                        disabled={busy}
+                    >
+                        <RefreshCw size={14} />
+                    </IconButton>
+                ) : (
+                    <IconButton
+                        size="sm"
+                        variant="danger"
+                        aria-label={`Delete ${label}`}
+                        onClick={() => onDelete(placement)}
+                    >
+                        <Trash2 size={14} />
+                    </IconButton>
+                )}
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Compact, non-draggable row for a widget nested inside a layout-group
+ * container. It mirrors `PlacementBubble`'s actions (enable switch, edit,
+ * delete / restore) but omits the drag grip: a child's render order and
+ * its container assignment are edited from the modal, not by dragging,
+ * so the nesting display stays out of the zone's sortable list. The "edit"
+ * modal is where an operator detaches the widget (set container to "None")
+ * or moves it to a different group.
+ *
+ * @param placement - The nested child placement to render.
+ * @param typeInfo - Resolved widget-type label/owner for display.
+ * @param busy - Whether a mutation for this row is in flight.
+ * @param onToggleEnabled - Enable/disable handler.
+ * @param onEdit - Opens the edit modal.
+ * @param onDelete - Deletes an operator-source child.
+ * @param onRestore - Restores a plugin-source child's defaults.
+ */
+function ChildPlacementRow({
+    placement,
+    typeInfo,
+    busy,
+    onToggleEnabled,
+    onEdit,
+    onDelete,
+    onRestore
+}: PlacementBubbleProps) {
+    const label = placement.title ?? typeInfo?.label ?? placement.typeId;
+
+    return (
+        <div className={styles.bubble}>
+            <span className={styles.bubble_handle} aria-hidden />
+            <div className={styles.bubble_main}>
+                <div className={styles.bubble_top}>
+                    <span className={styles.widget_label}>{label}</span>
+                    <Badge tone={sourceTone(placement.source)}>
+                        {placement.source === 'plugin'
+                            ? `plugin: ${placement.pluginId ?? '?'}`
+                            : 'operator'}
+                    </Badge>
+                </div>
+                <span className={styles.widget_meta}>{placement.typeId}</span>
             </div>
             <div className={styles.bubble_actions}>
                 <Switch
@@ -1866,13 +2020,19 @@ interface PlacementFormProps {
     defaultRoutes?: string[];
     types: IWidgetTypeSnapshot | null;
     zones: IZoneSnapshot | null;
+    /**
+     * Every loaded placement, so the form can offer the layout-group
+     * containers in the selected zone as parent options.
+     */
+    placements: IPlacement[];
     onSubmit: (data: IPlacementCreate | IPlacementPatch) => Promise<void>;
     onCancel: () => void;
 }
 
-function PlacementForm({ mode, initial, defaultRoutes, types, zones, onSubmit, onCancel }: PlacementFormProps) {
+function PlacementForm({ mode, initial, defaultRoutes, types, zones, placements, onSubmit, onCancel }: PlacementFormProps) {
     const [typeId, setTypeId] = useState<string>(initial?.typeId ?? '');
     const [zoneId, setZoneId] = useState<string>(initial?.zoneId ?? '');
+    const [parentId, setParentId] = useState<string>(initial?.parentId ?? '');
     const [routes, setRoutes] = useState<string[]>(initial?.routes ?? defaultRoutes ?? []);
     const [routeDraft, setRouteDraft] = useState<string>('');
     const [order, setOrder] = useState<number>(initial?.order ?? 100);
@@ -1890,6 +2050,29 @@ function PlacementForm({ mode, initial, defaultRoutes, types, zones, onSubmit, o
     const selectedSchema = useMemo(() => findConfigSchema(types, typeId), [types, typeId]);
     const configFields = useMemo(() => extractConfigFields(selectedSchema), [selectedSchema]);
     const hasSchemaFields = configFields.length > 0;
+
+    // A layout group cannot itself be nested; the Container picker is
+    // hidden for it. For every other type, offer the layout-group
+    // containers that live in the selected zone as parent options. The
+    // row being edited is excluded so it can never parent itself.
+    const isLayoutGroup = typeId === LAYOUT_GROUP_TYPE_ID;
+    const containers = useMemo(
+        () => placements.filter(p =>
+            p.typeId === LAYOUT_GROUP_TYPE_ID &&
+            !p.parentId &&
+            p.id !== initial?.id &&
+            p.zoneId === zoneId
+        ),
+        [placements, initial?.id, zoneId]
+    );
+
+    // Drop a stale parent selection when the operator switches to a zone
+    // (or a type) where the chosen container is no longer valid.
+    useEffect(() => {
+        if (parentId && !containers.some(c => c.id === parentId)) {
+            setParentId('');
+        }
+    }, [containers, parentId]);
 
     const [configValue, setConfigValue] = useState<Record<string, unknown>>(
         () => coerceInitialConfig(configFields, initial?.instanceConfig as Record<string, unknown> | undefined)
@@ -2056,9 +2239,14 @@ function PlacementForm({ mode, initial, defaultRoutes, types, zones, onSubmit, o
             setSaving(true);
             try {
                 if (mode === 'create') {
+                    // Only nest non-group widgets; a layout group is always
+                    // top-level. The backend forces the child's zone and
+                    // clears its routes when a parent is supplied.
+                    const effectiveParent = !isLayoutGroup && parentId.length > 0 ? parentId : undefined;
                     const payload: IPlacementCreate = {
                         typeId,
                         zoneId,
+                        parentId: effectiveParent,
                         routes,
                         order,
                         title: title.trim().length > 0 ? title.trim() : undefined,
@@ -2093,8 +2281,22 @@ function PlacementForm({ mode, initial, defaultRoutes, types, zones, onSubmit, o
                             : hadInitialTitleUrl
                                 ? null
                                 : undefined;
+                    // Container reassignment, three-state like title:
+                    //   - a selected container → attach (string)
+                    //   - cleared after having had one → null (detach)
+                    //   - never had one and none selected → omit
+                    // A layout group is never nested, so it always omits.
+                    const hadInitialParent = typeof initial?.parentId === 'string';
+                    const parentIdPatch: string | null | undefined = isLayoutGroup
+                        ? undefined
+                        : parentId.length > 0
+                            ? parentId
+                            : hadInitialParent
+                                ? null
+                                : undefined;
                     const payload: IPlacementPatch = {
                         zoneId,
+                        parentId: parentIdPatch,
                         routes,
                         order,
                         title: titlePatch,
@@ -2108,7 +2310,7 @@ function PlacementForm({ mode, initial, defaultRoutes, types, zones, onSubmit, o
                 setSaving(false);
             }
         },
-        [configFields, configValue, enabled, initial?.title, initial?.titleUrl, mode, onSubmit, order, rawMode, rawText, routes, title, titleUrl, typeId, zoneId]
+        [configFields, configValue, enabled, initial?.title, initial?.titleUrl, initial?.parentId, isLayoutGroup, mode, onSubmit, order, parentId, rawMode, rawText, routes, title, titleUrl, typeId, zoneId]
     );
 
     const canSubmit = typeId.length > 0 && zoneId.length > 0;
@@ -2159,6 +2361,29 @@ function PlacementForm({ mode, initial, defaultRoutes, types, zones, onSubmit, o
                     ))}
                 </Select>
             </div>
+
+            {!isLayoutGroup && containers.length > 0 && (
+                <div className={styles.field}>
+                    <label htmlFor="wp-parent">Container</label>
+                    <Select
+                        id="wp-parent"
+                        value={parentId}
+                        onChange={(e) => setParentId(e.target.value)}
+                        disabled={saving}
+                    >
+                        <option value="">None — place directly in the zone</option>
+                        {containers.map(c => (
+                            <option key={c.id} value={c.id}>
+                                {c.title ?? 'Layout group'} (…{c.id.slice(-6)})
+                            </option>
+                        ))}
+                    </Select>
+                    <span className={styles.field_hint}>
+                        Nest this widget inside a layout group in this zone. The group controls its own
+                        row/column arrangement, and its route filter governs visibility.
+                    </span>
+                </div>
+            )}
 
             <div className={styles.field}>
                 <label htmlFor="wp-routes">Routes</label>

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -648,77 +648,124 @@ export default function WidgetsAdminPage() {
     );
 
     /**
-     * Persist a drag-end gesture. Within-zone drops reorder; cross-zone
-     * drops additionally rewrite the moved placement's zoneId. Both
-     * paths renumber positions sequentially (10, 20, 30…) and emit one
-     * PATCH per placement whose order or zone actually changed. The
-     * local placement list is updated optimistically so the bubble
-     * snaps into place before the network round-trip resolves; a
+     * Persist a drag-end gesture across three move types: reorder within a
+     * list, move between zones, and nest into / detach from a layout-group
+     * container. The drop target decides which: a container's children
+     * region (`containerId` in the drop data) nests the widget; a child
+     * row nests it into that child's container; a zone or a top-level item
+     * places it directly in the zone, detaching it if it was nested.
+     *
+     * Each affected list (the source and, on a cross-list move, the
+     * destination) is renumbered sequentially (10, 20, 30…). The moved row
+     * additionally gets a `parentId` patch when its container changed
+     * (a string attaches — the backend then forces its zone and clears its
+     * routes — `null` detaches) and a `zoneId` patch on a plain zone move.
+     * The list is updated optimistically so the row snaps into place; a
      * failed PATCH falls back to a refetch.
      */
     const handleDragEnd = useCallback(
         async (event: DragEndEvent): Promise<void> => {
             const { active, over } = event;
             if (!over) return;
-            const sourceZone = active.data.current?.zoneId as string | undefined;
-            const destZone = (over.data.current?.zoneId as string | undefined) ?? String(over.id);
-            if (!sourceZone || !destZone) return;
-            if (active.id === over.id && sourceZone === destZone) return;
+            const moved = placements.find(p => p.id === String(active.id));
+            if (!moved) return;
 
-            const sameZone = sourceZone === destZone;
-            // Reorder only the placements the current view actually shows.
-            // `grouped` renders global-only placements when no route is
-            // selected and route-matching placements otherwise; the drag
-            // renumber must use the identical predicate or it interleaves and
-            // PATCHes hidden placements (route-scoped rows in the unfiltered
-            // view, other-route rows in a filtered view) the operator never
-            // sees. The resolver only ever orders placements among those that
-            // match a given path, so renumbering the visible subset is safe.
+            const overData = over.data.current ?? {};
+
+            // Resolve the destination list. A container drop region and a
+            // child row both name a container; anything else (zone droppable
+            // or top-level item) targets a zone directly.
+            let destContainerId: string | null = null;
+            let destZone: string | undefined;
+            if (typeof overData.containerId === 'string') {
+                destContainerId = overData.containerId;
+                destZone = overData.zoneId as string | undefined;
+            } else if (typeof overData.parentId === 'string') {
+                destContainerId = overData.parentId;
+                destZone = overData.zoneId as string | undefined;
+            } else {
+                destZone = (overData.zoneId as string | undefined) ?? String(over.id);
+            }
+            if (!destZone) return;
+
+            // A layout group is always top-level — never nest one.
+            if (moved.typeId === LAYOUT_GROUP_TYPE_ID) destContainerId = null;
+            // Dropping a container onto its own children region is a no-op.
+            if (destContainerId === moved.id) return;
+
+            const sourceContainerId = moved.parentId ?? null;
+            const srcKey = sourceContainerId ? `c:${sourceContainerId}` : `z:${moved.zoneId}`;
+            const dstKey = destContainerId ? `c:${destContainerId}` : `z:${destZone}`;
+            const sameList = srcKey === dstKey;
+            if (active.id === over.id && sameList) return;
+
+            // The visible-subset predicate constrains only top-level zone
+            // lists — route-scoped rows the operator isn't viewing must not
+            // be renumbered. A container's children carry no route filter of
+            // their own, so a child list is always its full set.
             const visibleInView = (p: IPlacement): boolean =>
                 selectedRoute === null
                     ? p.routes.length === 0
                     : placementMatchesRoute(p.routes, selectedRoute);
-            const sourceList = placements
-                .filter(p => p.zoneId === sourceZone && visibleInView(p))
-                .sort((a, b) => a.order - b.order);
-            const moved = sourceList.find(p => p.id === active.id);
-            if (!moved) return;
+            const listFor = (containerId: string | null, zoneId: string): IPlacement[] =>
+                (containerId
+                    ? placements.filter(p => p.parentId === containerId)
+                    : placements.filter(p => !p.parentId && p.zoneId === zoneId && visibleInView(p))
+                ).sort((a, b) => a.order - b.order);
 
-            const sourceWithoutActive = sourceList.filter(p => p.id !== active.id);
-            const destListPrev = sameZone
-                ? sourceWithoutActive
-                : placements
-                    .filter(p => p.zoneId === destZone && visibleInView(p))
-                    .sort((a, b) => a.order - b.order);
+            const sourceList = listFor(sourceContainerId, moved.zoneId);
+            const sourceWithoutActive = sourceList.filter(p => p.id !== moved.id);
+            const destListPrev = sameList ? sourceWithoutActive : listFor(destContainerId, destZone);
 
-            const insertIdx =
-                over.id === destZone
-                    ? destListPrev.length
-                    : (() => {
-                        const target = destListPrev.findIndex(p => p.id === over.id);
-                        return target < 0 ? destListPrev.length : target;
-                    })();
+            const overIsArea =
+                typeof overData.containerId === 'string' || String(over.id) === destZone;
+            const insertIdx = overIsArea
+                ? destListPrev.length
+                : (() => {
+                    const target = destListPrev.findIndex(p => p.id === String(over.id));
+                    return target < 0 ? destListPrev.length : target;
+                })();
 
+            const movedNext: IPlacement = {
+                ...moved,
+                parentId: destContainerId ?? undefined,
+                zoneId: destZone
+            };
             const newDest = [
                 ...destListPrev.slice(0, insertIdx),
-                sameZone ? moved : { ...moved, zoneId: destZone },
+                movedNext,
                 ...destListPrev.slice(insertIdx)
             ];
-            const newSource = sameZone ? newDest : sourceWithoutActive;
+            const newSource = sameList ? newDest : sourceWithoutActive;
+
+            const parentChanged = (moved.parentId ?? null) !== destContainerId;
+            const zoneChanged = moved.zoneId !== destZone;
 
             interface IOp { id: string; patch: IPlacementPatch }
             const ops: IOp[] = [];
-            const collect = (list: IPlacement[], rewriteZoneFor?: string): void => {
-                list.forEach((p, idx) => {
+            newDest.forEach((p, idx) => {
+                const nextOrder = (idx + 1) * 10;
+                const patch: IPlacementPatch = {};
+                if (p.order !== nextOrder) patch.order = nextOrder;
+                if (p.id === moved.id) {
+                    if (parentChanged) {
+                        // Attach (string) or detach (null). On attach the
+                        // backend forces the child's zone and clears its
+                        // routes, so an explicit zoneId is unnecessary.
+                        patch.parentId = destContainerId;
+                    }
+                    if (destContainerId === null && zoneChanged) {
+                        patch.zoneId = destZone;
+                    }
+                }
+                if (Object.keys(patch).length > 0) ops.push({ id: p.id, patch });
+            });
+            if (!sameList) {
+                newSource.forEach((p, idx) => {
                     const nextOrder = (idx + 1) * 10;
-                    const patch: IPlacementPatch = {};
-                    if (p.order !== nextOrder) patch.order = nextOrder;
-                    if (rewriteZoneFor === p.id) patch.zoneId = destZone;
-                    if (Object.keys(patch).length > 0) ops.push({ id: p.id, patch });
+                    if (p.order !== nextOrder) ops.push({ id: p.id, patch: { order: nextOrder } });
                 });
-            };
-            collect(newSource);
-            if (!sameZone) collect(newDest, moved.id);
+            }
 
             if (ops.length === 0) return;
 
@@ -727,11 +774,19 @@ export default function WidgetsAdminPage() {
                 for (const op of ops) {
                     const existing = byId.get(op.id);
                     if (!existing) continue;
-                    byId.set(op.id, {
-                        ...existing,
-                        order: op.patch.order ?? existing.order,
-                        zoneId: op.patch.zoneId ?? existing.zoneId
-                    });
+                    const next: IPlacement = { ...existing };
+                    if (op.patch.order !== undefined) next.order = op.patch.order;
+                    if (op.patch.zoneId !== undefined) next.zoneId = op.patch.zoneId;
+                    if (op.patch.parentId !== undefined) {
+                        if (op.patch.parentId === null) {
+                            next.parentId = undefined;
+                        } else {
+                            next.parentId = op.patch.parentId;
+                            next.zoneId = destZone;
+                            next.routes = [];
+                        }
+                    }
+                    byId.set(op.id, next);
                 }
                 return Array.from(byId.values());
             });
@@ -739,7 +794,7 @@ export default function WidgetsAdminPage() {
             try {
                 await Promise.all(ops.map(op => patchPlacement(op.id, op.patch)));
             } catch (err) {
-                notifyError('Could not reorder placements', err);
+                notifyError('Could not move placement', err);
                 void fetchAll(false);
             }
         },
@@ -1136,26 +1191,17 @@ function ZoneSection({
                                         onRestore={onRestore}
                                     />
                                     {isContainer && (
-                                        <div className={styles.bubble_children}>
-                                            {kids.length === 0 ? (
-                                                <span className={styles.bubble_children_empty}>
-                                                    Empty group — edit a widget and set its container to this group.
-                                                </span>
-                                            ) : (
-                                                kids.map(child => (
-                                                    <ChildPlacementRow
-                                                        key={child.id}
-                                                        placement={child}
-                                                        typeInfo={lookupType(types, child.typeId)}
-                                                        busy={busyId === child.id}
-                                                        onToggleEnabled={onToggleEnabled}
-                                                        onEdit={onEdit}
-                                                        onDelete={onDelete}
-                                                        onRestore={onRestore}
-                                                    />
-                                                ))
-                                            )}
-                                        </div>
+                                        <GroupDropArea
+                                            containerId={placement.id}
+                                            zoneId={zoneId}
+                                            childPlacements={kids}
+                                            types={types}
+                                            busyId={busyId}
+                                            onToggleEnabled={onToggleEnabled}
+                                            onEdit={onEdit}
+                                            onDelete={onDelete}
+                                            onRestore={onRestore}
+                                        />
                                     )}
                                 </Fragment>
                             );
@@ -1287,13 +1333,15 @@ function PlacementBubble({
 }
 
 /**
- * Compact, non-draggable row for a widget nested inside a layout-group
- * container. It mirrors `PlacementBubble`'s actions (enable switch, edit,
- * delete / restore) but omits the drag grip: a child's render order and
- * its container assignment are edited from the modal, not by dragging,
- * so the nesting display stays out of the zone's sortable list. The "edit"
- * modal is where an operator detaches the widget (set container to "None")
- * or moves it to a different group.
+ * Sortable row for a widget nested inside a layout-group container.
+ *
+ * Mirrors `PlacementBubble`'s actions (enable switch, edit, delete /
+ * restore) and is draggable via its own grip: dragging a child reorders
+ * it within its group, moves it to another group, or — dropped on the
+ * zone background — detaches it back to the zone. Its `useSortable` data
+ * carries `parentId` so `handleDragEnd` knows which container it came
+ * from. The id lives in the container's own `SortableContext`, so it
+ * reorders independently of the zone's top-level list.
  *
  * @param placement - The nested child placement to render.
  * @param typeInfo - Resolved widget-type label/owner for display.
@@ -1312,11 +1360,31 @@ function ChildPlacementRow({
     onDelete,
     onRestore
 }: PlacementBubbleProps) {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+        id: placement.id,
+        data: { zoneId: placement.zoneId, parentId: placement.parentId }
+    });
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition
+    };
     const label = placement.title ?? typeInfo?.label ?? placement.typeId;
 
     return (
-        <div className={styles.bubble}>
-            <span className={styles.bubble_handle} aria-hidden />
+        <div
+            ref={setNodeRef}
+            style={style}
+            className={cn(styles.bubble, isDragging && styles['bubble--dragging'])}
+        >
+            <button
+                type="button"
+                className={styles.bubble_handle}
+                aria-label={`Drag ${label} (reorder or move out of the group)`}
+                {...attributes}
+                {...listeners}
+            >
+                <GripVertical size={16} aria-hidden />
+            </button>
             <div className={styles.bubble_main}>
                 <div className={styles.bubble_top}>
                     <span className={styles.widget_label}>{label}</span>
@@ -1365,6 +1433,85 @@ function ChildPlacementRow({
                     </IconButton>
                 )}
             </div>
+        </div>
+    );
+}
+
+interface GroupDropAreaProps {
+    containerId: string;
+    zoneId: string;
+    childPlacements: IPlacement[];
+    types: IWidgetTypeSnapshot | null;
+    busyId: string | null;
+    onToggleEnabled: (placement: IPlacement, next: boolean) => void;
+    onEdit: (placement: IPlacement) => void;
+    onDelete: (placement: IPlacement) => void;
+    onRestore: (placement: IPlacement) => void;
+}
+
+/**
+ * Droppable, sortable region holding a layout-group container's children.
+ *
+ * The wrapper is a dnd-kit droppable keyed `group:<containerId>` (so a
+ * drop anywhere in the region — including an empty group — lands a widget
+ * in this container), and it hosts its own `SortableContext` over the
+ * child ids so children reorder independently of the zone's top-level
+ * list. `handleDragEnd` reads the droppable's `containerId` to attach the
+ * dragged widget. The region always renders for a container, even when
+ * empty, so there is a target to drop the first child into.
+ *
+ * @param containerId - The layout-group placement id this region nests under.
+ * @param zoneId - Zone the container lives in, forwarded as drop data.
+ * @param childPlacements - The container's children, pre-sorted by order.
+ * @param types - Type snapshot for resolving child labels.
+ * @param busyId - Placement id with an in-flight mutation, if any.
+ * @param onToggleEnabled - Enable/disable handler passed to each child.
+ * @param onEdit - Edit-modal opener passed to each child.
+ * @param onDelete - Delete handler passed to each child.
+ * @param onRestore - Restore-defaults handler passed to each child.
+ */
+function GroupDropArea({
+    containerId,
+    zoneId,
+    childPlacements,
+    types,
+    busyId,
+    onToggleEnabled,
+    onEdit,
+    onDelete,
+    onRestore
+}: GroupDropAreaProps) {
+    const { setNodeRef, isOver } = useDroppable({
+        id: `group:${containerId}`,
+        data: { containerId, zoneId }
+    });
+    const childIds = useMemo(() => childPlacements.map(c => c.id), [childPlacements]);
+
+    return (
+        <div
+            ref={setNodeRef}
+            className={cn(styles.bubble_children, isOver && styles['bubble_children--drop-target'])}
+        >
+            <SortableContext id={`group:${containerId}`} items={childIds} strategy={verticalListSortingStrategy}>
+                {childPlacements.length === 0 ? (
+                    <span className={styles.bubble_children_empty}>
+                        Empty group — drag a widget here to nest it.
+                    </span>
+                ) : (
+                    childPlacements.map(child => (
+                        <ChildPlacementRow
+                            key={child.id}
+                            placement={child}
+                            typeInfo={lookupType(types, child.typeId)}
+                            busy={busyId === child.id}
+                            onToggleEnabled={onToggleEnabled}
+                            onEdit={onEdit}
+                            onDelete={onDelete}
+                            onRestore={onRestore}
+                        />
+                    ))
+                )}
+            </SortableContext>
         </div>
     );
 }

--- a/src/frontend/components/widgets/WidgetZone.module.scss
+++ b/src/frontend/components/widgets/WidgetZone.module.scss
@@ -18,6 +18,22 @@
     gap: var(--zone-gap, var(--gap-md));
 }
 
+// A layout-group container nested inside a zone item. It is the same
+// flex container as a zone — driven by the same operator-chosen
+// `--zone-*` custom properties the component injects per group — so an
+// operator can arrange a row of widgets inside a column zone (or vice
+// versa). `width: 100%` lets it fill the zone item it lives in so its
+// own justify/align have the full width to work against.
+.group {
+    display: flex;
+    width: 100%;
+    flex-direction: var(--zone-flex-direction, column);
+    justify-content: var(--zone-justify-content, flex-start);
+    align-items: var(--zone-align-items, stretch);
+    flex-wrap: var(--zone-flex-wrap, nowrap);
+    gap: var(--zone-gap, var(--gap-md));
+}
+
 .item {
     // Allow flex items to shrink below their content width so a wide
     // widget (e.g. the block ticker) in a row layout reflows instead of

--- a/src/frontend/components/widgets/WidgetZone.tsx
+++ b/src/frontend/components/widgets/WidgetZone.tsx
@@ -21,6 +21,16 @@ const DEFAULT_LAYOUT: IZoneLayoutConfig = {
 };
 
 /**
+ * Widget-type id of the structural layout-group container. Mirrors the
+ * backend `LAYOUT_GROUP_TYPE_ID`. A widget with this id has no React
+ * component in the registry; the renderer special-cases it, drawing its
+ * `children` inside a nested flex container instead of looking up a
+ * component. Keeping the literal here avoids a frontend import of backend
+ * module code.
+ */
+const LAYOUT_GROUP_TYPE_ID = 'core:layout-group';
+
+/**
  * Map a token gap size to the CSS value the container's `gap` resolves
  * to. Sizes map to the `--gap-*` design tokens (never a raw length) so
  * zone spacing stays on the token scale; `none` is a literal `0`.
@@ -122,6 +132,83 @@ function WidgetRenderer({ widget, route, params }: WidgetRendererProps) {
 }
 
 /**
+ * Render a layout-group container: a nested flex box whose arrangement
+ * comes from the group's own resolved layout, holding the widgets an
+ * operator dropped into it.
+ *
+ * A layout group is structural, not a widget component — it has no entry
+ * in the component registry. Its flex config rides in `widget.data` (the
+ * backend echoes the group's `instanceConfig` as an `IZoneLayoutConfig`),
+ * and its `children` are the nested placements the resolver attached.
+ * Renders nothing when the group is empty so a stray container never
+ * leaves an empty box on the page.
+ *
+ * @param widget - The layout-group widget carrying `data` (its layout)
+ *   and `children` (the nested widgets).
+ * @param route - Current URL path, forwarded to each child.
+ * @param params - Route params, forwarded to each child.
+ */
+function LayoutGroupContainer({ widget, route, params }: WidgetRendererProps) {
+    const children = widget.children ?? [];
+    if (children.length === 0) {
+        return null;
+    }
+
+    const layout = (widget.data as IZoneLayoutConfig | null) ?? DEFAULT_LAYOUT;
+
+    return (
+        <div
+            className={styles.group}
+            style={zoneStyle(layout)}
+            data-widget-group={widget.id}
+        >
+            {children.map(child => (
+                <WidgetItem key={child.id} widget={child} route={route} params={params} />
+            ))}
+        </div>
+    );
+}
+
+/**
+ * Render one placed widget as a flex item: an optional operator heading
+ * (optionally linked) above the widget body. The body is either the
+ * nested layout-group container (when the item is a `core:layout-group`)
+ * or the widget's registered component via `WidgetRenderer`.
+ *
+ * Shared by the zone's top-level items and a layout group's children so
+ * both levels render identically — heading, min-width shrink, and data
+ * attributes stay in one place.
+ *
+ * @param widget - The widget data to render as an item.
+ * @param route - Current URL path passed through to the renderer.
+ * @param params - Route params passed through to the renderer.
+ */
+function WidgetItem({ widget, route, params }: WidgetRendererProps) {
+    return (
+        <div
+            className={styles.item}
+            data-widget-id={widget.id}
+            data-plugin-id={widget.pluginId}
+        >
+            {widget.title && (
+                <h2 className={styles.item_title}>
+                    {widget.titleUrl ? (
+                        <Link href={widget.titleUrl}>{widget.title}</Link>
+                    ) : (
+                        widget.title
+                    )}
+                </h2>
+            )}
+            {widget.id === LAYOUT_GROUP_TYPE_ID ? (
+                <LayoutGroupContainer widget={widget} route={route} params={params} />
+            ) : (
+                <WidgetRenderer widget={widget} route={route} params={params} />
+            )}
+        </div>
+    );
+}
+
+/**
  * Widget zone component for rendering plugin widgets with SSR support.
  *
  * This is a server component that renders plugin widgets during SSR.
@@ -190,23 +277,7 @@ export function WidgetZone({
             style={zoneStyle(effectiveLayout)}
         >
             {zoneWidgets.map(widget => (
-                <div
-                    key={widget.id}
-                    className={styles.item}
-                    data-widget-id={widget.id}
-                    data-plugin-id={widget.pluginId}
-                >
-                    {widget.title && (
-                        <h2 className={styles.item_title}>
-                            {widget.titleUrl ? (
-                                <Link href={widget.titleUrl}>{widget.title}</Link>
-                            ) : (
-                                widget.title
-                            )}
-                        </h2>
-                    )}
-                    <WidgetRenderer widget={widget} route={route} params={params} />
-                </div>
+                <WidgetItem key={widget.id} widget={widget} route={route} params={params} />
             ))}
         </div>
     );

--- a/src/frontend/components/widgets/WidgetZone.tsx
+++ b/src/frontend/components/widgets/WidgetZone.tsx
@@ -184,6 +184,16 @@ function LayoutGroupContainer({ widget, route, params }: WidgetRendererProps) {
  * @param params - Route params passed through to the renderer.
  */
 function WidgetItem({ widget, route, params }: WidgetRendererProps) {
+    // An empty layout group renders nothing (its container returns null),
+    // so skip the wrapper and title entirely — otherwise the operator
+    // heading and the flex-gap slot of an empty item leave a stray
+    // artifact in the zone.
+    const isEmptyLayoutGroup =
+        widget.id === LAYOUT_GROUP_TYPE_ID && (widget.children?.length ?? 0) === 0;
+    if (isEmptyLayoutGroup) {
+        return null;
+    }
+
     return (
         <div
             className={styles.item}

--- a/src/frontend/components/widgets/WorldClocksWidget.module.scss
+++ b/src/frontend/components/widgets/WorldClocksWidget.module.scss
@@ -1,24 +1,25 @@
 /**
  * Scoped styles for the world-clocks widget.
  *
- * A flag + time row that must stay compact and survive any host width —
- * it ships in site-wide zones (ticker, footer) where the available space
- * is unknown — so it wraps with flexbox and tightens its gap via a
- * container query rather than a viewport media query.
+ * A compact flag + time row that ships in site-wide zones (ticker, footer)
+ * where the available width is unknown. Wrap, horizontal alignment, and gap
+ * are operator-controlled per placement: the component sets the
+ * `--world-clocks-*` custom properties from the SSR `instanceConfig`, and the
+ * rules below consume them with fallbacks matching the schema defaults
+ * (single non-wrapping, left-aligned row at the medium token gap). Because
+ * spacing is now an explicit operator choice, there is no responsive gap
+ * override — honouring the chosen value beats silently retightening it.
  */
-
-@use '../../app/breakpoints' as *;
 
 .clocks {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: var(--world-clocks-wrap, nowrap);
+    justify-content: var(--world-clocks-justify, flex-start);
     align-items: center;
-    gap: var(--gap-md);
+    gap: var(--world-clocks-gap, var(--gap-md));
     margin: 0;
     padding: 0;
     list-style: none;
-    container-type: inline-size;
-    container-name: world-clocks;
 }
 
 .clock {

--- a/src/frontend/components/widgets/WorldClocksWidget.tsx
+++ b/src/frontend/components/widgets/WorldClocksWidget.tsx
@@ -2,8 +2,14 @@
  * @fileoverview Core "world clocks" widget renderer.
  *
  * Renders the operator-configured clock row carried by the
- * `core:world-clocks` widget type: a compact, horizontally-wrapping
- * sequence of country flag + live local time, one cell per time zone.
+ * `core:world-clocks` widget type: a compact, horizontal sequence of
+ * country flag + live local time, one cell per time zone. The row's
+ * wrap, horizontal alignment, and spacing are operator-set via the
+ * placement's `instanceConfig` and applied as inline CSS custom
+ * properties (see {@link WorldClocksWidget}); they default to a single
+ * non-wrapping, left-aligned row because the widget is a flex child of
+ * its zone, whose min-content width would otherwise collapse a wrapping
+ * row to one clock and stack the rest vertically.
  *
  * SSR + Live Updates: the flags and structure derive entirely from the
  * SSR `data` prop and render on the server with no hydration risk. The
@@ -28,7 +34,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import type { ComponentType, SVGProps } from 'react';
+import type { ComponentType, CSSProperties, SVGProps } from 'react';
 import * as FlagComponents from 'country-flag-icons/react/3x2';
 import type { IWidgetComponentProps } from '@/types';
 import styles from './WorldClocksWidget.module.scss';
@@ -72,6 +78,12 @@ interface IWorldClocksData {
     zones?: IWorldClockZone[];
     /** Render 12-hour (AM/PM) time when true, otherwise 24-hour. */
     hour12?: boolean;
+    /** `flex-wrap` for the row: keep one line (`nowrap`) or reflow (`wrap`). */
+    wrap?: 'nowrap' | 'wrap';
+    /** `justify-content` distributing the clocks across the widget width. */
+    justify?: 'flex-start' | 'center' | 'flex-end' | 'space-between';
+    /** Token gap size between clocks (`sm`/`md`/`lg` → `--gap-*`). */
+    gap?: 'sm' | 'md' | 'lg';
 }
 
 /**
@@ -155,17 +167,35 @@ function ClockCell({
 }
 
 /**
- * World-clocks widget: a compact, wrapping row of country flag + live
- * local time per operator-configured time zone. See the file overview for
- * the SSR + Live Updates and flag-source rationale.
+ * World-clocks widget: a compact row of country flag + live local time per
+ * operator-configured time zone, with operator-controlled wrap, alignment,
+ * and spacing applied as inline custom properties. See the file overview
+ * for the SSR + Live Updates, layout-default, and flag-source rationale.
  *
  * @param props - Widget component props; only the SSR `data` is consumed
  *   (the row needs no plugin context, route, or live socket).
  * @returns The clock row, or null when no zones are configured.
  */
 export function WorldClocksWidget({ data }: IWidgetComponentProps) {
-    const { zones = [], hour12 = false } = (data ?? {}) as IWorldClocksData;
+    const {
+        zones = [],
+        hour12 = false,
+        wrap = 'nowrap',
+        justify = 'flex-start',
+        gap = 'md'
+    } = (data ?? {}) as IWorldClocksData;
     const [now, setNow] = useState<Date | null>(null);
+
+    // Operator layout choices ride to the SCSS via custom properties rather
+    // than conditional class names: the values come straight from the SSR
+    // `data` prop, so the inline style is identical on server and client and
+    // adds no hydration risk, while the stylesheet keeps the design-token gap
+    // and sensible fallbacks. `gap` maps to a `--gap-*` token, never a raw size.
+    const layoutStyle = {
+        '--world-clocks-wrap': wrap,
+        '--world-clocks-justify': justify,
+        '--world-clocks-gap': `var(--gap-${gap})`
+    } as CSSProperties;
 
     useEffect(() => {
         // Mount gate: set the first time only after hydration, then align
@@ -193,7 +223,7 @@ export function WorldClocksWidget({ data }: IWidgetComponentProps) {
     }
 
     return (
-        <ul className={styles.clocks} aria-label="World clocks">
+        <ul className={styles.clocks} style={layoutStyle} aria-label="World clocks">
             {zones.map((zone, index) => (
                 <ClockCell
                     key={`${zone.timeZone}-${index}`}

--- a/src/frontend/components/widgets/types.ts
+++ b/src/frontend/components/widgets/types.ts
@@ -52,4 +52,13 @@ export interface WidgetData {
      * Optional on the wire; the renderer defaults it to `{}` on read.
      */
     instanceConfig?: Record<string, unknown>;
+
+    /**
+     * Child widgets nested inside this item, present only when `id` is the
+     * `core:layout-group` container type. The resolver fills it from
+     * placements pointing at this container; `WidgetZone` draws them inside
+     * a nested flex container. One level deep — children carry no children
+     * of their own.
+     */
+    children?: WidgetData[];
 }


### PR DESCRIPTION
Adds operator-controlled grouping to widget zones: a `core:layout-group` container holds other widgets with its own flexbox arrangement (e.g. a row inside a column zone), without a new zone or render site. Nesting is intentionally one level deep.

## Backend
- `parentId` threaded through the types package, Mongo document, placement service, and admin controller (three-state on PATCH, like `title`).
- `WidgetsService` enforces the contract: parent must exist, be a top-level `core:layout-group`, and a group can never itself be nested (`InvalidParentPlacementError` → 400); a child is forced into the parent's zone with cleared routes; deleting a container detaches its children back to the zone instead of cascade-deleting.
- New `core:layout-group` widget type whose `instanceConfig` is an `IZoneLayoutConfig`; the SSR resolver assembles a two-level tree and drops orphaned children. Migration `003` adds a sparse `parentId` index.

## Frontend
- `WidgetZone` special-cases the container structurally (nested flex box from the group's layout, children via a shared item helper) — no component-registry entry, documented as the deliberate exception.
- `/system/widgets` editor: drag a widget onto a group to nest it, drag a child out to detach, plus a keyboard-accessible Container picker in the modal. Nested rows render under their container.

## Also included
- World-clocks widget gains wrap/justify/gap layout controls (separate commit).
- Two shared test-mock fixes the work surfaced: `updateMany` honors `$unset`; `matchesFilter` compares ObjectId-valued non-`_id` fields by value.

Verified: full `tsc --noEmit` clean; full vitest suite green (1128 passed) including new resolver and service nesting tests.