### PR TITLE
feat(ai-tools): slide-over master-detail and triage UX across governance tabs

### DIFF
--- a/src/frontend/app/(core)/system/ai-tools/components/ApprovalDetailPanel.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/ApprovalDetailPanel.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+/**
+ * @fileoverview Slide-over body for one parked approval — the detail half of the
+ * Approvals queue. Approving runs an irreversible/external/paid effect *now*, so
+ * the decision must be made against the full picture, not a truncated argument
+ * preview: this panel shows the dominant risk class and full capability badges, a
+ * caution when the effect spends money or cannot be undone, the trigger context,
+ * and the complete pretty-printed arguments. Approve/Reject live here beside that
+ * payload; the parent owns the confirm-for-dangerous and close behaviour.
+ */
+
+import type { IPendingApproval } from '../../../../../modules/ai-tools';
+import { AlertTriangle, Check, X } from 'lucide-react';
+import { Button } from '../../../../../components/ui/Button';
+import { ClientTime } from '../../../../../components/ui/ClientTime';
+import { CapabilityBadges } from './CapabilityBadges';
+import { RiskChip } from './RiskChip';
+import styles from '../page.module.scss';
+
+/**
+ * The detail panel for one parked approval, rendered inside the SlideOver body.
+ *
+ * @param props.approval - The held invocation awaiting a decision.
+ * @param props.busy - Whether this approval's approve/reject is in flight.
+ * @param props.onApprove - Runs the held action (parent confirms dangerous classes first).
+ * @param props.onReject - Discards the held action (parent confirms first).
+ * @returns The approval detail body with in-panel actions.
+ */
+export function ApprovalDetailPanel({ approval, busy, onApprove, onReject }: {
+    approval: IPendingApproval;
+    busy: boolean;
+    onApprove: (approval: IPendingApproval) => void;
+    onReject: (approval: IPendingApproval) => void;
+}) {
+    const capability = approval.capability;
+    const actor = approval.context.actor;
+    const actorLabel = `${actor.kind}${actor.id ? ` · ${actor.id}` : ''}`;
+    // A money-spending or unrecoverable effect deserves an explicit caution above
+    // the run button, separate from the always-present capability badges.
+    const highStakes = capability?.spendsMoney === true || capability?.reversible === false;
+
+    return (
+        <div className={styles.detail}>
+            <div className={styles.detail_meta}>
+                <div className={styles.detail_meta_row}>
+                    <span className="text-muted">{approval.providerId}</span>
+                    <RiskChip capability={capability} />
+                </div>
+                <CapabilityBadges capability={capability} />
+            </div>
+
+            {highStakes && (
+                <div className={styles.detail_caution}>
+                    <AlertTriangle size={18} aria-hidden="true" style={{ flexShrink: 0 }} />
+                    <span>
+                        Approving runs this effect immediately and it
+                        {capability?.reversible === false ? ' cannot be undone' : ''}
+                        {capability?.spendsMoney ? ' spends money' : ''}. Review the arguments below before approving.
+                    </span>
+                </div>
+            )}
+
+            <div className={styles.detail_section}>
+                <span className={styles.detail_section_title}>Context</span>
+                <dl className={styles.kv}>
+                    <dt className={styles.kv_label}>Trigger</dt>
+                    <dd className={styles.kv_value}>{approval.context.triggerPath}</dd>
+                    <dt className={styles.kv_label}>Actor</dt>
+                    <dd className={styles.kv_value}>{actorLabel}</dd>
+                    <dt className={styles.kv_label}>AI provider</dt>
+                    <dd className={styles.kv_value}>{approval.context.aiProviderId}</dd>
+                    {approval.context.callerPluginId && (
+                        <>
+                            <dt className={styles.kv_label}>Caller</dt>
+                            <dd className={styles.kv_value}>{approval.context.callerPluginId}</dd>
+                        </>
+                    )}
+                    {approval.context.endUser && (
+                        <>
+                            <dt className={styles.kv_label}>End user</dt>
+                            <dd className={styles.kv_value}>{approval.context.endUser.userId}</dd>
+                        </>
+                    )}
+                    <dt className={styles.kv_label}>Parked</dt>
+                    <dd className={styles.kv_value}><ClientTime date={approval.createdAt} format="datetime" /></dd>
+                </dl>
+            </div>
+
+            <div className={styles.detail_section}>
+                <span className={styles.detail_section_title}>Arguments</span>
+                <pre className={styles.args_block}>{JSON.stringify(approval.input, null, 2)}</pre>
+            </div>
+
+            <div className={styles.detail_actions}>
+                <Button
+                    variant="primary"
+                    size="md"
+                    loading={busy}
+                    onClick={() => onApprove(approval)}
+                    aria-label={`Approve ${approval.toolName}`}
+                >
+                    <Check size={18} /> Approve
+                </Button>
+                <Button
+                    variant="danger"
+                    size="md"
+                    disabled={busy}
+                    onClick={() => onReject(approval)}
+                    aria-label={`Reject ${approval.toolName}`}
+                >
+                    <X size={18} /> Reject
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/frontend/app/(core)/system/ai-tools/components/InvocationDetailPanel.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/InvocationDetailPanel.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+/**
+ * @fileoverview Slide-over body for one audit record — the detail half of the
+ * Activity feed. The feed row is terminal triage (tool, status, duration); this
+ * panel surfaces everything the `IToolInvocationRecord` actually captured but the
+ * row hides: the capability class at invocation, the redacted arguments, the
+ * result digest, the sanitized and raw error bodies (admin-only forensics), the
+ * cost, the end-user principal, the correlation ids, and the untrusted-content
+ * screen verdict. An auditor reconstructing "what did this call do, and what came
+ * back" reads it here rather than from source.
+ */
+
+import type { IToolInvocationRecord, ToolInvocationStatus } from '@/types';
+import { Badge } from '../../../../../components/ui/Badge';
+import { ClientTime } from '../../../../../components/ui/ClientTime';
+import { CapabilityBadges } from './CapabilityBadges';
+import styles from '../page.module.scss';
+
+/**
+ * Map an invocation status to a badge tone. Exported so the Activity feed row and
+ * this panel colour a status identically.
+ *
+ * @param status - The terminal invocation status.
+ * @returns The badge tone for that status.
+ */
+export function statusTone(status: ToolInvocationStatus): 'success' | 'warning' | 'danger' | 'info' {
+    switch (status) {
+        case 'ok': return 'success';
+        case 'denied': return 'warning';
+        case 'pending-approval': return 'info';
+        default: return 'danger';
+    }
+}
+
+/**
+ * The detail panel for one invocation record, rendered inside the SlideOver body.
+ *
+ * @param props.record - The audit record to expand.
+ * @returns The record detail body.
+ */
+export function InvocationDetailPanel({ record }: { record: IToolInvocationRecord }) {
+    const actorLabel = `${record.actor.kind}${record.actor.id ? ` · ${record.actor.id}` : ''}`;
+
+    return (
+        <div className={styles.detail}>
+            <div className={styles.detail_meta}>
+                <div className={styles.detail_meta_row}>
+                    <span className="text-muted">{record.providerId}</span>
+                    <Badge tone={statusTone(record.status)}>{record.status}</Badge>
+                </div>
+                <CapabilityBadges capability={record.capability} />
+            </div>
+
+            <div className={styles.detail_section}>
+                <span className={styles.detail_section_title}>Invocation</span>
+                <dl className={styles.kv}>
+                    <dt className={styles.kv_label}>AI provider</dt>
+                    <dd className={styles.kv_value}>{record.aiProviderId}</dd>
+                    <dt className={styles.kv_label}>Actor</dt>
+                    <dd className={styles.kv_value}>{actorLabel}</dd>
+                    <dt className={styles.kv_label}>Trigger</dt>
+                    <dd className={styles.kv_value}>{record.triggerPath}</dd>
+                    {record.endUserId && (
+                        <>
+                            <dt className={styles.kv_label}>End user</dt>
+                            <dd className={styles.kv_value}>{record.endUserId}</dd>
+                        </>
+                    )}
+                    <dt className={styles.kv_label}>Duration</dt>
+                    <dd className={styles.kv_value}>{record.durationMs}ms</dd>
+                    {record.costUsd !== undefined && (
+                        <>
+                            <dt className={styles.kv_label}>Cost</dt>
+                            <dd className={styles.kv_value}>≈ ${record.costUsd.toFixed(4)}</dd>
+                        </>
+                    )}
+                    <dt className={styles.kv_label}>Time</dt>
+                    <dd className={styles.kv_value}><ClientTime date={record.createdAt} format="datetime" /></dd>
+                    {record.conversationId && (
+                        <>
+                            <dt className={styles.kv_label}>Conversation</dt>
+                            <dd className={styles.kv_value}>{record.conversationId}</dd>
+                        </>
+                    )}
+                    {record.queryId && (
+                        <>
+                            <dt className={styles.kv_label}>Query</dt>
+                            <dd className={styles.kv_value}>{record.queryId}</dd>
+                        </>
+                    )}
+                </dl>
+            </div>
+
+            <div className={styles.detail_section}>
+                <span className={styles.detail_section_title}>Arguments</span>
+                <p className="text-subtle" style={{ margin: 0, fontSize: 'var(--font-size-caption)' }}>
+                    Redacted by the tool&apos;s declared sensitivity.
+                </p>
+                <pre className={styles.args_block}>{JSON.stringify(record.input, null, 2)}</pre>
+            </div>
+
+            <div className={styles.detail_section}>
+                <span className={styles.detail_section_title}>Result</span>
+                <p className={styles.kv_value} style={{ margin: 0 }}>
+                    {record.resultDigest ?? 'No result preview stored.'}
+                </p>
+            </div>
+
+            {(record.error || record.errorRaw) && (
+                <div className={styles.detail_section}>
+                    <span className={styles.detail_section_title}>Error</span>
+                    <div className={styles.detail_error}>
+                        {record.error && <span>{record.error}</span>}
+                        {record.errorRaw && <span className={styles.mono}>{record.errorRaw}</span>}
+                    </div>
+                </div>
+            )}
+
+            {record.screen && (
+                <div className={styles.detail_section}>
+                    <span className={styles.detail_section_title}>Untrusted-content screen</span>
+                    <dl className={styles.kv}>
+                        <dt className={styles.kv_label}>Verdict</dt>
+                        <dd className={styles.kv_value}>
+                            <Badge tone={record.screen.flagged ? 'danger' : 'success'}>
+                                {record.screen.flagged ? 'withheld' : 'passed'}
+                            </Badge>
+                        </dd>
+                        {record.screen.reason && (
+                            <>
+                                <dt className={styles.kv_label}>Reason</dt>
+                                <dd className={styles.kv_value}>{record.screen.reason}</dd>
+                            </>
+                        )}
+                    </dl>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/frontend/app/(core)/system/ai-tools/components/RegistryToolRow.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/RegistryToolRow.tsx
@@ -1,99 +1,74 @@
 'use client';
 
 /**
- * @fileoverview One Registry Tools row: the tool's identity, provider,
- * capability badges, and enable toggle, with a chevron that discloses an inline
- * policy editor. The editor lives behind the chevron rather than in adjacent
- * columns so the row stays scannable and the trifecta-arming policy knobs keep a
- * deliberate click between them and the everyday enable toggle — the reason the
- * former standalone Policy tab folded into the Registry here.
+ * @fileoverview One Registry Tools row, reshaped for fast triage. The two
+ * questions an operator asks first — is it live, and how dangerous is it — lead
+ * the row as the enable toggle and the single dominant risk chip; the name and a
+ * one-line description teaser follow. The full model-facing description, the
+ * parameter schema, and the policy editor moved off the row into the slide-over
+ * (opened by clicking the row or the name) so the list stays scannable instead
+ * of every row unrolling a wall of model-facing prose.
+ *
+ * The enable switch and its cell stop click propagation so toggling a tool never
+ * also opens the panel; everything else on the row is a path into the detail.
  */
 
-import { useState } from 'react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
-import type { IAiToolInfo, IToolPolicy } from '@/types';
+import type { MouseEvent } from 'react';
+import type { IAiToolInfo } from '@/types';
 import { Badge } from '../../../../../components/ui/Badge';
 import { Switch } from '../../../../../components/ui/Switch';
 import { Tr, Td } from '../../../../../components/ui/Table';
-import type { IPolicyResponse } from '../../../../../modules/ai-tools';
-import { CapabilityBadges } from './CapabilityBadges';
-import { ToolPolicyEditor } from './ToolPolicyEditor';
+import { RiskChip } from './RiskChip';
 import styles from '../page.module.scss';
 
-/** Usage tally shape from `GET /policy`. */
-type Usage = IPolicyResponse['usage'][string];
-
 /**
- * A tool's main row plus its collapsible policy editor.
+ * A single tool's registry row.
  *
- * @param props.tool - The tool to render (name, description, provider, capability, enabled state).
- * @param props.override - The tool's saved policy override, or undefined when it runs on class defaults; presence drives the "override" badge.
- * @param props.usage - Audit-trail tallies passed through to the editor.
- * @param props.defaults - The governor's resolved class defaults passed through to the editor.
+ * @param props.tool - The tool to render (enabled, capability, name, description, provider).
+ * @param props.hasOverride - Whether the tool carries a saved policy override; drives the "override" badge.
  * @param props.busy - Whether an enable toggle for this tool is in flight, disabling the switch.
- * @param props.columnCount - Total column count, so the expanded editor cell can span the full table width.
- * @param props.onToggle - Enable/disable handler the parent owns (it reloads and re-checks the trifecta).
- * @param props.onPolicyChanged - Called after a save/clear so the parent refetches policy and the trifecta.
- * @returns The row fragment (main row, and the editor row while expanded).
+ * @param props.onToggle - Enable/disable handler the parent owns (reloads and re-checks the trifecta).
+ * @param props.onSelect - Opens the detail slide-over for this tool.
+ * @returns The table row.
  */
-export function RegistryToolRow({ tool, override, usage, defaults, busy, columnCount, onToggle, onPolicyChanged }: {
+export function RegistryToolRow({ tool, hasOverride, busy, onToggle, onSelect }: {
     tool: IAiToolInfo;
-    override?: IToolPolicy;
-    usage?: Usage;
-    defaults?: { requireApproval: boolean; allowUnattended: boolean };
+    hasOverride: boolean;
     busy: boolean;
-    columnCount: number;
     onToggle: (name: string, enabled: boolean) => void;
-    onPolicyChanged: () => void;
+    onSelect: (tool: IAiToolInfo) => void;
 }) {
-    const [open, setOpen] = useState(false);
-    const hasOverride = override !== undefined;
+    /**
+     * Keep a click inside the enable cell from bubbling to the row's open
+     * handler, so toggling a tool never also opens the panel.
+     *
+     * @param event - The cell click event.
+     */
+    const stopCellClick = (event: MouseEvent<HTMLTableCellElement>) => {
+        event.stopPropagation();
+    };
 
     return (
-        <>
-            <Tr>
-                <Td>
-                    <button
-                        type="button"
-                        className={styles.expand_button}
-                        onClick={() => setOpen(current => !current)}
-                        aria-expanded={open}
-                        aria-label={`${open ? 'Hide' : 'Edit'} policy for ${tool.name}`}
-                    >
-                        {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        <Tr className={styles.tool_row} onClick={() => onSelect(tool)}>
+            <Td onClick={stopCellClick}>
+                <Switch
+                    on={tool.enabled}
+                    onChange={(next) => onToggle(tool.name, next)}
+                    disabled={busy}
+                    aria-label={`${tool.enabled ? 'Disable' : 'Enable'} ${tool.name}`}
+                />
+            </Td>
+            <Td><RiskChip capability={tool.capability} /></Td>
+            <Td>
+                <div className={styles.tool_cell}>
+                    <button type="button" className={styles.tool_name_button} onClick={() => onSelect(tool)}>
+                        {tool.name}
                     </button>
-                </Td>
-                <Td>
-                    <div className={styles.tool_cell}>
-                        <span className={styles.tool_name}>{tool.name}</span>
-                        {hasOverride && <Badge tone="info">override</Badge>}
-                    </div>
-                    <div className={styles.tool_desc}>{tool.description}</div>
-                </Td>
-                <Td muted>{tool.provider}</Td>
-                <Td><CapabilityBadges capability={tool.capability} /></Td>
-                <Td>
-                    <Switch
-                        on={tool.enabled}
-                        onChange={(next) => onToggle(tool.name, next)}
-                        disabled={busy}
-                        aria-label={`${tool.enabled ? 'Disable' : 'Enable'} ${tool.name}`}
-                    />
-                </Td>
-            </Tr>
-            {open && (
-                <Tr isExpanded>
-                    <Td colSpan={columnCount}>
-                        <ToolPolicyEditor
-                            tool={tool}
-                            override={override}
-                            usage={usage}
-                            defaults={defaults}
-                            onChanged={onPolicyChanged}
-                        />
-                    </Td>
-                </Tr>
-            )}
-        </>
+                    {hasOverride && <Badge tone="info">override</Badge>}
+                </div>
+            </Td>
+            <Td><span className={styles.tool_teaser}>{tool.description}</span></Td>
+            <Td muted>{tool.provider}</Td>
+        </Tr>
     );
 }

--- a/src/frontend/app/(core)/system/ai-tools/components/RegistryToolRow.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/RegistryToolRow.tsx
@@ -61,7 +61,11 @@ export function RegistryToolRow({ tool, hasOverride, busy, onToggle, onSelect }:
             <Td><RiskChip capability={tool.capability} /></Td>
             <Td>
                 <div className={styles.tool_cell}>
-                    <button type="button" className={styles.tool_name_button} onClick={() => onSelect(tool)}>
+                    <button
+                        type="button"
+                        className={styles.tool_name_button}
+                        onClick={(event) => { event.stopPropagation(); onSelect(tool); }}
+                    >
                         {tool.name}
                     </button>
                     {hasOverride && <Badge tone="info">override</Badge>}

--- a/src/frontend/app/(core)/system/ai-tools/components/RiskChip.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/RiskChip.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+/**
+ * @fileoverview Collapses a tool's full capability declaration into the single
+ * dominant risk class shown in the registry list — the one signal an admin
+ * triages by. The detailed multi-badge breakdown stays in the slide-over
+ * (CapabilityBadges); the list needs one scannable chip, sorted dangerous-first.
+ *
+ * Irreversibility outranks side effect: an external-but-irreversible tool reads
+ * as "destructive" (danger tone + lock glyph) because that is the property an
+ * auditor must catch first, and the lock distinguishes it from a reversible
+ * external tool that shares the danger tone. Read/write below it map cool→warm;
+ * an unclassified tool is flagged warning so the missing declaration is visible
+ * rather than silently treated as safe. This module also exports the rank and
+ * presentation maps so the registry sorts and filters off the same definition.
+ */
+
+import { Lock } from 'lucide-react';
+import type { IAiToolCapability } from '@/types';
+import { Badge } from '../../../../../components/ui/Badge';
+
+/** The single dominant risk class derived from a capability. */
+export type RiskClass = 'destructive' | 'external' | 'write' | 'unclassified' | 'read';
+
+/**
+ * Reduce a capability to its dominant risk class. Irreversibility wins outright;
+ * otherwise the declared side effect is the class. An absent or side-effect-less
+ * capability is `unclassified` — the governor's read/internal default, surfaced
+ * so the missing declaration shows.
+ *
+ * @param capability - The tool's capability, or undefined when unclassified.
+ * @returns The dominant risk class.
+ */
+export function riskClassOf(capability?: IAiToolCapability): RiskClass {
+    let result: RiskClass;
+    if (!capability || !capability.sideEffect) {
+        result = 'unclassified';
+    } else if (capability.reversible === false) {
+        result = 'destructive';
+    } else {
+        result = capability.sideEffect;
+    }
+    return result;
+}
+
+/**
+ * Sort weight per class, dangerous-first, so the registry's default ordering
+ * meets the high-stakes tools at the top of an audit sweep.
+ */
+const RISK_RANK: Record<RiskClass, number> = {
+    destructive: 4,
+    external: 3,
+    write: 2,
+    unclassified: 1,
+    read: 0
+};
+
+/**
+ * Numeric risk weight for a capability, for the registry's default sort.
+ *
+ * @param capability - The tool's capability, or undefined when unclassified.
+ * @returns The class's sort weight (higher is more dangerous).
+ */
+export function riskRankOf(capability?: IAiToolCapability): number {
+    return RISK_RANK[riskClassOf(capability)];
+}
+
+/** Tone and label per class, shared by the list chip and the filter pills. */
+export const RISK_PRESENTATION: Record<RiskClass, { tone: 'neutral' | 'warning' | 'danger'; label: string }> = {
+    destructive: { tone: 'danger', label: 'destructive' },
+    external: { tone: 'danger', label: 'external' },
+    write: { tone: 'warning', label: 'write' },
+    unclassified: { tone: 'warning', label: 'unclassified' },
+    read: { tone: 'neutral', label: 'read' }
+};
+
+/** Display order for the filter pills — dangerous-first, unclassified last. */
+export const RISK_CLASS_ORDER: RiskClass[] = ['destructive', 'external', 'write', 'read', 'unclassified'];
+
+/**
+ * The dominant-risk chip for one tool's registry row.
+ *
+ * @param props.capability - The tool's capability classification.
+ * @returns A single tone-coded badge, with a lock glyph on the destructive class.
+ */
+export function RiskChip({ capability }: { capability?: IAiToolCapability }) {
+    const riskClass = riskClassOf(capability);
+    const { tone, label } = RISK_PRESENTATION[riskClass];
+    return (
+        <Badge tone={tone}>
+            {riskClass === 'destructive' && <Lock size={12} aria-hidden="true" />}
+            {label}
+        </Badge>
+    );
+}

--- a/src/frontend/app/(core)/system/ai-tools/components/ToolDetailPanel.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/ToolDetailPanel.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+/**
+ * @fileoverview Slide-over body for one registry tool — the detail half of the
+ * master-detail registry. It holds the surfaces too heavy for a list row: the
+ * full model-facing description (the field that dominates tool selection, so an
+ * admin must be able to read it in full), the input-parameter schema, and the
+ * policy override editor. Tabs keep the panel scannable instead of one long
+ * scroll, and the always-on meta strip (provider, full capability badges, the
+ * enable toggle) gives triage context regardless of the active tab.
+ *
+ * The panel reads its live tool/override from props the parent refetches on any
+ * change, so editing policy here and toggling enable stay in sync with the list
+ * behind it.
+ */
+
+import { useState } from 'react';
+import type { IAiToolInfo, IToolPolicy } from '@/types';
+import { cn } from '../../../../../lib/cn';
+import { Switch } from '../../../../../components/ui/Switch';
+import type { IPolicyResponse } from '../../../../../modules/ai-tools';
+import { CapabilityBadges } from './CapabilityBadges';
+import { ToolPolicyEditor } from './ToolPolicyEditor';
+import { ToolSchemaView } from './ToolSchemaView';
+import styles from '../page.module.scss';
+
+/** Usage tally shape from `GET /policy`. */
+type Usage = IPolicyResponse['usage'][string];
+
+/** Which detail surface is showing. */
+type DetailTab = 'description' | 'policy' | 'schema';
+
+/**
+ * The detail panel for one tool, rendered inside the SlideOver body.
+ *
+ * @param props.tool - The selected tool (live — re-derived from the parent's list on every reload).
+ * @param props.override - The tool's saved policy override, passed through to the editor.
+ * @param props.usage - Audit-trail tallies passed through to the editor.
+ * @param props.defaults - The governor's resolved class defaults passed through to the editor.
+ * @param props.busy - Whether an enable toggle for this tool is in flight, disabling the switch.
+ * @param props.onToggle - Enable/disable handler the parent owns (reloads and re-checks the trifecta).
+ * @param props.onPolicyChanged - Called after a save/clear so the parent refetches policy and the trifecta.
+ * @returns The tabbed detail body.
+ */
+export function ToolDetailPanel({ tool, override, usage, defaults, busy, onToggle, onPolicyChanged }: {
+    tool: IAiToolInfo;
+    override?: IToolPolicy;
+    usage?: Usage;
+    defaults?: { requireApproval: boolean; allowUnattended: boolean };
+    busy: boolean;
+    onToggle: (name: string, enabled: boolean) => void;
+    onPolicyChanged: () => void;
+}) {
+    const [tab, setTab] = useState<DetailTab>('description');
+    const propertyCount = Object.keys(tool.inputSchema?.properties ?? {}).length;
+
+    return (
+        <div className={styles.detail}>
+            <div className={styles.detail_meta}>
+                <div className={styles.detail_meta_row}>
+                    <span className="text-muted">{tool.provider}</span>
+                    <Switch
+                        on={tool.enabled}
+                        onChange={(next) => onToggle(tool.name, next)}
+                        disabled={busy}
+                        aria-label={`${tool.enabled ? 'Disable' : 'Enable'} ${tool.name}`}
+                    />
+                </div>
+                <CapabilityBadges capability={tool.capability} />
+            </div>
+
+            <div className={cn('segmented-control', styles.detail_tabs)} role="tablist" aria-label="Tool detail sections">
+                <button
+                    type="button"
+                    role="tab"
+                    aria-selected={tab === 'description'}
+                    className={cn(tab === 'description' && 'is-active')}
+                    onClick={() => setTab('description')}
+                >
+                    Description
+                </button>
+                <button
+                    type="button"
+                    role="tab"
+                    aria-selected={tab === 'policy'}
+                    className={cn(tab === 'policy' && 'is-active')}
+                    onClick={() => setTab('policy')}
+                >
+                    Policy
+                </button>
+                <button
+                    type="button"
+                    role="tab"
+                    aria-selected={tab === 'schema'}
+                    className={cn(tab === 'schema' && 'is-active')}
+                    onClick={() => setTab('schema')}
+                >
+                    Schema{propertyCount ? ` (${propertyCount})` : ''}
+                </button>
+            </div>
+
+            {tab === 'description' && (
+                <p className={styles.detail_description}>{tool.description}</p>
+            )}
+            {tab === 'policy' && (
+                <ToolPolicyEditor
+                    tool={tool}
+                    override={override}
+                    usage={usage}
+                    defaults={defaults}
+                    onChanged={onPolicyChanged}
+                />
+            )}
+            {tab === 'schema' && (
+                <ToolSchemaView schema={tool.inputSchema} />
+            )}
+        </div>
+    );
+}

--- a/src/frontend/app/(core)/system/ai-tools/components/ToolSchemaView.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/ToolSchemaView.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+/**
+ * @fileoverview Read-only view of a tool's input parameter schema for the
+ * registry slide-over. An admin auditing a tool needs to see exactly what the
+ * model is allowed to pass — each parameter's name, type, whether it's required,
+ * and its description — without reading source. JSON Schema property values can
+ * be booleans, so each is read defensively. Tools that take no parameters get a
+ * plain note rather than an empty list.
+ */
+
+import type { IAiToolInputSchema } from '@/types';
+import { cn } from '../../../../../lib/cn';
+import { Badge } from '../../../../../components/ui/Badge';
+import styles from '../page.module.scss';
+
+/** The fields surfaced for one parameter, read defensively from the schema. */
+interface IParamView {
+    name: string;
+    type: string;
+    description?: string;
+    required: boolean;
+}
+
+/**
+ * Read one JSON Schema property fragment into the small shape the view renders.
+ * A fragment may legally be a boolean (`true`/`false`) per JSON Schema, so guard
+ * before reading fields and fall back to `any` for an absent/odd type.
+ *
+ * @param name - The parameter name (the property key).
+ * @param definition - The raw JSON Schema property value (object or boolean).
+ * @param required - Whether the schema lists this parameter as required.
+ * @returns The flattened parameter view.
+ */
+function toParamView(name: string, definition: unknown, required: boolean): IParamView {
+    const fragment = (definition && typeof definition === 'object') ? definition as Record<string, unknown> : {};
+    const rawType = fragment.type;
+    const type = Array.isArray(rawType)
+        ? rawType.join(' | ')
+        : typeof rawType === 'string' ? rawType : 'any';
+    const description = typeof fragment.description === 'string' ? fragment.description : undefined;
+    return { name, type, description, required };
+}
+
+/**
+ * The Schema tab body for one tool.
+ *
+ * @param props.schema - The tool's input schema (top-level object with properties).
+ * @returns A parameter list, or a no-parameters note.
+ */
+export function ToolSchemaView({ schema }: { schema: IAiToolInputSchema }) {
+    const properties = schema?.properties ?? {};
+    const requiredSet = new Set(schema?.required ?? []);
+    const params = Object.entries(properties).map(([name, def]) => toParamView(name, def, requiredSet.has(name)));
+
+    return params.length === 0
+        ? <p className="text-muted">This tool takes no parameters.</p>
+        : (
+            <ul className={cn('list--plain', styles.schema_list)}>
+                {params.map(param => (
+                    <li key={param.name} className={styles.schema_param}>
+                        <div className={styles.schema_param_head}>
+                            <span className={styles.schema_param_name}>{param.name}</span>
+                            <span className={styles.mono}>{param.type}</span>
+                            {param.required && <Badge tone="info">required</Badge>}
+                        </div>
+                        {param.description && <p className={styles.schema_param_desc}>{param.description}</p>}
+                    </li>
+                ))}
+            </ul>
+        );
+}

--- a/src/frontend/app/(core)/system/ai-tools/page.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/page.module.scss
@@ -219,26 +219,6 @@
     min-width: 0;
 }
 
-/* Chevron toggle in the Tools row that discloses the inline policy editor.
- * Bare (borderless) so it reads as an affordance on the row, not a button
- * competing with the enable switch. */
-.expand_button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: var(--icon-button-bare-padding-md);
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--color-text-muted);
-    border-radius: var(--icon-button-bare-border-radius);
-    transition: color var(--transition-base);
-}
-
-.expand_button:hover {
-    color: var(--color-text);
-}
-
 /* Inline per-tool policy editor revealed under an expanded Tools row. Declares a
  * container so the field grid reflows to the editor's own width, not the
  * viewport — correct inside the slideout/modal contexts this dashboard renders
@@ -410,4 +390,287 @@
     .trifecta_legs {
         grid-template-columns: repeat(3, minmax(0, 1fr));
     }
+}
+
+/* ============================================================================
+ * REGISTRY LIST — TRIAGE LAYOUT
+ *
+ * Risk + enabled-state lead each row; the full description, schema, and policy
+ * editor live in the slide-over (see .detail below), so the row carries only a
+ * one-line teaser. The whole row opens the slide-over.
+ * ========================================================================== */
+
+/* Row reads as interactive — clicking it opens the detail slide-over. */
+.tool_row {
+    cursor: pointer;
+}
+
+/* Tool name rendered as a bare button so it is keyboard-focusable and opens the
+ * slide-over without an extra control competing on the row. */
+.tool_name_button {
+    padding: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text);
+    text-align: left;
+}
+
+.tool_name_button:hover {
+    color: var(--color-primary);
+    text-decoration: underline;
+}
+
+/* One-line description teaser: clamp to a single line with an ellipsis so a long
+ * model-facing description never blows the row height — the full text lives in
+ * the slide-over. */
+.tool_teaser {
+    display: block;
+    max-width: 52ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+}
+
+/* Search input in the filter bar: grow to fill, but keep a sane floor so it does
+ * not collapse beside the risk pills when the bar wraps. */
+.search_input {
+    flex: 1 1 16rem;
+    min-width: 12rem;
+}
+
+/* Risk-class filter pills. */
+.risk_filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-xs);
+    align-items: center;
+}
+
+.risk_filter {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--padding-2xs) var(--padding-sm);
+    border-radius: var(--radius-full);
+    border: var(--chip-border);
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--letter-spacing-wide);
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: var(--chip-transition);
+}
+
+.risk_filter:hover {
+    color: var(--color-text);
+}
+
+.risk_filter--active {
+    background: var(--color-primary-alpha-15);
+    border-color: var(--color-primary-alpha-38);
+    color: var(--color-text);
+}
+
+/* ============================================================================
+ * TOOL DETAIL — SLIDE-OVER BODY
+ * ========================================================================== */
+
+.detail {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+}
+
+/* Always-on context strip above the tabs: provider + enable toggle, then the
+ * full capability badge breakdown. */
+.detail_meta {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+}
+
+.detail_meta_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--gap-md);
+}
+
+/* Tab switcher reuses the global .segmented-control; this only keeps it hugging
+ * its content rather than stretching across the panel. */
+.detail_tabs {
+    align-self: flex-start;
+    max-width: 100%;
+}
+
+/* Full model-facing description: preserve the author's line breaks and keep a
+ * readable measure so the prose the model selects on is legible in full. */
+.detail_description {
+    margin: 0;
+    white-space: pre-wrap;
+    font-size: var(--font-size-body);
+    line-height: var(--line-height-relaxed);
+    color: var(--color-text);
+    max-width: var(--max-width-prose);
+}
+
+/* Schema tab: one card per parameter. */
+.schema_list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+}
+
+.schema_param {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+    padding: var(--padding-sm);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface-muted);
+}
+
+.schema_param_head {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    flex-wrap: wrap;
+}
+
+.schema_param_name {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text);
+}
+
+.schema_param_desc {
+    margin: 0;
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+}
+
+/* ============================================================================
+ * SHARED DETAIL SURFACES — invocation + approval slide-over bodies
+ *
+ * Both the Activity record panel and the Approvals panel render the same shapes:
+ * a meta strip, labelled fact rows, a JSON argument block, and tone-coded
+ * sections. Classes live here so the two panels read identically.
+ * ========================================================================== */
+
+/* A titled block within a detail panel. */
+.detail_section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+}
+
+.detail_section_title {
+    font-size: var(--font-size-caption);
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-wide);
+    color: var(--color-text-subtle);
+}
+
+/* Label/value fact grid (a definition list). Labels hug their content; values
+ * take the rest and wrap long ids. */
+.kv {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: var(--gap-2xs) var(--gap-md);
+    align-items: baseline;
+    margin: 0;
+}
+
+.kv_label {
+    font-size: var(--font-size-caption);
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-wide);
+    color: var(--color-text-subtle);
+}
+
+.kv_value {
+    margin: 0;
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text);
+    word-break: break-word;
+}
+
+/* Pretty-printed JSON arguments — scrolls rather than stretching the panel. */
+.args_block {
+    margin: 0;
+    padding: var(--padding-sm);
+    background: var(--color-surface-muted);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono, monospace);
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 20rem;
+    overflow: auto;
+}
+
+/* Forensic error block (sanitized + raw), tinted danger. */
+.detail_error {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+    padding: var(--padding-sm);
+    border-radius: var(--radius-sm);
+    background: var(--color-danger-alpha-18);
+    border: var(--border-width-thin) solid var(--color-danger-alpha-50);
+    color: var(--color-danger-text);
+    font-size: var(--font-size-body-sm);
+    word-break: break-word;
+}
+
+/* High-stakes caution above an approval's actions (irreversible / spends money /
+ * external). */
+.detail_caution {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--gap-sm);
+    padding: var(--alert-padding);
+    border-radius: var(--radius-md);
+    background: var(--color-warning-alpha-15);
+    border: var(--border-width-thin) solid var(--color-warning-alpha-40);
+    color: var(--color-warning-text);
+    font-size: var(--font-size-body-sm);
+}
+
+/* Action row at the foot of the approval panel. */
+.detail_actions {
+    display: flex;
+    gap: var(--gap-sm);
+    flex-wrap: wrap;
+}
+
+/* Bulk-action bar above the approvals table. */
+.bulk_bar {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    flex-wrap: wrap;
+}
+
+/* Degraded trifecta banner shown when the status could not be evaluated — an
+ * absent banner must never read as "safe". */
+.trifecta_degraded {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    font-size: var(--font-size-body-sm);
+    color: var(--color-warning-text);
+}
+
+/* Pagination row under a feed table. */
+.pager {
+    display: flex;
+    justify-content: flex-end;
 }

