### PR TITLE
feat(widgets): per-child relative widths and responsive collapse

### DIFF
--- a/docs/plugins/plugins-widget-zones.md
+++ b/docs/plugins/plugins-widget-zones.md
@@ -34,7 +34,7 @@ Per request, the host layout reads the `x-pathname` middleware header and calls 
 
 ## Operator Editing
 
-`/system/widgets` is the placement editor. Each placement appears as a bubble in its zone; operators can toggle, edit, reorder (drag-and-drop, including cross-zone), restore plugin defaults, or delete operator-created rows. Mutations broadcast `widgets:placements-update` over WebSocket so every open admin tab refetches and public pages re-pull widget data. The full REST contract is in [system-api-widgets.md](../system/system-api-widgets.md).
+`/system/widgets` is the placement editor. Each placement appears as a bubble in its zone; operators can toggle, edit, reorder (drag-and-drop, including cross-zone), restore plugin defaults, or delete operator-created rows. A zone (or a `core:layout-group` nested in one) also exposes its flexbox arrangement, a per-row relative-width control, and a `collapseBelow` breakpoint that stacks a side-by-side row into a column on narrow containers — see the [Widgets Module README](../../src/backend/modules/widgets/README.md#single-level-grouping) for the per-child width and container-query collapse mechanism. Mutations broadcast `widgets:placements-update` over WebSocket so every open admin tab refetches and public pages re-pull widget data. The full REST contract is in [system-api-widgets.md](../system/system-api-widgets.md).
 
 ## Detail Documents
 

--- a/docs/system/system-api-widgets.md
+++ b/docs/system/system-api-widgets.md
@@ -21,7 +21,7 @@ The placements controller validates inputs against the live `IZoneRegistry` and 
 | GET | `/api/admin/system/zones` | — | `IZoneSnapshot` |
 | PATCH | `/api/admin/system/zones/:zoneId/layout` | `IZoneLayoutConfig` | `{ success, layoutConfig }` |
 
-GET is the tracks-grouped catalogue of every registered zone with host (`site` / `core` / `plugin` / `admin`), registration metadata, and each zone's effective `layoutConfig` (the operator override, else a default derived from the descriptor's coarse `layout` hint). PATCH persists an operator's flexbox layout for a zone — `404` on an unknown zone, `400` on an off-enum flex value — and fires `widgets:placements-update` so admin UIs refetch.
+GET is the tracks-grouped catalogue of every registered zone with host (`site` / `core` / `plugin` / `admin`), registration metadata, and each zone's effective `layoutConfig` (the operator override, else a default derived from the descriptor's coarse `layout` hint). PATCH persists an operator's flexbox layout for a zone — `404` on an unknown zone, `400` on an off-enum flex value — and fires `widgets:placements-update` so admin UIs refetch. `IZoneLayoutConfig` also carries an optional `collapseBelow` breakpoint (`never` / `mobile-sm` / `mobile-md` / `mobile-lg` / `tablet` / `desktop`); off-enum values are dropped, an absent value means the row never collapses.
 
 ### Widget Types — read-only introspection
 
@@ -60,6 +60,7 @@ The placements controller refuses input on any of:
 - `zoneId` not registered in `IZoneRegistry`.
 - `routes` entry that doesn't start with `/`, contains whitespace, or carries a glob marker outside the trailing segment.
 - `order` outside `[0, 10000]`, non-integer, or non-finite.
