### PR TITLE
feat(ai-tools): live saved-prompt times, larger enable switch, disabled-tool sort

### DIFF
--- a/src/frontend/app/(core)/system/ai-tools/tabs/RegistryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/RegistryTab.tsx
@@ -4,8 +4,9 @@
  * @fileoverview Registry tab — every registered tool with provider attribution,
  * a single dominant risk chip, and an enable toggle, plus the Provider panel.
  * The list is built for triage: risk and enabled-state lead, a search box and
- * per-class risk filters narrow it, and the default sort surfaces the most
- * dangerous tools first. Clicking a row opens a right slide-over holding the
+ * per-class risk filters narrow it, and the default sort keeps enabled tools at
+ * the top (disabled tools sink to the bottom) with the most dangerous tools
+ * first within each group. Clicking a row opens a right slide-over holding the
  * full model-facing description, the input schema, and the per-tool policy
  * editor — the heavy surfaces that used to bloat each row. Toggling a tool or
  * saving a policy override re-checks the trifecta via the `onChanged` callback
@@ -121,8 +122,10 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
     const disabledCount = tools.filter(tool => !tool.enabled).length;
     const toolsSummary = `${tools.length} tools · ${disabledCount} disabled · ${overrideCount} overrides`;
 
-    // Apply the three filters, then sort dangerous-first (then by name) so an
-    // audit sweep meets the high-stakes tools at the top.
+    // Apply the three filters, then sort: enabled tools first so the live set
+    // an operator acts on stays together at the top and disabled tools sink to
+    // the bottom; within each group, dangerous-first (then by name) so an audit
+    // sweep still meets the high-stakes tools at the top of the active list.
     const query = search.trim().toLowerCase();
     const visibleTools = tools
         .filter(tool => !onlyOverrides || policy.overrides[tool.name] !== undefined)
@@ -132,6 +135,9 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
             || tool.description.toLowerCase().includes(query)
             || tool.provider.toLowerCase().includes(query))
         .sort((a, b) => {
+            if (a.enabled !== b.enabled) {
+                return a.enabled ? -1 : 1;
+            }
             const byRisk = riskRankOf(b.capability) - riskRankOf(a.capability);
             return byRisk !== 0 ? byRisk : a.name.localeCompare(b.name);
         });

