### PR TITLE
feat(notifications): admin toasts for curation holds; persistent notification toasts

### DIFF
--- a/src/backend/modules/ai-tools/AiToolsModule.ts
+++ b/src/backend/modules/ai-tools/AiToolsModule.ts
@@ -99,6 +99,21 @@ const SCHEDULED_PROMPT_NOTIFY_CATEGORY = 'ai-tools.scheduled-prompt-run';
 const SCHEDULED_PROMPT_CONTENT_TYPE = 'ai-tools:scheduled-prompt-run';
 
 /**
+ * Notification category id for new curation holds. Registered on the
+ * `'notifications'` service in run(); every item held for review fans a toast to
+ * admins through it, and any admin can silence it from their preferences.
+ */
+const CURATION_HELD_NOTIFY_CATEGORY = 'ai-tools.curation-held';
+
+/**
+ * Content type id this module registers for the curation-held notification.
+ * `notify()` carries the held item's title/body by reference under this type;
+ * its `describe(ref)` echoes them into a descriptor — content-registry-symmetric
+ * with both the scheduled-prompt notification and curation itself.
+ */
+const CURATION_HELD_CONTENT_TYPE = 'ai-tools:curation-held';
+
+/**
  * Service-registry name of the notifications service this module fires through.
  * Held as a local literal rather than imported from the notifications module so
  * ai-tools stays decoupled from that module's source — the only contract
@@ -423,6 +438,31 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
             WebSocketService.getInstance().emit({ event, payload });
         });
 
+        // Fan every new curation hold to admins as a toast. Resolves the
+        // notifications service per call (lazy, robust — it never unregisters at
+        // runtime) and swallows dispatch errors so a notification fault never
+        // disturbs a hold. Fires on every hold, including ones the governor then
+        // auto-approves. The category/content type are registered below.
+        this.curation.setOnHold((item, typeLabel) => {
+            const svc = this.serviceRegistry.get<INotificationService>(NOTIFICATIONS_SERVICE);
+            if (!svc) {
+                return;
+            }
+            void svc
+                .notify({
+                    category: CURATION_HELD_NOTIFY_CATEGORY,
+                    typeId: CURATION_HELD_CONTENT_TYPE,
+                    ref: {
+                        title: `New ${typeLabel} held for review`,
+                        body: item.preview.title ?? item.preview.body
+                    },
+                    severity: 'info',
+                    firedBy: item.source,
+                    data: { curationId: item.id, typeId: item.typeId }
+                })
+                .catch((error) => this.logger.warn({ error, curationId: item.id }, 'Failed to dispatch curation-hold notification'));
+        });
+
         this.serviceRegistry.register(AI_TOOLS_SERVICE, this.registry);
         this.serviceRegistry.register(AI_TOOL_GOVERNOR_SERVICE, this.governor);
         this.serviceRegistry.register(AI_PROVIDERS_SERVICE, this.providerRegistry);
@@ -463,8 +503,35 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
                 adminConfigurable: true,
                 mutable: true
             });
+
+            // Register the curation-held content type and its admin-targeted
+            // category, mirroring the scheduled-prompt wiring above. The
+            // descriptor carries only title/body, which is what the toast channel
+            // accepts — so a new hold routes to admins as a toast.
+            this.serviceRegistry.get<IContentRegistry>(CONTENT_TYPES_SERVICE)?.register(
+                {
+                    typeId: CURATION_HELD_CONTENT_TYPE,
+                    label: 'Curation item held for review',
+                    describe: (ref) => ({
+                        title: typeof ref.title === 'string' ? ref.title : undefined,
+                        body: typeof ref.body === 'string' ? ref.body : undefined
+                    })
+                },
+                this.metadata.id
+            );
+            notifications.registerCategory({
+                id: CURATION_HELD_NOTIFY_CATEGORY,
+                label: 'Curation items held for review',
+                description: 'Fires when an item is held in the curation queue for human review.',
+                source: this.metadata.id,
+                defaultAudience: { groups: [ADMIN_GROUP_ID] },
+                channelDefaults: { toast: true },
+                userConfigurable: true,
+                adminConfigurable: true,
+                mutable: true
+            });
         } else {
-            this.logger.warn('notifications service unavailable; scheduled-prompt run notifications disabled');
+            this.logger.warn('notifications service unavailable; scheduled-prompt and curation-hold notifications disabled');
         }
 
         // Fans each scheduled-prompt run outcome to admins. Resolves the

--- a/src/backend/modules/ai-tools/services/curation-service.ts
+++ b/src/backend/modules/ai-tools/services/curation-service.ts
@@ -45,6 +45,16 @@ interface IRegisteredType {
 /** Broadcast sink for dashboard refetch signals (a no-op until wired). */
 type BroadcastFn = (event: string, payload: unknown) => void;
 
