### PR TITLE
fix(system/widgets): declutter Widget Placements admin UI

### DIFF
--- a/src/frontend/app/(core)/system/widgets/page.module.scss
+++ b/src/frontend/app/(core)/system/widgets/page.module.scss
@@ -31,7 +31,6 @@
 .filter_bar {
     display: flex;
     align-items: flex-end;
-    justify-content: space-between;
     gap: var(--gap-md);
     flex-wrap: wrap;
 }
@@ -40,8 +39,9 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-2xs);
-    min-width: var(--max-width-xs);
-    flex: 1 1 var(--max-width-xs);
+    flex: 1 1 240px;
+    min-width: 0;
+    max-width: var(--max-width-sm);
 }
 
 .filter_label {
@@ -108,26 +108,104 @@
     flex-wrap: wrap;
 }
 
-/* Per-zone flexbox layout controls — a wrapping row of compact labeled
-   selects (preset + granular). Each field stays narrow so the whole row
-   fits several controls before wrapping on tight containers. */
+/* Right-aligned cluster: placement count + the layout disclosure toggle. */
+.zone_header_meta {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    margin-left: auto;
+    flex-wrap: wrap;
+}
+
+/* Disclosure that opens the per-zone layout panel. Reads as a quiet chip so
+   it sits in the header without competing with the zone title or actions; the
+   trailing preset name keeps the active arrangement visible while collapsed. */
+.layout_toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-2xs);
+    padding: var(--padding-2xs) var(--padding-xs);
+    background: var(--color-surface-muted);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    color: var(--color-text-muted);
+    font-size: var(--font-size-caption);
+    cursor: pointer;
+    transition: color var(--transition-base), background-color var(--transition-base), border-color var(--transition-base);
+}
+
+.layout_toggle:hover {
+    color: var(--color-text);
+    border-color: var(--color-border-strong);
+}
+
+.layout_toggle--open {
+    color: var(--color-text);
+    border-color: var(--color-primary-alpha-38);
+    background: var(--color-primary-alpha-10);
+}
+
+.layout_toggle:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 var(--border-width-medium) var(--color-focus-alpha-25);
+}
+
+.layout_toggle_text {
+    font-weight: var(--font-weight-medium);
+    color: inherit;
+}
+
+/* The active preset name, set apart from the "Layout" label so it reads as
+   the current value rather than part of the control name. */
+.layout_toggle_preset {
+    padding-left: var(--padding-xs);
+    border-left: var(--border-width-thin) solid var(--color-border-strong);
+    color: var(--color-text);
+}
+
+/* Per-zone flexbox layout panel — revealed by the header toggle. A bordered
+   surface that groups the essential controls (preset / gap / collapse) above a
+   labeled fine-tune row (the four flex axes). Each field stays a fixed, legible
+   width and wraps as the container narrows, so controls never stretch thin on
+   wide screens nor crush together mid-range. */
 .zone_layout {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+    padding: var(--card-padding-sm);
+    background: var(--color-surface-muted);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-sm);
+}
+
+.zone_layout_group {
     display: flex;
     flex-wrap: wrap;
     gap: var(--gap-sm);
     align-items: flex-end;
-    padding: var(--padding-xs) 0;
-    border-bottom: var(--border-width-thin) solid var(--color-border);
+}
+
+.zone_layout_advanced {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+}
+
+.zone_layout_advanced_label {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-subtle);
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-wide);
 }
 
 .zone_layout_field {
     display: flex;
     flex-direction: column;
     gap: var(--gap-2xs);
-    // Share the row and wrap as space runs out; min-width:0 lets the
-    // selects shrink below content width instead of forcing overflow.
-    flex: 1 1 auto;
-    min-width: 0;
+    // Hold a steady width and wrap when the container runs out of room, rather
+    // than growing to fill (which stretched the selects thin on wide screens).
+    flex: 0 1 180px;
+    min-width: 150px;
 }
 
 .zone_label {
@@ -148,7 +226,6 @@
 }
 
 .zone_count {
-    margin-left: auto;
     color: var(--color-text-muted);
     font-size: var(--font-size-caption);
 }