+- `layoutWeight` outside `[1, 12]`, non-integer, or non-finite. Sets the row's relative width (a `flex-grow` weight) when its container lays out in a row; pass `layoutWeight: null` on PATCH to clear it back to auto width (`$unset`).
 - `title` empty after trim, or longer than 80 characters. Pass `title: null` on PATCH to clear an existing override (`$unset`).
 - `titleUrl` not a root-relative internal path (must start with a single `/`; protocol-relative, absolute, or scheme URLs are rejected), or longer than 512 characters. Pass `titleUrl: null` on PATCH to clear the heading link (`$unset`).
 - `instanceConfig` not a plain object.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -171,6 +171,7 @@ export type {
     ZoneFlexWrap,
     ZoneGapSize,
     ZoneLayoutPreset,
+    ZoneCollapseBreakpoint,
     // Internal — used only by widgets-module implementation. Consumers
     // (plugins, other modules) reach zone state through IWidgetsService.
     IZoneRegistry,

--- a/packages/types/src/widget-placements/IPlacementService.ts
+++ b/packages/types/src/widget-placements/IPlacementService.ts
@@ -59,6 +59,13 @@ export interface IPlacementPatch {
     parentId?: string | null;
     routes?: string[];
     order?: number;
+    /**
+     * Set the placement's relative row width as a flex weight, or clear it
+     * back to auto width with `null` (`$unset`). Omission leaves the
+     * current width unchanged — the same three-state convention as
+     * `title`/`titleUrl`. See {@link IWidgetPlacement.layoutWeight}.
+     */
+    layoutWeight?: number | null;
     title?: string | null;
     titleUrl?: string | null;
     instanceConfig?: Record<string, unknown>;

--- a/packages/types/src/widget-placements/IWidgetPlacement.ts
+++ b/packages/types/src/widget-placements/IWidgetPlacement.ts
@@ -55,6 +55,19 @@ export interface IWidgetPlacement {
     readonly routes: ReadonlyArray<string>;
     /** Sort order within the zone (lower renders first). */
     readonly order: number;
+    /**
+     * Relative horizontal width of this placement when its container (zone
+     * or layout group) lays its items out in a row. Expressed as a flex
+     * *weight* — the renderer applies it as `flex-grow` against a zero
+     * basis, so children with weights `2` and `1` split the row two-thirds
+     * to one-third regardless of content width. Omitted means "auto": the
+     * item keeps its natural, content-driven width exactly as before this
+     * field existed. A layout property of the placement's participation in
+     * its container — a sibling of `order`, deliberately not part of
+     * `instanceConfig` (which is widget-type content the data fetcher
+     * reads). Bounded to a small integer at the admin boundary.
+     */
+    readonly layoutWeight?: number;
     /** Optional heading rendered above the widget. */
     readonly title?: string;
     /**
@@ -101,6 +114,11 @@ export interface IPlacementInput {
     parentId?: string;
     routes: string[];
     order?: number;
+    /**
+     * Relative row width as a flex weight. See
+     * {@link IWidgetPlacement.layoutWeight}. Omitted means auto width.
+     */
+    layoutWeight?: number;
     title?: string;
     /** Optional root-relative link target for the heading. See {@link IWidgetPlacement.titleUrl}. */
     titleUrl?: string;

--- a/packages/types/src/widget-zones/IZoneLayoutConfig.ts
+++ b/packages/types/src/widget-zones/IZoneLayoutConfig.ts
@@ -43,6 +43,32 @@ export type ZoneFlexWrap = 'nowrap' | 'wrap';
 export type ZoneGapSize = 'none' | 'sm' | 'md' | 'lg';
 
 /**
+ * Width threshold at which a row layout collapses to a single stacked
+ * column.
+ *
+ * Side-by-side widgets work on a wide host but crush on a narrow one, so
+ * an operator picks the container width below which the flex container
+ * flips to a column and each weighted child takes the full width. The
+ * values name the platform breakpoints (`mobile-sm` 360px … `desktop`
+ * 1200px) so the renderer can map each to a `@container` query against a
+ * `_breakpoints` variable rather than a hand-typed pixel value; `'never'`
+ * (the default when the field is unset) keeps the row at every width,
+ * preserving the historical behaviour for layouts created before this
+ * field existed.
+ *
+ * The threshold is measured against the *container's own* width — the
+ * zone or layout group — not the viewport, so a group nested in a narrow
+ * sidebar collapses independently of one spanning the full page.
+ */
+export type ZoneCollapseBreakpoint =
+    | 'never'
+    | 'mobile-sm'
+    | 'mobile-md'
+    | 'mobile-lg'
+    | 'tablet'
+    | 'desktop';
+
+/**
  * Named popular layout the admin UI offers as a one-click preset. Each
  * preset sets the four flex properties; `'custom'` marks a config the
  * operator hand-tuned past any preset so the UI shows the granular
@@ -77,4 +103,12 @@ export interface IZoneLayoutConfig {
     flexWrap: ZoneFlexWrap;
     /** Inter-item gap as a token size. */
     gap: ZoneGapSize;
+    /**
+     * Container width below which the layout collapses to a single
+     * stacked column (and weighted children reset to full width). Optional
+     * — absent or `'never'` means the row never collapses, the behaviour
+     * for every layout created before this field existed. See
+     * {@link ZoneCollapseBreakpoint}.
+     */
+    collapseBelow?: ZoneCollapseBreakpoint;
 }

--- a/packages/types/src/widget-zones/index.ts
+++ b/packages/types/src/widget-zones/index.ts
@@ -32,5 +32,6 @@ export type {
     ZoneAlignItems,
     ZoneFlexWrap,
     ZoneGapSize,
-    ZoneLayoutPreset
+    ZoneLayoutPreset,
+    ZoneCollapseBreakpoint
 } from './IZoneLayoutConfig.js';

--- a/packages/types/src/widget/IWidgetData.ts
+++ b/packages/types/src/widget/IWidgetData.ts
@@ -29,6 +29,16 @@ export interface IWidgetData {
     order: number;
 
     /**
+     * Relative horizontal width of this item when its container lays out
+     * in a row, carried verbatim from the resolved placement's
+     * `layoutWeight`. The `WidgetZone` renderer applies it as a
+     * `flex-grow` weight against a zero basis so sibling weights become
+     * width ratios. Absent means auto width — the historical behaviour for
+     * every placement created before the field existed.
+     */
+    layoutWeight?: number;
+
+    /**
      * Optional display title.
      */
     title?: string;

--- a/src/backend/modules/widgets/README.md
+++ b/src/backend/modules/widgets/README.md
@@ -60,7 +60,7 @@ All endpoints require admin auth (cookie path: verified wallet + admin group; se
 | Method | Path | Body | Returns | Notes |
 |---|---|---|---|---|
 | GET | `/api/admin/system/zones` | — | `IZoneSnapshot` — tracks (one per host) → zones, each carrying its effective `layoutConfig` | |
-| PATCH | `/api/admin/system/zones/:zoneId/layout` | `IZoneLayoutConfig` | `{ success, layoutConfig }` | 404 unknown zone; 400 off-enum flex value. Persists the operator's flexbox override |
+| PATCH | `/api/admin/system/zones/:zoneId/layout` | `IZoneLayoutConfig` | `{ success, layoutConfig }` | 404 unknown zone; 400 off-enum flex value. Persists the operator's flexbox override, including the optional `collapseBelow` breakpoint |
 
 ### Widget Types — read-only
 
@@ -75,7 +75,7 @@ All endpoints require admin auth (cookie path: verified wallet + admin group; se
 | GET | `/api/admin/system/widgets/placements` | — | `{ success, placements: IWidgetPlacement[] }` | Query: `zoneId?`, `pluginId?`, `source?` (`plugin`\|`operator`), `enabledOnly?` |
 | GET | `/api/admin/system/widgets/placements/:id` | — | `{ success, placement }` or 404 | |
 | POST | `/api/admin/system/widgets/placements` | `IPlacementInput` | `{ success, placement }` 201 | Always `source: 'operator'`; rejects unknown `typeId`/`zoneId`. Optional `parentId` nests the row in a layout group (400 if the parent isn't a top-level `core:layout-group`); a nested row's `zoneId` is forced to the parent's zone and its `routes` cleared |
-| PATCH | `/api/admin/system/widgets/placements/:id` | `IPlacementPatch` | `{ success, placement }` or 404 | Operator-editable on every row, including plugin-source. `title: null` / `titleUrl: null` clears that field; `titleUrl` must be a root-relative internal path. `parentId` is three-state like `title` — a 24-hex id attaches (forcing zone + clearing routes), `null` detaches to the zone, omission leaves nesting unchanged |
+| PATCH | `/api/admin/system/widgets/placements/:id` | `IPlacementPatch` | `{ success, placement }` or 404 | Operator-editable on every row, including plugin-source. `title: null` / `titleUrl: null` clears that field; `titleUrl` must be a root-relative internal path. `parentId` is three-state like `title` — a 24-hex id attaches (forcing zone + clearing routes), `null` detaches to the zone, omission leaves nesting unchanged. `layoutWeight` is three-state too — an integer 1–12 sets the row's relative width, `null` clears it to auto, omission leaves it unchanged |
 | DELETE | `/api/admin/system/widgets/placements/:id` | — | 204 / 400 / 404 | 400 on plugin-source rows (use disable or restore-defaults). Deleting a `core:layout-group` container detaches its children back to the zone (clears their `parentId`) rather than cascade-deleting them |
 | POST | `/api/admin/system/widgets/placements/:id/restore-defaults` | — | `{ success, placement }` | 400 on operator rows; 409 when plugin has not registered in this process |
 
@@ -119,6 +119,7 @@ The placement service emits via a callback `WidgetsModule.init()` wires to `WebS
 | `parentId` | ObjectId? | Set only on a child nested in a `core:layout-group`; references the container row's `_id`. Exposed publicly as the hex string `parentId`. Sparse-indexed (migration 003) |
 | `routes` | string[] | Route filter — empty matches every route |
 | `order` | number | Sort key within zone (lower renders first); plugin default `100` |
+| `layoutWeight` | number? | Relative row width as a flex weight (`flex-grow` against a zero basis) when the container lays out in a row; absent means auto width. Bounded 1–12 at the admin boundary. Cleared on restore-defaults alongside `parentId` |
 | `title` | string? | Operator override of widget heading |
 | `titleUrl` | string? | Operator-only root-relative URL that links the heading; only renders when `title` is set |
 | `instanceConfig` | object? | Per-instance config; the type's data fetcher consumes it |
@@ -138,6 +139,7 @@ Indexes (migration 001): `(typeId, pluginId)` sparse unique for plugin-row atomi
 | `preset` | string? | Last-selected named preset, or `custom` when hand-tuned |
 | `flexDirection` / `justifyContent` / `alignItems` / `flexWrap` | string | Flex container properties |
 | `gap` | string | Token gap size (`none`/`sm`/`md`/`lg` → `--gap-*`) |
+| `collapseBelow` | string? | Container width below which the zone collapses to a stacked column (`never`/`mobile-sm`/`mobile-md`/`mobile-lg`/`tablet`/`desktop`). Absent/`never` keeps the row at every width |
 | `updatedAt` | Date | |
 
 ## Lifecycle Semantics
@@ -169,6 +171,10 @@ An operator can group widgets inside a zone by placing a `core:layout-group` con
 A child points at its container through the placement `parentId`. `WidgetsService` enforces the contract on create/attach — the parent must exist, be a `core:layout-group`, and be top-level; a layout group can never itself be nested — and forces the child into the parent's zone with an empty route filter so the container alone governs where the group renders (`InvalidParentPlacementError` → HTTP 400 otherwise). Deleting a container calls `IPlacementService.detachChildrenOf`, relocating its children back to the zone (`$unset parentId`) so operator-configured widgets survive.
 
 The container's `instanceConfig` *is* an `IZoneLayoutConfig`; its data fetcher echoes the normalized config as the widget `data`, and `WidgetZone` styles the nested flex container from it. At SSR, `PlacementResolver` fetches placements flat, then assembles a two-level tree: each child is nested under its container's `IWidgetData.children` (sorted by the child's `order`), only top-level items are returned, and a child whose container did not resolve (disabled / route-filtered / failed) is dropped as an orphan — the same silent-skip discipline as an unregistered type.
+
+**Per-child relative width.** Each child carries an optional `layoutWeight` (a placement field, sibling of `order` — *not* `instanceConfig`). The renderer applies it as a `flex-grow` weight against a zero basis, so children with weights `2` and `1` split a row two-thirds / one-third regardless of content. Absent means auto width — unchanged from before the field existed. Operators set it from the per-row width dropdown under the group (and on top-level zone rows), since width is a property of how the container arranges its children, not of any one widget type.
+
+**Responsive collapse.** A row layout (zone or group) can collapse to a stacked column below a chosen breakpoint via `IZoneLayoutConfig.collapseBelow`. The mechanism is a container query, not a viewport media query: a flex container cannot query its own width, so `WidgetZone` wraps each container in a layout-neutral element that establishes `container-type: inline-size`, and the inner flex container carries a `.collapse_*` class whose `@container` rule flips it to a column and resets weighted children to natural width once the wrapper is narrower than the breakpoint. Measuring the container's own width means a group nested in a narrow sidebar collapses independently of one spanning the page. `never` (the default) never collapses.
 
 **Per-zone flexbox layout.** Every zone renders as a CSS flex container; placed widgets are flex items. The arrangement (direction, justify, align, wrap, gap) is an `IZoneLayoutConfig` an operator sets per zone from `/system/widgets` and the `WidgetZone` renderer applies via inline CSS custom properties (gap maps to `--gap-*` tokens). Overrides persist in `module_widgets_zone_layouts`; a zone with no row uses a default derived from its descriptor's coarse `layout` hint (`vertical` → stacked column, so untouched zones look unchanged). `WidgetsService.listZones()` merges the override (else the default) into each zone's `layoutConfig`, and `/api/widgets` returns a `zoneId → layoutConfig` map so SSR applies layout without a second call.
 

--- a/src/backend/modules/widgets/__tests__/placements.controller.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.controller.test.ts
@@ -372,3 +372,65 @@ describe('PlacementsController titleUrl validation', () => {
         );
     });
 });
+
+describe('PlacementsController layoutWeight validation', () => {
+    let widgets: IWidgetsService;
+    let logger: ISystemLogService;
+    let controller: PlacementsController;
+    let res: ReturnType<typeof buildResponseStub>;
+
+    beforeEach(() => {
+        logger = buildLoggerStub();
+        res = buildResponseStub();
+    });
+
+    it.each([0, 13, 2.5, -1])('rejects an out-of-range or fractional layoutWeight: %s', async (layoutWeight) => {
+        widgets = buildWidgetsServiceStub({
+            createPlacement: vi.fn(async () => { throw new Error('should not reach service'); })
+        });
+        controller = new PlacementsController(widgets, logger);
+
+        const req = { body: { ...validCreateBody, layoutWeight } } as Request;
+
+        await controller.createPlacement(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json.mock.calls[0][0].error).toMatch(/layoutWeight/);
+        expect(widgets.createPlacement).not.toHaveBeenCalled();
+    });
+
+    it('accepts an in-range layoutWeight and forwards it to the service', async () => {
+        widgets = buildWidgetsServiceStub({
+            createPlacement: vi.fn(async () => ({ id: 'new-id' } as IWidgetPlacement))
+        });
+        controller = new PlacementsController(widgets, logger);
+
+        const req = { body: { ...validCreateBody, layoutWeight: 2 } } as Request;
+
+        await controller.createPlacement(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(201);
+        expect(widgets.createPlacement).toHaveBeenCalledWith(
+            expect.objectContaining({ layoutWeight: 2 })
+        );
+    });
+
+    it('forwards layoutWeight: null on patch as an explicit clear signal', async () => {
+        widgets = buildWidgetsServiceStub({
+            updatePlacement: vi.fn(async () => ({ id: 'p1' } as IWidgetPlacement))
+        });
+        controller = new PlacementsController(widgets, logger);
+
+        const req = {
+            params: { id: 'p1' },
+            body: { layoutWeight: null }
+        } as unknown as Request;
+
+        await controller.updatePlacement(req, res);
+
+        expect(widgets.updatePlacement).toHaveBeenCalledWith(
+            'p1',
+            expect.objectContaining({ layoutWeight: null })
+        );
+    });
+});

--- a/src/backend/modules/widgets/__tests__/placements.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.test.ts
@@ -380,6 +380,22 @@ describe('PlacementService CRUD', () => {
         expect(cleared?.title).toBe('Operator Title');
     });
 
+    it('persists layoutWeight on create and clears it with layoutWeight: null', async () => {
+        const placement = await service.create({
+            typeId: 't',
+            zoneId: 'main-after',
+            routes: ['/'],
+            layoutWeight: 2
+        });
+        expect(placement.layoutWeight).toBe(2);
+
+        const updated = await service.update(placement.id, { layoutWeight: 3 });
+        expect(updated?.layoutWeight).toBe(3);
+
+        const cleared = await service.update(placement.id, { layoutWeight: null });
+        expect(cleared?.layoutWeight).toBeUndefined();
+    });
+
     it('update preserves untouched fields', async () => {
         const placement = await service.create({
             typeId: 't',

--- a/src/backend/modules/widgets/__tests__/widgets.service.test.ts
+++ b/src/backend/modules/widgets/__tests__/widgets.service.test.ts
@@ -700,15 +700,18 @@ describe('WidgetsService zone layout', () => {
             justifyContent: 'center',
             alignItems: 'center',
             flexWrap: 'nowrap',
-            gap: 'lg'
+            gap: 'lg',
+            collapseBelow: 'mobile-lg'
         });
         expect(stored.flexDirection).toBe('row');
+        expect(stored.collapseBelow).toBe('mobile-lg');
 
         const zone = findZone(widgets, 'main-after');
         expect(zone?.layoutConfig.flexDirection).toBe('row');
         expect(zone?.layoutConfig.justifyContent).toBe('center');
         expect(zone?.layoutConfig.gap).toBe('lg');
         expect(zone?.layoutConfig.preset).toBe('row-center');
+        expect(zone?.layoutConfig.collapseBelow).toBe('mobile-lg');
     });
 
     it('rejects a layout write for an unregistered zone', async () => {

--- a/src/backend/modules/widgets/api/placements.controller.ts
+++ b/src/backend/modules/widgets/api/placements.controller.ts
@@ -56,6 +56,18 @@ interface IInstanceConfigFieldError {
 const MAX_ORDER = 10_000;
 
 /**
+ * Bounds on a placement's `layoutWeight` (relative row width). The value
+ * is a flex-grow weight, so the absolute number only matters relative to
+ * its siblings — `1`/`2`/`3` already expresses every common split. Capping
+ * at 12 keeps the value a small integer (a sane ratio, not an accidental
+ * 9999) while leaving room for finer ratios than the admin UI's preset
+ * buttons offer; the floor of 1 forbids `0` (which would collapse the item
+ * to zero width) and negatives.
+ */
+const MIN_LAYOUT_WEIGHT = 1;
+const MAX_LAYOUT_WEIGHT = 12;
+
+/**
  * Upper bound on a placement `title` override length. Matches the
  * column budget of the rendered card heading.
  */
@@ -395,7 +407,7 @@ export class PlacementsController {
     };
 
     private parseCreateBody(body: unknown):
-        | { input: { typeId: string; zoneId: string; parentId?: string; routes: string[]; order?: number; title?: string; titleUrl?: string; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
+        | { input: { typeId: string; zoneId: string; parentId?: string; routes: string[]; order?: number; layoutWeight?: number; title?: string; titleUrl?: string; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
         | { error: string } {
         if (!body || typeof body !== 'object') {
             return { error: 'Request body must be an object' };
@@ -425,6 +437,9 @@ export class PlacementsController {
         const orderResult = this.parseOrder(b.order);
         if ('error' in orderResult) return orderResult;
 
+        const layoutWeightResult = this.parseLayoutWeight(b.layoutWeight);
+        if ('error' in layoutWeightResult) return layoutWeightResult;
+
         const titleResult = this.parseTitle(b.title);
         if ('error' in titleResult) return titleResult;
 
@@ -443,6 +458,7 @@ export class PlacementsController {
                 parentId: parentIdResult.parentId,
                 routes: routesResult.routes,
                 order: orderResult.order,
+                layoutWeight: layoutWeightResult.layoutWeight,
                 title: titleResult.title,
                 titleUrl: titleUrlResult.titleUrl,
                 instanceConfig: instanceConfigResult.instanceConfig,
@@ -452,13 +468,13 @@ export class PlacementsController {
     }
 
     private parsePatchBody(body: unknown):
-        | { patch: { zoneId?: string; routes?: string[]; order?: number; title?: string | null; titleUrl?: string | null; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
+        | { patch: { zoneId?: string; routes?: string[]; order?: number; layoutWeight?: number | null; title?: string | null; titleUrl?: string | null; instanceConfig?: Record<string, unknown>; enabled?: boolean } }
         | { error: string } {
         if (!body || typeof body !== 'object') {
             return { error: 'Request body must be an object' };
         }
         const b = body as Record<string, unknown>;
-        const patch: { zoneId?: string; parentId?: string | null; routes?: string[]; order?: number; title?: string | null; titleUrl?: string | null; instanceConfig?: Record<string, unknown>; enabled?: boolean } = {};
+        const patch: { zoneId?: string; parentId?: string | null; routes?: string[]; order?: number; layoutWeight?: number | null; title?: string | null; titleUrl?: string | null; instanceConfig?: Record<string, unknown>; enabled?: boolean } = {};
 
         if (b.zoneId !== undefined) {
             if (typeof b.zoneId !== 'string' || b.zoneId.length === 0) {
@@ -494,6 +510,17 @@ export class PlacementsController {
             const result = this.parseOrder(b.order);
             if ('error' in result) return result;
             if (result.order !== undefined) patch.order = result.order;
+        }
+
+        if (b.layoutWeight !== undefined) {
+            if (b.layoutWeight === null) {
+                // Explicit clear back to auto width.
+                patch.layoutWeight = null;
+            } else {
+                const result = this.parseLayoutWeight(b.layoutWeight);
+                if ('error' in result) return result;
+                if (result.layoutWeight !== undefined) patch.layoutWeight = result.layoutWeight;
+            }
         }
 
         if (b.title !== undefined) {
@@ -581,6 +608,32 @@ export class PlacementsController {
             return { error: `order must be between 0 and ${MAX_ORDER}` };
         }
         return { order: value };
+    }
+
+    /**
+     * Validate an optional `layoutWeight` (relative row width). Accepts a
+     * small positive integer in `[MIN_LAYOUT_WEIGHT, MAX_LAYOUT_WEIGHT]`
+     * (nest under that width ratio) or absence (auto width). `null` is the
+     * patch caller's explicit-clear signal and is handled there, never
+     * reaching here. Bounding at the boundary keeps an out-of-range or
+     * fractional weight out of the stored document and the inline CSS the
+     * renderer emits.
+     *
+     * @param value - Raw `layoutWeight` from the request body.
+     * @returns The validated weight (or undefined when absent), or an error.
+     */
+    private parseLayoutWeight(value: unknown): { layoutWeight?: number } | { error: string } {
+        if (value === undefined) return { layoutWeight: undefined };
+        if (typeof value !== 'number' || !Number.isFinite(value)) {
+            return { error: 'layoutWeight must be a finite number' };
+        }
+        if (!Number.isInteger(value)) {
+            return { error: 'layoutWeight must be an integer' };
+        }
+        if (value < MIN_LAYOUT_WEIGHT || value > MAX_LAYOUT_WEIGHT) {
+            return { error: `layoutWeight must be between ${MIN_LAYOUT_WEIGHT} and ${MAX_LAYOUT_WEIGHT}` };
+        }
+        return { layoutWeight: value };
     }
 
     private parseTitle(value: unknown): { title?: string } | { error: string } {

--- a/src/backend/modules/widgets/api/zones.controller.ts
+++ b/src/backend/modules/widgets/api/zones.controller.ts
@@ -19,6 +19,7 @@ const ALIGN_ITEMS = ['stretch', 'flex-start', 'center', 'flex-end', 'baseline'] 
 const FLEX_WRAPS = ['nowrap', 'wrap'] as const;
 const GAP_SIZES = ['none', 'sm', 'md', 'lg'] as const;
 const LAYOUT_PRESETS = ['row-left', 'row-center', 'row-between', 'row-right', 'row-wrap', 'column', 'custom'] as const;
+const COLLAPSE_BREAKPOINTS = ['never', 'mobile-sm', 'mobile-md', 'mobile-lg', 'tablet', 'desktop'] as const;
 
 /**
  * Validate and coerce an operator-supplied layout body into a typed
@@ -56,6 +57,12 @@ function validateLayoutBody(body: unknown): { config?: IZoneLayoutConfig; error?
     if (b.preset !== undefined) {
         const preset = check('preset', LAYOUT_PRESETS);
         if (preset) config.preset = preset;
+    }
+    // collapseBelow is optional; accept only a known breakpoint, else omit
+    // (an omitted/unknown value means the zone never collapses).
+    if (b.collapseBelow !== undefined) {
+        const collapseBelow = check('collapseBelow', COLLAPSE_BREAKPOINTS);
+        if (collapseBelow) config.collapseBelow = collapseBelow;
     }
     return { config };
 }

--- a/src/backend/modules/widgets/database/IWidgetPlacementDocument.ts
+++ b/src/backend/modules/widgets/database/IWidgetPlacementDocument.ts
@@ -44,6 +44,13 @@ export interface IWidgetPlacementDocument {
     routes: string[];
     /** Sort order within the zone (lower renders first). */
     order: number;
+    /**
+     * Relative row width as a flex weight (see
+     * `IWidgetPlacement.layoutWeight`). Absent means auto width. Stored as
+     * a plain number; Mongoose tolerates the optional field with no
+     * migration since unset rows simply omit it.
+     */
+    layoutWeight?: number;
     /** Optional heading rendered above the widget. */
     title?: string;
     /** Optional root-relative URL linking the heading. Operator-only. */

--- a/src/backend/modules/widgets/database/IZoneLayoutDocument.ts
+++ b/src/backend/modules/widgets/database/IZoneLayoutDocument.ts
@@ -16,6 +16,7 @@
 
 import type { ObjectId } from 'mongodb';
 import type {
+    IZoneLayoutConfig,
     ZoneFlexDirection,
     ZoneJustifyContent,
     ZoneAlignItems,
@@ -45,6 +46,14 @@ export interface IZoneLayoutDocument {
     flexWrap: ZoneFlexWrap;
     /** Inter-item gap as a token size. */
     gap: ZoneGapSize;
+    /**
+     * Container width below which the zone collapses to a stacked column.
+     * Absent or `'never'` means the zone never collapses — the behaviour
+     * for every zone configured before this field existed. Typed off
+     * `IZoneLayoutConfig` so the document and the public config never
+     * drift.
+     */
+    collapseBelow?: IZoneLayoutConfig['collapseBelow'];
     updatedAt: Date;
 }
 

--- a/src/backend/modules/widgets/placements/placement-resolver.ts
+++ b/src/backend/modules/widgets/placements/placement-resolver.ts
@@ -217,6 +217,10 @@ export class PlacementResolver {
                 zone: placement.zoneId,
                 pluginId: owner,
                 order: placement.order,
+                // Carry the placement's relative row width through to the
+                // renderer so it can size this flex item; absent leaves it
+                // auto-width as before.
+                layoutWeight: placement.layoutWeight,
                 title: placement.title,
                 titleUrl: placement.titleUrl,
                 data,

--- a/src/backend/modules/widgets/placements/placement.service.ts
+++ b/src/backend/modules/widgets/placements/placement.service.ts
@@ -301,6 +301,7 @@ export class PlacementService implements IPlacementService {
         if (input.parentId !== undefined && ObjectId.isValid(input.parentId)) {
             doc.parentId = new ObjectId(input.parentId);
         }
+        if (input.layoutWeight !== undefined) doc.layoutWeight = input.layoutWeight;
         if (input.title !== undefined) doc.title = input.title;
         if (input.titleUrl !== undefined) doc.titleUrl = input.titleUrl;
         if (input.instanceConfig !== undefined) doc.instanceConfig = input.instanceConfig;
@@ -333,6 +334,13 @@ export class PlacementService implements IPlacementService {
         }
         if (patch.routes !== undefined) setOps.routes = [...patch.routes];
         if (patch.order !== undefined) setOps.order = patch.order;
+        if (patch.layoutWeight === null) {
+            // Explicit clear — drop the weight so the item falls back to
+            // auto (content-driven) width.
+            unsetOps.layoutWeight = '';
+        } else if (patch.layoutWeight !== undefined) {
+            setOps.layoutWeight = patch.layoutWeight;
+        }
         if (patch.title === null) {
             // Explicit unset signal — drop the title field so the
             // placement falls back to the widget-type label.
@@ -423,11 +431,14 @@ export class PlacementService implements IPlacementService {
         // Plugin registration defaults never nest a widget, so a faithful
         // restore must drop any operator-applied `parentId` — otherwise the
         // UI reports "defaults restored" while the resolver still renders
-        // the widget inside the old container. Also `$unset` the optional
+        // the widget inside the old container. `layoutWeight` is dropped for
+        // the same reason: it is a row-layout property of the container the
+        // widget was nested in, meaningless once the row falls back to a
+        // plain top-level plugin placement. Also `$unset` the optional
         // title field when the plugin never set one so the restored row
         // matches a fresh plugin registration exactly, not "plugin defaults
         // plus operator title".
-        const unsetOps: Record<string, ''> = { parentId: '' };
+        const unsetOps: Record<string, ''> = { parentId: '', layoutWeight: '' };
         if (defaults.title !== undefined) {
             setOps.title = defaults.title;
         } else {
@@ -498,6 +509,7 @@ function toPublic(doc: IWidgetPlacementDocument): IWidgetPlacement {
         parentId: doc.parentId ? doc.parentId.toHexString() : undefined,
         routes: doc.routes,
         order: doc.order,
+        layoutWeight: doc.layoutWeight,
         title: doc.title,
         titleUrl: doc.titleUrl,
         instanceConfig: doc.instanceConfig,

--- a/src/backend/modules/widgets/widget-types/core-widget-types.ts
+++ b/src/backend/modules/widgets/widget-types/core-widget-types.ts
@@ -397,7 +397,21 @@ async function fetchLayoutGroupData(
             ? config.gap
             : DEFAULT_GROUP_LAYOUT.gap;
 
-    return { flexDirection, justifyContent, alignItems, flexWrap, gap };
+    // Collapse breakpoint is optional; normalize to a known value or omit
+    // it entirely (the renderer treats an absent value as 'never', so a
+    // legacy container with no collapse setting keeps its row at every
+    // width).
+    const collapseBelow: IZoneLayoutConfig['collapseBelow'] | undefined =
+        config.collapseBelow === 'mobile-sm' ||
+        config.collapseBelow === 'mobile-md' ||
+        config.collapseBelow === 'mobile-lg' ||
+        config.collapseBelow === 'tablet' ||
+        config.collapseBelow === 'desktop' ||
+        config.collapseBelow === 'never'
+            ? config.collapseBelow
+            : undefined;
+
+    return { flexDirection, justifyContent, alignItems, flexWrap, gap, collapseBelow };
 }
 
 /**
@@ -455,6 +469,14 @@ export const LAYOUT_GROUP_CONFIG_SCHEMA: JSONSchema7 = {
             default: 'md',
             title: 'Gap',
             description: 'Spacing between grouped widgets, mapped to the --gap-* tokens.'
+        },
+        collapseBelow: {
+            type: 'string',
+            enum: ['never', 'mobile-sm', 'mobile-md', 'mobile-lg', 'tablet', 'desktop'],
+            default: 'never',
+            title: 'Collapse below',
+            description:
+                'Stack the grouped widgets into a single column when the group is narrower than this breakpoint (measured against the group\'s own width, not the screen). Widths reset to full when collapsed. "never" keeps the row at every width.'
         }
     }
 };

--- a/src/backend/modules/widgets/zones/zone-layout.service.ts
+++ b/src/backend/modules/widgets/zones/zone-layout.service.ts
@@ -189,6 +189,9 @@ export class ZoneLayoutService {
         if (config.preset !== undefined) {
             setOps.preset = config.preset;
         }
+        if (config.collapseBelow !== undefined) {
+            setOps.collapseBelow = config.collapseBelow;
+        }
 
         await collection.updateOne(
             { zoneId },
@@ -202,7 +205,8 @@ export class ZoneLayoutService {
             justifyContent: config.justifyContent,
             alignItems: config.alignItems,
             flexWrap: config.flexWrap,
-            gap: config.gap
+            gap: config.gap,
+            collapseBelow: config.collapseBelow
         };
         this.cache.set(zoneId, stored);
 
@@ -244,6 +248,7 @@ function toConfig(doc: IZoneLayoutDocument): IZoneLayoutConfig {
         justifyContent: doc.justifyContent,
         alignItems: doc.alignItems,
         flexWrap: doc.flexWrap,
-        gap: doc.gap
+        gap: doc.gap,
+        collapseBelow: doc.collapseBelow
     };
 }

--- a/src/backend/modules/widgets/zones/zone-layout.service.ts
+++ b/src/backend/modules/widgets/zones/zone-layout.service.ts
@@ -186,18 +186,28 @@ export class ZoneLayoutService {
             gap: config.gap,
             updatedAt: now
         };
+        // Optional fields use $set when present and $unset when omitted so a
+        // full-config write never leaves a stale breakpoint/preset behind:
+        // the persisted row, the returned config, and the in-memory cache
+        // stay identical, and a later load() cannot resurrect a value the
+        // caller dropped.
+        const unsetOps: Partial<Record<'preset' | 'collapseBelow', ''>> = {};
         if (config.preset !== undefined) {
             setOps.preset = config.preset;
+        } else {
+            unsetOps.preset = '';
         }
         if (config.collapseBelow !== undefined) {
             setOps.collapseBelow = config.collapseBelow;
+        } else {
+            unsetOps.collapseBelow = '';
         }
 
-        await collection.updateOne(
-            { zoneId },
-            { $set: setOps, $setOnInsert: { zoneId } },
-            { upsert: true }
-        );
+        const update: Record<string, unknown> = { $set: setOps, $setOnInsert: { zoneId } };
+        if (Object.keys(unsetOps).length > 0) {
+            update.$unset = unsetOps;
+        }
+        await collection.updateOne({ zoneId }, update, { upsert: true });
 
         const stored: IZoneLayoutConfig = {
             preset: config.preset,

--- a/src/frontend/app/(core)/system/widgets/page.module.scss
+++ b/src/frontend/app/(core)/system/widgets/page.module.scss
@@ -275,6 +275,13 @@
     gap: var(--gap-xs);
 }
 
+// Compact relative-width dropdown sitting inline in a row's action cluster.
+// The Select sizes intrinsically to its short labels (Auto / 1×–4×); the
+// smaller caption font keeps it from crowding the switch and icon buttons.
+.width_select {
+    font-size: var(--font-size-caption);
+}
+
 /* Children of a layout-group container, indented under its bubble with a
  * left rule so the nesting reads at a glance. Non-draggable in this
  * iteration — order and container assignment are edited from the modal. */

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -90,6 +90,12 @@ interface IPlacement {
     parentId?: string;
     routes: string[];
     order: number;
+    /**
+     * Relative row width as a flex weight when the container lays out in a
+     * row. Absent means auto (content) width. Edited via the per-row width
+     * control on a layout group's children (and top-level zone rows).
+     */
+    layoutWeight?: number;
     title?: string;
     titleUrl?: string;
     instanceConfig?: Record<string, unknown>;
@@ -114,6 +120,12 @@ interface IPlacementPatch {
     parentId?: string | null | undefined;
     routes?: string[];
     order?: number;
+    /**
+     * Set the relative row width, or clear it back to auto with `null`.
+     * Omission leaves it unchanged — the same three-state convention as
+     * `title`.
+     */
+    layoutWeight?: number | null | undefined;
     title?: string | null | undefined;
     titleUrl?: string | null | undefined;
     instanceConfig?: Record<string, unknown>;
@@ -287,6 +299,37 @@ const WRAP_OPTIONS = ['nowrap', 'wrap'] as const;
 const GAP_OPTIONS = ['none', 'sm', 'md', 'lg'] as const;
 
 /**
+ * Collapse-breakpoint dropdown options. The value is the
+ * `ZoneCollapseBreakpoint` stored on the layout; the label spells out the
+ * pixel width so an operator picks a threshold without memorising the
+ * breakpoint names. `'never'` is first (the default) so an untouched
+ * control reads "Never (stay a row)".
+ */
+const COLLAPSE_OPTIONS: ReadonlyArray<{ value: NonNullable<IZoneLayoutConfig['collapseBelow']>; label: string }> = [
+    { value: 'never', label: 'Never (stay a row)' },
+    { value: 'mobile-sm', label: 'Below 360px (mobile S)' },
+    { value: 'mobile-md', label: 'Below 480px (mobile M)' },
+    { value: 'mobile-lg', label: 'Below 768px (mobile L)' },
+    { value: 'tablet', label: 'Below 1024px (tablet)' },
+    { value: 'desktop', label: 'Below 1200px (desktop)' }
+];
+
+/**
+ * Per-row relative-width options. The empty value clears `layoutWeight`
+ * back to auto (content) width; the numbered values set the flex weight so
+ * two rows at `2×` and `1×` split a row two-thirds / one-third. Kept short
+ * (1×–4×) because finer ratios are rarely useful and the raw weight is
+ * still editable via the modal's JSON for power users.
+ */
+const WIDTH_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+    { value: '', label: 'Auto' },
+    { value: '1', label: '1×' },
+    { value: '2', label: '2×' },
+    { value: '3', label: '3×' },
+    { value: '4', label: '4×' }
+];
+
+/**
  * Per-zone flexbox controls: a preset dropdown that sets the common
  * arrangements in one click, plus granular dropdowns (direction,
  * justify, align, wrap, gap) for fine-tuning. Selecting a preset applies
@@ -404,6 +447,17 @@ function ZoneLayoutControls({
                     disabled={disabled}
                 >
                     {GAP_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
+                </Select>
+            </div>
+            <div className={styles.zone_layout_field}>
+                <label className={styles.filter_label} htmlFor={`zl-collapse-${zoneId}`}>Collapse</label>
+                <Select
+                    id={`zl-collapse-${zoneId}`}
+                    value={layout.collapseBelow ?? 'never'}
+                    onChange={(e) => applyGranular({ collapseBelow: e.target.value as IZoneLayoutConfig['collapseBelow'] }, true)}
+                    disabled={disabled}
+                >
+                    {COLLAPSE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
                 </Select>
             </div>
         </div>
@@ -1077,6 +1131,7 @@ export default function WidgetsAdminPage() {
                                                 onEdit={(p) => openPlacementModal('edit', p)}
                                                 onDelete={openDeleteModal}
                                                 onRestore={(p) => restoreDefaults(p.id)}
+                                                onSetWidth={(p, weight) => togglePlacement(p.id, { layoutWeight: weight })}
                                                 onLayoutChange={setZoneLayout}
                                             />
                                         ))}
@@ -1107,6 +1162,7 @@ interface ZoneSectionProps {
     onEdit: (placement: IPlacement) => void;
     onDelete: (placement: IPlacement) => void;
     onRestore: (placement: IPlacement) => void;
+    onSetWidth: (placement: IPlacement, weight: number | null) => void;
     onLayoutChange: (zoneId: string, config: IZoneLayoutConfig) => void;
 }
 
@@ -1122,6 +1178,7 @@ function ZoneSection({
     onEdit,
     onDelete,
     onRestore,
+    onSetWidth,
     onLayoutChange
 }: ZoneSectionProps) {
     const zoneInfo = lookupZone(zones, zoneId);
@@ -1189,6 +1246,7 @@ function ZoneSection({
                                         onEdit={onEdit}
                                         onDelete={onDelete}
                                         onRestore={onRestore}
+                                        onSetWidth={onSetWidth}
                                     />
                                     {isContainer && (
                                         <GroupDropArea
@@ -1201,6 +1259,7 @@ function ZoneSection({
                                             onEdit={onEdit}
                                             onDelete={onDelete}
                                             onRestore={onRestore}
+                                            onSetWidth={onSetWidth}
                                         />
                                     )}
                                 </Fragment>
@@ -1225,6 +1284,52 @@ interface PlacementBubbleProps {
     onEdit: (placement: IPlacement) => void;
     onDelete: (placement: IPlacement) => void;
     onRestore: (placement: IPlacement) => void;
+    /**
+     * Set this row's relative width (a flex weight) or clear it to auto
+     * with `null`. Drives the inline width dropdown so an operator tunes
+     * side-by-side widths without opening the modal.
+     */
+    onSetWidth: (placement: IPlacement, weight: number | null) => void;
+}
+
+/**
+ * Inline relative-width dropdown for a placement row.
+ *
+ * Surfaces per-child width tuning on the row itself — the layout-group's
+ * own editing surface — so an operator builds a "two-thirds / one-third"
+ * row by setting each child's width here rather than hand-editing JSON.
+ * Selecting "Auto" clears the weight (`null`); a number sets the flex
+ * weight. Extracted so the top-level and nested rows share one control.
+ *
+ * @param placement - The row whose width this edits.
+ * @param disabled - Whether the control is inert (a write is in flight).
+ * @param onSetWidth - Persists the new weight (or `null` to clear).
+ */
+function WidthSelect({
+    placement,
+    disabled,
+    onSetWidth
+}: {
+    placement: IPlacement;
+    disabled: boolean;
+    onSetWidth: (placement: IPlacement, weight: number | null) => void;
+}) {
+    const value = placement.layoutWeight !== undefined ? String(placement.layoutWeight) : '';
+    return (
+        <Select
+            className={styles.width_select}
+            value={value}
+            disabled={disabled}
+            aria-label={`Relative width for ${placement.title ?? placement.typeId}`}
+            title="Relative width when this row sits in a side-by-side layout"
+            onChange={(e) => {
+                const raw = e.target.value;
+                onSetWidth(placement, raw === '' ? null : Number(raw));
+            }}
+        >
+            {WIDTH_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+        </Select>
+    );
 }
 
 /**
@@ -1241,7 +1346,8 @@ function PlacementBubble({
     onToggleEnabled,
     onEdit,
     onDelete,
-    onRestore
+    onRestore,
+    onSetWidth
 }: PlacementBubbleProps) {
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
         id: placement.id,
@@ -1292,6 +1398,7 @@ function PlacementBubble({
                 </div>
             </div>
             <div className={styles.bubble_actions}>
+                <WidthSelect placement={placement} disabled={busy} onSetWidth={onSetWidth} />
                 <Switch
                     size="sm"
                     on={placement.enabled}
@@ -1358,7 +1465,8 @@ function ChildPlacementRow({
     onToggleEnabled,
     onEdit,
     onDelete,
-    onRestore
+    onRestore,
+    onSetWidth
 }: PlacementBubbleProps) {
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
         id: placement.id,
@@ -1397,6 +1505,7 @@ function ChildPlacementRow({
                 <span className={styles.widget_meta}>{placement.typeId}</span>
             </div>
             <div className={styles.bubble_actions}>
+                <WidthSelect placement={placement} disabled={busy} onSetWidth={onSetWidth} />
                 <Switch
                     size="sm"
                     on={placement.enabled}
@@ -1447,6 +1556,7 @@ interface GroupDropAreaProps {
     onEdit: (placement: IPlacement) => void;
     onDelete: (placement: IPlacement) => void;
     onRestore: (placement: IPlacement) => void;
+    onSetWidth: (placement: IPlacement, weight: number | null) => void;
 }
 
 /**
@@ -1479,7 +1589,8 @@ function GroupDropArea({
     onToggleEnabled,
     onEdit,
     onDelete,
-    onRestore
+    onRestore,
+    onSetWidth
 }: GroupDropAreaProps) {
     const { setNodeRef, isOver } = useDroppable({
         id: `group:${containerId}`,
@@ -1508,6 +1619,7 @@ function GroupDropArea({
                             onEdit={onEdit}
                             onDelete={onDelete}
                             onRestore={onRestore}
+                            onSetWidth={onSetWidth}
                         />
                     ))
                 )}

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -318,8 +318,7 @@ const COLLAPSE_OPTIONS: ReadonlyArray<{ value: NonNullable<IZoneLayoutConfig['co
  * Per-row relative-width options. The empty value clears `layoutWeight`
  * back to auto (content) width; the numbered values set the flex weight so
  * two rows at `2×` and `1×` split a row two-thirds / one-third. Kept short
- * (1×–4×) because finer ratios are rarely useful and the raw weight is
- * still editable via the modal's JSON for power users.
+ * (1×–4×) because finer ratios are rarely useful.
  */
 const WIDTH_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
     { value: '', label: 'Auto' },
@@ -1303,15 +1302,20 @@ interface PlacementBubbleProps {
  *
  * @param placement - The row whose width this edits.
  * @param disabled - Whether the control is inert (a write is in flight).
+ * @param label - Human-readable widget name for the control's accessible
+ *   name, so a screen reader announces "Relative width for Layout group"
+ *   rather than the raw typeId (`core:layout-group`).
  * @param onSetWidth - Persists the new weight (or `null` to clear).
  */
 function WidthSelect({
     placement,
     disabled,
+    label,
     onSetWidth
 }: {
     placement: IPlacement;
     disabled: boolean;
+    label: string;
     onSetWidth: (placement: IPlacement, weight: number | null) => void;
 }) {
     const value = placement.layoutWeight !== undefined ? String(placement.layoutWeight) : '';
@@ -1320,7 +1324,7 @@ function WidthSelect({
             className={styles.width_select}
             value={value}
             disabled={disabled}
-            aria-label={`Relative width for ${placement.title ?? placement.typeId}`}
+            aria-label={`Relative width for ${label}`}
             title="Relative width when this row sits in a side-by-side layout"
             onChange={(e) => {
                 const raw = e.target.value;
@@ -1398,7 +1402,7 @@ function PlacementBubble({
                 </div>
             </div>
             <div className={styles.bubble_actions}>
-                <WidthSelect placement={placement} disabled={busy} onSetWidth={onSetWidth} />
+                <WidthSelect placement={placement} disabled={busy} label={label} onSetWidth={onSetWidth} />
                 <Switch
                     size="sm"
                     on={placement.enabled}
@@ -1505,7 +1509,7 @@ function ChildPlacementRow({
                 <span className={styles.widget_meta}>{placement.typeId}</span>
             </div>
             <div className={styles.bubble_actions}>
-                <WidthSelect placement={placement} disabled={busy} onSetWidth={onSetWidth} />
+                <WidthSelect placement={placement} disabled={busy} label={label} onSetWidth={onSetWidth} />
                 <Switch
                     size="sm"
                     on={placement.enabled}

--- a/src/frontend/components/widgets/WidgetZone.module.scss
+++ b/src/frontend/components/widgets/WidgetZone.module.scss
@@ -7,7 +7,41 @@
  * token-backed fallbacks. Keeping the values in custom properties lets the
  * same static rule render a stacked column, a centered row, or a wrapping
  * grid depending on the operator's choice — no per-layout class needed.
+ *
+ * Responsive collapse is container-query driven: a flex container cannot
+ * query its own width, so each container is wrapped in a layout-neutral
+ * element (`.zone_container` / `.group_container`) that establishes the
+ * `container-type`. The inner flex container then carries a `.collapse_*`
+ * class whose `@container` rule flips it to a column below the chosen
+ * breakpoint. Both wrappers share the `widget-layout` container name; a
+ * `@container widget-layout (...)` query resolves to the *nearest* such
+ * ancestor, so a group nested in a zone collapses against the group's own
+ * width while the zone collapses against the zone's — no per-level naming
+ * needed.
  */
+
+@use '../../app/breakpoints' as *;
+
+/**
+ * Container-query context for a zone. Layout-neutral (full-width block) so
+ * wrapping the flex container changes nothing visually; its only job is to
+ * give the inner `.zone` an ancestor whose inline width `@container` rules
+ * can measure.
+ */
+.zone_container {
+    display: block;
+    width: 100%;
+    container-type: inline-size;
+    container-name: widget-layout;
+}
+
+/** Container-query context for a layout group — see `.zone_container`. */
+.group_container {
+    display: block;
+    width: 100%;
+    container-type: inline-size;
+    container-name: widget-layout;
+}
 
 .zone {
     display: flex;
@@ -39,6 +73,73 @@
     // widget (e.g. the block ticker) in a row layout reflows instead of
     // forcing the container to overflow.
     min-width: 0;
+}
+
+// A weighted item takes a relative share of a row. The weight rides in the
+// `--item-grow` custom property (set inline by the renderer) and feeds
+// `flex-grow`; the zero basis makes sibling weights pure ratios (a `2` and
+// a `1` split two-thirds / one-third regardless of content). Kept in this
+// class — never inline `flex` — so the collapse rules below can override it.
+.item_weighted {
+    flex: var(--item-grow, 1) 1 0;
+}
+
+// Responsive collapse. Each class flips the inner flex container to a
+// column once its wrapper is narrower than the named breakpoint, and resets
+// its own *direct* weighted children (the child combinator keeps a zone's
+// collapse from reaching into a nested group's children) to natural,
+// full-width stacking — `flex: 0 0 auto` undoes the zero-basis grow that
+// only makes sense on a row's main axis. The breakpoint variable must be
+// interpolated (`#{…}`) inside `@container` or Sass silently drops the
+// condition.
+.collapse_mobile_sm {
+    @container widget-layout (max-width: #{$breakpoint-mobile-sm}) {
+        flex-direction: column;
+
+        > .item_weighted {
+            flex: 0 0 auto;
+        }
+    }
+}
+
+.collapse_mobile_md {
+    @container widget-layout (max-width: #{$breakpoint-mobile-md}) {
+        flex-direction: column;
+
+        > .item_weighted {
+            flex: 0 0 auto;
+        }
+    }
+}
+
+.collapse_mobile_lg {
+    @container widget-layout (max-width: #{$breakpoint-mobile-lg}) {
+        flex-direction: column;
+
+        > .item_weighted {
+            flex: 0 0 auto;
+        }
+    }
+}
+
+.collapse_tablet {
+    @container widget-layout (max-width: #{$breakpoint-tablet}) {
+        flex-direction: column;
+
+        > .item_weighted {
+            flex: 0 0 auto;
+        }
+    }
+}
+
+.collapse_desktop {
+    @container widget-layout (max-width: #{$breakpoint-desktop}) {
+        flex-direction: column;
+
+        > .item_weighted {
+            flex: 0 0 auto;
+        }
+    }
 }
 
 .item_title {

--- a/src/frontend/components/widgets/WidgetZone.module.scss
+++ b/src/frontend/components/widgets/WidgetZone.module.scss
@@ -89,7 +89,12 @@
 // its own *direct* weighted children (the child combinator keeps a zone's
 // collapse from reaching into a nested group's children) to natural,
 // full-width stacking — `flex: 0 0 auto` undoes the zero-basis grow that
-// only makes sense on a row's main axis. The breakpoint variable must be
+// only makes sense on a row's main axis. `align-self: stretch` is the
+// load-bearing half: once the container is a column the cross axis is
+// horizontal, so item width is governed by alignment, not flex; without it a
+// row preset's `align-items: center` (or flex-start/flex-end) leaves the
+// collapsed weighted items at content width instead of spanning the column.
+// It is a no-op under the `stretch` default. The breakpoint variable must be
 // interpolated (`#{…}`) inside `@container` or Sass silently drops the
 // condition.
 .collapse_mobile_sm {
@@ -98,6 +103,7 @@
 
         > .item_weighted {
             flex: 0 0 auto;
+            align-self: stretch;
         }
     }
 }
@@ -108,6 +114,7 @@
 
         > .item_weighted {
             flex: 0 0 auto;
+            align-self: stretch;
         }
     }
 }
@@ -118,6 +125,7 @@
 
         > .item_weighted {
             flex: 0 0 auto;
+            align-self: stretch;
         }
     }
 }
@@ -128,6 +136,7 @@
 
         > .item_weighted {
             flex: 0 0 auto;
+            align-self: stretch;
         }
     }
 }