--- a/src/frontend/app/(core)/system/ai-tools/tabs/SavedPromptsPanel.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/SavedPromptsPanel.tsx
@@ -145,9 +145,17 @@ export function SavedPromptsPanel({
         if (!open || !hasActiveSchedule) {
             return;
         }
-        const id = setInterval(() => { void loadPrompts(); }, RUN_REFRESH_MS);
+        const id = setInterval(() => {
+            // Silent background refresh: hit the API directly and replace the
+            // list without toggling `loading`, so the open panel never flashes to
+            // the "Loading…" placeholder mid-view every 30s. Errors are swallowed
+            // — the next tick retries — matching loadPrompts' silent-failure stance.
+            listSavedPrompts()
+                .then(onPromptsChange)
+                .catch(() => {});
+        }, RUN_REFRESH_MS);
         return () => clearInterval(id);
-    }, [open, hasActiveSchedule, loadPrompts]);
+    }, [open, hasActiveSchedule, onPromptsChange]);
 
     /** Persist a new prompt with the current composer text. */
     const handleSave = useCallback(async () => {

--- a/src/frontend/app/(core)/system/ai-tools/tabs/SavedPromptsPanel.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/SavedPromptsPanel.tsx
@@ -39,6 +39,25 @@ import { describeCron, formatRelativeTime, getMsUntilNextCron, formatTimeUntil }
 import { PromptEditModal } from './PromptEditModal';
 import styles from './SavedPromptsPanel.module.scss';
 
+/**
+ * How often (ms) the open panel re-renders so the "next run" countdown and the
+ * "last run … ago" relative times advance without a manual refresh. One second
+ * keeps the sub-minute countdown smooth; the work is a cheap re-render over a
+ * short list, gated to while the panel is open.
+ */
+const TICK_MS = 1000;
+
+/**
+ * How often (ms) the open panel refetches the saved-prompt list while at least
+ * one schedule is active, so a `lastRunAt` written by the backend
+ * `ai-tools:run-scheduled-prompts` job appears without a page refresh. There is
+ * no WebSocket signal for a scheduled run, so this poll is the refresh channel;
+ * the backend job ticks every two minutes, so a 30s cadence surfaces a new run
+ * within at most 30s while staying light. Gated to active schedules so an
+ * all-manual prompt list never polls.
+ */
+const RUN_REFRESH_MS = 30_000;
+
 interface SavedPromptsPanelProps {
     /** Shared saved-prompts list, owned by the parent Query tab. */
     prompts: ISavedPrompt[];
@@ -71,6 +90,13 @@ export function SavedPromptsPanel({
     const [loading, setLoading] = useState(false);
     const [saveName, setSaveName] = useState('');
     const loadedRef = useRef(false);
+    /**
+     * Wall-clock used to derive the live "next run" countdown and "last run …
+     * ago" labels. Ticked while the panel is open so both advance on their own;
+     * only read inside the open panel body, which renders solely after a user
+     * opens it, so there is no SSR hydration concern.
+     */
+    const [now, setNow] = useState(() => Date.now());
 
     /** First-open fetch. Later opens reuse the parent's list (kept fresh on writes). */
     const loadPrompts = useCallback(async () => {
@@ -90,6 +116,38 @@ export function SavedPromptsPanel({
             void loadPrompts();
         }
     }, [open, loadPrompts]);
+
+    /**
+     * Whether any prompt carries a live (non-paused, valid-looking) cron. Drives
+     * the run-refresh poll gate so an all-manual list never polls the backend.
+     */
+    const hasActiveSchedule = prompts.some(
+        sp => !!sp.cron && sp.cron.trim().length > 0 && sp.scheduleEnabled !== false
+    );
+
+    // Advance `now` once a second while the panel is open so the next-run
+    // countdown and the last-run relative labels update on their own. The
+    // interval is the only writer, torn down on close/unmount.
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+        setNow(Date.now());
+        const id = setInterval(() => setNow(Date.now()), TICK_MS);
+        return () => clearInterval(id);
+    }, [open]);
+
+    // Refetch the prompt list while the panel is open and a schedule is live, so
+    // a backend-written `lastRunAt` surfaces without a manual refresh. Gated on
+    // `hasActiveSchedule` (a primitive, so the effect re-subscribes only when the
+    // gate flips, not on every list refresh) to keep an all-manual list quiet.
+    useEffect(() => {
+        if (!open || !hasActiveSchedule) {
+            return;
+        }
+        const id = setInterval(() => { void loadPrompts(); }, RUN_REFRESH_MS);
+        return () => clearInterval(id);
+    }, [open, hasActiveSchedule, loadPrompts]);
 
     /** Persist a new prompt with the current composer text. */
     const handleSave = useCallback(async () => {
@@ -254,7 +312,9 @@ export function SavedPromptsPanel({
                     // a "next run" there would mislead. getMsUntilNextCron returns null on
                     // an unparseable expression, which also suppresses the line.
                     const scheduleActive = !!sp.cron && sp.cron.trim().length > 0 && sp.scheduleEnabled !== false;
-                    const msUntilNextRun = scheduleActive ? getMsUntilNextCron(sp.cron as string, Date.now()) : null;
+                    // `now` is ticked each second while open, so this re-derives
+                    // and the countdown advances on its own.
+                    const msUntilNextRun = scheduleActive ? getMsUntilNextCron(sp.cron as string, now) : null;
                     return (
                     <li key={sp.id} className={`${styles.row} ${sp.lastRunError ? styles.row_error : ''}`}>
                         <div className={styles.row_main}>
@@ -267,18 +327,17 @@ export function SavedPromptsPanel({
                             >
                                 {sp.name}
                             </button>
-                            {(sp.lastRunAt || msUntilNextRun !== null) && (
-                                <div className={styles.row_meta}>
-                                    {/* A scheduled prompt that has yet to fire says so rather
-                                        than omitting the last-run line — the meta row only
-                                        renders here when a schedule is active, so the falsy
-                                        branch always means "scheduled, not yet run". */}
-                                    {sp.lastRunAt
-                                        ? <span>Last run {formatRelativeTime(sp.lastRunAt)}</span>
-                                        : <span>Never run yet</span>}
-                                    {msUntilNextRun !== null && <span>Next run {formatTimeUntil(msUntilNextRun)}</span>}
-                                </div>
-                            )}
+                            <div className={styles.row_meta}>
+                                {/* Last run always shows — including for a prompt with no
+                                    active schedule — so an operator can see when a prompt
+                                    last fired regardless of whether it is currently cron-
+                                    enabled; "Never run yet" covers the not-yet-fired case.
+                                    Next run shows only for a live schedule. */}
+                                {sp.lastRunAt
+                                    ? <span>Last run {formatRelativeTime(sp.lastRunAt)}</span>
+                                    : <span>Never run yet</span>}
+                                {msUntilNextRun !== null && <span>Next run {formatTimeUntil(msUntilNextRun)}</span>}
+                            </div>
                         </div>
                         <div className={styles.row_actions}>
                             {renderScheduleChip(sp)}

--- a/src/frontend/components/ui/Switch/Switch.tsx
+++ b/src/frontend/components/ui/Switch/Switch.tsx
@@ -37,13 +37,28 @@ const sizeClass: Record<SwitchSize, string> = {
 
 /**
  * Icon pixel sizes aligned to the design-system `--icon-size-*` ladder in
- * primitives.scss (sm=18, md=20, lg=24). Hardcoded here because CSS custom
- * properties can't be read synchronously by the lucide-react `size` prop.
+ * primitives.scss — one rung larger than the old mapping (sm=`--icon-size-md`,
+ * md=`--icon-size-lg`, lg=`--icon-size-xl`) so the toggle reads as a deliberate
+ * control rather than a faint glyph. The previous 18/20/24 ladder was too small
+ * to communicate state at a glance in a dense table row. Hardcoded here because
+ * CSS custom properties can't be read synchronously by the lucide-react `size`
+ * prop.
  */
 const iconSize: Record<SwitchSize, number> = {
-    sm: 18,
-    md: 20,
-    lg: 24
+    sm: 20,
+    md: 24,
+    lg: 32
+};
+
+/**
+ * Stroke weights per state. A heavier stroke when `on` makes the active
+ * (success-colored) toggle visually assertive, while the lighter `off` stroke
+ * keeps an inactive control quiet — so the two states differ in weight as well
+ * as color and knob position, the redundancy the old single-weight icon lacked.
+ */
+const strokeWidth: Record<'on' | 'off', number> = {
+    on: 2.5,
+    off: 2
 };
 
 /**
@@ -81,7 +96,7 @@ export function Switch({
                 }
             }}
         >
-            <Icon size={iconSize[size]} />
+            <Icon size={iconSize[size]} strokeWidth={on ? strokeWidth.on : strokeWidth.off} />
         </button>
     );
 }


### PR DESCRIPTION
## What changed

Three UI improvements to the core `/system/ai-tools` dashboard.

**Query tab — saved prompts**
The panel now ticks a per-second clock while open, so the *next run* countdown and *last run … ago* labels advance on their own with no refresh. While any schedule is active it also polls the prompt list (there is no WebSocket signal for a scheduled run), so a backend-written `lastRunAt` appears within ~30s. The last-run line now always renders — including for prompts with no active cron — showing the time if available or "Never run yet".

**Core Switch component**
The lucide toggle icon moves up one rung on the `--icon-size-*` token ladder (sm/md/lg → 20/24/32px) and uses a heavier stroke when on, so enable state reads at a glance instead of as a faint glyph. The `on`/`onChange` API is unchanged, so every call site keeps working.

**Registry tab — tools list**
Enabled tools now sort above disabled ones, with disabled tools sinking to the bottom; dangerous-first-then-name ordering is preserved within each group.

Frontend typecheck passes. The related removal of the `memo-find-by-text` AI tool lives in the `trp-memo-tracker` plugin repo and ships separately.