### PR TITLE
perf(network-activity): pre-aggregate widget series via scheduled rollup

### DIFF
--- a/src/backend/database/models/core-network-activity-rollup-model.ts
+++ b/src/backend/database/models/core-network-activity-rollup-model.ts
@@ -70,7 +70,14 @@ const CoreNetworkActivityRollupSchema = new Schema<CoreNetworkActivityRollupDoc>
 // `bucketStart` scan within a `bucketType` for the latest N points.
 CoreNetworkActivityRollupSchema.index({ bucketType: 1, bucketStart: 1 }, { unique: true });
 
+// The third argument pins the physical collection name. Without it Mongoose
+// would bind the model (and build its unique index) on the pluralized default
+// `corenetworkactivityrollups`, while the job and read path use the raw
+// `core_network_activity_rollups` collection — leaving the (bucketType,
+// bucketStart) unique key unenforced on the actual data and allowing duplicate
+// buckets under concurrent upserts.
 export const CoreNetworkActivityRollupModel = model<CoreNetworkActivityRollupDoc>(
     'CoreNetworkActivityRollup',
-    CoreNetworkActivityRollupSchema
+    CoreNetworkActivityRollupSchema,
+    CORE_NETWORK_ACTIVITY_ROLLUPS_COLLECTION
 );

--- a/src/backend/database/models/core-network-activity-rollup-model.ts
+++ b/src/backend/database/models/core-network-activity-rollup-model.ts
@@ -1,0 +1,76 @@
+/**
+ * @fileoverview Core network-activity rollup model.
+ *
+ * Pre-aggregated time buckets backing the `core:network-activity` widget. The
+ * widget plots transactions, native transfers, and native TRX transfer volume
+ * over a 1h/24h/7d window; computing those over raw blocks and (especially) the
+ * multi-million-row `transactions` collection at request time blew the SSR
+ * widget resolver's 5-second budget, so the widget was silently dropped from
+ * the page. This collection holds the answer pre-computed by the
+ * `network-activity:rollup` scheduler job, so the request path is a cheap
+ * bounded read instead of a live aggregation — mirroring the resource-tracker
+ * and dust-tracker rollup pattern, adapted to core.
+ *
+ * Two granularities share the collection, discriminated by `bucketType`:
+ * `minute` serves the 1h window (60 points), `hourly` serves 24h/7d (24/168
+ * points). `(bucketType, bucketStart)` is the natural key, so the job upserts
+ * idempotently — re-running for a bucket overwrites rather than duplicates.
+ *
+ * This is the first core-owned collection to adopt the `core_` name prefix; the
+ * legacy core collections (`transactions`, `blocks`, etc.) predate the
+ * convention and are not renamed here.
+ *
+ * @module backend/database/models/core-network-activity-rollup-model
+ */
+
+import { Schema, model, type Document } from 'mongoose';
+
+/**
+ * Physical collection name. `core_`-prefixed to mark core ownership; passed to
+ * `database.registerModel`/`getCollection` as the logical key.
+ */
+export const CORE_NETWORK_ACTIVITY_ROLLUPS_COLLECTION = 'core_network_activity_rollups';
+
+/**
+ * Plain field interface for rollup documents. Use with `.lean()` / raw
+ * collection reads to avoid Mongoose Document type friction.
+ */
+export interface CoreNetworkActivityRollupFields {
+    /** Granularity tier — `minute` (1h window) or `hourly` (24h/7d windows). */
+    bucketType: 'minute' | 'hourly';
+    /** UTC start of the bucket, truncated to the tier (minute or hour). */
+    bucketStart: Date;
+    /** Total transactions of every contract type in the bucket. */
+    transactions: number;
+    /** Native `TransferContract` transfers in the bucket. */
+    transfers: number;
+    /** Summed native TRX moved by those transfers (TRC20/USDT excluded). */
+    volume: number;
+    /** Insert time; used only for debugging/auditing, not for windowing. */
+    createdAt: Date;
+}
+
+/** Mongoose document interface for rollup records. */
+export interface CoreNetworkActivityRollupDoc extends Document, CoreNetworkActivityRollupFields {}
+
+const CoreNetworkActivityRollupSchema = new Schema<CoreNetworkActivityRollupDoc>(
+    {
+        bucketType: { type: String, enum: ['minute', 'hourly'], required: true },
+        bucketStart: { type: Date, required: true },
+        transactions: { type: Number, default: 0 },
+        transfers: { type: Number, default: 0 },
+        volume: { type: Number, default: 0 },
+        createdAt: { type: Date, default: Date.now }
+    },
+    { versionKey: false }
+);
+
+// Natural key: one document per (tier, bucket). Unique so upserts are
+// idempotent, and it also serves the request-time read — a descending
+// `bucketStart` scan within a `bucketType` for the latest N points.
+CoreNetworkActivityRollupSchema.index({ bucketType: 1, bucketStart: 1 }, { unique: true });
+
+export const CoreNetworkActivityRollupModel = model<CoreNetworkActivityRollupDoc>(
+    'CoreNetworkActivityRollup',
+    CoreNetworkActivityRollupSchema
+);

--- a/src/backend/database/models/index.ts
+++ b/src/backend/database/models/index.ts
@@ -8,3 +8,4 @@ export * from './token-model.js';
 export * from './delegation-flow-model.js';
 export * from './contract-activity-model.js';
 export * from './system-config-model.js';
+export * from './core-network-activity-rollup-model.js';