+/**
+ * Listener invoked once per newly held item, immediately after it is persisted.
+ * It lets an external consumer (the module) fan an admin notification on each
+ * hold without the curation service taking a dependency on the notification
+ * service — the same decoupling {@link BroadcastFn} gives the dashboard signal.
+ * The registered type's label is passed alongside the item so the consumer need
+ * not reach back into the registry. Optional; until wired, holds raise nothing.
+ */
+type HoldListenerFn = (item: ICurationItem, typeLabel: string) => void;
+
 /** WebSocket event the dashboard listens on to refetch the queue. */
 export const CURATIONS_CHANGED_EVENT = 'ai-tools:curations-changed';
 
@@ -61,6 +71,7 @@ export const CURATION_AUTO_APPROVE_DECIDED_BY = 'system:policy-auto-approve';
 export class CurationService implements ICurationService {
     private readonly types = new Map<string, IRegisteredType>();
     private broadcast: BroadcastFn | null = null;
+    private holdListener: HoldListenerFn | null = null;
 
     /**
      * @param logger - Module-scoped logger.
@@ -84,6 +95,19 @@ export class CurationService implements ICurationService {
      */
     setBroadcast(fn: BroadcastFn): void {
         this.broadcast = fn;
+    }
+
+    /**
+     * Wire a listener fired once per new hold so the module can fan an admin
+     * notification. Kept separate from the broadcast sink because the two carry
+     * different intents: the broadcast is a fire-and-forget dashboard refetch
+     * nudge, while this delivers the held item itself for a targeted toast.
+     * Optional; until set, new holds raise no notification.
+     *
+     * @param fn - Listener invoked with the held item and its type's label.
+     */
+    setOnHold(fn: HoldListenerFn): void {
+        this.holdListener = fn;
     }
 
     /**
@@ -165,6 +189,10 @@ export class CurationService implements ICurationService {
      * owning type's `onApprove` before this returns. A bypass that fails to
      * commit propagates exactly as a manual approval's failure would.
      *
+     * The hold listener fires for every hold — before the auto-approve branch —
+     * so an admin is notified whenever anything enters the queue, regardless of
+     * whether a policy bypass then decides it immediately.
+     *
      * @param input - The type id, opaque ref, and optional attribution.
      * @returns The stored envelope — `approved` when auto-approved, else `pending`.
      * @throws When the type id is not registered.
@@ -187,6 +215,10 @@ export class CurationService implements ICurationService {
         };
         await this.queue.insert(item);
         await this.notifyChanged();
+        // Notify on every hold, before the auto-approve branch. The listener is a
+        // synchronous fire-and-forget sink the module owns; it must not throw, so
+        // a notification fault cannot derail the hold.
+        this.holdListener?.(item, entry.type.label);
         let result = item;
         if (shouldAutoApproveCuration()) {
             this.logger.info({ id: item.id, typeId: item.typeId }, 'Curation auto-approved by tool policy (interactive bypass)');

--- a/src/backend/modules/ai-tools/services/curation-service.ts
+++ b/src/backend/modules/ai-tools/services/curation-service.ts
@@ -216,9 +216,13 @@ export class CurationService implements ICurationService {
         await this.queue.insert(item);
         await this.notifyChanged();
         // Notify on every hold, before the auto-approve branch. The listener is a
-        // synchronous fire-and-forget sink the module owns; it must not throw, so
-        // a notification fault cannot derail the hold.
-        this.holdListener?.(item, entry.type.label);
+        // synchronous fire-and-forget sink the module owns; guard it so a faulty
+        // listener cannot derail the hold or its downstream auto-approve.
+        try {
+            this.holdListener?.(item, entry.type.label);
+        } catch (error) {
+            this.logger.warn({ error, id: item.id }, 'Curation hold listener failed');
+        }
         let result = item;
         if (shouldAutoApproveCuration()) {
             this.logger.info({ id: item.id, typeId: item.typeId }, 'Curation auto-approved by tool policy (interactive bypass)');

--- a/src/backend/modules/widgets/README.md
+++ b/src/backend/modules/widgets/README.md
@@ -13,7 +13,7 @@ Owns every concern of the widget subsystem behind a single public surface: `IWid
 | WebSocket event | `widgets:placements-update` (also fired on zone-layout change — no separate event) |
 | Types package | `@delphian/tronrelic-types` — `IWidgetsService`, `IRegisterWidgetTypeInput`, `IRegisterZoneInput`, `IRegisterWidgetInput`, `IWidgetPlacement`, `IPlacementInput`, `IPlacementPatch`, `IPlacementListFilter`, `IWidgetType`, `IWidgetPlacementContext`, `IZoneDescriptor`, `IZoneSnapshot`, `IZoneLayoutConfig`, `IWidgetTypeSnapshot` |
 | Storage | `module_widgets_placements`, `module_widgets_zone_layouts` (MongoDB) |
-| Migration | `module:widgets:001_create_widget_placements` (placements collection + 4 indexes); `module:widgets:002_seed_block_ticker_placement` (idempotent seed of one operator-source `core:block-ticker` placement in `ticker-after`, guarded on absence so it runs once and never fights an operator edit); `module:widgets:003_add_parent_id_index` (sparse `parentId` index for child grouping). The zone-layouts collection needs no migration — `ZoneLayoutService.load()` creates its unique index idempotently at boot. |
+| Migration | `module:widgets:001_create_widget_placements` (placements collection + 4 indexes); `module:widgets:002_seed_block_ticker_placement` (idempotent seed of one operator-source `core:block-ticker` placement in `ticker-after`, guarded on absence so it runs once and never fights an operator edit); `module:widgets:003_add_parent_id_index` (sparse `parentId` index for child grouping); `module:widgets:004_repair_plugin_placement_index` (drops the mis-scoped sparse unique `(typeId, pluginId)` index and recreates it partial — `partialFilterExpression: { pluginId: { $exists: true } }` — so operators can place a widget type more than once). The zone-layouts collection needs no migration — `ZoneLayoutService.load()` creates its unique index idempotently at boot. |
 | System menu node | "Widgets" under the System container — seeded by `WidgetsModule.run()` |
 
 ## Source Map
@@ -128,7 +128,7 @@ The placement service emits via a callback `WidgetsModule.init()` wires to `WebS
 | `pluginId` | string? | Set only when `source === 'plugin'` |
 | `createdAt` / `updatedAt` | Date | |
 
-Indexes (migration 001): `(typeId, pluginId)` sparse unique for plugin-row atomicity; `(enabled, zoneId, order)` for SSR queries; `routes` multikey; `source`.
+Indexes: `(typeId, pluginId)` unique for plugin-row atomicity — **partial**, `partialFilterExpression: { pluginId: { $exists: true } }` (migration 004; migration 001 created it `sparse`, which wrongly indexed pluginId-less operator rows and blocked a second operator placement of the same `typeId`); `(enabled, zoneId, order)` for SSR queries; `routes` multikey; `source` (all migration 001). Because the unique index covers only plugin rows, operator-source placements may repeat a `typeId` in any zone freely.
 
 `module_widgets_zone_layouts` collection (one row per zone with an operator override; zones with no row fall back to a descriptor-derived default):
 

--- a/src/backend/modules/widgets/migrations/001_create_widget_placements.ts
+++ b/src/backend/modules/widgets/migrations/001_create_widget_placements.ts
@@ -47,9 +47,16 @@ export const migration: IMigration = {
 
         // Upsert filter for `ensurePluginPlacement`: unique on
         // (typeId, pluginId) so the disable→enable cycle finds the
-        // existing row instead of creating a duplicate. Sparse so
-        // operator placements (which omit `pluginId`) are excluded
-        // from the unique constraint and can share a `typeId` freely.
+        // existing row instead of creating a duplicate.
+        //
+        // NOTE: this `sparse` option is mis-scoped and is corrected by
+        // migration 004. A *compound* sparse index still indexes a
+        // document that has at least one keyed field, so operator rows
+        // (which carry `typeId` but omit `pluginId`) are indexed with a
+        // null `pluginId` and a second operator placement of the same
+        // `typeId` collides. Migration 004 replaces this with a partial
+        // index scoped to `pluginId`-bearing rows. This call is left
+        // as-is so the historical migration record stays faithful.
         await context.database.createIndex(
             collection,
             { typeId: 1, pluginId: 1 },

--- a/src/backend/modules/widgets/migrations/004_repair_plugin_placement_index.ts
+++ b/src/backend/modules/widgets/migrations/004_repair_plugin_placement_index.ts
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview Repair the plugin-placement uniqueness index so operators
+ * can place the same widget type more than once.
+ *
+ * Migration 001 created `plugin_placement_identity` on `(typeId, pluginId)`
+ * as a `unique` + `sparse` index, intending to constrain only plugin-source
+ * rows (which carry a `pluginId`) while leaving operator-source rows (which
+ * omit it) unconstrained. That intent is wrong for a *compound* sparse
+ * index: MongoDB indexes a document when it contains *at least one* of the
+ * keyed fields, and operator rows always carry `typeId`. So every operator
+ * row is indexed with `pluginId` recorded as null, and a second operator
+ * placement of the same widget type — anywhere, in any zone — collides on
+ * `(typeId, null)` and is rejected with a duplicate-key error (E11000).
+ *
+ * The fix swaps the sparse index for a `partialFilterExpression` that only
+ * indexes rows where `pluginId` actually exists. Plugin-row atomicity (the
+ * `ensurePluginPlacement` upsert that relies on a single row per
+ * `(typeId, pluginId)`) is preserved, while operator rows fall entirely
+ * outside the index and may repeat a `typeId` freely. The index keeps the
+ * same name and key, so it must be dropped and recreated — index options
+ * cannot be altered in place.
+ *
+ * Idempotent: it drops `plugin_placement_identity` only when present (so a
+ * retry after a mid-migration failure does not throw `IndexNotFound`) and
+ * recreates it from scratch, leaving the collection with exactly one
+ * correctly-scoped uniqueness index regardless of which state the previous
+ * attempt left behind.
+ *
+ * @module backend/modules/widgets/migrations/004_repair_plugin_placement_index
+ */
+
+import type { IMigration, IMigrationContext } from '@/types';
+
+/** Physical collection name, matching migration 001 and the placement service. */
+const COLLECTION = 'module_widgets_placements';
+
+/** Name of the uniqueness index being repaired; reused so no stale index survives. */
+const INDEX_NAME = 'plugin_placement_identity';
+
+export const migration: IMigration = {
+    id: '004_repair_plugin_placement_index',
+    description:
+        'Replace the sparse unique (typeId, pluginId) index on ' +
+        'module_widgets_placements with a partial index scoped to ' +
+        'pluginId-bearing rows, so operators can place a widget type more ' +
+        'than once.',
+    dependencies: ['module:widgets:001_create_widget_placements'],
+
+    /**
+     * Drop the mis-scoped sparse index and recreate it as a partial unique
+     * index. The drop is guarded on presence so a retry after a partial
+     * failure is safe; the create uses `partialFilterExpression` (absent
+     * from the `IDatabaseService.createIndex` option surface), so the
+     * migration reaches the native driver collection directly.
+     *
+     * @param context - Migration context exposing the database service.
+     */
+    async up(context: IMigrationContext): Promise<void> {
+        const collection = context.database.getCollection(COLLECTION);
+
+        // Drop only when present: a retry that already dropped (but had not
+        // yet recreated) the index must not throw IndexNotFound.
+        const existing = await collection.listIndexes().toArray();
+        const hasIndex = existing.some(index => index.name === INDEX_NAME);
+        if (hasIndex) {
+            await collection.dropIndex(INDEX_NAME);
+        }
+
+        // Partial filter indexes only plugin-source rows (those with a
+        // pluginId), so the unique constraint guards the ensurePluginPlacement
+        // upsert without ever touching operator rows.
+        await collection.createIndex(
+            { typeId: 1, pluginId: 1 },
+            {
+                name: INDEX_NAME,
+                unique: true,
+                partialFilterExpression: { pluginId: { $exists: true } }
+            }
+        );
+
+        return;
+    }
+};

--- a/src/frontend/components/layout/BlockTicker/BlockTicker.module.scss
+++ b/src/frontend/components/layout/BlockTicker/BlockTicker.module.scss
@@ -8,22 +8,22 @@
 @use '../../../app/breakpoints' as *;
 
 /*
- * fit-content makes the bar — surface and top/bottom borders included — an
- * intrinsically sized flex item rather than a full-width block. A widget
- * zone/group can then center or left/right-align it via --zone-justify-content /
- * --zone-align-items; a full-width root would fill the zone and leave that
- * alignment config nothing to act on. The core layout group owns the real width
- * ceiling (per-row relative width / collapseBelow); `max-width: 100%` here is
- * only a safety cap so the intrinsically-sized bar can never grow the page wider
- * than its parent, while `.container` scrolls its nowrap metrics internally on
- * viewports too narrow to show them all.
+ * No explicit width: the bar's cross-axis size follows its zone's flex
+ * alignment. align-items: stretch (the zone default) fills the zone width —
+ * stretch operating as expected — while center / flex-start / flex-end leave a
+ * non-stretched flex item intrinsically sized, so --zone-justify-content /
+ * --zone-align-items can still position it (an `auto` width yields to alignment;
+ * a hardcoded width or `fit-content` would not, defeating stretch). The core
+ * layout group owns the real width ceiling (per-row relative width /
+ * collapseBelow); `max-width: 100%` here is only a safety cap so the bar can
+ * never grow the page wider than its parent, while `.container` scrolls its
+ * nowrap metrics internally on viewports too narrow to show them all.
  */
 .ticker {
     background: var(--color-surface);
     border-top: var(--border-width-thin) solid var(--color-border);
     border-bottom: var(--border-width-thin) solid var(--color-border);
     margin-top: var(--spacing-4);
-    width: fit-content;
     max-width: 100%;
 }
 

--- a/src/frontend/components/socket/NotificationHandler.tsx
+++ b/src/frontend/components/socket/NotificationHandler.tsx
@@ -50,8 +50,10 @@ export function NotificationHandler(): null {
 
         /**
          * Forward an incoming notification to the toast provider, mapping
-         * severity to tone and defaulting a generous dwell time since these are
-         * targeted (not broadcast) and worth reading.
+         * severity to tone. These toasts never auto-dismiss (`duration: 0`):
+         * they are identity-targeted, deliberately dispatched, and must persist
+         * until the recipient manually closes them so a notification is never
+         * missed by timing out while unattended.
          *
          * @param payload - Display fields from the backend.
          */
@@ -63,7 +65,7 @@ export function NotificationHandler(): null {
                 tone: SEVERITY_TONE[payload.severity] ?? 'info',
                 title: payload.title,
                 description: payload.body,
-                duration: 8000
+                duration: 0
             });
         };
 


