### PR TITLE
feat(charts): add actions header slot for title + controls on one row

### DIFF
--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -288,6 +288,8 @@ export interface IChartComponents {
         }>;
         /** Optional heading rendered above the chart. Lets a caller (e.g. a widget surfacing an operator-set graph title) label the chart without wrapping it in its own header. Omitted renders no title element. */
         title?: string;
+        /** Optional controls rendered on the right of the chart's header row, sharing that row with the title. Lets a widget place its window/view toggles on the same line as the title instead of stacking a separate toolbar above the chart. Omitted renders no header actions. */
+        actions?: React.ReactNode;
         yAxisFormatter?: (value: number) => string;
         xAxisFormatter?: (value: Date) => string;
         /** Custom formatter for the tooltip's date heading; falls back to xAxisFormatter. Lets the axis keep compact relative labels while the tooltip shows an absolute localized date. */
@@ -326,6 +328,8 @@ export interface IChartComponents {
         }>;
         /** Optional heading rendered above the chart. Lets a caller (e.g. a widget surfacing an operator-set graph title) label the chart without wrapping it in its own header. Omitted renders no title element. */
         title?: string;
+        /** Optional controls rendered on the right of the chart's header row, sharing that row with the title. Lets a widget place its resource/window toggles on the same line as the title instead of stacking a separate toolbar above the chart. Omitted renders no header actions. */
+        actions?: React.ReactNode;
         /** Rendering density (default: 'normal') */
         mode?: 'normal' | 'widget';
         /** Chart height in pixels (default: 320 normal, 120 widget) */

--- a/src/frontend/components/layout/BlockTicker/BlockTicker.module.scss
+++ b/src/frontend/components/layout/BlockTicker/BlockTicker.module.scss
@@ -7,11 +7,21 @@
 
 @use '../../../app/breakpoints' as *;
 
+/*
+ * fit-content makes the bar — surface and top/bottom borders included — an
+ * intrinsically sized flex item rather than a full-width block. A widget
+ * zone/group can then center or left/right-align it via --zone-justify-content /
+ * --zone-align-items; a full-width root would fill the zone and leave that
+ * alignment config nothing to act on. No max-width cap here on purpose: the core
+ * layout group owns width constraints (per-row relative width / collapseBelow),
+ * so the bar shrinks to its metrics and the group decides any ceiling.
+ */
 .ticker {
     background: var(--color-surface);
     border-top: var(--border-width-thin) solid var(--color-border);
     border-bottom: var(--border-width-thin) solid var(--color-border);
     margin-top: var(--spacing-4);
+    width: fit-content;
 }
 
 .container {
@@ -19,16 +29,8 @@
     align-items: center;
     gap: var(--gap-md);
     padding: var(--padding-xs) var(--container-padding-desktop);
-    width: min($breakpoint-tablet, 100%);
-    margin: 0 auto;
     font-size: var(--font-size-caption);
     line-height: var(--line-height-tight);
-    overflow-x: auto;
-    scrollbar-width: none;
-}
-
-.container::-webkit-scrollbar {
-    display: none;
 }
 
 .item {

--- a/src/frontend/components/layout/BlockTicker/BlockTicker.module.scss
+++ b/src/frontend/components/layout/BlockTicker/BlockTicker.module.scss
@@ -12,9 +12,11 @@
  * intrinsically sized flex item rather than a full-width block. A widget
  * zone/group can then center or left/right-align it via --zone-justify-content /
  * --zone-align-items; a full-width root would fill the zone and leave that
- * alignment config nothing to act on. No max-width cap here on purpose: the core
- * layout group owns width constraints (per-row relative width / collapseBelow),
- * so the bar shrinks to its metrics and the group decides any ceiling.
+ * alignment config nothing to act on. The core layout group owns the real width
+ * ceiling (per-row relative width / collapseBelow); `max-width: 100%` here is
+ * only a safety cap so the intrinsically-sized bar can never grow the page wider
+ * than its parent, while `.container` scrolls its nowrap metrics internally on
+ * viewports too narrow to show them all.
  */
 .ticker {
     background: var(--color-surface);
@@ -22,6 +24,7 @@
     border-bottom: var(--border-width-thin) solid var(--color-border);
     margin-top: var(--spacing-4);
     width: fit-content;
+    max-width: 100%;
 }
 
 .container {
@@ -31,6 +34,12 @@
     padding: var(--padding-xs) var(--container-padding-desktop);
     font-size: var(--font-size-caption);
     line-height: var(--line-height-tight);
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+
+.container::-webkit-scrollbar {
+    display: none;
 }
 
 .item {

--- a/src/frontend/features/charts/components/BarChart/BarChart.module.css
+++ b/src/frontend/features/charts/components/BarChart/BarChart.module.css
@@ -17,13 +17,37 @@
     margin: 0;
 }
 
-/* Optional caller-supplied chart heading (e.g. an operator-set graph title). */
+/* Optional header row: the caller-supplied title on the left and any header
+   actions on the right, sharing one line. The row owns the bottom gap to the
+   plot; it wraps so a narrow container drops the actions below the title rather
+   than overflowing. */
+.chart__header {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--gap-sm);
+    margin-bottom: var(--gap-sm);
+}
+
+/* Optional caller-supplied chart heading (e.g. an operator-set graph title). The
+   header row owns the spacing, so the heading itself carries no margin. */
 .chart__title {
-    margin: 0 0 var(--gap-sm);
+    margin: 0;
     color: var(--color-text);
     font-size: var(--font-size-heading-sm);
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
+}
+
+/* Caller-supplied header controls. `margin-left: auto` anchors them to the right
+   edge whether or not a title is present, so a control-only header still aligns
+   its toggles right (matching the previous standalone toolbar). */
+.chart__actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--gap-sm);
+    margin-left: auto;
 }
 
 /* Positioning context for the interactive tooltip. Wraps only the SVG and the

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -60,6 +60,14 @@ interface BarChartProps {
      * in its own header. Omitted renders no title element.
      */
     title?: string;