@@ -138,6 +147,7 @@
 
         > .item_weighted {
             flex: 0 0 auto;
+            align-self: stretch;
         }
     }
 }

--- a/src/frontend/components/widgets/WidgetZone.tsx
+++ b/src/frontend/components/widgets/WidgetZone.tsx
@@ -4,6 +4,7 @@ import type { IZoneLayoutConfig, ZoneGapSize } from '@/types';
 import type { WidgetData } from './types';
 import { getWidgetComponent } from './getWidgetComponent';
 import { WidgetWithContext } from './WidgetWithContext';
+import { cn } from '../../lib/cn';
 import styles from './WidgetZone.module.scss';
 
 /**
@@ -72,6 +73,61 @@ function zoneStyle(layout: IZoneLayoutConfig): CSSProperties {
         '--zone-flex-wrap': layout.flexWrap,
         '--zone-gap': gapToCss(layout.gap)
     } as CSSProperties;
+}
+
+/**
+ * Map a layout's `collapseBelow` breakpoint to the modifier class that
+ * arms the matching `@container` rule on the flex container.
+ *
+ * A flex container cannot query its own width, so the wrapper element
+ * (`.zone_container` / `.group_container`) carries `container-type` and
+ * the inner flex container takes one of these classes; the colocated SCSS
+ * pairs each class with a `@container` block that flips the inner
+ * container to a column below the named breakpoint. Returning `undefined`
+ * for `'never'` (or an absent/unknown value) means no class is applied and
+ * the row never collapses — the historical behaviour preserved for layouts
+ * saved before the field existed.
+ *
+ * @param collapseBelow - The layout's chosen collapse breakpoint.
+ * @returns The modifier class name, or `undefined` to never collapse.
+ */
+function collapseClassFor(collapseBelow: IZoneLayoutConfig['collapseBelow']): string | undefined {
+    switch (collapseBelow) {
+        case 'mobile-sm':
+            return styles.collapse_mobile_sm;
+        case 'mobile-md':
+            return styles.collapse_mobile_md;
+        case 'mobile-lg':
+            return styles.collapse_mobile_lg;
+        case 'tablet':
+            return styles.collapse_tablet;
+        case 'desktop':
+            return styles.collapse_desktop;
+        case 'never':
+        default:
+            return undefined;
+    }
+}
+
+/**
+ * Build the inline style that sets a flex item's relative row width.
+ *
+ * The width rides as the `--item-grow` custom property (consumed by the
+ * `.item_weighted` rule as a `flex-grow` weight against a zero basis)
+ * rather than an inline `flex`/`flex-basis` declaration. That distinction
+ * is load-bearing: the collapse `@container` rule resets weighted children
+ * to full width through a class selector, and an inline `flex` shorthand
+ * would outrank it and defeat the collapse. Returns `undefined` when the
+ * item carries no weight so an unweighted item stays exactly as before.
+ *
+ * @param layoutWeight - The placement's relative weight, if any.
+ * @returns A style object setting `--item-grow`, or `undefined`.
+ */
+function itemWeightStyle(layoutWeight: number | undefined): CSSProperties | undefined {
+    if (typeof layoutWeight !== 'number') {
+        return undefined;
+    }
+    return { '--item-grow': layoutWeight } as CSSProperties;
 }
 
 /**
@@ -156,15 +212,21 @@ function LayoutGroupContainer({ widget, route, params }: WidgetRendererProps) {
 
     const layout = (widget.data as IZoneLayoutConfig | null) ?? DEFAULT_LAYOUT;
 
+    // Outer wrapper carries the container-query context so the inner flex
+    // container can collapse based on its OWN width (an element cannot
+    // query itself). The inner `.group` keeps the flex styling and the
+    // `data-widget-group` hook exactly as before.
     return (
-        <div
-            className={styles.group}
-            style={zoneStyle(layout)}
-            data-widget-group={widget.id}
-        >
-            {children.map(child => (
-                <WidgetItem key={child.id} widget={child} route={route} params={params} />
-            ))}
+        <div className={styles.group_container}>
+            <div
+                className={cn(styles.group, collapseClassFor(layout.collapseBelow))}
+                style={zoneStyle(layout)}
+                data-widget-group={widget.id}
+            >
+                {children.map(child => (
+                    <WidgetItem key={child.id} widget={child} route={route} params={params} />
+                ))}
+            </div>
         </div>
     );
 }
@@ -194,9 +256,15 @@ function WidgetItem({ widget, route, params }: WidgetRendererProps) {
         return null;
     }
 
+    // A weighted item gets the `.item_weighted` class plus the `--item-grow`
+    // custom property the class consumes; an unweighted item renders exactly
+    // as before (auto width, no inline style).
+    const weightStyle = itemWeightStyle(widget.layoutWeight);
+
     return (
         <div
-            className={styles.item}
+            className={cn(styles.item, weightStyle && styles.item_weighted)}
+            style={weightStyle}
             data-widget-id={widget.id}
             data-plugin-id={widget.pluginId}
         >
@@ -280,15 +348,21 @@ export function WidgetZone({
 
     const effectiveLayout = layout ?? DEFAULT_LAYOUT;
 
+    // Outer wrapper carries the container-query context so the zone's flex
+    // container collapses based on its OWN rendered width (an element cannot
+    // query itself). The inner `.zone` keeps the flex styling and the
+    // `data-zone` hook unchanged.
     return (
-        <div
-            className={styles.zone}
-            data-zone={name}
-            style={zoneStyle(effectiveLayout)}
-        >
-            {zoneWidgets.map(widget => (
-                <WidgetItem key={widget.id} widget={widget} route={route} params={params} />
-            ))}
+        <div className={styles.zone_container}>
+            <div
+                className={cn(styles.zone, collapseClassFor(effectiveLayout.collapseBelow))}
+                data-zone={name}
+                style={zoneStyle(effectiveLayout)}
+            >
+                {zoneWidgets.map(widget => (
+                    <WidgetItem key={widget.id} widget={widget} route={route} params={params} />
+                ))}
+            </div>
         </div>
     );
 }

--- a/src/frontend/components/widgets/types.ts
+++ b/src/frontend/components/widgets/types.ts
@@ -26,6 +26,15 @@ export interface WidgetData {
     order: number;
 
     /**
+     * Relative horizontal width of this item when its container lays out
+     * in a row, carried from the resolved placement. The renderer applies
+     * it as a `flex-grow` weight (against a zero basis) so sibling weights
+     * become width ratios; absent means auto width — the historical
+     * behaviour.
+     */
+    layoutWeight?: number;
+
+    /**
      * Optional display title.
      */
     title?: string;


