### PR TITLE
fix(widgets): import breakpoints partial in WorldClocksWidget SCSS

### DIFF
--- a/src/frontend/components/widgets/WorldClocksWidget.module.scss
+++ b/src/frontend/components/widgets/WorldClocksWidget.module.scss
@@ -11,6 +11,8 @@
  * override — honouring the chosen value beats silently retightening it.
  */
 
+@use '../../app/breakpoints' as *;
+
 .clocks {
     display: flex;
     flex-wrap: var(--world-clocks-wrap, nowrap);


### PR DESCRIPTION
## Why

The production Docker build failed at `npm run build:frontend`:

```
./components/widgets/WorldClocksWidget.module.scss
Undefined variable.
49 │ @container world-clocks (max-width: #{$breakpoint-mobile-md}) {
> Build failed because of webpack errors
```

The `@container` query references `$breakpoint-mobile-md` but the module never imported the breakpoints partial, so SASS treated the variable as undefined and aborted the build. Introduced in `2fcb6ad5` (world-clocks wrap/justify/gap layout controls).

## How

Add the standard `@use '../../app/breakpoints' as *;` import that every other breakpoint-using SCSS module already carries. The interpolation itself was already correct; only the import was missing. It is the file's sole `$breakpoint` reference, so one import resolves it.