+    /**
+     * Optional controls rendered on the right of the chart's header row, sharing
+     * that row with the title. Lets a caller (e.g. a widget with resource/window
+     * toggles) place its controls on the same line as the title instead of
+     * stacking its own toolbar above the chart, which left the title beneath the
+     * toggles. Omitted renders no header actions.
+     */
+    actions?: ReactNode;
     /** Rendering density (default: 'normal') */
     mode?: BarChartMode;
     /** Chart height in pixels (default: 320 in normal mode, 120 in widget mode) */
@@ -268,6 +276,7 @@ function resolveColor(color: string | undefined, index: number) {
 export function BarChart({
     series,
     title,
+    actions,
     mode = 'normal',
     height: propHeight,
     yAxisFormatter = value => value.toLocaleString(),
@@ -509,10 +518,23 @@ export function BarChart({
         };
     }, [series, hiddenSeries, containerWidth, height, chrome, fixedYMin, fixedYMax, seriesColors]);
 
+    // Optional header row shared by the empty and populated renders: the
+    // operator-set title on the left, caller-supplied controls (e.g. a widget's
+    // resource/window toggles) on the right. Kept a direct child of the figure —
+    // outside the `.plot` positioning context — so a rendered header never
+    // offsets the tooltip's SVG-relative top. Renders nothing when neither is
+    // supplied so an untitled, control-less chart is unchanged.
+    const header = (title || actions) ? (
+        <div className={styles.chart__header}>
+            {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
+            {actions ? <div className={styles.chart__actions}>{actions}</div> : null}
+        </div>
+    ) : null;
+
     if (!chartData) {
         return (
             <div className={cn(styles.chart, className)}>
-                {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
+                {header}
                 {/*
                   * Reserve the chart's pixel height while empty so an async
                   * empty→populated transition does not shift surrounding layout (CLS).
@@ -613,11 +635,11 @@ export function BarChart({
 
     return (
         <figure ref={setContainer} className={cn(styles.chart, isWidget && styles['chart--widget'], className)}>
-            {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
+            {header}
             {/*
               * Positioning context for the absolutely-positioned tooltip. The tooltip
               * uses `top: tooltipTopPx`, an SVG-derived Y coordinate that is only valid
-              * measured from the SVG's top edge. The optional title is kept a direct
+              * measured from the SVG's top edge. The optional header is kept a direct
               * child of the figure (outside this wrapper), so the wrapper begins exactly
               * where the SVG does — a rendered title cannot push the SVG down and shift
               * every tooltip upward by the heading's height. The legend stays outside the

--- a/src/frontend/features/charts/components/LineChart/LineChart.module.css
+++ b/src/frontend/features/charts/components/LineChart/LineChart.module.css
@@ -15,13 +15,37 @@
     margin: 0;
 }
 
-/* Optional caller-supplied chart heading (e.g. an operator-set graph title). */
+/* Optional header row: the caller-supplied title on the left and any header
+   actions on the right, sharing one line. The row owns the bottom gap to the
+   plot; it wraps so a narrow container drops the actions below the title rather
+   than overflowing. */
+.chart__header {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--gap-sm);
+    margin-bottom: var(--gap-sm);
+}
+
+/* Optional caller-supplied chart heading (e.g. an operator-set graph title). The
+   header row owns the spacing, so the heading itself carries no margin. */
 .chart__title {
-    margin: 0 0 var(--gap-sm);
+    margin: 0;
     color: var(--color-text);
     font-size: var(--font-size-heading-sm);
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
+}
+
+/* Caller-supplied header controls. `margin-left: auto` anchors them to the right
+   edge whether or not a title is present, so a control-only header still aligns
+   its toggles right (matching the previous standalone toolbar). */
+.chart__actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--gap-sm);
+    margin-left: auto;
 }
 
 /* Positioning context for the interactive tooltip. Wraps only the SVG and the

--- a/src/frontend/features/charts/components/LineChart/LineChart.tsx
+++ b/src/frontend/features/charts/components/LineChart/LineChart.tsx
@@ -50,6 +50,14 @@ interface LineChartProps {
      * in its own header. Omitted renders no title element.
      */
     title?: string;
+    /**
+     * Optional controls rendered on the right of the chart's header row, sharing
+     * that row with the title. Lets a caller (e.g. a widget with window/view
+     * toggles) place its controls on the same line as the title instead of
+     * stacking its own toolbar above the chart, which left the title beneath the
+     * toggles. Omitted renders no header actions.
+     */
+    actions?: ReactNode;
     /** Chart height in pixels (default: 320) */
     height?: number;
     /** Custom formatter for Y-axis labels */
@@ -192,6 +200,7 @@ function toDate(value: string) {
 export function LineChart({
     series,
     title,
+    actions,
     height = 320,
     yAxisFormatter = value => value.toLocaleString(),
     xAxisFormatter = value => value.toLocaleDateString(),
@@ -397,10 +406,23 @@ export function LineChart({
         };
     }, [series, height, containerWidth, fixedMinDate, fixedMaxDate, fixedYMin, fixedYMax, hiddenSeries]);
 
+    // Optional header row shared by the empty and populated renders: the
+    // operator-set title on the left, caller-supplied controls (e.g. a widget's
+    // window/view toggles) on the right. Kept a direct child of the figure —
+    // outside the `.plot` positioning context — so a rendered header never
+    // offsets the tooltip's SVG-relative `top`. Renders nothing when neither is
+    // supplied so an untitled, control-less chart is unchanged.
+    const header = (title || actions) ? (
+        <div className={styles.chart__header}>
+            {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
+            {actions ? <div className={styles.chart__actions}>{actions}</div> : null}
+        </div>
+    ) : null;
+
     if (!chartData) {
         return (
             <div className={cn(styles.chart, className)}>
-                {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
+                {header}
                 {/*
                   * Reserve the chart's pixel height while empty so an async
                   * empty→populated transition does not shift surrounding layout (CLS).
@@ -489,11 +511,11 @@ export function LineChart({
 
     return (
         <figure ref={containerRef} className={cn(styles.chart, className)}>
-            {title ? <h3 className={styles.chart__title}>{title}</h3> : null}
+            {header}
             {/*
               * Positioning context for the absolutely-positioned tooltip. The tooltip
               * uses `top: tooltip.y`, an SVG viewBox-unit Y coordinate that is only
-              * valid measured from the SVG's top edge. The optional title is kept a
+              * valid measured from the SVG's top edge. The optional header is kept a
               * direct child of the figure (outside this wrapper), so the wrapper begins
               * exactly where the SVG does — a rendered title cannot push the SVG down
               * and shift every tooltip upward by the heading's height. The legend is


### PR DESCRIPTION
## Summary

Core `LineChart` and `BarChart` gain an optional `actions` prop. When a `title` and/or `actions` is present, each chart renders a single flex header row — title on the left, controls right-anchored (`margin-left: auto`) — instead of a bare `<h3>` block that a consumer's separate toolbar sat above. Previously a widget that rendered its own toggle row above a titled chart left the title stacked *beneath* the toggles; now the title shares the toggle row.

The header is a direct child of the `<figure>`, outside the `.plot` positioning context, so it never offsets the tooltip's SVG-relative `top`. The `actions` prop is also declared on `IChartComponents.LineChart`/`.BarChart` in the types package so plugin widgets can pass their toggles through.

Also moves the BlockTicker width cap from `.container` to `.ticker` so the whole bar is an intrinsically-sized flex item that widget-zone alignment (`--zone-justify-content` / `--zone-align-items`) can act on.

## Notes

- Consumers `trp-dust-tracker` (DustActivityWidget) and `trp-resource-tracker` (ResourceDelegationsWidget) are updated in their own repos to pass toggles via `actions`; those land as separate plugin submits once the types change publishes.
- `actions` is an additive optional prop — untitled, control-less charts are unchanged.