### PR DESCRIPTION
## Why

Operators could put widgets in a row via a layout group or zone, but every child shrank to share the row equally and a row never collapsed on narrow containers. This adds operator-controlled relative widths and responsive collapse, configured entirely from `/system/widgets`.

## What

- **Per-child relative width** (`layoutWeight`, a top-level placement field, integer 1–12). Applied as a `flex-grow` weight against a zero basis, so children with weights `2` and `1` split a row two-thirds / one-third. Edited via an Auto / 1×–4× dropdown on each row (top-level zone rows and nested group children).
- **Responsive collapse** (`collapseBelow` on `IZoneLayoutConfig`). Below the chosen breakpoint the row flips to a stacked column and weighted children reset to full width. Surfaces as a dropdown in the schema-driven layout-group editor and a new control in the zone layout controls.
- **Mechanism.** Each flex container is wrapped in a `container-type: inline-size` element so it can collapse against its *own* width (an element cannot query itself). Width rides as an `--item-grow` custom property + `.item_weighted` class — never inline `flex` — so the class-based `@container` collapse rule can override it.
- Zones and layout groups share the same layout engine and reach feature parity (parity-control unification; `ZoneLayoutControls` retained, no migration).

Unset fields render identically to before. Backend tsc, frontend tsc, and types build pass; widgets tests 118 pass (+7 covering the new validation and round-trips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)