--- a/src/frontend/app/(core)/system/ai-tools/page.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/page.tsx
@@ -5,16 +5,20 @@
  *
  * Four tabs (Query — the default — then Registry, Activity, Approvals) plus a
  * lethal-trifecta banner and a live pending-approval count on the Approvals tab.
- * Curation moved to its own surface at /system/curation. Per-tool policy editing
- * is not its own tab — each Registry
- * tool row expands to its policy editor — so this shell carries no Policy tab.
+ * When holds are already waiting on first load the shell opens on Approvals
+ * instead of Query, so the operator lands on the decision that needs them. The
+ * trifecta banner renders a degraded state on load failure rather than vanishing
+ * — an absent security signal must never read as "safe". Curation moved to its
+ * own surface at /system/curation. Per-tool policy editing is not its own tab —
+ * the Registry slide-over carries it — so this shell has no Policy tab.
  * Admin-gated by the /system layout; like the other system pages it is a client
- * component that fetches over the cookie-authenticated admin API. Governed
- * events arrive as WebSocket refetch signals — the data itself always comes from
- * the gated REST feed, never a global broadcast.
+ * component that fetches over the cookie-authenticated admin API. Governed events
+ * arrive as WebSocket refetch signals — the data itself always comes from the
+ * gated REST feed, never a global broadcast.
  */
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { AlertTriangle } from 'lucide-react';
 import type { ITrifectaStatus } from '@/types';
 import { Page, PageHeader } from '../../../../components/layout';
 import { Badge } from '../../../../components/ui/Badge';
