### PR TITLE
feat(types): expose title prop on LineChart and BarChart plugin contracts

### DIFF
--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -286,6 +286,8 @@ export interface IChartComponents {
             /** Optional aggregate annotation rendered after the label in the legend only (not the tooltip). Lets the legend act as a complete key, e.g. a window total. */
             legendValue?: React.ReactNode;
         }>;
+        /** Optional heading rendered above the chart. Lets a caller (e.g. a widget surfacing an operator-set graph title) label the chart without wrapping it in its own header. Omitted renders no title element. */
+        title?: string;
         yAxisFormatter?: (value: number) => string;
         xAxisFormatter?: (value: Date) => string;
         /** Custom formatter for the tooltip's date heading; falls back to xAxisFormatter. Lets the axis keep compact relative labels while the tooltip shows an absolute localized date. */
@@ -322,6 +324,8 @@ export interface IChartComponents {
             /** Optional aggregate annotation rendered after the label in the legend only (not the tooltip or bar title). Lets the legend act as a complete key, e.g. a window total. */
             legendValue?: React.ReactNode;
         }>;
+        /** Optional heading rendered above the chart. Lets a caller (e.g. a widget surfacing an operator-set graph title) label the chart without wrapping it in its own header. Omitted renders no title element. */
+        title?: string;
         /** Rendering density (default: 'normal') */
         mode?: 'normal' | 'widget';
         /** Chart height in pixels (default: 320 normal, 120 widget) */


### PR DESCRIPTION
The core `LineChart` and `BarChart` components already accept and render an optional `title` heading (`<h3>` above the chart), but the `IChartComponents` contract published to plugins in `packages/types/src/plugin/IFrontendPluginContext.ts` omitted it. Plugins reaching the charts through `context.charts.LineChart` / `context.charts.BarChart` therefore could not pass `title` without a TypeScript error.

This adds `title?: string` to both chart contracts, matching the JSDoc already on the source components. The prop is optional, so existing plugins are unaffected; the runtime already supported it.