--- a/src/backend/modules/blockchain/blockchain.service.ts
+++ b/src/backend/modules/blockchain/blockchain.service.ts
@@ -7,6 +7,7 @@ import { ProcessedTransaction } from '@/types';
 import { TransactionModel, type TransactionDoc, type TransactionFields } from '../../database/models/transaction-model.js';
 import { SyncStateModel, type SyncStateDoc, type SyncStateFields } from '../../database/models/sync-state-model.js';
 import { BlockModel, type BlockDoc, type BlockStats, type BlockFields } from '../../database/models/block-model.js';
+import { CORE_NETWORK_ACTIVITY_ROLLUPS_COLLECTION, type CoreNetworkActivityRollupFields } from '../../database/models/core-network-activity-rollup-model.js';
 import { DelegationFlowModel, ContractActivityModel, TokenModel } from '../../database/models/index.js';
 import { QueueService } from '../../services/queue.service.js';
 import { blockchainConfig } from '../../config/blockchain.js';
@@ -523,133 +524,55 @@ export class BlockchainService implements IBlockchainService {
     }
 
     /**
-     * Build the combined network-activity overview series for a window.
+     * Read the pre-computed network-activity overview series for a window.
      *
-     * Why: the core `core:network-activity` widget plots transactions, native
-     * transfers, and native TRX transfer volume on one chart, toggled
-     * client-side between the three. Counts are read from the pre-aggregated
-     * `blocks` collection (cheap); TRX volume is not stored per block, so it is
-     * summed from `amountTRX` over `TransferContract` rows in the
-     * `transactions` collection. The two aggregations run in parallel and merge
-     * by bucket key.
+     * Backs the core `core:network-activity` widget — transactions, native
+     * transfers, and native TRX transfer volume per bucket. The series is
+     * pre-aggregated by the `network-activity:rollup` scheduler job into the
+     * `core_network_activity_rollups` collection (see {@link runOverviewRollup}),
+     * so this read is a bounded fetch of at most 168 small documents rather than
+     * a live aggregation over the multi-million-row transactions collection.
+     * That live aggregation previously exceeded the SSR widget resolver's
+     * 5-second budget, so the resolver silently dropped the widget from the page;
+     * reading pre-baked buckets keeps the request well inside the budget.
      *
-     * Volume is intentionally native-TRX only: `TriggerSmartContract`
-     * (USDT/TRC20) carries the token amount in ABI-encoded contract data, not
-     * `amountTRX`, so it is excluded rather than silently under-counted. The
-     * `{ type, timestamp }` index serves the volume aggregation; `{ timestamp }`
-     * serves the block aggregation.
+     * Results anchor on the latest stored bucket (sort descending, take N, then
+     * reverse to chronological), so the series stays correct even when sync lags.
      *
-     * @param window - `1h` (per-minute buckets, 60 points) or `24h`/`7d`
-     *   (hourly buckets, 24/168 points). Matches the widget's window toggle.
+     * @param window - `1h` (minute buckets, 60 points) or `24h`/`7d` (hourly
+     *   buckets, 24/168 points). Matches the widget's window toggle.
      * @returns Buckets sorted chronologically; each carries all three metrics.
      */
     async getOverviewTimeseries(window: '1h' | '24h' | '7d') {
-        const WINDOW_SPECS: Record<'1h' | '24h' | '7d', { ms: number; format: string }> = {
-            '1h': { ms: 60 * 60 * 1000, format: '%Y-%m-%d %H:%M' },
-            '24h': { ms: 24 * 60 * 60 * 1000, format: '%Y-%m-%d %H:00' },
-            '7d': { ms: 7 * 24 * 60 * 60 * 1000, format: '%Y-%m-%d %H:00' }
+        const WINDOW_SPECS: Record<'1h' | '24h' | '7d', { bucketType: 'minute' | 'hourly'; count: number }> = {
+            '1h': { bucketType: 'minute', count: 60 },
+            '24h': { bucketType: 'hourly', count: 24 },
+            '7d': { bucketType: 'hourly', count: 168 }
         };
         const spec = WINDOW_SPECS[window];
         if (!spec) {
             throw new Error(`getOverviewTimeseries: unsupported window '${window}'`);
         }
 
-        // Cache the assembled series in Redis for 60s, keyed by window. The 7d
-        // volume aggregation sums non-indexed `amountTRX` over every
-        // `TransferContract` row in range — an index-supported match that still
-        // fetches each matched document — so concurrent SSR/widget callers would
-        // otherwise repeat a heavy fetch-and-sum. 60s staleness is acceptable:
-        // the frontend already refetches at 60s and the return shape is plain
-        // JSON. A cache fault degrades to the live query rather than failing.
-        const cacheKey = `${env.REDIS_NAMESPACE}:overview-timeseries:${window}`;
-        try {
-            const cached = await this.redis.get(cacheKey);
-            if (cached) {
-                return JSON.parse(cached) as Array<{ date: string; transactions: number; transfers: number; volume: number }>;
-            }
-        } catch (error) {
-            logger.warn({ error, window }, 'Overview timeseries cache read failed; querying live');
-        }
+        const rollups = BlockchainService.getDatabase().getCollection<CoreNetworkActivityRollupFields>(
+            CORE_NETWORK_ACTIVITY_ROLLUPS_COLLECTION
+        );
+        const rows = await rollups
+            .find({ bucketType: spec.bucketType })
+            .sort({ bucketStart: -1 })
+            .limit(spec.count)
+            .toArray();
 
-        const startDate = new Date(Date.now() - spec.ms);
-        const database = BlockchainService.getDatabase();
-        const blocksCollection = database.getCollection<BlockDoc>(BlockchainService.BLOCKS_COLLECTION);
-        const transactionsCollection = database.getCollection<TransactionDoc>(BlockchainService.TRANSACTIONS_COLLECTION);
-
-        interface CountBucket { _id: string; transactions: number; transfers: number; }
-        interface VolumeBucket { _id: string; volume: number; }
-
-        const [countRows, volumeRows] = await Promise.all([
-            blocksCollection
-                .aggregate<CountBucket>([
-                    { $match: { timestamp: { $gte: startDate } } },
-                    {
-                        $group: {
-                            _id: { $dateToString: { format: spec.format, date: '$timestamp' } },
-                            transactions: { $sum: '$transactionCount' },
-                            transfers: { $sum: '$stats.transfers' }
-                        }
-                    }
-                ])
-                .toArray(),
-            transactionsCollection
-                .aggregate<VolumeBucket>([
-                    { $match: { type: 'TransferContract', timestamp: { $gte: startDate } } },
-                    {
-                        $group: {
-                            _id: { $dateToString: { format: spec.format, date: '$timestamp' } },
-                            volume: { $sum: '$amountTRX' }
-                        }
-                    }
-                ])
-                .toArray()
-        ]);
-
-        // Union the two aggregations by bucket key. Seed from the block counts,
-        // then layer volume on top — a bucket can have blocks but no native
-        // transfers (volume stays 0), and (rarely) vice versa — so default the
-        // absent side to 0 rather than dropping the bucket.
-        const buckets = new Map<string, { transactions: number; transfers: number; volume: number }>();
-        for (const row of countRows) {
-            buckets.set(row._id, { transactions: row.transactions, transfers: row.transfers, volume: 0 });
-        }
-        for (const row of volumeRows) {
-            const existing = buckets.get(row._id);
-            if (existing) {
-                existing.volume = row.volume;
-            } else {
-                buckets.set(row._id, { transactions: 0, transfers: 0, volume: row.volume });
-            }
-        }
-
-        const result = Array.from(buckets.entries())
-            .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-            .map(([bucket, metrics]) => {
-                // MongoDB returns bucket keys like "2025-10-13 01:00" (UTC, no
-                // zone). Append seconds + 'Z' so they parse as UTC ISO — the same
-                // conversion getTransactionTimeseries uses.
-                let isoDate: string;
-                try {
-                    const parsed = new Date(`${bucket}:00Z`);
-                    isoDate = Number.isNaN(parsed.getTime()) ? bucket : parsed.toISOString();
-                } catch {
-                    isoDate = bucket;
-                }
-                return {
-                    date: isoDate,
-                    transactions: metrics.transactions,
-                    transfers: metrics.transfers,
-                    volume: Number(metrics.volume.toFixed(6))
-                };
-            });
-
-        try {
-            await this.redis.setex(cacheKey, 60, JSON.stringify(result));
-        } catch (error) {
-            logger.warn({ error, window }, 'Overview timeseries cache write failed');
-        }
-
-        return result;
+        // The read is newest-first (descending bucketStart); reverse to ascending
+        // chronological order for the chart.
+        return rows
+            .reverse()
+            .map((row) => ({
+                date: (row.bucketStart instanceof Date ? row.bucketStart : new Date(row.bucketStart)).toISOString(),
+                transactions: row.transactions ?? 0,
+                transfers: row.transfers ?? 0,
+                volume: row.volume ?? 0
+            }));
     }
 
     /**

--- a/src/backend/modules/blockchain/overview-rollup.job.ts
+++ b/src/backend/modules/blockchain/overview-rollup.job.ts
@@ -1,0 +1,322 @@
+/**
+ * @fileoverview Network-activity rollup job.
+ *
+ * Pre-computes the buckets backing the `core:network-activity` widget into the
+ * `core_network_activity_rollups` collection so the request path is a cheap read
+ * instead of a live aggregation. This mirrors the resource-tracker /
+ * dust-tracker rollup pattern: a scheduled job maintains pre-aggregated buckets;
+ * the widget reads them.
+ *
+ * Why a job at all: the volume series sums `amountTRX` over every
+ * `TransferContract` row in the window. Run live for a 7-day window over the
+ * multi-million-row `transactions` collection, that scan exceeds the SSR widget
+ * resolver's 5-second budget and the widget is dropped from the page. The job
+ * never does that at request time and bounds its own work too — each run
+ * recomputes only a small recent window (the in-progress bucket plus a little
+ * lag) and backfills history one bounded chunk at a time, so it never scans the
+ * full week in a single pass after the first few catch-up runs.
+ *
+ * Idempotent by construction: buckets are upserted on `(bucketType,
+ * bucketStart)`, so recomputing a bucket overwrites it. Old buckets are pruned
+ * to keep the collection bounded.
+ *
+ * @module backend/modules/blockchain/overview-rollup.job
+ */
+
+import type { IDatabaseService } from '@/types';
+import type { BlockDoc } from '../../database/models/block-model.js';
+import type { TransactionDoc } from '../../database/models/transaction-model.js';
+import {
+    CORE_NETWORK_ACTIVITY_ROLLUPS_COLLECTION,
+    type CoreNetworkActivityRollupFields
+} from '../../database/models/core-network-activity-rollup-model.js';
+import { logger } from '../../lib/logger.js';
+
+/** Core blocks collection — mirrors `BlockchainService.BLOCKS_COLLECTION`. */
+const BLOCKS_COLLECTION = 'blocks';
+/** Core transactions collection — mirrors `BlockchainService.TRANSACTIONS_COLLECTION`. */
+const TRANSACTIONS_COLLECTION = 'transactions';
+
+const HOUR_MS = 60 * 60 * 1000;
+const MINUTE_MS = 60 * 1000;
+
+/** MongoDB `$dateToString` formats per tier; both parse back to UTC ISO. */
+const HOURLY_FORMAT = '%Y-%m-%d %H:00';
+const MINUTE_FORMAT = '%Y-%m-%d %H:%M';
+
+/** Hourly buckets a 7d window needs (168), so backfill targets `current − 167h`. */
+const TARGET_HOURLY_BUCKETS = 168;
+/** Recent hourly buckets recomputed each run: the in-progress hour plus 2 prior, to absorb late blocks. */
+const RECENT_HOURLY_HOURS = 3;
+/** Recent minute buckets recomputed each run — covers the 60-point 1h window plus margin. */
+const RECENT_MINUTE_MINUTES = 75;
+/** Older history filled per run, newest-first, until the 7d window is covered. */
+const BACKFILL_CHUNK_HOURS = 48;
+/** Hourly buckets kept (8d) — margin beyond the 7d read window. */
+const HOURLY_RETENTION_HOURS = 8 * 24;
+/** Minute buckets kept (3h) — margin beyond the 1h read window. */
+const MINUTE_RETENTION_HOURS = 3;
+
+/** One assembled bucket prior to upsert. */
+interface IRollupBucket {
+    bucketStart: Date;
+    transactions: number;
+    transfers: number;
+    volume: number;
+}
+
+/**
+ * Truncate a date to the start of its UTC hour. Buckets are UTC because
+ * `$dateToString` defaults to UTC, so flooring must match.
+ *
+ * @param date - Source instant.
+ * @returns A new Date at the top of the UTC hour.
+ */
+function floorToHour(date: Date): Date {
+    const floored = new Date(date.getTime());
+    floored.setUTCMinutes(0, 0, 0);
+    return floored;
+}
+
+/**
+ * Truncate a date to the start of its UTC minute.
+ *
+ * @param date - Source instant.
+ * @returns A new Date at the top of the UTC minute.
+ */
+function floorToMinute(date: Date): Date {
+    const floored = new Date(date.getTime());
+    floored.setUTCSeconds(0, 0);
+    return floored;
+}
+
+/**
+ * Parse a `$dateToString` bucket key (UTC, no zone) into a Date. Appends
+ * seconds + `Z` so both the hourly (`… HH:00`) and minute (`… HH:MM`) formats
+ * resolve as UTC ISO — the same conversion the legacy timeseries used.
+ *
+ * @param key - Bucket key emitted by the aggregation.
+ * @returns The parsed Date, or null when the key is unparseable.
+ */
+function parseBucketKey(key: string): Date | null {
+    const parsed = new Date(`${key}:00Z`);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/**
+ * Compute the combined buckets for a time range at a given granularity.
+ *
+ * Runs the cheap block-count aggregation and the transactions volume
+ * aggregation in parallel over the bounded `[startDate, endDate)` range, then
+ * merges them by bucket key. Callers keep the range small (a recent window or a
+ * single backfill chunk) so neither aggregation scans the whole collection.
+ *
+ * @param database - Database service for raw collection access.
+ * @param format - `$dateToString` format selecting the bucket granularity.
+ * @param startDate - Inclusive range start.
+ * @param endDate - Exclusive range end.
+ * @returns Assembled buckets (unordered); empty when the range has no blocks.
+ */
+async function computeBuckets(
+    database: IDatabaseService,
+    format: string,
+    startDate: Date,
+    endDate: Date
+): Promise<IRollupBucket[]> {
+    const blocks = database.getCollection<BlockDoc>(BLOCKS_COLLECTION);
+    const transactions = database.getCollection<TransactionDoc>(TRANSACTIONS_COLLECTION);
+
+    interface ICountRow { _id: string; transactions: number; transfers: number; }
+    interface IVolumeRow { _id: string; volume: number; }
+
+    const [countRows, volumeRows] = await Promise.all([
+        blocks
+            .aggregate<ICountRow>([
+                { $match: { timestamp: { $gte: startDate, $lt: endDate } } },
+                {
+                    $group: {
+                        _id: { $dateToString: { format, date: '$timestamp' } },
+                        transactions: { $sum: '$transactionCount' },
+                        transfers: { $sum: '$stats.transfers' }
+                    }
+                }
+            ])
+            .toArray(),
+        transactions
+            .aggregate<IVolumeRow>([
+                { $match: { type: 'TransferContract', timestamp: { $gte: startDate, $lt: endDate } } },
+                {
+                    $group: {
+                        _id: { $dateToString: { format, date: '$timestamp' } },
+                        volume: { $sum: '$amountTRX' }
+                    }
+                }
+            ])
+            .toArray()
+    ]);
+
+    // Union by bucket key: seed from block counts, layer volume on top. A bucket
+    // can have blocks but no native transfers (volume 0), and (rarely) vice
+    // versa, so default the absent side rather than dropping the bucket.
+    const merged = new Map<string, { transactions: number; transfers: number; volume: number }>();
+    for (const row of countRows) {
+        merged.set(row._id, { transactions: row.transactions, transfers: row.transfers, volume: 0 });
+    }
+    for (const row of volumeRows) {
+        const existing = merged.get(row._id);
+        if (existing) {
+            existing.volume = row.volume;
+        } else {
+            merged.set(row._id, { transactions: 0, transfers: 0, volume: row.volume });
+        }
+    }
+
+    const buckets: IRollupBucket[] = [];
+    for (const [key, metrics] of merged) {
+        const bucketStart = parseBucketKey(key);
+        if (!bucketStart) {
+            continue;
+        }
+        buckets.push({
+            bucketStart,
+            transactions: metrics.transactions,
+            transfers: metrics.transfers,
+            volume: Number(metrics.volume.toFixed(6))
+        });
+    }
+    return buckets;
+}
+
+/**
+ * Idempotently upsert a batch of buckets for one tier. Keyed on `(bucketType,
+ * bucketStart)` so recomputing a bucket overwrites it; `createdAt` is stamped
+ * only on first insert.
+ *
+ * @param database - Database service for raw collection access.
+ * @param bucketType - Tier the buckets belong to.
+ * @param buckets - Assembled buckets to persist; a no-op when empty.
+ */
+async function upsertBuckets(
+    database: IDatabaseService,
+    bucketType: CoreNetworkActivityRollupFields['bucketType'],
+    buckets: IRollupBucket[]
+): Promise<void> {
+    if (buckets.length === 0) {
+        return;
+    }
+    const collection = database.getCollection<CoreNetworkActivityRollupFields>(
+        CORE_NETWORK_ACTIVITY_ROLLUPS_COLLECTION
+    );
+    await collection.bulkWrite(
+        buckets.map((bucket) => ({
+            updateOne: {
+                filter: { bucketType, bucketStart: bucket.bucketStart },
+                update: {
+                    $set: {
+                        bucketType,
+                        bucketStart: bucket.bucketStart,
+                        transactions: bucket.transactions,
+                        transfers: bucket.transfers,
+                        volume: bucket.volume
+                    },
+                    $setOnInsert: { createdAt: new Date() }
+                },
+                upsert: true
+            }
+        }))
+    );
+}
+
+/**
+ * Read the sync frontier — the timestamp of the most recently processed block.
+ *
+ * Anchoring rollups on the latest block (not the wall clock) keeps the buckets
+ * correct even when sync lags, matching how the sibling widgets anchor on their
+ * latest rollup.
+ *
+ * @param database - Database service for raw collection access.
+ * @returns The latest block timestamp, or null when no blocks exist yet.
+ */
+async function getFrontier(database: IDatabaseService): Promise<Date | null> {
+    const blocks = database.getCollection<BlockDoc>(BLOCKS_COLLECTION);
+    const latest = await blocks.find({}, { projection: { timestamp: 1 } })
+        .sort({ timestamp: -1 })
+        .limit(1)
+        .toArray();
+    const timestamp = latest[0]?.timestamp;
+    return timestamp ? new Date(timestamp) : null;
+}
+
+/**
+ * Run one pass of the network-activity rollup.
+ *
+ * Each run does three bounded things: recompute the recent hourly window (the
+ * in-progress hour plus lag), fill one chunk of older hourly history until the
+ * 7-day window is covered, and recompute the recent minute window for the 1h
+ * view. None of these scans the full collection: the recent windows are a few
+ * hours, and the backfill is capped per run, so the heavy week-long scan never
+ * happens in a single pass once history is filled. Stale buckets are pruned.
+ *
+ * Safe to call on an empty collection (first deploy): the recent windows seed
+ * the newest buckets immediately and the backfill walks history backward over
+ * subsequent runs. Failures are logged, not thrown, so a bad run doesn't wedge
+ * the scheduler.
+ *
+ * @param database - Database service for raw collection access.
+ */
+export async function runOverviewRollup(database: IDatabaseService): Promise<void> {
+    try {
+        const frontier = await getFrontier(database);
+        if (!frontier) {
+            logger.debug('network-activity rollup: no blocks indexed yet, skipping');
+            return;
+        }
+
+        const currentHour = floorToHour(frontier);
+        const currentMinute = floorToMinute(frontier);
+        const collection = database.getCollection<CoreNetworkActivityRollupFields>(
+            CORE_NETWORK_ACTIVITY_ROLLUPS_COLLECTION
+        );
+
+        // 1. Recent hourly recompute — the in-progress hour plus the prior two,
+        // so late-arriving blocks are absorbed and the current hour finalizes as
+        // it completes. End is the next hour boundary (exclusive).
+        const recentHourStart = new Date(currentHour.getTime() - (RECENT_HOURLY_HOURS - 1) * HOUR_MS);
+        const hourlyEnd = new Date(currentHour.getTime() + HOUR_MS);
+        await upsertBuckets(database, 'hourly', await computeBuckets(database, HOURLY_FORMAT, recentHourStart, hourlyEnd));
+
+        // 2. Backfill older hourly history one bounded chunk per run, newest-first,
+        // until the 7-day window is covered. After the first few catch-up runs the
+        // oldest present bucket reaches the target and this becomes a no-op.
+        const desiredOldest = new Date(currentHour.getTime() - (TARGET_HOURLY_BUCKETS - 1) * HOUR_MS);
+        const oldestDoc = await collection.find({ bucketType: 'hourly' })
+            .sort({ bucketStart: 1 })
+            .limit(1)
+            .toArray();
+        const oldestPresent = oldestDoc[0]?.bucketStart ? new Date(oldestDoc[0].bucketStart) : recentHourStart;
+        if (oldestPresent.getTime() > desiredOldest.getTime()) {
+            const chunkEnd = oldestPresent; // exclusive — strictly older buckets
+            const chunkStart = new Date(
+                Math.max(desiredOldest.getTime(), oldestPresent.getTime() - BACKFILL_CHUNK_HOURS * HOUR_MS)
+            );
+            await upsertBuckets(database, 'hourly', await computeBuckets(database, HOURLY_FORMAT, chunkStart, chunkEnd));
+        }
+
+        // 3. Recent minute recompute for the 1h window.
+        const recentMinuteStart = new Date(currentMinute.getTime() - RECENT_MINUTE_MINUTES * MINUTE_MS);
+        const minuteEnd = new Date(currentMinute.getTime() + MINUTE_MS);
+        await upsertBuckets(database, 'minute', await computeBuckets(database, MINUTE_FORMAT, recentMinuteStart, minuteEnd));
+
+        // 4. Prune stale buckets to keep the collection bounded.
+        await collection.deleteMany({
+            bucketType: 'minute',
+            bucketStart: { $lt: new Date(frontier.getTime() - MINUTE_RETENTION_HOURS * HOUR_MS) }
+        });
+        await collection.deleteMany({
+            bucketType: 'hourly',
+            bucketStart: { $lt: new Date(frontier.getTime() - HOURLY_RETENTION_HOURS * HOUR_MS) }
+        });
+    } catch (error) {
+        logger.warn({ error }, 'network-activity rollup run failed');
+    }
+}

--- a/src/backend/modules/blockchain/overview-rollup.job.ts
+++ b/src/backend/modules/blockchain/overview-rollup.job.ts
@@ -99,7 +99,10 @@ function floorToMinute(date: Date): Date {
  * @returns The parsed Date, or null when the key is unparseable.
  */
 function parseBucketKey(key: string): Date | null {
-    const parsed = new Date(`${key}:00Z`);
+    // Normalize the single space to `T` so the string is strict ISO 8601
+    // ("2025-10-13T01:00:00Z") rather than the space form, whose parsing is
+    // implementation-defined per the ECMAScript spec even though V8 accepts it.
+    const parsed = new Date(`${key.replace(' ', 'T')}:00Z`);
     return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
@@ -115,7 +118,9 @@ function parseBucketKey(key: string): Date | null {
  * @param format - `$dateToString` format selecting the bucket granularity.
  * @param startDate - Inclusive range start.
  * @param endDate - Exclusive range end.
- * @returns Assembled buckets (unordered); empty when the range has no blocks.
+ * @returns One bucket per tick across the range in ascending order, zero-filled
+ *   where no blocks/transfers were observed, so callers always see a contiguous
+ *   series and the backfill cursor advances even over empty ranges.
  */
 async function computeBuckets(
     database: IDatabaseService,
@@ -171,18 +176,34 @@ async function computeBuckets(
         }
     }
 
-    const buckets: IRollupBucket[] = [];
+    const byTime = new Map<number, IRollupBucket>();
     for (const [key, metrics] of merged) {
         const bucketStart = parseBucketKey(key);
         if (!bucketStart) {
             continue;
         }
-        buckets.push({
+        byTime.set(bucketStart.getTime(), {
             bucketStart,
             transactions: metrics.transactions,
             transfers: metrics.transfers,
             volume: Number(metrics.volume.toFixed(6))
         });
+    }
+
+    // Materialize every expected bucket across [startDate, endDate), zero-filling
+    // any tick the aggregation produced no row for. Without this a range with no
+    // blocks returns no buckets, so the backfill cursor (the oldest stored
+    // bucket) never advances past the gap and re-queries the same empty range
+    // every run, while the read path returns a short/holey series. Callers pass
+    // tier-aligned ranges, so every aggregated bucket key lands exactly on a step
+    // tick; keying by getTime() avoids re-deriving the $dateToString UTC string.
+    // Bounded by the caller's window (<=168 hourly / <=75 minute ticks).
+    const stepMs = format === MINUTE_FORMAT ? MINUTE_MS : HOUR_MS;
+    const buckets: IRollupBucket[] = [];
+    for (let tick = startDate.getTime(); tick < endDate.getTime(); tick += stepMs) {
+        buckets.push(
+            byTime.get(tick) ?? { bucketStart: new Date(tick), transactions: 0, transfers: 0, volume: 0 }
+        );
     }
     return buckets;
 }
@@ -259,64 +280,61 @@ async function getFrontier(database: IDatabaseService): Promise<Date | null> {
  *
  * Safe to call on an empty collection (first deploy): the recent windows seed
  * the newest buckets immediately and the backfill walks history backward over
- * subsequent runs. Failures are logged, not thrown, so a bad run doesn't wedge
- * the scheduler.
+ * subsequent runs. Failures propagate to the caller so the scheduler records
+ * the run as failed (surfaced on `/system/scheduler`); the fire-and-forget boot
+ * kick in core-jobs guards itself with `.catch()` to avoid an unhandledRejection.
  *
  * @param database - Database service for raw collection access.
  */
 export async function runOverviewRollup(database: IDatabaseService): Promise<void> {
-    try {
-        const frontier = await getFrontier(database);
-        if (!frontier) {
-            logger.debug('network-activity rollup: no blocks indexed yet, skipping');
-            return;
-        }
-
-        const currentHour = floorToHour(frontier);
-        const currentMinute = floorToMinute(frontier);
-        const collection = database.getCollection<CoreNetworkActivityRollupFields>(
-            CORE_NETWORK_ACTIVITY_ROLLUPS_COLLECTION
-        );
-
-        // 1. Recent hourly recompute — the in-progress hour plus the prior two,
-        // so late-arriving blocks are absorbed and the current hour finalizes as
-        // it completes. End is the next hour boundary (exclusive).
-        const recentHourStart = new Date(currentHour.getTime() - (RECENT_HOURLY_HOURS - 1) * HOUR_MS);
-        const hourlyEnd = new Date(currentHour.getTime() + HOUR_MS);
-        await upsertBuckets(database, 'hourly', await computeBuckets(database, HOURLY_FORMAT, recentHourStart, hourlyEnd));
-
-        // 2. Backfill older hourly history one bounded chunk per run, newest-first,
-        // until the 7-day window is covered. After the first few catch-up runs the
-        // oldest present bucket reaches the target and this becomes a no-op.
-        const desiredOldest = new Date(currentHour.getTime() - (TARGET_HOURLY_BUCKETS - 1) * HOUR_MS);
-        const oldestDoc = await collection.find({ bucketType: 'hourly' })
-            .sort({ bucketStart: 1 })
-            .limit(1)
-            .toArray();
-        const oldestPresent = oldestDoc[0]?.bucketStart ? new Date(oldestDoc[0].bucketStart) : recentHourStart;
-        if (oldestPresent.getTime() > desiredOldest.getTime()) {
-            const chunkEnd = oldestPresent; // exclusive — strictly older buckets
-            const chunkStart = new Date(
-                Math.max(desiredOldest.getTime(), oldestPresent.getTime() - BACKFILL_CHUNK_HOURS * HOUR_MS)
-            );
-            await upsertBuckets(database, 'hourly', await computeBuckets(database, HOURLY_FORMAT, chunkStart, chunkEnd));
-        }
-
-        // 3. Recent minute recompute for the 1h window.
-        const recentMinuteStart = new Date(currentMinute.getTime() - RECENT_MINUTE_MINUTES * MINUTE_MS);
-        const minuteEnd = new Date(currentMinute.getTime() + MINUTE_MS);
-        await upsertBuckets(database, 'minute', await computeBuckets(database, MINUTE_FORMAT, recentMinuteStart, minuteEnd));
-
-        // 4. Prune stale buckets to keep the collection bounded.
-        await collection.deleteMany({
-            bucketType: 'minute',
-            bucketStart: { $lt: new Date(frontier.getTime() - MINUTE_RETENTION_HOURS * HOUR_MS) }
-        });
-        await collection.deleteMany({
-            bucketType: 'hourly',
-            bucketStart: { $lt: new Date(frontier.getTime() - HOURLY_RETENTION_HOURS * HOUR_MS) }
-        });
-    } catch (error) {
-        logger.warn({ error }, 'network-activity rollup run failed');
+    const frontier = await getFrontier(database);
+    if (!frontier) {
+        logger.debug('network-activity rollup: no blocks indexed yet, skipping');
+        return;
     }
+
+    const currentHour = floorToHour(frontier);
+    const currentMinute = floorToMinute(frontier);
+    const collection = database.getCollection<CoreNetworkActivityRollupFields>(
+        CORE_NETWORK_ACTIVITY_ROLLUPS_COLLECTION
+    );
+
+    // 1. Recent hourly recompute — the in-progress hour plus the prior two,
+    // so late-arriving blocks are absorbed and the current hour finalizes as
+    // it completes. End is the next hour boundary (exclusive).
+    const recentHourStart = new Date(currentHour.getTime() - (RECENT_HOURLY_HOURS - 1) * HOUR_MS);
+    const hourlyEnd = new Date(currentHour.getTime() + HOUR_MS);
+    await upsertBuckets(database, 'hourly', await computeBuckets(database, HOURLY_FORMAT, recentHourStart, hourlyEnd));
+
+    // 2. Backfill older hourly history one bounded chunk per run, newest-first,
+    // until the 7-day window is covered. After the first few catch-up runs the
+    // oldest present bucket reaches the target and this becomes a no-op.
+    const desiredOldest = new Date(currentHour.getTime() - (TARGET_HOURLY_BUCKETS - 1) * HOUR_MS);
+    const oldestDoc = await collection.find({ bucketType: 'hourly' })
+        .sort({ bucketStart: 1 })
+        .limit(1)
+        .toArray();
+    const oldestPresent = oldestDoc[0]?.bucketStart ? new Date(oldestDoc[0].bucketStart) : recentHourStart;
+    if (oldestPresent.getTime() > desiredOldest.getTime()) {
+        const chunkEnd = oldestPresent; // exclusive — strictly older buckets
+        const chunkStart = new Date(
+            Math.max(desiredOldest.getTime(), oldestPresent.getTime() - BACKFILL_CHUNK_HOURS * HOUR_MS)
+        );
+        await upsertBuckets(database, 'hourly', await computeBuckets(database, HOURLY_FORMAT, chunkStart, chunkEnd));
+    }
+
+    // 3. Recent minute recompute for the 1h window.
+    const recentMinuteStart = new Date(currentMinute.getTime() - RECENT_MINUTE_MINUTES * MINUTE_MS);
+    const minuteEnd = new Date(currentMinute.getTime() + MINUTE_MS);
+    await upsertBuckets(database, 'minute', await computeBuckets(database, MINUTE_FORMAT, recentMinuteStart, minuteEnd));
+
+    // 4. Prune stale buckets to keep the collection bounded.
+    await collection.deleteMany({
+        bucketType: 'minute',
+        bucketStart: { $lt: new Date(frontier.getTime() - MINUTE_RETENTION_HOURS * HOUR_MS) }
+    });
+    await collection.deleteMany({
+        bucketType: 'hourly',
+        bucketStart: { $lt: new Date(frontier.getTime() - HOURLY_RETENTION_HOURS * HOUR_MS) }
+    });
 }

--- a/src/backend/modules/scheduler/jobs/core-jobs.ts
+++ b/src/backend/modules/scheduler/jobs/core-jobs.ts
@@ -17,6 +17,11 @@ import { UsdtParametersFetcher } from '../../usdt-parameters/usdt-parameters-fet
 import { SystemLogService } from '../../logs/index.js';
 import { SystemConfigService } from '../../../services/system-config/index.js';
 import { CacheModel, type CacheDoc } from '../../../database/models/cache-model.js';
+import {
+    CoreNetworkActivityRollupModel,
+    CORE_NETWORK_ACTIVITY_ROLLUPS_COLLECTION
+} from '../../../database/models/core-network-activity-rollup-model.js';
+import { runOverviewRollup } from '../../blockchain/overview-rollup.job.js';
 import { SchedulerService } from '../services/scheduler.service.js';
 
 /**
@@ -39,6 +44,9 @@ export async function registerCoreJobs(
 ): Promise<void> {
     // Register CacheModel for cache cleanup job
     database.registerModel('caches', CacheModel);
+
+    // Register the network-activity rollup model so its unique index is built.
+    database.registerModel(CORE_NETWORK_ACTIVITY_ROLLUPS_COLLECTION, CoreNetworkActivityRollupModel);
 
     // Inject database into BlockchainService before first getInstance() call
     BlockchainService.setDependencies(database);
@@ -66,6 +74,19 @@ export async function registerCoreJobs(
     scheduler.register('blockchain:prune', '0 * * * *', async () => {
         await blockchainService.pruneOldTransactions(24 * 7, 2);
     });
+
+    // Network-activity rollup: every 5 minutes. Pre-aggregates the
+    // transactions/transfers/volume buckets backing the core:network-activity
+    // widget so the request path is a cheap read instead of a live week-long
+    // aggregation. Each run recomputes only a bounded recent window and backfills
+    // one chunk of history, so it never scans the full window in a single pass.
+    scheduler.register('network-activity:rollup', '*/5 * * * *', async () => {
+        await runOverviewRollup(database);
+    });
+
+    // Kick one rollup now (fire-and-forget) so the widget has data without
+    // waiting for the first cron tick; the job catches and logs its own errors.
+    void runOverviewRollup(database);
 
     // Cache cleanup: every hour
     scheduler.register('cache:cleanup', '0 * * * *', async () => {

--- a/src/backend/modules/scheduler/jobs/core-jobs.ts
+++ b/src/backend/modules/scheduler/jobs/core-jobs.ts
@@ -45,7 +45,10 @@ export async function registerCoreJobs(
     // Register CacheModel for cache cleanup job
     database.registerModel('caches', CacheModel);
 
-    // Register the network-activity rollup model so its unique index is built.
+    // Register the network-activity rollup model. The model is bound to the
+    // `core_network_activity_rollups` collection at definition time (third
+    // model() arg), where Mongoose autoIndex builds its unique index; this
+    // registration just makes the model resolvable by collection name.
     database.registerModel(CORE_NETWORK_ACTIVITY_ROLLUPS_COLLECTION, CoreNetworkActivityRollupModel);
 
     // Inject database into BlockchainService before first getInstance() call
@@ -85,8 +88,12 @@ export async function registerCoreJobs(
     });
 
     // Kick one rollup now (fire-and-forget) so the widget has data without
-    // waiting for the first cron tick; the job catches and logs its own errors.
-    void runOverviewRollup(database);
+    // waiting for the first cron tick. The scheduled run lets failures throw so
+    // the scheduler records them; this boot kick has no scheduler wrapper, so it
+    // guards itself with .catch() to avoid an unhandledRejection.
+    void runOverviewRollup(database).catch((error) => {
+        logger.warn({ error }, 'Initial network-activity rollup failed');
+    });
 
     // Cache cleanup: every hour
     scheduler.register('cache:cleanup', '0 * * * *', async () => {


### PR DESCRIPTION
## Problem

The `core:network-activity` widget aggregated its full window over raw `blocks` and the multi-million-row `transactions` collection **at SSR time**. The 7d volume series (`$sum amountTRX` over every `TransferContract`) exceeded the widget resolver's **5-second per-fetcher budget**, so the resolver silently dropped the widget from the page. Diagnosed on prod: the cold `overview?window=7d` request never returned.

## Fix — adopt the sibling rollup pattern

Rebuilt the data layer to mirror resource-tracker / dust-tracker: a scheduled job pre-aggregates buckets; the request path reads them.

- **`core_network_activity_rollups`** collection — the first `core_`-prefixed core collection (legacy core collections predate the convention and are unchanged). Minute tier (1h window) + hourly tier (24h/7d), keyed `(bucketType, bucketStart)` for idempotent upserts.
- **`network-activity:rollup` job** (every 5 min) — each run recomputes only a bounded recent window (in-progress hour + 2 prior; last 75 min) and backfills one 48h chunk of older history newest-first until 7d is covered, then prunes. Never scans the full window in a single pass after catch-up. A fire-and-forget kick at boot seeds data immediately.
- **`getOverviewTimeseries` is now a bounded read** — `find({bucketType}).sort({bucketStart:-1}).limit(N)`, ≤168 small docs, anchored on the latest bucket. Removed the runtime aggregation and the Redis cache (both were band-aids for the query that no longer exists). This keeps the SSR fetch well inside the 5s budget.

Frontend widget and the `getOverviewTimeseries` contract are unchanged.

## Post-deploy behavior

Widget shows its empty state for the first few minutes, fills recent data within ~5 min, and reaches the full 7d series after ~20 min as backfill chunks complete, then stays current via the cheap recompute.

## Note

During the first ~4 catch-up runs each backfill chunk does a bounded 48h `amountTRX` sum — far smaller than the old 7d scan, finite, never repeated once history is filled. The optional further mitigation is a `{type, timestamp, amountTRX}` covering index; left out here to stay close to the sibling pattern and avoid an index build on the large collection.