@@ -482,17 +559,36 @@
 /* Responsive                                                          */
 /* ------------------------------------------------------------------ */
 
+/* Large phones / narrow panels: the zone header's meta cluster keeps its own
+   line so the title never collides with the toggle. */
+@container widgets-admin (max-width: #{$breakpoint-mobile-lg}) {
+    .zone_header_meta {
+        margin-left: 0;
+        width: 100%;
+        justify-content: space-between;
+    }
+}
+
+/* Primary mobile: stack the page-level control rows, drop the bubble to two
+   columns with the action cluster on its own wrapping line, and let the layout
+   fields share two-up rather than each on its own line. */
 @container widgets-admin (max-width: #{$breakpoint-mobile-md}) {
     .toolbar {
         flex-direction: column;
         align-items: stretch;
     }
+    .filter_bar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .filter_field {
+        max-width: none;
+    }
     .field_row {
         grid-template-columns: minmax(0, 1fr);
     }
-    .zone_count {
-        margin-left: 0;
-        width: 100%;
+    .layout_toggle_preset {
+        display: none;
     }
     .bubble {
         grid-template-columns: auto minmax(0, 1fr);
@@ -500,5 +596,14 @@
     .bubble_actions {
         grid-column: 1 / -1;
         justify-content: flex-end;
+        flex-wrap: wrap;
+    }
+}
+
+/* Small Android: layout-panel fields go full width so the selects stay tappable
+   and their labels never truncate. */
+@container widgets-admin (max-width: #{$breakpoint-mobile-sm}) {
+    .zone_layout_field {
+        flex-basis: 100%;
     }
 }

--- a/src/frontend/app/(core)/system/widgets/page.module.scss
+++ b/src/frontend/app/(core)/system/widgets/page.module.scss
@@ -582,6 +582,9 @@
         align-items: stretch;
     }
     .filter_field {
+        // Column .filter_bar makes flex-basis act on the main (vertical) axis;
+        // reset to auto so the field sizes to its content instead of 240px tall.
+        flex-basis: auto;
         max-width: none;
     }
     .field_row {

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -32,7 +32,7 @@ import {
     type FormEvent,
     type KeyboardEvent
 } from 'react';
-import { GripVertical, Pencil, Plus, RefreshCw, Trash2, X } from 'lucide-react';
+import { ChevronDown, ChevronUp, GripVertical, Pencil, Plus, RefreshCw, SlidersHorizontal, Trash2, X } from 'lucide-react';
 import {
     DndContext,
     KeyboardSensor,
@@ -382,82 +382,95 @@ function ZoneLayoutControls({
 
     return (
         <div className={styles.zone_layout}>
-            <div className={styles.zone_layout_field}>
-                <label className={styles.filter_label} htmlFor={`zl-preset-${zoneId}`}>Layout</label>
-                <Select
-                    id={`zl-preset-${zoneId}`}
-                    value={layout.preset ?? 'custom'}
-                    onChange={(e) => applyPreset(e.target.value as ZoneLayoutPreset)}
-                    disabled={disabled}
-                >
-                    {PRESET_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </Select>
+            {/* Essential controls: the preset drives the arrangement; gap and
+                collapse threshold are the two operators most often touch. */}
+            <div className={styles.zone_layout_group}>
+                <div className={styles.zone_layout_field}>
+                    <label className={styles.filter_label} htmlFor={`zl-preset-${zoneId}`}>Layout</label>
+                    <Select
+                        id={`zl-preset-${zoneId}`}
+                        value={layout.preset ?? 'custom'}
+                        onChange={(e) => applyPreset(e.target.value as ZoneLayoutPreset)}
+                        disabled={disabled}
+                    >
+                        {PRESET_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                    </Select>
+                </div>
+                <div className={styles.zone_layout_field}>
+                    <label className={styles.filter_label} htmlFor={`zl-gap-${zoneId}`}>Gap</label>
+                    <Select
+                        id={`zl-gap-${zoneId}`}
+                        value={layout.gap}
+                        onChange={(e) => applyGranular({ gap: e.target.value as IZoneLayoutConfig['gap'] }, true)}
+                        disabled={disabled}
+                    >
+                        {GAP_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
+                    </Select>
+                </div>
+                <div className={styles.zone_layout_field}>
+                    <label className={styles.filter_label} htmlFor={`zl-collapse-${zoneId}`}>Collapse</label>
+                    <Select
+                        id={`zl-collapse-${zoneId}`}
+                        value={layout.collapseBelow ?? 'never'}
+                        onChange={(e) => applyGranular({ collapseBelow: e.target.value as IZoneLayoutConfig['collapseBelow'] }, true)}
+                        disabled={disabled}
+                    >
+                        {COLLAPSE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                    </Select>
+                </div>
             </div>
-            <div className={styles.zone_layout_field}>
-                <label className={styles.filter_label} htmlFor={`zl-dir-${zoneId}`}>Direction</label>
-                <Select
-                    id={`zl-dir-${zoneId}`}
-                    value={layout.flexDirection}
-                    onChange={(e) => applyGranular({ flexDirection: e.target.value as IZoneLayoutConfig['flexDirection'] }, false)}
-                    disabled={disabled}
-                >
-                    {DIRECTION_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
-                </Select>
-            </div>
-            <div className={styles.zone_layout_field}>
-                <label className={styles.filter_label} htmlFor={`zl-justify-${zoneId}`}>Justify</label>
-                <Select
-                    id={`zl-justify-${zoneId}`}
-                    value={layout.justifyContent}
-                    onChange={(e) => applyGranular({ justifyContent: e.target.value as IZoneLayoutConfig['justifyContent'] }, false)}
-                    disabled={disabled}
-                >
-                    {JUSTIFY_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
-                </Select>
-            </div>
-            <div className={styles.zone_layout_field}>
-                <label className={styles.filter_label} htmlFor={`zl-align-${zoneId}`}>Align</label>
-                <Select
-                    id={`zl-align-${zoneId}`}
-                    value={layout.alignItems}
-                    onChange={(e) => applyGranular({ alignItems: e.target.value as IZoneLayoutConfig['alignItems'] }, false)}
-                    disabled={disabled}
-                >
-                    {ALIGN_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
-                </Select>
-            </div>
-            <div className={styles.zone_layout_field}>
-                <label className={styles.filter_label} htmlFor={`zl-wrap-${zoneId}`}>Wrap</label>
-                <Select
-                    id={`zl-wrap-${zoneId}`}
-                    value={layout.flexWrap}
-                    onChange={(e) => applyGranular({ flexWrap: e.target.value as IZoneLayoutConfig['flexWrap'] }, false)}
-                    disabled={disabled}
-                >
-                    {WRAP_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
-                </Select>
-            </div>
-            <div className={styles.zone_layout_field}>
-                <label className={styles.filter_label} htmlFor={`zl-gap-${zoneId}`}>Gap</label>
-                <Select
-                    id={`zl-gap-${zoneId}`}
-                    value={layout.gap}
-                    onChange={(e) => applyGranular({ gap: e.target.value as IZoneLayoutConfig['gap'] }, true)}
-                    disabled={disabled}
-                >
-                    {GAP_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
-                </Select>
-            </div>
-            <div className={styles.zone_layout_field}>
-                <label className={styles.filter_label} htmlFor={`zl-collapse-${zoneId}`}>Collapse</label>
-                <Select
-                    id={`zl-collapse-${zoneId}`}
-                    value={layout.collapseBelow ?? 'never'}
-                    onChange={(e) => applyGranular({ collapseBelow: e.target.value as IZoneLayoutConfig['collapseBelow'] }, true)}
-                    disabled={disabled}
-                >
-                    {COLLAPSE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </Select>
+
+            {/* Fine-tune: the four flex axes the preset normally sets. Grouped
+                under a label so an operator reads them as the advanced tier
+                rather than peers of the preset. */}
+            <div className={styles.zone_layout_advanced}>
+                <span className={styles.zone_layout_advanced_label}>Fine-tune arrangement</span>
+                <div className={styles.zone_layout_group}>
+                    <div className={styles.zone_layout_field}>
+                        <label className={styles.filter_label} htmlFor={`zl-dir-${zoneId}`}>Direction</label>
+                        <Select
+                            id={`zl-dir-${zoneId}`}
+                            value={layout.flexDirection}
+                            onChange={(e) => applyGranular({ flexDirection: e.target.value as IZoneLayoutConfig['flexDirection'] }, false)}
+                            disabled={disabled}
+                        >
+                            {DIRECTION_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
+                        </Select>
+                    </div>
+                    <div className={styles.zone_layout_field}>
+                        <label className={styles.filter_label} htmlFor={`zl-justify-${zoneId}`}>Justify</label>
+                        <Select
+                            id={`zl-justify-${zoneId}`}
+                            value={layout.justifyContent}
+                            onChange={(e) => applyGranular({ justifyContent: e.target.value as IZoneLayoutConfig['justifyContent'] }, false)}
+                            disabled={disabled}
+                        >
+                            {JUSTIFY_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
+                        </Select>
+                    </div>
+                    <div className={styles.zone_layout_field}>
+                        <label className={styles.filter_label} htmlFor={`zl-align-${zoneId}`}>Align</label>
+                        <Select
+                            id={`zl-align-${zoneId}`}
+                            value={layout.alignItems}
+                            onChange={(e) => applyGranular({ alignItems: e.target.value as IZoneLayoutConfig['alignItems'] }, false)}
+                            disabled={disabled}
+                        >
+                            {ALIGN_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
+                        </Select>
+                    </div>
+                    <div className={styles.zone_layout_field}>
+                        <label className={styles.filter_label} htmlFor={`zl-wrap-${zoneId}`}>Wrap</label>
+                        <Select
+                            id={`zl-wrap-${zoneId}`}
+                            value={layout.flexWrap}
+                            onChange={(e) => applyGranular({ flexWrap: e.target.value as IZoneLayoutConfig['flexWrap'] }, false)}
+                            disabled={disabled}
+                        >
+                            {WRAP_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
+                        </Select>
+                    </div>
+                </div>
             </div>
         </div>
     );
@@ -1165,6 +1178,17 @@ interface ZoneSectionProps {
     onLayoutChange: (zoneId: string, config: IZoneLayoutConfig) => void;
 }
 
+/**
+ * One zone: a drop target holding its placements, with the zone's flexbox
+ * layout controls tucked behind a collapsed disclosure in the header.
+ *
+ * The layout controls are an occasional, advanced task — surfacing all seven
+ * selects on every zone at once buried the actual placements in control noise.
+ * Collapsing them (with the active preset name shown on the toggle so the
+ * current arrangement stays legible while closed) keeps the scannable content —
+ * the widgets and their order — front and centre, and lets an operator open the
+ * controls only for the zone they are tuning.
+ */
 function ZoneSection({
     zoneId,
     zoneLabel,
@@ -1182,6 +1206,21 @@ function ZoneSection({
 }: ZoneSectionProps) {
     const zoneInfo = lookupZone(zones, zoneId);
     const { setNodeRef, isOver } = useDroppable({ id: zoneId, data: { zoneId } });
+
+    // Layout controls collapse by default; the operator opens them per-zone.
+    const [layoutOpen, setLayoutOpen] = useState(false);
+
+    // Human-readable name of the zone's active preset, shown on the toggle so
+    // a custom or non-default arrangement stays visible while the panel is shut.
+    const presetLabel = useMemo(() => {
+        const match = PRESET_OPTIONS.find(o => o.value === (layoutConfig.preset ?? 'custom'));
+        return match ? match.label : 'Custom';
+    }, [layoutConfig.preset]);
+
+    // Relative width is a flex weight, so it only takes effect when the zone
+    // arranges its top-level rows along a row axis. In a column it is inert, so
+    // the inline width control is suppressed for those rows.
+    const zoneIsRow = layoutConfig.flexDirection === 'row' || layoutConfig.flexDirection === 'row-reverse';
 
     // Split the zone's placements into the top-level rows (drawn in the
     // sortable list) and the children nested inside layout-group
@@ -1211,17 +1250,35 @@ function ZoneSection({
                     <span className={styles.zone_id}>{zoneId}</span>
                 </h3>
                 {zoneInfo && <Badge tone="neutral">{zoneInfo.host}</Badge>}
-                <span className={styles.zone_count}>
-                    {placements.length} {placements.length === 1 ? 'placement' : 'placements'}
-                </span>
+                <div className={styles.zone_header_meta}>
+                    <span className={styles.zone_count}>
+                        {placements.length} {placements.length === 1 ? 'placement' : 'placements'}
+                    </span>
+                    <button
+                        type="button"
+                        className={cn(styles.layout_toggle, layoutOpen && styles['layout_toggle--open'])}
+                        onClick={() => setLayoutOpen(open => !open)}
+                        aria-expanded={layoutOpen}
+                        aria-label={`${layoutOpen ? 'Hide' : 'Show'} layout controls for ${zoneLabel}`}
+                    >
+                        <SlidersHorizontal size={14} aria-hidden />
+                        <span className={styles.layout_toggle_text}>Layout</span>
+                        <span className={styles.layout_toggle_preset}>{presetLabel}</span>
+                        {layoutOpen
+                            ? <ChevronUp size={14} aria-hidden />
+                            : <ChevronDown size={14} aria-hidden />}
+                    </button>
+                </div>
             </header>
 
-            <ZoneLayoutControls
-                zoneId={zoneId}
-                layout={layoutConfig}
-                disabled={busyId !== null}
-                onChange={onLayoutChange}
-            />
+            {layoutOpen && (
+                <ZoneLayoutControls
+                    zoneId={zoneId}
+                    layout={layoutConfig}
+                    disabled={busyId !== null}
+                    onChange={onLayoutChange}
+                />
+            )}
 
             <SortableContext id={zoneId} items={itemIds} strategy={verticalListSortingStrategy}>
                 <div ref={setNodeRef} className={styles.bubbles}>
@@ -1235,12 +1292,18 @@ function ZoneSection({
                             const kids = isContainer
                                 ? childrenByParent.get(placement.id) ?? []
                                 : [];
+                            // A layout group carries its own arrangement in its
+                            // instanceConfig (default column); its children's
+                            // width control follows that, not the zone's.
+                            const groupDirection = placement.instanceConfig?.flexDirection;
+                            const groupIsRow = groupDirection === 'row' || groupDirection === 'row-reverse';
                             return (
                                 <Fragment key={placement.id}>
                                     <PlacementBubble
                                         placement={placement}
                                         typeInfo={lookupType(types, placement.typeId)}
                                         busy={busyId === placement.id}
+                                        showWidth={zoneIsRow}
                                         onToggleEnabled={onToggleEnabled}
                                         onEdit={onEdit}
                                         onDelete={onDelete}
@@ -1254,6 +1317,7 @@ function ZoneSection({
                                             childPlacements={kids}
                                             types={types}
                                             busyId={busyId}
+                                            showWidth={groupIsRow}
                                             onToggleEnabled={onToggleEnabled}
                                             onEdit={onEdit}
                                             onDelete={onDelete}
@@ -1289,6 +1353,13 @@ interface PlacementBubbleProps {
      * side-by-side widths without opening the modal.
      */
     onSetWidth: (placement: IPlacement, weight: number | null) => void;
+    /**
+     * Whether the row's container (the zone for a top-level row, the parent
+     * layout group for a nested child) lays out in a row. Relative width is a
+     * flex weight that only takes effect along a row axis, so the inline width
+     * control is hidden in a column arrangement where it would be inert noise.
+     */
+    showWidth: boolean;
 }
 
 /**
@@ -1347,6 +1418,7 @@ function PlacementBubble({
     placement,
     typeInfo,
     busy,
+    showWidth,
     onToggleEnabled,
     onEdit,
     onDelete,
@@ -1402,7 +1474,9 @@ function PlacementBubble({
                 </div>
             </div>
             <div className={styles.bubble_actions}>
-                <WidthSelect placement={placement} disabled={busy} label={label} onSetWidth={onSetWidth} />
+                {showWidth && (
+                    <WidthSelect placement={placement} disabled={busy} label={label} onSetWidth={onSetWidth} />
+                )}
                 <Switch
                     size="sm"
                     on={placement.enabled}
@@ -1461,11 +1535,14 @@ function PlacementBubble({
  * @param onEdit - Opens the edit modal.
  * @param onDelete - Deletes an operator-source child.
  * @param onRestore - Restores a plugin-source child's defaults.
+ * @param showWidth - Whether the parent group lays out in a row, gating the
+ *   inline relative-width control (a flex weight is inert in a column).
  */
 function ChildPlacementRow({
     placement,
     typeInfo,
     busy,
+    showWidth,
     onToggleEnabled,
     onEdit,
     onDelete,
@@ -1509,7 +1586,9 @@ function ChildPlacementRow({
                 <span className={styles.widget_meta}>{placement.typeId}</span>
             </div>
             <div className={styles.bubble_actions}>
-                <WidthSelect placement={placement} disabled={busy} label={label} onSetWidth={onSetWidth} />
+                {showWidth && (
+                    <WidthSelect placement={placement} disabled={busy} label={label} onSetWidth={onSetWidth} />
+                )}
                 <Switch
                     size="sm"
                     on={placement.enabled}
@@ -1561,6 +1640,12 @@ interface GroupDropAreaProps {
     onDelete: (placement: IPlacement) => void;
     onRestore: (placement: IPlacement) => void;
     onSetWidth: (placement: IPlacement, weight: number | null) => void;
+    /**
+     * Whether the layout group lays out its children in a row, forwarded to
+     * each child so the inline width control only shows where a flex weight
+     * actually applies.
+     */
+    showWidth: boolean;
 }
 
 /**
@@ -1583,6 +1668,8 @@ interface GroupDropAreaProps {
  * @param onEdit - Edit-modal opener passed to each child.
  * @param onDelete - Delete handler passed to each child.
  * @param onRestore - Restore-defaults handler passed to each child.
+ * @param showWidth - Whether this group is row-arranged, gating each child's
+ *   inline relative-width control.
  */
 function GroupDropArea({
     containerId,
@@ -1590,6 +1677,7 @@ function GroupDropArea({
     childPlacements,
     types,
     busyId,
+    showWidth,
     onToggleEnabled,
     onEdit,
     onDelete,
@@ -1619,6 +1707,7 @@ function GroupDropArea({
                             placement={child}
                             typeInfo={lookupType(types, child.typeId)}
                             busy={busyId === child.id}
+                            showWidth={showWidth}
                             onToggleEnabled={onToggleEnabled}
                             onEdit={onEdit}
                             onDelete={onDelete}


### PR DESCRIPTION
## Why

The `/system/widgets` Widget Placements page rendered all seven per-zone flexbox controls (Layout, Direction, Justify, Align, Wrap, Gap, Collapse) unconditionally for **every** zone — including empty and single-widget zones where arrangement is meaningless. Across the many zones in each track that produced a wall of always-on dropdowns that buried the actual content: the placements and their order. The fields used `flex: 1 1 auto`, so they stretched thin on wide screens and wrapped unpredictably mid-range, and the only responsive breakpoint was 480px. The filter bar's `space-between` flung its two field groups to opposite screen edges.

## What changed

- **Progressive disclosure.** Per-zone layout controls collapse behind a `Layout` toggle in the zone header. The toggle shows the active preset name so the current arrangement stays legible while closed; an operator opens the panel only for the zone they're tuning.
- **Tiered controls.** When open, essential controls (preset / gap / collapse) are separated from a labeled *Fine-tune arrangement* group (the four flex axes).
- **Wide screens.** Layout fields hold a steady ~180px and wrap cleanly instead of stretching; the filter bar is left-aligned and grouped.
- **Below mobile.** Container-query tiers at 768 / 480 / 360px restack the zone header meta, toolbar, filter bar, and bubble action cluster; fields go full-width on small Android.
- **Relevance gating.** The inline relative-width dropdown now renders only when the row's container (zone for top-level rows, parent layout group for nested children) is row-oriented, since the `layoutWeight` flex weight is inert in a column.

Drag-drop, route filtering, width tuning, and the create/edit modal are behaviorally unchanged — this is a presentation and responsiveness reorganization.