### PR TITLE
feat(frontend): responsive heading scale, chart titles, SCSS token cleanup

### DIFF
--- a/src/frontend/app/globals.scss
+++ b/src/frontend/app/globals.scss
@@ -69,6 +69,57 @@ a:hover {
   color: var(--color-secondary);
 }
 
+/* Base heading typography
+ *
+ * Bare h1–h6 inherit the semantic heading scale so headings read consistently
+ * site-wide without each component restyling the tag. Spacing is owned by the
+ * layout primitives (Stack/Grid/Page gap), so margins are zeroed here rather
+ * than reintroduced — components that need heading spacing use a layout gap.
+ * Scoped component/module rules still override on specificity. */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  /*
+   * Responsive heading multiplier. The size tokens stay immutable; only this
+   * factor shifts per breakpoint (1 desktop, 0.75 tablet, 0.5 mobile) in the
+   * @media blocks below, so headings shrink on smaller shells without any
+   * token redefinition. Theme overrides of the size tokens still apply.
+   */
+  --heading-scale: 1;
+  margin: 0;
+  color: var(--color-text);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-tight);
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+h1 {
+  font-size: calc(var(--font-size-heading-xl) * var(--heading-scale));
+}
+
+h2 {
+  font-size: calc(var(--font-size-heading-lg) * var(--heading-scale));
+}
+
+h3 {
+  font-size: calc(var(--font-size-heading-md) * var(--heading-scale));
+}
+
+h4 {
+  font-size: calc(var(--font-size-heading-sm) * var(--heading-scale));
+}
+
+h5 {
+  font-size: calc(var(--font-size-body-lg) * var(--heading-scale));
+}
+
+h6 {
+  font-size: calc(var(--font-size-body) * var(--heading-scale));
+}
+
 main {
   flex: 1 1 0;
   min-height: 0;
@@ -105,7 +156,7 @@ main {
 }
 
 .table-row--flash {
-  animation: rowFlash 2.4s ease-out;
+  animation: rowFlash var(--duration-flash) ease-out;
 }
 
 /**
@@ -137,7 +188,7 @@ main {
   border-color: var(--color-success-alpha-45);
 
   svg {
-    animation: live-pulse 2s ease-in-out infinite;
+    animation: live-pulse var(--duration-pulse) ease-in-out infinite;
   }
 
   &:hover {
@@ -161,23 +212,23 @@ main {
 .stat-grid {
   display: grid;
   gap: var(--grid-gap-sm);
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(var(--stat-grid-min), 1fr));
 }
 
 .stat-card__label {
   color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-body-sm);
   letter-spacing: var(--letter-spacing-wide);
   text-transform: uppercase;
 }
 
 .stat-card__value {
-  font-size: var(--font-size-xl);
+  font-size: var(--font-size-heading-md);
   font-weight: var(--font-weight-bold);
 }
 
 .stat-card__delta {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-body-sm);
   color: var(--color-text-muted);
 }
 
@@ -334,8 +385,8 @@ button:focus-visible {
 .form-footer {
   display: flex;
   justify-content: flex-end;
-  gap: var(--spacing-5);
-  margin-top: var(--spacing-10);
+  gap: var(--form-footer-gap);
+  margin-top: var(--form-footer-margin-top);
 }
 
 .table-scroll {
@@ -364,7 +415,7 @@ button:focus-visible {
 /* Tablet and below */
 @media (max-width: $breakpoint-desktop) {
   .layout-nav {
-    padding: var(--spacing-8) var(--spacing-10);
+    padding: var(--nav-padding);
   }
 
   main {
@@ -377,11 +428,33 @@ button:focus-visible {
   }
 }
 
+/* Tablet and below — shrink headings to 75% (placed before the mobile block so
+ * the mobile 50% override wins at narrower widths). */
+@media (max-width: $breakpoint-tablet) {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    --heading-scale: 0.75;
+  }
+}
+
 /* Mobile and below */
 @media (max-width: $breakpoint-mobile) {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    --heading-scale: 0.5;
+  }
+
   .layout-nav {
     flex-direction: column;
-    gap: var(--spacing-6);
+    gap: var(--nav-gap);
     align-items: flex-start;
   }
 
@@ -412,11 +485,12 @@ button:focus-visible {
   }
 
   /*
-   * Reduce table cell padding by 50% on mobile.
-   * Default: var(--spacing-6) var(--spacing-8) → Mobile: var(--spacing-3) var(--spacing-4)
+   * Dense table cells on narrow viewports. Select the compact token rather than
+   * redefining --table-cell-padding so the token's meaning stays constant.
    */
-  :root {
-    --table-cell-padding: var(--spacing-3) var(--spacing-4);
+  .table th,
+  .table td {
+    padding: var(--table-cell-padding-compact);
   }
 
   .input-group {

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -356,6 +356,7 @@
     --grid-gap-md: var(--spacing-10);           /* 1.5rem */
     --grid-gap-lg: var(--spacing-12);           /* 2rem */
     --grid-responsive-min: 280px;               /* auto-fit minmax floor for <Grid columns="responsive">; consumers override at their scope */
+    --stat-grid-min: 220px;                     /* auto-fit minmax floor for the .stat-grid utility */
     --grid-bg-image: none;
     --grid-bg-opacity: 0.08;
     --grid-bg-size: 140px;
@@ -399,6 +400,10 @@
     /* Input Group */
     --input-group-gap: var(--spacing-5);        /* 0.75rem */
 
+    /* Form Footer — trailing action row (e.g. Cancel / Save) */
+    --form-footer-gap: var(--spacing-5);        /* 0.75rem - gap between footer actions */
+    --form-footer-margin-top: var(--spacing-10);/* 1.5rem - separation from form body */
+
     /* ========================================================================
      * NAVIGATION COMPONENT TOKENS
      * ======================================================================== */
@@ -412,6 +417,10 @@
      * (e.g. brand-tinted) without touching every nav component. */
     --color-nav-tab-active-background: rgba(255, 255, 255, 0.1);
     --color-nav-tab-active-border: rgba(255, 255, 255, 0.2);
+
+    /* Navigation - Layout (responsive shell overrides in globals.scss) */
+    --nav-padding: var(--spacing-8) var(--spacing-10);  /* 1.1rem 1.5rem - condensed nav padding below desktop */
+    --nav-gap: var(--spacing-6);                        /* 0.85rem - stacked nav gap on mobile */
 
     /* ========================================================================
      * TABLE COMPONENT TOKENS
@@ -428,6 +437,7 @@
 
     /* Table - Cells */
     --table-cell-padding: var(--spacing-6) var(--spacing-8); /* 0.85rem 1.1rem */
+    --table-cell-padding-compact: var(--spacing-3) var(--spacing-4); /* 0.4rem 0.5rem - dense cells on narrow viewports */
     --table-cell-border: var(--border-width-thin) solid rgba(255, 255, 255, 0.05);
 
     /* Table - Row Hover */

--- a/src/frontend/features/charts/components/BarChart/BarChart.module.css
+++ b/src/frontend/features/charts/components/BarChart/BarChart.module.css
@@ -17,6 +17,15 @@
     margin: 0;
 }
 
+/* Optional caller-supplied chart heading (e.g. an operator-set graph title). */
+.chart__title {
+    margin: 0 0 var(--gap-sm);
+    color: var(--color-text);
+    font-size: var(--font-size-heading-sm);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+}
+
 .chart svg {
     width: 100%;
     /* Height is set explicitly per instance via the SVG `height` attribute rather

--- a/src/frontend/features/charts/components/BarChart/BarChart.module.css
+++ b/src/frontend/features/charts/components/BarChart/BarChart.module.css
@@ -26,6 +26,23 @@
     line-height: var(--line-height-tight);
 }
 
+/* Positioning context for the interactive tooltip. Wraps only the SVG and the
+   tooltip so the absolutely-positioned tooltip measures `top` from the SVG's top
+   edge — the optional title sits outside this wrapper and cannot offset it. */
+.plot {
+    position: relative;
+}
+
+/* Empty-state body. The inline min-height (the data-driven chart height) reserves
+   the chart-area box so an empty→populated transition does not shift layout; this
+   rule centers the placeholder label within that reserved box. */
+.chart__empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-muted);
+}
+
 .chart svg {
     width: 100%;
     /* Height is set explicitly per instance via the SVG `height` attribute rather

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -54,6 +54,12 @@ type BarChartMode = 'normal' | 'widget';
 interface BarChartProps {
     /** Array of data series to plot as grouped columns */
     series: BarChartSeries[];
+    /**
+     * Optional heading rendered above the chart. Lets a caller (e.g. a widget
+     * surfacing an operator-set graph title) label the chart without wrapping it
+     * in its own header. Omitted renders no title element.
+     */
+    title?: string;
     /** Rendering density (default: 'normal') */
     mode?: BarChartMode;
     /** Chart height in pixels (default: 320 in normal mode, 120 in widget mode) */
@@ -261,6 +267,7 @@ function resolveColor(color: string | undefined, index: number) {
  */
 export function BarChart({
     series,
+    title,
     mode = 'normal',
     height: propHeight,
     yAxisFormatter = value => value.toLocaleString(),
@@ -503,7 +510,12 @@ export function BarChart({
     }, [series, hiddenSeries, containerWidth, height, chrome, fixedYMin, fixedYMax, seriesColors]);
 
     if (!chartData) {
-        return <div className={cn(styles.chart, className)}>{emptyLabel}</div>;
+        return (
+            <div className={cn(styles.chart, className)}>
+                {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
+                {emptyLabel}
+            </div>
+        );
     }
 
     const { width, height: chartHeight, bars, categories, yTicks, xTicks, baselineY, seriesLookup } = chartData;
@@ -592,6 +604,7 @@ export function BarChart({
 
     return (
         <figure ref={setContainer} className={cn(styles.chart, isWidget && styles['chart--widget'], className)}>
+            {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
             {/*
               * Render at a fixed pixel height with a uniformly-scaled viewBox so the
               * chart occupies its final box during SSR. Height no longer derives from

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -513,7 +513,16 @@ export function BarChart({
         return (
             <div className={cn(styles.chart, className)}>
                 {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
-                {emptyLabel}
+                {/*
+                  * Reserve the chart's pixel height while empty so an async
+                  * empty→populated transition does not shift surrounding layout (CLS).
+                  * The height is a data-driven dimension (the data-viz exception), so it
+                  * rides inline; the label's flex-centering lives in the module. Mirrors
+                  * the populated layout — title above, chart-area box below.
+                  */}
+                <div className={styles.chart__empty} style={{ minHeight: height }}>
+                    {emptyLabel}
+                </div>
             </div>
         );
     }
@@ -606,18 +615,28 @@ export function BarChart({
         <figure ref={setContainer} className={cn(styles.chart, isWidget && styles['chart--widget'], className)}>
             {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
             {/*
-              * Render at a fixed pixel height with a uniformly-scaled viewBox so the
-              * chart occupies its final box during SSR. Height no longer derives from
-              * the pre-measurement viewBox aspect ratio (CSS `height: auto`), which
-              * made the server paint the chart at the wrong height and grow it after
-              * the ResizeObserver fired — the visible "loading" jump. With
-              * `preserveAspectRatio="xMinYMid meet"` the viewBox scales uniformly and
-              * left-anchors inside the fixed box; once the observer matches the viewBox
-              * width to the rendered width the mapping is 1:1, so before measurement the
-              * content is undistorted (transient empty space on the right) rather than
-              * horizontally stretched.
+              * Positioning context for the absolutely-positioned tooltip. The tooltip
+              * uses `top: tooltipTopPx`, an SVG-derived Y coordinate that is only valid
+              * measured from the SVG's top edge. The optional title is kept a direct
+              * child of the figure (outside this wrapper), so the wrapper begins exactly
+              * where the SVG does — a rendered title cannot push the SVG down and shift
+              * every tooltip upward by the heading's height. The legend stays outside the
+              * wrapper too so it is not captured by the positioning context.
               */}
-            <svg
+            <div className={styles.plot}>
+                {/*
+                  * Render at a fixed pixel height with a uniformly-scaled viewBox so the
+                  * chart occupies its final box during SSR. Height no longer derives from
+                  * the pre-measurement viewBox aspect ratio (CSS `height: auto`), which
+                  * made the server paint the chart at the wrong height and grow it after
+                  * the ResizeObserver fired — the visible "loading" jump. With
+                  * `preserveAspectRatio="xMinYMid meet"` the viewBox scales uniformly and
+                  * left-anchors inside the fixed box; once the observer matches the viewBox
+                  * width to the rendered width the mapping is 1:1, so before measurement the
+                  * content is undistorted (transient empty space on the right) rather than
+                  * horizontally stretched.
+                  */}
+                <svg
                 viewBox={`0 0 ${width} ${chartHeight}`}
                 height={chartHeight}
                 preserveAspectRatio="xMinYMid meet"
@@ -710,6 +729,7 @@ export function BarChart({
                     ))}
                 </div>
             )}
+            </div>
 
             {resolvedShowLegend && (
                 <figcaption className={styles.legend}>

--- a/src/frontend/features/charts/components/LineChart/LineChart.module.css
+++ b/src/frontend/features/charts/components/LineChart/LineChart.module.css
@@ -15,6 +15,15 @@
     margin: 0;
 }
 
+/* Optional caller-supplied chart heading (e.g. an operator-set graph title). */
+.chart__title {
+    margin: 0 0 var(--gap-sm);
+    color: var(--color-text);
+    font-size: var(--font-size-heading-sm);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+}
+
 .chart svg {
     width: 100%;
     /* Height is set explicitly per instance via the SVG `height` attribute rather

--- a/src/frontend/features/charts/components/LineChart/LineChart.module.css
+++ b/src/frontend/features/charts/components/LineChart/LineChart.module.css
@@ -24,6 +24,23 @@
     line-height: var(--line-height-tight);
 }
 
+/* Positioning context for the interactive tooltip. Wraps only the SVG and the
+   tooltip so the absolutely-positioned tooltip measures `top` from the SVG's top
+   edge — the optional title sits outside this wrapper and cannot offset it. */
+.plot {
+    position: relative;
+}
+
+/* Empty-state body. The inline min-height (the data-driven chart height) reserves
+   the chart-area box so an empty→populated transition does not shift layout; this
+   rule centers the placeholder label within that reserved box. */
+.chart__empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-muted);
+}
+
 .chart svg {
     width: 100%;
     /* Height is set explicitly per instance via the SVG `height` attribute rather

--- a/src/frontend/features/charts/components/LineChart/LineChart.tsx
+++ b/src/frontend/features/charts/components/LineChart/LineChart.tsx
@@ -44,6 +44,12 @@ export interface ChartSeries {
 interface LineChartProps {
     /** Array of data series to plot */
     series: ChartSeries[];
+    /**
+     * Optional heading rendered above the chart. Lets a caller (e.g. a widget
+     * surfacing an operator-set graph title) label the chart without wrapping it
+     * in its own header. Omitted renders no title element.
+     */
+    title?: string;
     /** Chart height in pixels (default: 320) */
     height?: number;
     /** Custom formatter for Y-axis labels */
@@ -185,6 +191,7 @@ function toDate(value: string) {
  */
 export function LineChart({
     series,
+    title,
     height = 320,
     yAxisFormatter = value => value.toLocaleString(),
     xAxisFormatter = value => value.toLocaleDateString(),
@@ -391,7 +398,12 @@ export function LineChart({
     }, [series, height, containerWidth, fixedMinDate, fixedMaxDate, fixedYMin, fixedYMax, hiddenSeries]);
 
     if (!chartData) {
-        return <div className={cn(styles.chart, className)}>{emptyLabel}</div>;
+        return (
+            <div className={cn(styles.chart, className)}>
+                {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
+                {emptyLabel}
+            </div>
+        );
     }
 
     const { width, height: chartHeight, normalizedSeries, yTicks, xTicks, domainPoints, zeroLineY } = chartData;
@@ -468,6 +480,7 @@ export function LineChart({
 
     return (
         <figure ref={containerRef} className={cn(styles.chart, className)}>
+            {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
             {/*
               * Render at a fixed pixel height with a uniformly-scaled viewBox so the
               * chart occupies its final box during SSR. Height no longer derives from

--- a/src/frontend/features/charts/components/LineChart/LineChart.tsx
+++ b/src/frontend/features/charts/components/LineChart/LineChart.tsx
@@ -401,7 +401,16 @@ export function LineChart({
         return (
             <div className={cn(styles.chart, className)}>
                 {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
-                {emptyLabel}
+                {/*
+                  * Reserve the chart's pixel height while empty so an async
+                  * empty→populated transition does not shift surrounding layout (CLS).
+                  * The height is a data-driven dimension (the data-viz exception), so it
+                  * rides inline; the label's flex-centering lives in the module. Mirrors
+                  * the populated layout — title above, chart-area box below.
+                  */}
+                <div className={styles.chart__empty} style={{ minHeight: height }}>
+                    {emptyLabel}
+                </div>
             </div>
         );
     }
@@ -482,18 +491,28 @@ export function LineChart({
         <figure ref={containerRef} className={cn(styles.chart, className)}>
             {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
             {/*
-              * Render at a fixed pixel height with a uniformly-scaled viewBox so the
-              * chart occupies its final box during SSR. Height no longer derives from
-              * the pre-measurement viewBox aspect ratio (CSS `height: auto`), which
-              * made the server paint the chart short and then grow it to full height
-              * after the ResizeObserver fired — the visible "loading" jump. With
-              * `preserveAspectRatio="xMinYMid meet"` the viewBox scales uniformly and
-              * left-anchors inside the fixed box; once the observer matches the viewBox
-              * width to the rendered width the mapping is 1:1, so before measurement the
-              * content is undistorted (transient empty space on the right) rather than
-              * horizontally stretched.
+              * Positioning context for the absolutely-positioned tooltip. The tooltip
+              * uses `top: tooltip.y`, an SVG viewBox-unit Y coordinate that is only
+              * valid measured from the SVG's top edge. The optional title is kept a
+              * direct child of the figure (outside this wrapper), so the wrapper begins
+              * exactly where the SVG does — a rendered title cannot push the SVG down
+              * and shift every tooltip upward by the heading's height. The legend is
+              * likewise left outside so it is not captured by the positioning context.
               */}
-            <svg
+            <div className={styles.plot}>
+                {/*
+                  * Render at a fixed pixel height with a uniformly-scaled viewBox so the
+                  * chart occupies its final box during SSR. Height no longer derives from
+                  * the pre-measurement viewBox aspect ratio (CSS `height: auto`), which
+                  * made the server paint the chart short and then grow it to full height
+                  * after the ResizeObserver fired — the visible "loading" jump. With
+                  * `preserveAspectRatio="xMinYMid meet"` the viewBox scales uniformly and
+                  * left-anchors inside the fixed box; once the observer matches the viewBox
+                  * width to the rendered width the mapping is 1:1, so before measurement the
+                  * content is undistorted (transient empty space on the right) rather than
+                  * horizontally stretched.
+                  */}
+                <svg
                 viewBox={`0 0 ${width} ${chartHeight}`}
                 height={chartHeight}
                 preserveAspectRatio="xMinYMid meet"
@@ -637,6 +656,7 @@ export function LineChart({
                     )}
                 </div>
             )}
+            </div>
 
             {showLegend && (
                 <figcaption className={styles.legend}>


### PR DESCRIPTION
## Summary

Three related frontend refinements:

**Responsive heading typography.** Bare `h1`–`h6` now inherit the semantic heading scale so headings render consistently site-wide without each component restyling the tag. A single `--heading-scale` multiplier shifts per breakpoint (1 desktop, 0.75 tablet, 0.5 mobile) while the size tokens stay immutable, so theme overrides of the size tokens still apply. Margins are zeroed; heading spacing is owned by the layout primitives.

**SCSS token cleanup.** Foundation primitives and hardcoded values in `globals.scss` are replaced with semantic tokens — animation durations (`--duration-flash`, `--duration-pulse`), `--stat-grid-min`, form-footer spacing, nav layout, and a `--table-cell-padding-compact` selected on narrow viewports rather than redefining the base token. New tokens are defined in `semantic-tokens.scss`.

**Chart titles.** `BarChart` and `LineChart` accept an optional `title` prop rendering a caller-supplied heading above the chart (e.g. a widget surfacing an operator-set graph title), covering both the empty and populated render paths.