@@ -45,27 +49,46 @@ const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
 export default function AiToolsAdminPage() {
     const [activeTab, setActiveTab] = useState<TabId>('query');
     const [trifecta, setTrifecta] = useState<ITrifectaStatus | null>(null);
+    const [trifectaError, setTrifectaError] = useState(false);
     const [pending, setPending] = useState(0);
+    /** True once the initial pending fetch has auto-routed, so it fires at most once. */
+    const autoRoutedRef = useRef(false);
+    /** True once the operator picks a tab, so auto-routing never yanks them away. */
+    const userPickedRef = useRef(false);
 
     const refreshTrifecta = useCallback(async () => {
         try {
             setTrifecta(await getTrifecta());
+            setTrifectaError(false);
         } catch {
-            /* secondary data — leave the banner absent on failure */
+            // Surface an explicit degraded banner — a missing trifecta signal
+            // must not be mistaken for a clean one.
+            setTrifectaError(true);
         }
     }, []);
 
-    const refreshPending = useCallback(async () => {
+    const refreshPending = useCallback(async (): Promise<number | null> => {
         try {
-            setPending(await getApprovalsCount());
+            const count = await getApprovalsCount();
+            setPending(count);
+            return count;
         } catch {
-            /* secondary data — leave the count as-is on failure */
+            return null;
         }
     }, []);
 
+    // On first load, evaluate the trifecta and, if holds are already waiting,
+    // open on Approvals rather than the default Query — unless the operator has
+    // already chosen a tab.
     useEffect(() => {
         void refreshTrifecta();
-        void refreshPending();
+        void (async () => {
+            const count = await refreshPending();
+            if (count && count > 0 && !autoRoutedRef.current && !userPickedRef.current) {
+                autoRoutedRef.current = true;
+                setActiveTab('approvals');
+            }
+        })();
     }, [refreshTrifecta, refreshPending]);
 
     // Keep the pending-approvals badge live regardless of which tab is open.
@@ -78,11 +101,29 @@ export default function AiToolsAdminPage() {
         };
     }, [refreshPending]);
 
+    /**
+     * Select a tab and record that the operator drove the choice, so the initial
+     * auto-route to Approvals cannot later override their pick.
+     *
+     * @param id - The tab to open.
+     */
+    const pickTab = useCallback((id: TabId) => {
+        userPickedRef.current = true;
+        setActiveTab(id);
+    }, []);
+
     return (
         <Page>
             <PageHeader title="AI Tools" subtitle="Govern every tool an AI agent can invoke — registry, activity, approvals, and per-tool policy." />
             <div className={styles.container}>
-                {trifecta && <TrifectaPanel status={trifecta} />}
+                {trifecta
+                    ? <TrifectaPanel status={trifecta} />
+                    : trifectaError && (
+                        <div className={styles.trifecta_degraded} role="status">
+                            <AlertTriangle size={16} aria-hidden="true" />
+                            Trifecta status unavailable — the enabled tool set could not be evaluated. Retry from any tab action.
+                        </div>
+                    )}
 
                 <div className={styles.tabs} role="tablist" aria-label="AI tool governance sections">
                     {TABS.map(tab => (
@@ -91,7 +132,7 @@ export default function AiToolsAdminPage() {
                             role="tab"
                             aria-selected={activeTab === tab.id}
                             className={activeTab === tab.id ? styles.tab__active : styles.tab}
-                            onClick={() => setActiveTab(tab.id)}
+                            onClick={() => pickTab(tab.id)}
                         >
                             {tab.label}
                             {tab.id === 'approvals' && pending > 0 && (

--- a/src/frontend/app/(core)/system/ai-tools/tabs/ActivityTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/ActivityTab.tsx
@@ -9,7 +9,7 @@
  * full record: arguments, result digest, forensic error, cost, and screen verdict.
  */
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { RefreshCw } from 'lucide-react';
 import type { IToolInvocationRecord, IAiToolInfo, ToolInvocationStatus, ToolTriggerPath } from '@/types';
 import { Stack } from '../../../../../components/layout';
@@ -43,19 +43,35 @@ export function ActivityTab() {
     const [toolName, setToolName] = useState<string>('');
     const [offset, setOffset] = useState(0);
     const [tools, setTools] = useState<IAiToolInfo[]>([]);
-    const [selectedId, setSelectedId] = useState<string | null>(null);
+    const [selectedRecord, setSelectedRecord] = useState<IToolInvocationRecord | null>(null);
+    /**
+     * Monotonic load id. A response commits state only while it is still the
+     * newest in-flight request, so an out-of-order resolve — rapid filter changes
+     * or a socket-driven refetch racing a filter change — never overwrites the
+     * table with rows that no longer match the active filter.
+     */
+    const requestId = useRef(0);
 
     const load = useCallback(async () => {
+        const id = ++requestId.current;
         const query: IActivityQuery = { limit: PAGE_LIMIT, offset };
         if (status) query.status = status;
         if (triggerPath) query.triggerPath = triggerPath;
         if (toolName) query.toolName = toolName;
         try {
             const page = await listActivity(query);
+            // Drop a response a newer load already superseded so out-of-order
+            // resolves don't overwrite the table with stale rows.
+            if (id !== requestId.current) {
+                return;
+            }
             setItems(page.records);
             setTotal(page.total);
             setError(null);
         } catch (err) {
+            if (id !== requestId.current) {
+                return;
+            }
             setError(err instanceof Error ? err.message : 'Failed to load activity');
         } finally {
             setLoading(false);
@@ -101,7 +117,6 @@ export function ActivityTab() {
     }, []);
 
     const currentPage = Math.floor(offset / PAGE_LIMIT) + 1;
-    const selectedRecord = selectedId ? items.find(record => record.id === selectedId) ?? null : null;
 
     return (
         <Stack gap="md">
@@ -170,7 +185,7 @@ export function ActivityTab() {
                                             key={record.id}
                                             className={styles.tool_row}
                                             hasError={record.status === 'error'}
-                                            onClick={() => setSelectedId(record.id)}
+                                            onClick={() => setSelectedRecord(record)}
                                         >
                                             <Td muted className={styles.col_time}><ClientTime date={record.createdAt} format="datetime" /></Td>
                                             <Td><span className={styles.tool_name}>{record.toolName}</span></Td>
@@ -197,7 +212,7 @@ export function ActivityTab() {
 
             <SlideOver
                 open={selectedRecord !== null}
-                onClose={() => setSelectedId(null)}
+                onClose={() => setSelectedRecord(null)}
                 label={selectedRecord ? `Invocation ${selectedRecord.toolName}` : undefined}
                 title={selectedRecord ? <span className={styles.tool_name}>{selectedRecord.toolName}</span> : null}
             >

--- a/src/frontend/app/(core)/system/ai-tools/tabs/ActivityTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/ActivityTab.tsx
@@ -2,33 +2,28 @@
 
 /**
  * @fileoverview Activity tab — the live invocation audit feed. Filterable by
- * tool, status, and trigger path; refetches on the `ai-tools:activity` WebSocket
- * signal (a timestamp-only refetch cue — the records themselves come from this
- * admin-gated endpoint, never a global broadcast).
+ * tool, status, and trigger path, paged through the full history (not just the
+ * newest page), and refetched on the `ai-tools:activity` WebSocket signal (a
+ * timestamp-only refetch cue — the records themselves come from this admin-gated
+ * endpoint, never a global broadcast). Clicking a row opens a slide-over with the
+ * full record: arguments, result digest, forensic error, cost, and screen verdict.
  */
 
 import { useEffect, useState, useCallback } from 'react';
 import { RefreshCw } from 'lucide-react';
-import type { IToolInvocationRecord, ToolInvocationStatus, ToolTriggerPath } from '@/types';
+import type { IToolInvocationRecord, IAiToolInfo, ToolInvocationStatus, ToolTriggerPath } from '@/types';
 import { Stack } from '../../../../../components/layout';
 import { Button } from '../../../../../components/ui/Button';
 import { Select } from '../../../../../components/ui/Select';
 import { Badge } from '../../../../../components/ui/Badge';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
+import { Pagination } from '../../../../../components/ui/Pagination';
+import { SlideOver } from '../../../../../components/ui/SlideOver';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { getSocket } from '../../../../../lib/socketClient';
-import { listActivity, type IActivityQuery } from '../../../../../modules/ai-tools';
+import { listActivity, listTools, type IActivityQuery } from '../../../../../modules/ai-tools';
+import { InvocationDetailPanel, statusTone } from '../components/InvocationDetailPanel';
 import styles from '../page.module.scss';
-
-/** Map an invocation status to a badge tone. */
-function statusTone(status: ToolInvocationStatus): 'success' | 'warning' | 'danger' | 'info' {
-    switch (status) {
-        case 'ok': return 'success';
-        case 'denied': return 'warning';
-        case 'pending-approval': return 'info';
-        default: return 'danger';
-    }
-}
 
 /** Page size for the feed. */
 const PAGE_LIMIT = 50;
@@ -45,11 +40,16 @@ export function ActivityTab() {
     const [error, setError] = useState<string | null>(null);
     const [status, setStatus] = useState<ToolInvocationStatus | ''>('');
     const [triggerPath, setTriggerPath] = useState<ToolTriggerPath | ''>('');
+    const [toolName, setToolName] = useState<string>('');
+    const [offset, setOffset] = useState(0);
+    const [tools, setTools] = useState<IAiToolInfo[]>([]);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
 
     const load = useCallback(async () => {
-        const query: IActivityQuery = { limit: PAGE_LIMIT };
+        const query: IActivityQuery = { limit: PAGE_LIMIT, offset };
         if (status) query.status = status;
         if (triggerPath) query.triggerPath = triggerPath;
+        if (toolName) query.toolName = toolName;
         try {
             const page = await listActivity(query);
             setItems(page.records);
@@ -60,11 +60,28 @@ export function ActivityTab() {
         } finally {
             setLoading(false);
         }
-    }, [status, triggerPath]);
+    }, [status, triggerPath, toolName, offset]);
 
     useEffect(() => { void load(); }, [load]);
 
-    // Live refetch on the activity signal (fires after every governed call).
+    // Populate the tool filter once. A failure just leaves the filter empty.
+    useEffect(() => {
+        let cancelled = false;
+        void (async () => {
+            try {
+                const list = await listTools();
+                if (!cancelled) {
+                    setTools(list);
+                }
+            } catch {
+                /* secondary data — the tool filter simply offers no choices on failure */
+            }
+        })();
+        return () => { cancelled = true; };
+    }, []);
+
+    // Live refetch on the activity signal (fires after every governed call),
+    // keeping the current filters and page.
     useEffect(() => {
         const socket = getSocket();
         const handler = () => { void load(); };
@@ -72,17 +89,49 @@ export function ActivityTab() {
         return () => { socket.off('ai-tools:activity', handler); };
     }, [load]);
 
+    /**
+     * Apply a filter change and reset to the first page, so a narrowed result set
+     * never strands the viewer on an out-of-range offset.
+     *
+     * @param apply - Setter that records the new filter value.
+     */
+    const changeFilter = useCallback((apply: () => void) => {
+        apply();
+        setOffset(0);
+    }, []);
+
+    const currentPage = Math.floor(offset / PAGE_LIMIT) + 1;
+    const selectedRecord = selectedId ? items.find(record => record.id === selectedId) ?? null : null;
+
     return (
         <Stack gap="md">
             <div className={styles.filters}>
-                <Select value={status} onChange={(e) => setStatus(e.target.value as ToolInvocationStatus | '')} aria-label="Filter by status">
+                <Select
+                    value={toolName}
+                    onChange={(e) => changeFilter(() => setToolName(e.target.value))}
+                    aria-label="Filter by tool"
+                >
+                    <option value="">All tools</option>
+                    {tools.map(tool => (
+                        <option key={tool.name} value={tool.name}>{tool.name}</option>
+                    ))}
+                </Select>
+                <Select
+                    value={status}
+                    onChange={(e) => changeFilter(() => setStatus(e.target.value as ToolInvocationStatus | ''))}
+                    aria-label="Filter by status"
+                >
                     <option value="">All statuses</option>
                     <option value="ok">ok</option>
                     <option value="denied">denied</option>
                     <option value="pending-approval">pending-approval</option>
                     <option value="error">error</option>
                 </Select>
-                <Select value={triggerPath} onChange={(e) => setTriggerPath(e.target.value as ToolTriggerPath | '')} aria-label="Filter by trigger path">
+                <Select
+                    value={triggerPath}
+                    onChange={(e) => changeFilter(() => setTriggerPath(e.target.value as ToolTriggerPath | ''))}
+                    aria-label="Filter by trigger path"
+                >
                     <option value="">All triggers</option>
                     <option value="interactive">interactive</option>
                     <option value="scheduled">scheduled</option>
@@ -99,40 +148,61 @@ export function ActivityTab() {
             {error && <div className="alert" role="alert">{error}</div>}
 
             {!loading && items.length === 0
-                ? <div className={styles.placeholder}>No invocations recorded yet.</div>
+                ? <div className={styles.placeholder}>No invocations match the current filters.</div>
                 : (
-                    <div className="table-scroll">
-                        <Table>
-                            <Thead>
-                                <Tr>
-                                    <Th width="shrink" className={styles.col_time}>Time</Th>
-                                    <Th>Tool</Th>
-                                    <Th width="shrink">AI Provider</Th>
-                                    <Th width="shrink">Actor</Th>
-                                    <Th width="shrink">Trigger</Th>
-                                    <Th width="shrink">Status</Th>
-                                    <Th width="shrink">Duration</Th>
-                                </Tr>
-                            </Thead>
-                            <Tbody>
-                                {items.map(record => (
-                                    <Tr key={record.id} hasError={record.status === 'error'}>
-                                        <Td muted className={styles.col_time}><ClientTime date={record.createdAt} format="datetime" /></Td>
-                                        <Td>
-                                            <div className={styles.tool_name}>{record.toolName}</div>
-                                            {record.error && <div className={styles.mono}>{record.error}</div>}
-                                        </Td>
-                                        <Td muted>{record.aiProviderId}</Td>
-                                        <Td muted>{record.actor.kind}{record.actor.id ? ` · ${record.actor.id}` : ''}</Td>
-                                        <Td muted>{record.triggerPath}</Td>
-                                        <Td><Badge tone={statusTone(record.status)}>{record.status}</Badge></Td>
-                                        <Td muted>{record.durationMs}ms</Td>
+                    <>
+                        <div className="table-scroll">
+                            <Table>
+                                <Thead>
+                                    <Tr>
+                                        <Th width="shrink" className={styles.col_time}>Time</Th>
+                                        <Th>Tool</Th>
+                                        <Th width="shrink">AI Provider</Th>
+                                        <Th width="shrink">Actor</Th>
+                                        <Th width="shrink">Trigger</Th>
+                                        <Th width="shrink">Status</Th>
+                                        <Th width="shrink">Duration</Th>
                                     </Tr>
-                                ))}
-                            </Tbody>
-                        </Table>
-                    </div>
+                                </Thead>
+                                <Tbody>
+                                    {items.map(record => (
+                                        <Tr
+                                            key={record.id}
+                                            className={styles.tool_row}
+                                            hasError={record.status === 'error'}
+                                            onClick={() => setSelectedId(record.id)}
+                                        >
+                                            <Td muted className={styles.col_time}><ClientTime date={record.createdAt} format="datetime" /></Td>
+                                            <Td><span className={styles.tool_name}>{record.toolName}</span></Td>
+                                            <Td muted>{record.aiProviderId}</Td>
+                                            <Td muted>{record.actor.kind}{record.actor.id ? ` · ${record.actor.id}` : ''}</Td>
+                                            <Td muted>{record.triggerPath}</Td>
+                                            <Td><Badge tone={statusTone(record.status)}>{record.status}</Badge></Td>
+                                            <Td muted>{record.durationMs}ms</Td>
+                                        </Tr>
+                                    ))}
+                                </Tbody>
+                            </Table>
+                        </div>
+                        <div className={styles.pager}>
+                            <Pagination
+                                total={total}
+                                pageSize={PAGE_LIMIT}
+                                currentPage={currentPage}
+                                onPageChange={(page) => setOffset((page - 1) * PAGE_LIMIT)}
+                            />
+                        </div>
+                    </>
                 )}
+
+            <SlideOver
+                open={selectedRecord !== null}
+                onClose={() => setSelectedId(null)}
+                label={selectedRecord ? `Invocation ${selectedRecord.toolName}` : undefined}
+                title={selectedRecord ? <span className={styles.tool_name}>{selectedRecord.toolName}</span> : null}
+            >
+                {selectedRecord && <InvocationDetailPanel record={selectedRecord} />}
+            </SlideOver>
         </Stack>
     );
 }

--- a/src/frontend/app/(core)/system/ai-tools/tabs/ApprovalsTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/ApprovalsTab.tsx
@@ -2,27 +2,30 @@
 
 /**
  * @fileoverview Approvals tab — external/irreversible invocations the governor
- * parked for a human. Approve runs the call; reject discards it. Refetches on
- * the `ai-tools:approvals-changed` signal and reports the new count up via
- * `onChanged` so the header badge stays live.
+ * parked for a human. Each row leads with its dominant risk class and opens a
+ * slide-over holding the full arguments, capability, and trigger context, so the
+ * decision is made against the whole payload rather than a truncated preview.
+ * Approving a money-spending or unrecoverable action confirms first; a flooded
+ * queue can be cleared with a bulk reject. Refetches on the
+ * `ai-tools:approvals-changed` signal and reports the new count up via `onChanged`
+ * so the header badge stays live.
  */
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, type MouseEvent } from 'react';
 import { Check, X } from 'lucide-react';
 import { Stack } from '../../../../../components/layout';
 import { Button } from '../../../../../components/ui/Button';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
+import { SlideOver } from '../../../../../components/ui/SlideOver';
 import { useToast } from '../../../../../components/ui/ToastProvider';
+import { useModal } from '../../../../../components/ui/ModalProvider';
+import { ConfirmDialog } from '../../../../../components/ui/ConfirmDialog';
 import { getSocket } from '../../../../../lib/socketClient';
 import { listApprovals, approveInvocation, rejectInvocation, type IPendingApproval } from '../../../../../modules/ai-tools';
+import { RiskChip } from '../components/RiskChip';
+import { ApprovalDetailPanel } from '../components/ApprovalDetailPanel';
 import styles from '../page.module.scss';
-
-/** Truncate a JSON-stringified args object for inline preview. */
-function preview(input: Record<string, unknown>): string {
-    const text = JSON.stringify(input);
-    return text.length > 120 ? `${text.slice(0, 120)}…` : text;
-}
 
 /**
  * Approvals tab content.
@@ -36,11 +39,21 @@ export function ApprovalsTab({ onChanged }: { onChanged: () => void }) {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [busyId, setBusyId] = useState<string | null>(null);
+    const [bulkBusy, setBulkBusy] = useState(false);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+    const [checked, setChecked] = useState<Set<string>>(new Set());
     const { push } = useToast();
+    const { open, close } = useModal();
 
     const load = useCallback(async () => {
         try {
-            setApprovals(await listApprovals());
+            const list = await listApprovals();
+            setApprovals(list);
+            // Drop any checked/selected ids that no longer exist so a resolved
+            // hold never lingers in the selection or the open panel.
+            const live = new Set(list.map(approval => approval.id));
+            setChecked(previous => new Set([...previous].filter(id => live.has(id))));
+            setSelectedId(previous => (previous && live.has(previous) ? previous : null));
             setError(null);
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to load approvals');
@@ -58,6 +71,12 @@ export function ApprovalsTab({ onChanged }: { onChanged: () => void }) {
         return () => { socket.off('ai-tools:approvals-changed', handler); };
     }, [load, onChanged]);
 
+    /**
+     * Run or discard a single held action.
+     *
+     * @param id - The held request id.
+     * @param action - Whether to approve (run) or reject (discard).
+     */
     const resolve = useCallback(async (id: string, action: 'approve' | 'reject') => {
         setBusyId(id);
         try {
@@ -72,9 +91,126 @@ export function ApprovalsTab({ onChanged }: { onChanged: () => void }) {
         }
     }, [load, onChanged, push]);
 
+    /**
+     * Approve directly, no confirm. Used from the detail panel, where the full
+     * arguments and the risk caution are already on screen — opening the panel
+     * and approving there is itself the deliberate step (and avoids stacking a
+     * modal over the open slide-over).
+     *
+     * @param approval - The held action to approve.
+     */
+    const approveNow = useCallback((approval: IPendingApproval) => {
+        void resolve(approval.id, 'approve');
+    }, [resolve]);
+
+    /**
+     * Approve from the compact row, where the arguments are not visible. A
+     * money-spending or unrecoverable effect confirms first — those run
+     * immediately and cannot be taken back, so a deliberate second step guards a
+     * mis-click; a low-stakes hold approves directly.
+     *
+     * @param approval - The held action to approve.
+     */
+    const handleRowApprove = useCallback((approval: IPendingApproval) => {
+        const dangerous = approval.capability?.spendsMoney === true || approval.capability?.reversible === false;
+        if (!dangerous) {
+            void resolve(approval.id, 'approve');
+            return;
+        }
+        const modalId = open({
+            title: 'Approve action',
+            content: (
+                <ConfirmDialog
+                    label={approval.toolName}
+                    confirmLabel="Approve & run"
+                    message={<>Approving runs <strong>{approval.toolName}</strong> now. This effect cannot be undone. Continue?</>}
+                    onConfirm={async () => { await resolve(approval.id, 'approve'); close(modalId); }}
+                    onCancel={() => close(modalId)}
+                />
+            )
+        });
+    }, [resolve, open, close]);
+
+    /**
+     * Reject (discard) a held action without running it.
+     *
+     * @param approval - The held action to reject.
+     */
+    const handleReject = useCallback((approval: IPendingApproval) => {
+        void resolve(approval.id, 'reject');
+    }, [resolve]);
+
+    /**
+     * Reject every checked action after one confirmation — the escape hatch for a
+     * queue flooded by a looping or injected agent.
+     */
+    const handleBulkReject = useCallback(() => {
+        const ids = [...checked];
+        if (ids.length === 0) {
+            return;
+        }
+        const modalId = open({
+            title: 'Reject selected',
+            content: (
+                <ConfirmDialog
+                    label={`${ids.length} actions`}
+                    confirmLabel={`Reject ${ids.length}`}
+                    message={<>Reject <strong>{ids.length}</strong> parked action{ids.length === 1 ? '' : 's'}? They will not run.</>}
+                    onConfirm={async () => {
+                        setBulkBusy(true);
+                        try {
+                            for (const id of ids) {
+                                await rejectInvocation(id);
+                            }
+                            push({ tone: 'info', title: `Rejected ${ids.length}` });
+                            await load();
+                            onChanged();
+                        } catch (err) {
+                            push({ tone: 'danger', title: 'Bulk reject failed', description: err instanceof Error ? err.message : String(err) });
+                        } finally {
+                            setBulkBusy(false);
+                            close(modalId);
+                        }
+                    }}
+                    onCancel={() => close(modalId)}
+                />
+            )
+        });
+    }, [checked, open, close, load, onChanged, push]);
+
+    /**
+     * Toggle one row's checkbox without opening its detail panel.
+     *
+     * @param id - The held request id to toggle.
+     */
+    const toggleOne = useCallback((id: string) => {
+        setChecked(previous => {
+            const next = new Set(previous);
+            if (next.has(id)) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+            return next;
+        });
+    }, []);
+
     if (loading) {
         return <div className={styles.placeholder}>Loading approvals…</div>;
     }
+
+    const allChecked = approvals.length > 0 && approvals.every(approval => checked.has(approval.id));
+    const selectedApproval = selectedId ? approvals.find(approval => approval.id === selectedId) ?? null : null;
+
+    /** Toggle every row's checkbox at once. */
+    const toggleAll = () => {
+        setChecked(allChecked ? new Set() : new Set(approvals.map(approval => approval.id)));
+    };
+
+    /** Keep a checkbox/decision cell click from opening the row's detail panel. */
+    const stopCellClick = (event: MouseEvent<HTMLTableCellElement>) => {
+        event.stopPropagation();
+    };
 
     return (
         <Stack gap="md">
@@ -88,43 +224,91 @@ export function ApprovalsTab({ onChanged }: { onChanged: () => void }) {
             {approvals.length === 0
                 ? <div className={styles.placeholder}>No actions are awaiting approval.</div>
                 : (
-                    <div className="table-scroll">
-                        <Table>
-                            <Thead>
-                                <Tr>
-                                    <Th width="shrink">Parked</Th>
-                                    <Th>Tool</Th>
-                                    <Th width="shrink">Trigger</Th>
-                                    <Th>Arguments</Th>
-                                    <Th width="shrink">Decision</Th>
-                                </Tr>
-                            </Thead>
-                            <Tbody>
-                                {approvals.map(approval => (
-                                    <Tr key={approval.id}>
-                                        <Td muted><ClientTime date={approval.createdAt} format="datetime" /></Td>
-                                        <Td>
-                                            <div className={styles.tool_name}>{approval.toolName}</div>
-                                            <div className={styles.tool_desc}>{approval.providerId}</div>
-                                        </Td>
-                                        <Td muted>{approval.context.triggerPath}</Td>
-                                        <Td><span className={styles.mono}>{preview(approval.input)}</span></Td>
-                                        <Td>
-                                            <div className={styles.row_actions}>
-                                                <Button variant="primary" size="sm" loading={busyId === approval.id} onClick={() => { void resolve(approval.id, 'approve'); }}>
-                                                    <Check size={16} /> Approve
-                                                </Button>
-                                                <Button variant="danger" size="sm" disabled={busyId === approval.id} onClick={() => { void resolve(approval.id, 'reject'); }}>
-                                                    <X size={16} /> Reject
-                                                </Button>
-                                            </div>
-                                        </Td>
+                    <>
+                        {checked.size > 0 && (
+                            <div className={styles.bulk_bar}>
+                                <span className="text-muted" style={{ fontSize: 'var(--font-size-body-sm)' }}>
+                                    {checked.size} selected
+                                </span>
+                                <Button variant="danger" size="sm" loading={bulkBusy} onClick={handleBulkReject}>
+                                    <X size={16} /> Reject selected
+                                </Button>
+                            </div>
+                        )}
+                        <div className="table-scroll">
+                            <Table>
+                                <Thead>
+                                    <Tr>
+                                        <Th width="shrink">
+                                            <input
+                                                type="checkbox"
+                                                checked={allChecked}
+                                                onChange={toggleAll}
+                                                aria-label="Select all approvals"
+                                            />
+                                        </Th>
+                                        <Th width="shrink">Parked</Th>
+                                        <Th width="shrink">Risk</Th>
+                                        <Th>Tool</Th>
+                                        <Th width="shrink">Trigger</Th>
+                                        <Th width="shrink">Decision</Th>
                                     </Tr>
-                                ))}
-                            </Tbody>
-                        </Table>
-                    </div>
+                                </Thead>
+                                <Tbody>
+                                    {approvals.map(approval => (
+                                        <Tr
+                                            key={approval.id}
+                                            className={styles.tool_row}
+                                            onClick={() => setSelectedId(approval.id)}
+                                        >
+                                            <Td onClick={stopCellClick}>
+                                                <input
+                                                    type="checkbox"
+                                                    checked={checked.has(approval.id)}
+                                                    onChange={() => toggleOne(approval.id)}
+                                                    aria-label={`Select ${approval.toolName}`}
+                                                />
+                                            </Td>
+                                            <Td muted><ClientTime date={approval.createdAt} format="datetime" /></Td>
+                                            <Td><RiskChip capability={approval.capability} /></Td>
+                                            <Td>
+                                                <div className={styles.tool_name}>{approval.toolName}</div>
+                                                <div className={styles.tool_desc}>{approval.providerId}</div>
+                                            </Td>
+                                            <Td muted>{approval.context.triggerPath}</Td>
+                                            <Td onClick={stopCellClick}>
+                                                <div className={styles.row_actions}>
+                                                    <Button variant="primary" size="sm" loading={busyId === approval.id} onClick={() => handleRowApprove(approval)}>
+                                                        <Check size={16} /> Approve
+                                                    </Button>
+                                                    <Button variant="danger" size="sm" disabled={busyId === approval.id} onClick={() => handleReject(approval)}>
+                                                        <X size={16} /> Reject
+                                                    </Button>
+                                                </div>
+                                            </Td>
+                                        </Tr>
+                                    ))}
+                                </Tbody>
+                            </Table>
+                        </div>
+                    </>
                 )}
+
+            <SlideOver
+                open={selectedApproval !== null}
+                onClose={() => setSelectedId(null)}
+                label={selectedApproval ? `Approval ${selectedApproval.toolName}` : undefined}
+                title={selectedApproval ? <span className={styles.tool_name}>{selectedApproval.toolName}</span> : null}
+            >
+                {selectedApproval && (
+                    <ApprovalDetailPanel
+                        approval={selectedApproval}
+                        busy={busyId === selectedApproval.id}
+                        onApprove={approveNow}
+                        onReject={handleReject}
+                    />
+                )}
+            </SlideOver>
         </Stack>
     );
 }

--- a/src/frontend/app/(core)/system/ai-tools/tabs/RegistryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/RegistryTab.tsx
@@ -2,31 +2,41 @@
 
 /**
  * @fileoverview Registry tab — every registered tool with provider attribution,
- * capability badges, and an enable toggle, plus the Provider panel. Each tool
- * row expands to an inline policy editor (the former standalone Policy tab now
- * lives here, one editor per tool), and an "only overrides" filter turns the
- * list into a deviation inventory. Toggling a tool or saving a policy override
- * re-checks the trifecta via the `onChanged` callback the page owns — both can
- * form or break it.
+ * a single dominant risk chip, and an enable toggle, plus the Provider panel.
+ * The list is built for triage: risk and enabled-state lead, a search box and
+ * per-class risk filters narrow it, and the default sort surfaces the most
+ * dangerous tools first. Clicking a row opens a right slide-over holding the
+ * full model-facing description, the input schema, and the per-tool policy
+ * editor — the heavy surfaces that used to bloat each row. Toggling a tool or
+ * saving a policy override re-checks the trifecta via the `onChanged` callback
+ * the page owns, since both can form or break it.
  */
 
 import { useEffect, useState, useCallback } from 'react';
 import { AlertCircle } from 'lucide-react';
 import type { IAiToolInfo, IAiProviderInfo } from '@/types';
+import { cn } from '../../../../../lib/cn';
 import { Stack } from '../../../../../components/layout';
 import { Table, Thead, Tbody, Tr, Th } from '../../../../../components/ui/Table';
+import { Input } from '../../../../../components/ui/Input';
+import { SlideOver } from '../../../../../components/ui/SlideOver';
 import { useToast } from '../../../../../components/ui/ToastProvider';
 import { listTools, listProviders, setToolEnabled, getPolicy, type IPolicyResponse } from '../../../../../modules/ai-tools';
 import { ProviderPanel } from '../components/ProviderPanel';
 import { CollapsibleSection } from '../components/CollapsibleSection';
 import { RegistryToolRow } from '../components/RegistryToolRow';
+import { ToolDetailPanel } from '../components/ToolDetailPanel';
+import {
+    RISK_CLASS_ORDER,
+    RISK_PRESENTATION,
+    riskClassOf,
+    riskRankOf,
+    type RiskClass
+} from '../components/RiskChip';
 import { VariablesSection } from './VariablesSection';
 import { SystemPromptsSection } from './SystemPromptsSection';
 import { ScreenSettingsSection } from './ScreenSettingsSection';
 import styles from '../page.module.scss';
-
-/** Total column count of the Tools table — used so an expanded editor cell spans it. */
-const TOOL_COLUMN_COUNT = 5;
 
 /**
  * Registry tab content.
@@ -44,6 +54,9 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
     const [error, setError] = useState<string | null>(null);
     const [busyName, setBusyName] = useState<string | null>(null);
     const [onlyOverrides, setOnlyOverrides] = useState(false);
+    const [search, setSearch] = useState('');
+    const [riskFilter, setRiskFilter] = useState<Set<RiskClass>>(new Set());
+    const [selectedName, setSelectedName] = useState<string | null>(null);
     const { push } = useToast();
 
     const load = useCallback(async () => {
@@ -82,6 +95,24 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
         onChanged();
     }, [load, onChanged]);
 
+    /**
+     * Toggle a risk class in/out of the filter set. An empty set means no
+     * filter (every class shows).
+     *
+     * @param riskClass - The class whose membership is flipped.
+     */
+    const toggleRisk = useCallback((riskClass: RiskClass) => {
+        setRiskFilter(previous => {
+            const next = new Set(previous);
+            if (next.has(riskClass)) {
+                next.delete(riskClass);
+            } else {
+                next.add(riskClass);
+            }
+            return next;
+        });
+    }, []);
+
     if (loading) {
         return <div className={styles.placeholder}>Loading tools…</div>;
     }
@@ -89,9 +120,25 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
     const overrideCount = tools.filter(tool => policy.overrides[tool.name] !== undefined).length;
     const disabledCount = tools.filter(tool => !tool.enabled).length;
     const toolsSummary = `${tools.length} tools · ${disabledCount} disabled · ${overrideCount} overrides`;
-    const visibleTools = onlyOverrides
-        ? tools.filter(tool => policy.overrides[tool.name] !== undefined)
-        : tools;
+
+    // Apply the three filters, then sort dangerous-first (then by name) so an
+    // audit sweep meets the high-stakes tools at the top.
+    const query = search.trim().toLowerCase();
+    const visibleTools = tools
+        .filter(tool => !onlyOverrides || policy.overrides[tool.name] !== undefined)
+        .filter(tool => riskFilter.size === 0 || riskFilter.has(riskClassOf(tool.capability)))
+        .filter(tool => query === ''
+            || tool.name.toLowerCase().includes(query)
+            || tool.description.toLowerCase().includes(query)
+            || tool.provider.toLowerCase().includes(query))
+        .sort((a, b) => {
+            const byRisk = riskRankOf(b.capability) - riskRankOf(a.capability);
+            return byRisk !== 0 ? byRisk : a.name.localeCompare(b.name);
+        });
+
+    // Derive the open tool from the live list so a reload (after toggle/policy
+    // edit) flows fresh data into the panel rather than freezing a stale copy.
+    const selectedTool = selectedName ? tools.find(tool => tool.name === selectedName) ?? null : null;
 
     return (
         <Stack gap="md">
@@ -106,26 +153,49 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
                     ? <div className={styles.placeholder}>No tools are registered.</div>
                     : (
                         <Stack gap="sm">
-                            <label className={styles.check_label}>
-                                <input
-                                    type="checkbox"
-                                    checked={onlyOverrides}
-                                    onChange={(e) => setOnlyOverrides(e.target.checked)}
+                            <div className={styles.filters}>
+                                <Input
+                                    className={styles.search_input}
+                                    type="search"
+                                    placeholder="Search tools…"
+                                    aria-label="Search tools"
+                                    value={search}
+                                    onChange={(e) => setSearch(e.target.value)}
                                 />
-                                Only show tools with a policy override
-                            </label>
+                                <div className={styles.risk_filters} role="group" aria-label="Filter by risk class">
+                                    {RISK_CLASS_ORDER.map(riskClass => (
+                                        <button
+                                            key={riskClass}
+                                            type="button"
+                                            aria-pressed={riskFilter.has(riskClass)}
+                                            className={cn(styles.risk_filter, riskFilter.has(riskClass) && styles['risk_filter--active'])}
+                                            onClick={() => toggleRisk(riskClass)}
+                                        >
+                                            {RISK_PRESENTATION[riskClass].label}
+                                        </button>
+                                    ))}
+                                </div>
+                                <label className={styles.check_label}>
+                                    <input
+                                        type="checkbox"
+                                        checked={onlyOverrides}
+                                        onChange={(e) => setOnlyOverrides(e.target.checked)}
+                                    />
+                                    Only overrides
+                                </label>
+                            </div>
                             {visibleTools.length === 0
-                                ? <div className={styles.placeholder}>No tools have a policy override.</div>
+                                ? <div className={styles.placeholder}>No tools match the current filters.</div>
                                 : (
                                     <div className="table-scroll">
                                         <Table>
                                             <Thead>
                                                 <Tr>
-                                                    <Th width="shrink" aria-label="Expand policy" />
-                                                    <Th>Tool</Th>
-                                                    <Th width="shrink">Provider</Th>
-                                                    <Th>Capability</Th>
                                                     <Th width="shrink">Enabled</Th>
+                                                    <Th width="shrink">Risk</Th>
+                                                    <Th>Tool</Th>
+                                                    <Th width="expand">Description</Th>
+                                                    <Th width="shrink">Provider</Th>
                                                 </Tr>
                                             </Thead>
                                             <Tbody>
@@ -133,13 +203,10 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
                                                     <RegistryToolRow
                                                         key={tool.name}
                                                         tool={tool}
-                                                        override={policy.overrides[tool.name]}
-                                                        usage={policy.usage[tool.name]}
-                                                        defaults={policy.defaults[tool.name]}
+                                                        hasOverride={policy.overrides[tool.name] !== undefined}
                                                         busy={busyName === tool.name}
-                                                        columnCount={TOOL_COLUMN_COUNT}
                                                         onToggle={handleToggle}
-                                                        onPolicyChanged={handlePolicyChanged}
+                                                        onSelect={(selected) => setSelectedName(selected.name)}
                                                     />
                                                 ))}
                                             </Tbody>
@@ -152,6 +219,25 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
             <VariablesSection onChanged={onChanged} />
             <SystemPromptsSection />
             <ScreenSettingsSection />
+
+            <SlideOver
+                open={selectedTool !== null}
+                onClose={() => setSelectedName(null)}
+                label={selectedTool ? `Tool ${selectedTool.name}` : undefined}
+                title={selectedTool ? <span className={styles.tool_name}>{selectedTool.name}</span> : null}
+            >
+                {selectedTool && (
+                    <ToolDetailPanel
+                        tool={selectedTool}
+                        override={policy.overrides[selectedTool.name]}
+                        usage={policy.usage[selectedTool.name]}
+                        defaults={policy.defaults[selectedTool.name]}
+                        busy={busyName === selectedTool.name}
+                        onToggle={handleToggle}
+                        onPolicyChanged={handlePolicyChanged}
+                    />
+                )}
+            </SlideOver>
         </Stack>
     );
 }

--- a/src/frontend/app/(core)/system/curation/CurationQueue.tsx
+++ b/src/frontend/app/(core)/system/curation/CurationQueue.tsx
@@ -444,7 +444,7 @@ export function CurationQueue({ onChanged }: { onChanged: () => void }) {
                 : items.length === 0
                     ? <div className={styles.placeholder}>{isHistory ? 'No curation decisions yet.' : 'Nothing is awaiting curation.'}</div>
                     : (
-                        <div className="table-scroll">
+                        <div className={`table-scroll ${styles.curation_table}`}>
                             <Table>
                                 <Thead>
                                     <Tr>
@@ -457,15 +457,15 @@ export function CurationQueue({ onChanged }: { onChanged: () => void }) {
                                 <Tbody>
                                     {items.map(item => (
                                         <Tr key={item.id}>
-                                            <Td muted><ClientTime date={item.createdAt} format="datetime" /></Td>
-                                            <Td>
+                                            <Td muted data-label="Held"><ClientTime date={item.createdAt} format="datetime" /></Td>
+                                            <Td data-label="Type">
                                                 <div className={styles.tool_name}>{item.preview.title ?? item.typeId}</div>
                                                 <div className={styles.tool_desc}>
                                                     {item.providerId}{item.source ? ` · ${item.source}` : ''}
                                                 </div>
                                             </Td>
-                                            <Td><CurationPreview preview={item.preview} /></Td>
-                                            <Td>
+                                            <Td data-label="Preview"><CurationPreview preview={item.preview} /></Td>
+                                            <Td data-label="Decision">
                                                 {isHistory
                                                     ? <CurationDecision item={item} />
                                                     : (

--- a/src/frontend/app/(core)/system/curation/page.module.scss
+++ b/src/frontend/app/(core)/system/curation/page.module.scss
@@ -1,3 +1,5 @@
+@use '../../../breakpoints' as *;
+
 /* Page-level vertical rhythm for the curation admin surface. */
 .container {
     display: flex;
@@ -125,4 +127,47 @@
     display: flex;
     flex-wrap: wrap;
     gap: var(--gap-xs);
+}
+
+/* Mobile: a four-column curation table is too wide on phones, so collapse each
+   row into a stacked card. The shared Table declares container-name: table, so
+   we react to the table's own width — the switch stays correct inside slideouts
+   and modals, not just the full viewport. The column headers are dropped and
+   each cell carries its own label via the data-label attribute the rows set, so
+   the meaning of every value survives the layout change. */
+@container table (max-width: #{$breakpoint-mobile-lg}) {
+    .curation_table thead {
+        display: none;
+    }
+
+    .curation_table tr {
+        display: block;
+        padding: var(--padding-sm);
+        border-bottom: var(--border-width-thin) solid var(--color-border);
+    }
+
+    .curation_table td {
+        display: block;
+        padding: var(--padding-2xs) 0;
+        border-bottom: none;
+    }
+
+    /* Surface the dropped column header as an inline label above each value. */
+    .curation_table td::before {
+        content: attr(data-label);
+        display: block;
+        margin-bottom: var(--gap-2xs);
+        font-size: var(--font-size-caption);
+        font-weight: var(--font-weight-semibold);
+        letter-spacing: var(--letter-spacing-wide);
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+    }
+
+    /* The prose-width caps are unnecessary once each cell owns the full card
+       width; let preview and field content use the available space. */
+    .curation_table .curation_preview,
+    .curation_table .tool_desc {
+        max-width: none;
+    }
 }

--- a/src/frontend/components/ui/SlideOver/SlideOver.module.scss
+++ b/src/frontend/components/ui/SlideOver/SlideOver.module.scss
@@ -1,0 +1,97 @@
+/**
+ * Right-anchored slide-over panel: a full-height detail surface overlaying the
+ * page from the right edge. Surface tokens mirror the modal so the two overlays
+ * read as one system. Width uses design-constant max-width primitives — there
+ * is no use-case semantic for a slide-over width, so tier-3 primitives are the
+ * correct fallback. Declares a container so panel content reflows to the panel's
+ * own width rather than the viewport.
+ */
+
+.backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: var(--z-index-modal);
+    display: flex;
+    justify-content: flex-end;
+    background: var(--modal-backdrop-background);
+    backdrop-filter: var(--modal-backdrop-blur);
+}
+
+@keyframes slideOverIn {
+    from {
+        transform: translateX(100%);
+    }
+    to {
+        transform: translateX(0);
+    }
+}
+
+.panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    background: var(--modal-dialog-background);
+    border-left: var(--border-width-thin) solid var(--color-border-strong);
+    box-shadow: var(--shadow-lg);
+    animation: slideOverIn var(--duration-slide) ease-out;
+    container-type: inline-size;
+    container-name: slide-over;
+}
+
+.panel--md {
+    max-width: min(var(--max-width-md), 100%);
+}
+
+.panel--lg {
+    max-width: min(var(--max-width-lg), 100%);
+}
+
+.header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--gap-md);
+    padding: var(--modal-header-padding);
+    border-bottom: var(--modal-header-border);
+}
+
+.title {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+}
+
+.close {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--modal-close-size);
+    height: var(--modal-close-size);
+    background: var(--modal-close-background);
+    border: none;
+    border-radius: var(--radius-full);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: background-color var(--transition-base), color var(--transition-base);
+}
+
+.close:hover {
+    background: var(--modal-close-background-hover);
+    color: var(--color-text);
+}
+
+.body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: var(--modal-body-padding);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .panel {
+        animation: none;
+    }
+}

--- a/src/frontend/components/ui/SlideOver/SlideOver.tsx
+++ b/src/frontend/components/ui/SlideOver/SlideOver.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+/**
+ * @fileoverview Generic right-anchored slide-over panel — the master-detail
+ * primitive. A controlled overlay that enters from the right edge while keeping
+ * the page behind it visible, so an operator can review one item without losing
+ * the list. Rendered through a portal so its stacking escapes the table's
+ * overflow/transform contexts; closes on backdrop click or Escape; locks body
+ * scroll and hands focus to the panel (restoring it on close) for keyboard and
+ * assistive-tech users.
+ *
+ * Distinct from the centered ModalProvider: that queues transient dialogs
+ * imperatively, whereas this is a declarative, single-purpose detail surface
+ * whose content stays bound to the caller's current selection.
+ */
+
+import { useCallback, useEffect, useRef, useState, type MouseEvent, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { cn } from '../../../lib/cn';
+import styles from './SlideOver.module.scss';
+
+/** Width preset for the panel; falls back to a design-constant max-width. */
+type SlideOverWidth = 'md' | 'lg';
+
+/** Maps a width preset to its max-width class. */
+const widthClass: Record<SlideOverWidth, string> = {
+    md: styles['panel--md'],
+    lg: styles['panel--lg']
+};
+
+/**
+ * Controlled right-anchored slide-over.
+ *
+ * @param props.open - Whether the panel is shown; the parent owns this so the
+ *                     content stays bound to the current selection.
+ * @param props.onClose - Invoked on backdrop click, the close button, or Escape.
+ * @param props.title - Header content (e.g. the selected item's name).
+ * @param props.label - Accessible name for the dialog when the title is not plain text.
+ * @param props.width - Panel width preset.
+ * @param props.children - The panel body (scrolls independently of the header).
+ * @returns The portalled overlay, or null while closed / before mount.
+ */
+export function SlideOver({ open, onClose, title, label, width = 'md', children }: {
+    open: boolean;
+    onClose: () => void;
+    title?: ReactNode;
+    label?: string;
+    width?: SlideOverWidth;
+    children: ReactNode;
+}) {
+    const [mounted, setMounted] = useState(false);
+    const panelRef = useRef<HTMLElement | null>(null);
+    const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+    // Portal only after mount so SSR and first client render match — the panel
+    // is client-only chrome, never part of the server payload.
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
+    // While open: lock body scroll, close on Escape, and move focus into the
+    // panel, restoring it to the previously focused control on close so a
+    // keyboard user returns to where they were.
+    useEffect(() => {
+        if (!open) {
+            return undefined;
+        }
+        restoreFocusRef.current = document.activeElement as HTMLElement | null;
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+        panelRef.current?.focus();
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            document.body.style.overflow = previousOverflow;
+            restoreFocusRef.current?.focus?.();
+        };
+    }, [open, onClose]);
+
+    /**
+     * Close only when the backdrop itself is clicked, not when the click bubbles
+     * up from panel content.
+     *
+     * @param event - The backdrop mouse event.
+     */
+    const handleBackdropClick = useCallback((event: MouseEvent<HTMLDivElement>) => {
+        if (event.target === event.currentTarget) {
+            onClose();
+        }
+    }, [onClose]);
+
+    return (!mounted || !open) ? null : createPortal(
+        <div className={styles.backdrop} onClick={handleBackdropClick}>
+            <aside
+                ref={panelRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label={label}
+                tabIndex={-1}
+                className={cn(styles.panel, widthClass[width])}
+            >
+                <header className={styles.header}>
+                    <div className={styles.title}>{title}</div>
+                    <button type="button" className={styles.close} aria-label="Close panel" onClick={onClose}>
+                        <X size={18} />
+                    </button>
+                </header>
+                <div className={styles.body}>{children}</div>
+            </aside>
+        </div>,
+        document.body
+    );
+}

--- a/src/frontend/components/ui/SlideOver/index.ts
+++ b/src/frontend/components/ui/SlideOver/index.ts
@@ -1,0 +1,6 @@
+/**
+ * @fileoverview Public barrel for the SlideOver primitive. Consumers import the
+ * component from the directory root, not the implementation file.
+ */
+
+export { SlideOver } from './SlideOver';


### PR DESCRIPTION
Reshapes the `/system/ai-tools` governance dashboard around a reusable right-anchored slide-over, so each tab reads as one system instead of dense table dumps. The full model-facing tool descriptions and other heavy detail move off the rows and into the panel.

## New shared primitives
- **`SlideOver`** — generic controlled right panel (portal, Escape/backdrop close, body-scroll lock, focus handoff/restore), mirroring the modal tokens.
- **`RiskChip`** — derives one dominant risk class (read / write / external / destructive, irreversibility apex) from a tool's capability; shared by the list, filters, and sort.

## Registry
Reordered for triage — enabled state and risk lead, then name and a one-line description teaser. Added a search box, per-class risk filter pills, and a risk-descending default sort. Clicking a row opens the slide-over with **Description / Policy / Schema** tabs (the policy editor is reused; the input schema is now surfaced).

## Activity
Click-row slide-over surfacing everything the audit record captured but the row hid: capability badges, redacted arguments, result digest, sanitized + raw forensic error, cost, correlation ids, and the untrusted-content screen verdict. Added a **tool filter** and real **pagination** (the hard 50-row ceiling is gone).

## Approvals
A **RiskChip column** so the approver sees external/irreversible/spends-money before deciding; a detail slide-over with full pretty-printed arguments, capability context, a high-stakes caution, and in-panel Approve/Reject. Row-level Approve **confirms first** for money-spending/irreversible effects (args aren't visible there); added **bulk select + Reject** for queue floods.

## Shell
The lethal-trifecta banner renders an explicit **degraded state** on load failure instead of vanishing (absence must not read as "safe"), and the dashboard **opens on Approvals** when holds are already pending.

## Also
The curation admin table collapses to stacked cards on mobile via `data-label` cells and a container query.

Frontend type check (`npm run typecheck`) passes clean.