### PR DESCRIPTION
## Curation-hold admin notifications

Notifies all admins via toast whenever an item is held in the curation queue. `CurationService` gains a `setOnHold` sink (mirroring the existing `setBroadcast` decoupling) so it takes no dependency on the notification service; `AiToolsModule` registers a `ai-tools:curation-held` content type and an admin-targeted `ai-tools.curation-held` category (`channelDefaults: { toast: true }`, admin-silenceable) and fires `notify()` on **every** hold — before the auto-approve branch — copying the existing scheduled-prompt notification wiring.

## Persistent notification toasts

Notification-pipeline toasts (`NotificationHandler`) now pass `duration: 0`, so a targeted notification persists until the recipient manually dismisses it instead of auto-dismissing after 8s. `ToastProvider` already treats `duration <= 0` as no auto-dismiss.

## BlockTicker stretch fix

Dropped `width: fit-content` from `.ticker` so `align-items: stretch` (the widget-zone default) fills the zone width as expected; `max-width: 100%` stays as an overflow safety cap. Non-stretch zones (`center`/`flex-start`/`flex-end`) still leave the bar intrinsically sized so zone alignment config can position it.

## Included from working tree

Widget placement index repair (`migrations/004_repair_plugin_placement_index.ts`) plus related `001` migration and widgets `README` updates that were already staged — bundled by `/ship` staging the full working tree.