### PR TITLE
feat(admin): curation review cards, Switch rollout, modal a11y, AI query transcripts

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delphian/tronrelic-types",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "description": "Core type definitions for the TronRelic platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/types/src/ai-tools/IAiQueryRecord.ts
+++ b/packages/types/src/ai-tools/IAiQueryRecord.ts
@@ -7,6 +7,8 @@
  * provider concern and is not represented here.
  */
 
+import type { IAiTranscriptSegment } from './IAiTranscriptSegment.js';
+
 /**
  * How a recorded query was executed. `stream` and `programmatic` are the two
  * interactive shapes an admin drives from the Query tab. `scheduled` marks an
@@ -67,4 +69,15 @@ export interface IAiQueryRecord {
 
     /** Optional id grouping every turn of one multi-turn chat. */
     conversationId?: string;
+
+    /**
+     * Ordered transcript of the turn — thinking blocks, visible answer text,
+     * tool calls, and tool results in occurrence order — so a reopened
+     * conversation replays the whole turn rather than only `responseText`.
+     * Absent on records written before this field existed or when the provider
+     * reported no structured transcript; the Query tab falls back to
+     * `responseText` then. Thinking segments are present only when the operator
+     * enabled `persistThinking`.
+     */
+    transcript?: IAiTranscriptSegment[];
 }

--- a/packages/types/src/ai-tools/IAiQueryResult.ts
+++ b/packages/types/src/ai-tools/IAiQueryResult.ts
@@ -5,6 +5,8 @@
  * {@link IAiProvider.ask}, or {@link IAiProvider.queryStream}.
  */
 
+import type { IAiTranscriptSegment } from './IAiTranscriptSegment.js';
+
 /**
  * The complete result of a programmatic AI query.
  *
@@ -55,4 +57,13 @@ export interface IAiQueryResult {
      * matching rate; omitted by a provider that does not price queries.
      */
     costUsd?: number | null;
+
+    /**
+     * Ordered transcript of the turn — thinking blocks, visible answer text,
+     * tool calls, and tool results, in the order they occurred across every
+     * agentic round. Lets a surface render and core persist the whole turn, not
+     * just `responseText`. Absent when the provider does not report a structured
+     * transcript; a consumer falls back to `responseText` in that case.
+     */
+    transcript?: IAiTranscriptSegment[];
 }

--- a/packages/types/src/ai-tools/IAiStreamChunk.ts
+++ b/packages/types/src/ai-tools/IAiStreamChunk.ts
@@ -7,6 +7,8 @@
  * delta, a terminal completion signal with usage, or an error notification.
  */
 
+import type { IAiTranscriptSegment } from './IAiTranscriptSegment.js';
+
 /**
  * One streamed chunk of an AI response, correlated to its query by `queryId`.
  */
@@ -46,4 +48,14 @@ export interface IAiStreamChunk {
      * rate); omitted entirely by a provider that does not price queries.
      */
     costUsd?: number | null;
+
+    /**
+     * Ordered transcript of the completed turn — thinking, answer text, tool
+     * calls, and tool results in occurrence order — present on the terminal
+     * 'done' chunk so the live transcript can show the same structure history
+     * does without a reload. The streamed text deltas remain the live answer;
+     * this is the structured record finalized once the turn settles. Omitted by
+     * a provider that does not report a structured transcript.
+     */
+    transcript?: IAiTranscriptSegment[];
 }

--- a/packages/types/src/ai-tools/IAiTranscriptSegment.ts
+++ b/packages/types/src/ai-tools/IAiTranscriptSegment.ts
@@ -1,0 +1,97 @@
+/**
+ * @file IAiTranscriptSegment.ts
+ *
+ * Ordered, replayable record of everything an AI turn produced — not just its
+ * final answer text. A query history record that stores only `responseText`
+ * cannot reconstruct what the model reasoned about or which tools it called, so
+ * a reopened conversation loses the thinking blocks, tool calls, and tool
+ * results that were visible while it ran. This segment union is the missing
+ * structure: the provider emits the segments in the exact order they occurred
+ * across every agentic round, core persists them on the query record, and the
+ * Query tab renders them back so history shows the full turn, not a summary.
+ *
+ * Provider-neutral by design: the segments describe what happened in
+ * vendor-agnostic terms (think / speak / call a tool / receive a result) so any
+ * AI provider plugin populates the same shape and any surface renders it
+ * identically.
+ */
+
+/**
+ * The model's private reasoning for a turn. Present only when extended thinking
+ * is enabled and the operator opted into persisting it (`persistThinking`), so
+ * an operator who has chosen not to retain reasoning never finds it stored.
+ */
+export interface IAiThinkingSegment {
+    type: 'thinking';
+
+    /** The reasoning text, concatenated for one thinking block. */
+    text: string;
+}
+
+/**
+ * A run of the model's visible answer text. A turn yields one text segment per
+ * round that produced prose; tool calls between rounds split the answer into
+ * separate text segments, preserving the real interleaving of speech and action.
+ */
+export interface IAiTextSegment {
+    type: 'text';
+
+    /** The answer text for this run, as Markdown. */
+    text: string;
+}
+
+/**
+ * A tool the model invoked during the turn. Captures the call as the model made
+ * it — the tool name and the arguments — so history shows what the model tried,
+ * paired by `id` with the {@link IAiToolResultSegment} that answered it.
+ */
+export interface IAiToolUseSegment {
+    type: 'tool_use';
+
+    /** Provider tool-call id, matched against a tool_result's `toolUseId`. */
+    id: string;
+
+    /** The invoked tool's name. */
+    name: string;
+
+    /** The arguments the model supplied to the tool. */
+    input: unknown;
+
+    /**
+     * True when the tool ran on the provider's own infrastructure (e.g.
+     * Anthropic web search / fetch) rather than through the platform governor,
+     * so the UI can label a provider-hosted call distinctly.
+     */
+    server?: boolean;
+}
+
+/**
+ * The outcome of a tool call, paired to its {@link IAiToolUseSegment} by
+ * `toolUseId`. Stores the result the model was handed so history can show what
+ * came back, including whether the call failed.
+ */
+export interface IAiToolResultSegment {
+    type: 'tool_result';
+
+    /** The `id` of the tool_use this result answers. */
+    toolUseId: string;
+
+    /** The tool's returned content, or a digest of it for a provider-hosted call. */
+    content: string;
+
+    /** True when the tool reported an error rather than a successful result. */
+    isError?: boolean;
+
+    /** True when this answered a provider-hosted (server-side) tool call. */
+    server?: boolean;
+}
+
+/**
+ * One ordered piece of an AI turn's transcript. The full transcript is an array
+ * of these in occurrence order, spanning every agentic round of the turn.
+ */
+export type IAiTranscriptSegment =
+    | IAiThinkingSegment
+    | IAiTextSegment
+    | IAiToolUseSegment
+    | IAiToolResultSegment;

--- a/packages/types/src/ai-tools/index.ts
+++ b/packages/types/src/ai-tools/index.ts
@@ -47,6 +47,13 @@ export type { IAiConversationMessage } from './IAiConversationMessage.js';
 export type { IAiProvider } from './IAiProvider.js';
 export type { IAiStreamChunk } from './IAiStreamChunk.js';
 export type { IAiQueryRecord, AiQueryMode } from './IAiQueryRecord.js';
+export type {
+    IAiTranscriptSegment,
+    IAiThinkingSegment,
+    IAiTextSegment,
+    IAiToolUseSegment,
+    IAiToolResultSegment
+} from './IAiTranscriptSegment.js';
 export type { IAiQueryOptions } from './IAiQueryOptions.js';
 export type { IAiQueryResult } from './IAiQueryResult.js';
 export type { IModelInfo } from './IModelInfo.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -70,7 +70,7 @@ export type { ITronGridService, ITronGridAccountResponse, ITronGridAccountPermis
 export type { ITrc10, ITrc10FrozenSupply } from './trc10/index.js';
 export type { IBlockStats, IBlock, IBlockTransaction, IBlockTransactionParty, IBlockTransactionContract, IResourceUsage, IBlockchainService, ITransactionTimeseriesPoint, IOverviewTimeseriesPoint, OverviewTimeseriesWindow, ITransactionDetailService } from './blockchain/index.js';
 export type { IToolsService, IAddressConversionResult, IAddressValidationResult } from './tools/index.js';
-export type { IAiTool, IAiToolInputSchema, IAiConversationMessage, IAiProvider, IAiStreamChunk, IAiQueryRecord, AiQueryMode, IAiQueryOptions, IAiQueryResult, IModelInfo, ISavedPrompt } from './ai-tools/index.js';
+export type { IAiTool, IAiToolInputSchema, IAiConversationMessage, IAiProvider, IAiStreamChunk, IAiQueryRecord, AiQueryMode, IAiQueryOptions, IAiQueryResult, IModelInfo, ISavedPrompt, IAiTranscriptSegment, IAiThinkingSegment, IAiTextSegment, IAiToolUseSegment, IAiToolResultSegment } from './ai-tools/index.js';
 export { AI_TOOL_NAME_PATTERN } from './ai-tools/index.js';
 export { UNTRUSTED_CONTENT_NOTICE, UNTRUSTED_CONTENT_SYSTEM_CLAUSE, wrapUntrustedToolResult } from './ai-tools/index.js';
 export { DEFAULT_UNTRUSTED_SCREEN_CONFIG } from './ai-tools/index.js';

--- a/src/backend/modules/ai-tools/services/ai-query-history.service.ts
+++ b/src/backend/modules/ai-tools/services/ai-query-history.service.ts
@@ -26,7 +26,10 @@ const COLLECTION = 'module_ai-tools_query_history';
  * identical across paths: drift between them would make the same query render
  * differently depending on how it was launched. On success `result` carries the
  * model, usage, and cost; on failure `errorMessage` is set and the caller's
- * requested `fallbackModel` (if any) stands in for the unknown model.
+ * requested `fallbackModel` (if any) stands in for the unknown model. When the
+ * provider reports a structured transcript on `result`, it is persisted so a
+ * reopened conversation replays the whole turn (thinking, tool calls, tool
+ * results) rather than only `responseText`.
  *
  * @param mode - Execution mode the record is tagged with (`stream` for the
  *        admin stream path, `programmatic` for a non-streaming admin call,
@@ -67,7 +70,13 @@ export function buildAiQueryRecord(
         status: result ? 'completed' : 'failed',
         createdAt,
         completedAt: new Date().toISOString(),
-        ...(conversationId ? { conversationId } : {})
+        ...(conversationId ? { conversationId } : {}),
+        // Persist the structured transcript when the provider reported one, so a
+        // reopened conversation replays the turn's thinking, tool calls, and tool
+        // results — not just `responseText`. Absent when the query failed or the
+        // provider reports no transcript; the Query tab falls back to
+        // `responseText` then.
+        ...(result?.transcript && result.transcript.length > 0 ? { transcript: result.transcript } : {})
     };
 }
 

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
@@ -29,6 +29,9 @@
     --query-chat-height-md: 32rem;
     --query-composer-min-height: 4.5rem;
     --query-transcript-min-height: 6rem;
+    // Caps a tool call's argument/result block so a large payload scrolls within
+    // the bubble instead of pushing the answer text far down the transcript.
+    --query-tool-payload-max-height: 16rem;
 
     container-type: inline-size;
     container-name: ai-query;
@@ -564,4 +567,94 @@
     gap: var(--gap-xs);
     font-size: var(--font-size-caption);
     color: var(--color-text-muted);
+}
+
+/*
+ * ===========================================================================
+ * ASSISTANT TRANSCRIPT SEGMENTS — thinking, tool calls, tool results, text
+ * rendered in occurrence order when a turn is replayed (live `done` or history).
+ * ===========================================================================
+ */
+.segments {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+}
+
+/* Thinking — collapsed by default so a long reasoning chain never buries the
+   answer; the muted body reads as secondary, set off by a left accent rule. */
+.thinking {
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface-muted);
+    padding: var(--padding-xs) var(--padding-sm);
+}
+
+.thinking_summary {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    cursor: pointer;
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-muted);
+}
+
+.thinking_body {
+    margin-top: var(--gap-xs);
+    padding-left: var(--padding-sm);
+    border-left: var(--border-width-thick) solid var(--color-border);
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+    line-height: var(--line-height-relaxed);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+/* Tool call + result blocks share a bordered, muted-surface frame; the result
+   carries a left accent (success) that flips to danger when the tool errored. */
+.tool_call,
+.tool_result {
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface-muted);
+    padding: var(--padding-xs) var(--padding-sm);
+}
+
+.tool_result {
+    border-left: var(--border-width-thick) solid var(--color-success);
+}
+
+.tool_result--error {
+    border-left-color: var(--color-danger);
+}
+
+.tool_call_header {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-muted);
+}
+
+.tool_call_name {
+    font-family: var(--font-mono);
+    color: var(--color-text);
+}
+
+.tool_payload {
+    margin: var(--gap-xs) 0 0 0;
+    padding: var(--padding-xs);
+    max-height: var(--query-tool-payload-max-height);
+    overflow: auto;
+    background: var(--color-surface);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-caption);
+    color: var(--color-text);
+    line-height: var(--line-height-relaxed);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
 }

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
@@ -14,14 +14,14 @@
  */
 
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
-import { Send, Bot, User, AlertCircle, X, Copy, CheckCircle, Plus, History, MessageSquare, RefreshCw, ChevronDown, ChevronRight } from 'lucide-react';
+import { Send, Bot, User, AlertCircle, X, Copy, CheckCircle, Plus, History, MessageSquare, RefreshCw, ChevronDown, ChevronRight, Brain, Wrench, CornerDownRight } from 'lucide-react';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkGfm from 'remark-gfm';
 import remarkRehype from 'remark-rehype';
 import rehypeSanitize from 'rehype-sanitize';
 import rehypeStringify from 'rehype-stringify';
-import type { IAiConversationMessage, IAiQueryRecord, IAiStreamChunk, IModelInfo, ISavedPrompt } from '@/types';
+import type { IAiConversationMessage, IAiQueryRecord, IAiStreamChunk, IAiTranscriptSegment, IModelInfo, ISavedPrompt } from '@/types';
 import { Stack } from '../../../../../components/layout';
 import { Card } from '../../../../../components/ui/Card';
 import { Button } from '../../../../../components/ui/Button';
@@ -87,6 +87,17 @@ interface ChatTurn {
      * only displays the number it is handed.
      */
     costUsd?: number | null;
+
+    /**
+     * Ordered transcript of an assistant turn — thinking, answer text, tool
+     * calls, and tool results — captured from the terminal `done` chunk on a
+     * live turn or rebuilt from a reopened history record. When present it is
+     * rendered in place of `content`, so the bubble shows the whole turn rather
+     * than only the final answer. Absent on a user turn, on a turn still
+     * streaming, and on legacy records written before transcripts existed (which
+     * fall back to `content`).
+     */
+    segments?: IAiTranscriptSegment[];
 }
 
 /** A run of consecutive history records sharing one `conversationId`. */
@@ -157,6 +168,102 @@ function renderAssistantHtml(text: string, pending: boolean): string {
         html = `<pre>${escaped}</pre>`;
     }
     return html;
+}
+
+/**
+ * Pretty-print a tool's JSON argument or result payload for display. Tool input
+ * arrives as an arbitrary object the model produced and a result as a string the
+ * tool returned; both read best as indented JSON when they parse as such, and as
+ * raw text otherwise. Kept tolerant — a transcript must render even if a payload
+ * is malformed — so any stringify failure degrades to `String(value)` rather
+ * than throwing inside render.
+ *
+ * @param value - The tool input object, or the tool result string.
+ * @returns A human-readable, multi-line string safe to drop into a `<pre>`.
+ */
+function formatToolPayload(value: unknown): string {
+    let formatted: string;
+    if (typeof value === 'string') {
+        try {
+            formatted = JSON.stringify(JSON.parse(value), null, 2);
+        } catch {
+            formatted = value;
+        }
+    } else {
+        try {
+            formatted = JSON.stringify(value ?? null, null, 2);
+        } catch {
+            formatted = String(value);
+        }
+    }
+    return formatted;
+}
+
+/**
+ * Render an assistant turn's structured transcript — the thinking, tool calls,
+ * tool results, and answer text in the order they occurred. This is what lets a
+ * reopened conversation (or a just-completed live turn) show the whole turn
+ * instead of only its final answer: history persists no other structure, so
+ * without this the thinking and tool activity would be invisible. Thinking is
+ * tucked into a collapsed `<details>` so a long chain of reasoning never buries
+ * the answer; tool calls and results render as labelled blocks, errors flagged.
+ * Answer text reuses the same sanitized-Markdown pipeline as a streaming turn so
+ * the prose reads identically whether live or replayed.
+ *
+ * @param segments - The turn's ordered transcript segments.
+ * @returns The rendered transcript.
+ */
+function AssistantSegments({ segments }: { segments: IAiTranscriptSegment[] }) {
+    return (
+        <div className={styles.segments}>
+            {segments.map((segment, index) => {
+                if (segment.type === 'thinking') {
+                    return (
+                        <details key={index} className={styles.thinking}>
+                            <summary className={styles.thinking_summary}>
+                                <Brain size={14} /> Thinking
+                            </summary>
+                            <div className={styles.thinking_body}>{segment.text}</div>
+                        </details>
+                    );
+                }
+                if (segment.type === 'tool_use') {
+                    return (
+                        <div key={index} className={styles.tool_call}>
+                            <div className={styles.tool_call_header}>
+                                <Wrench size={14} />
+                                <span className={styles.tool_call_name}>{segment.name || 'tool'}</span>
+                                {segment.server && <Badge tone="info">server</Badge>}
+                            </div>
+                            <pre className={styles.tool_payload}>{formatToolPayload(segment.input)}</pre>
+                        </div>
+                    );
+                }
+                if (segment.type === 'tool_result') {
+                    return (
+                        <div
+                            key={index}
+                            className={`${styles.tool_result} ${segment.isError ? styles['tool_result--error'] : ''}`}
+                        >
+                            <div className={styles.tool_call_header}>
+                                <CornerDownRight size={14} />
+                                <span className={styles.tool_call_name}>{segment.isError ? 'Tool error' : 'Tool result'}</span>
+                            </div>
+                            <pre className={styles.tool_payload}>{formatToolPayload(segment.content)}</pre>
+                        </div>
+                    );
+                }
+                return (
+                    <div
+                        key={index}
+                        className={styles.turn_markdown}
+                        // Assistant text is sanitized by the rehype-sanitize pipeline in renderAssistantHtml.
+                        dangerouslySetInnerHTML={{ __html: renderAssistantHtml(segment.text, false) }}
+                    />
+                );
+            })}
+        </div>
+    );
 }
 
 /**
@@ -330,7 +437,15 @@ export function QueryTab() {
             updateTurn(turnId, turn => ({ content: turn.content + text }));
         } else if (chunk.type === 'done') {
             setStreaming(false);
-            updateTurn(turnId, { pending: false, usage: chunk.usage ?? null, costUsd: chunk.costUsd ?? null });
+            // Adopt the finalized transcript so the just-completed turn shows the
+            // same thinking/tool structure history does, without a reload. Absent
+            // for a plain text turn — the streamed `content` already covers it.
+            updateTurn(turnId, {
+                pending: false,
+                usage: chunk.usage ?? null,
+                costUsd: chunk.costUsd ?? null,
+                ...(chunk.transcript && chunk.transcript.length > 0 ? { segments: chunk.transcript } : {})
+            });
             streamingTurnIdRef.current = null;
             activeQueryIdRef.current = null;
         } else if (chunk.type === 'error') {
@@ -574,6 +689,11 @@ export function QueryTab() {
             const rebuilt: ChatTurn[] = [];
             for (const record of records) {
                 rebuilt.push({ id: generateUUID(), role: 'user', content: record.prompt });
+                // A turn has a body when it left answer text OR a structured
+                // transcript (a tool-only round can finish with no final text yet
+                // still have plenty to show). Only a truly empty, non-failed
+                // record falls back to the "No response recorded" note.
+                const hasBody = !!record.responseText || (record.transcript?.length ?? 0) > 0;
                 rebuilt.push({
                     id: generateUUID(),
                     role: 'assistant',
@@ -581,7 +701,8 @@ export function QueryTab() {
                     model: record.model,
                     usage: record.usage,
                     costUsd: record.costUsd ?? null,
-                    error: record.responseText ? null : (record.errorMessage ?? 'No response recorded')
+                    error: record.errorMessage ?? (hasBody ? null : 'No response recorded'),
+                    ...(record.transcript && record.transcript.length > 0 ? { segments: record.transcript } : {})
                 });
             }
             setStreaming(false);
@@ -731,6 +852,10 @@ export function QueryTab() {
 
                                             {isUser ? (
                                                 <div className={styles.turn_text}>{turn.content}</div>
+                                            ) : turn.segments && turn.segments.length > 0 ? (
+                                                // A settled turn (live `done` or reopened from history) renders its
+                                                // full transcript — thinking, tool calls, results, and text in order.
+                                                <AssistantSegments segments={turn.segments} />
                                             ) : (
                                                 <div
                                                     className={styles.turn_markdown}

--- a/src/frontend/app/(core)/system/curation/CurationQueue.tsx
+++ b/src/frontend/app/(core)/system/curation/CurationQueue.tsx
@@ -2,22 +2,35 @@
 
 /**
  * @fileoverview Curation queue — the central inbox of effects held for human
- * review across every content type. Each item renders from its content-agnostic
- * preview (title, body, media, fields); approving commits the effect through its
- * owning plugin, rejecting discards it. An item whose owning plugin is disabled
- * returns a 409 the toast surfaces, since it cannot be decided until re-enabled.
+ * review across every content type. Pending items render as focused review
+ * cards: the content on one side, a decision rail on the other holding the
+ * destination picker and Approve / Edit / Reject. Approving commits the effect
+ * through its owning plugin, rejecting discards it; an item whose owning plugin
+ * is disabled returns a 409 the toast surfaces, since it cannot be decided until
+ * re-enabled.
+ *
+ * The decision rail is built around one risk: an approval that fans content to a
+ * public destination cannot be undone. So the picker separates the calm
+ * internal/admin sinks from the amber external/public ones, and any approval
+ * whose selection includes an external destination is gated behind an explicit
+ * confirmation — internal-only approval and rejection stay one click, the fast
+ * path the queue depends on.
+ *
  * A Pending/History toggle switches between the live queue and the read-only
- * audit of past decisions — decisions never delete a record, so history is just
- * the decided items, rendered from their frozen snapshot with no actions.
- * Refetches on the `curation:changed` signal and reports the new count up via
- * `onChanged` so the header badge stays live. Like the sibling system surfaces
- * this is an admin client surface, not an SSR-first public component.
+ * audit of past decisions. Decisions never delete a record, so History is just
+ * the decided items rendered from their frozen snapshot as a scannable table —
+ * audit data you skim, not work you act on, which is why it keeps the table
+ * primitive the review cards deliberately leave behind. Refetches on the
+ * `curation:changed` signal and reports the new count up via `onChanged` so the
+ * header badge stays live. Like the sibling system surfaces this is an admin
+ * client surface, not an SSR-first public component.
  */
 
-import { useEffect, useState, useCallback } from 'react';
-import { Check, X, Pencil } from 'lucide-react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
+import { Check, X, Pencil, Lock, Globe, AlertTriangle } from 'lucide-react';
 import { Stack } from '../../../../components/layout';
 import { Button } from '../../../../components/ui/Button';
+import { Card } from '../../../../components/ui/Card';
 import { Textarea } from '../../../../components/ui/Textarea';
 import { Badge } from '../../../../components/ui/Badge';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../components/ui/Table';
@@ -40,9 +53,28 @@ import {
 } from '../../../../modules/curation';
 import styles from './page.module.scss';
 
-/** Truncate body text for the inline preview cell. */
+/** Body length past which the expandable preview collapses behind a toggle. */
+const COLLAPSE_AT = 280;
+
+/** Truncate body text for an inline preview. */
 function truncate(text: string, max = 160): string {
     return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/**
+ * Decide whether a destination's reach leaves the safe internal/admin zone —
+ * the single predicate that drives the picker's amber grouping and the
+ * publish-confirmation gate. A sink counts as external when it either leaves the
+ * platform (`egress` past `internal`) or widens to the public (`audience` is
+ * `public`); both are exposures an operator must not trigger by reflex. Erring
+ * toward "external" is deliberate: a false amber costs one confirmation click, a
+ * false calm costs an irreversible public publish.
+ *
+ * @param reach - The destination's reach classification.
+ * @returns True when delivering to this sink is an external/public exposure.
+ */
+function destinationIsExternal(reach: ICurationEligibleDestination['reach']): boolean {
+    return reach.egress !== 'internal' || reach.audience === 'public';
 }
 
 /**
@@ -91,18 +123,78 @@ function CurationEditForm({ initialBody, onCancel, onSave }: {
 }
 
 /**
+ * Confirmation body shown before an approval that would fan content to one or
+ * more external/public destinations. Restating exactly which public channels
+ * will fire — and that the effect cannot be undone — is the deliberate friction
+ * that turns a reflex click into a decision; the default focus sits on Cancel so
+ * the dangerous path is never the one a stray Enter takes.
+ *
+ * @param props.channels - The selected external/public destinations to name.
+ * @param props.onConfirm - Proceed with the approval and its destination fan-out.
+ * @param props.onCancel - Dismiss without approving, returning to the rail.
+ * @returns The confirmation form.
+ */
+function PublishConfirm({ channels, onConfirm, onCancel }: {
+    channels: ICurationEligibleDestination[];
+    onConfirm: () => void;
+    onCancel: () => void;
+}) {
+    return (
+        <Stack gap="md">
+            <div className={styles.confirm_warning} role="alert">
+                <AlertTriangle size={18} aria-hidden />
+                <span>This publishes externally and cannot be undone.</span>
+            </div>
+            <ul className={styles.confirm_list}>
+                {channels.map(channel => (
+                    <li key={channel.sinkId} className={styles.confirm_item}>
+                        <Globe size={14} aria-hidden />
+                        <span className={styles.dest_label}>{channel.label ?? channel.sinkId}</span>
+                        <Badge tone="warning">{channel.reach.egress}/{channel.reach.audience}</Badge>
+                    </li>
+                ))}
+            </ul>
+            <div className={styles.row_actions}>
+                <Button variant="ghost" size="sm" onClick={onCancel} autoFocus>Cancel</Button>
+                <Button variant="primary" size="sm" onClick={onConfirm}>
+                    <Check size={16} /> Publish to {channels.length} external channel{channels.length === 1 ? '' : 's'}
+                </Button>
+            </div>
+        </Stack>
+    );
+}
+
+/**
  * Render one held item's content-agnostic preview: body, an optional media
  * thumbnail, and labelled fields. Core knows nothing of the underlying payload —
- * the owning type flattened it into this descriptor.
+ * the owning type flattened it into this descriptor. In `expandable` mode (the
+ * review card) the full body is available behind an in-place expand so a long
+ * draft never forces a navigate-away; in compact mode (the history table) the
+ * body is hard-truncated to keep rows scannable.
  *
  * @param props.preview - The preview descriptor from the curation envelope.
- * @returns The preview cell content.
+ * @param props.expandable - Show the full body behind an expand toggle when long.
+ * @returns The preview content.
  */
-function CurationPreview({ preview }: { preview: ICurationItemView['preview'] }) {
+function CurationPreview({ preview, expandable = false }: { preview: ICurationItemView['preview']; expandable?: boolean }) {
+    const [expanded, setExpanded] = useState(false);
     const image = preview.media?.find(media => media.kind !== 'link');
+    const body = preview.body ?? '';
+    const isLong = expandable && body.length > COLLAPSE_AT;
+    const shownBody = !expandable
+        ? truncate(body)
+        : (expanded || !isLong ? body : truncate(body, COLLAPSE_AT));
+
+    const toggleExpanded = useCallback(() => { setExpanded(prev => !prev); }, []);
+
     return (
         <div className={styles.curation_preview}>
-            {preview.body && <div className={styles.curation_body}>{truncate(preview.body)}</div>}
+            {preview.body && <div className={styles.curation_body}>{shownBody}</div>}
+            {isLong && (
+                <Button variant="ghost" size="xs" onClick={toggleExpanded}>
+                    {expanded ? 'Show less' : 'Show full content'}
+                </Button>
+            )}
             {image && (
                 // Resolved public URL from the owning plugin; next/image adds no
                 // value for an admin-only, externally-sized thumbnail.
@@ -118,7 +210,7 @@ function CurationPreview({ preview }: { preview: ICurationItemView['preview'] })
                     ))}
                 </div>
             )}
-            {preview.editable && <Badge tone="info">editable</Badge>}
+            {!expandable && preview.editable && <Badge tone="info">editable</Badge>}
         </div>
     );
 }
@@ -193,22 +285,139 @@ function CurationDecision({ item }: { item: ICurationItemView }) {
 }
 
 /**
- * Pending-row actions for one held item: the destination picker (when the item's
- * type publishes to destinations and sinks are eligible) plus Approve / Edit /
- * Reject. The eligible destinations are SECONDARY data, lazily fetched per row
- * after mount, so they never block the primary queue render; an item with no
- * eligible destinations shows the classic plain Approve button unchanged. The
- * checkbox selection seeds from standing policy (`defaultSelected`) and the
- * curator confirms or overrides it before approving — the human review gate
- * doubling as the mandated-subset selector.
+ * One sink rendered as a labelled checkbox row inside the destination picker.
+ * The exposure icon and the reach badge are toned to the row's group — a lock
+ * and a neutral badge for internal, a globe and a warning badge for external —
+ * so an external destination never visually reads as calm.
+ *
+ * @param props.dest - The eligible destination to render.
+ * @param props.external - Whether this row belongs to the external/public group.
+ * @param props.checked - Whether the sink is in the current selection.
+ * @param props.disabled - Whether the input is locked (a decision is in flight).
+ * @param props.onToggle - Toggle this sink's membership in the selection.
+ * @returns The destination option row.
+ */
+function DestinationOption({ dest, external, checked, disabled, onToggle }: {
+    dest: ICurationEligibleDestination;
+    external: boolean;
+    checked: boolean;
+    disabled: boolean;
+    onToggle: (sinkId: string) => void;
+}) {
+    return (
+        <label className={styles.dest_option}>
+            <input
+                type="checkbox"
+                checked={checked}
+                disabled={disabled}
+                onChange={() => onToggle(dest.sinkId)}
+            />
+            {external
+                ? <Globe size={14} aria-hidden className={styles.dest_icon} />
+                : <Lock size={14} aria-hidden className={styles.dest_icon} />}
+            <span className={styles.dest_label}>{dest.label ?? dest.sinkId}</span>
+            <Badge tone={external ? 'warning' : 'neutral'}>{dest.reach.egress}/{dest.reach.audience}</Badge>
+        </label>
+    );
+}
+
+/**
+ * The destination picker for a held item that publishes to destinations. The
+ * sinks are split into an internal/admin group and an external/public group so
+ * the exposure of each choice is preattentive — a lock and a calm row versus a
+ * globe, an amber panel, and a warning-toned reach badge — rather than text the
+ * eye has to parse. A live summary names how many internal and external sinks
+ * the current selection will fire, the same count the confirmation gate keys
+ * off, so the operator sees the blast radius before committing.
+ *
+ * @param props.destinations - The item's eligible publish destinations.
+ * @param props.selected - The currently selected sink ids.
+ * @param props.busy - Whether this item's decision is in flight (locks inputs).
+ * @param props.onToggle - Toggle one sink's membership in the selection.
+ * @param props.onSetDefault - Persist the current selection as the type's default.
+ * @returns The grouped destination picker.
+ */
+function DestinationPicker({ destinations, selected, busy, onToggle, onSetDefault }: {
+    destinations: ICurationEligibleDestination[];
+    selected: Set<string>;
+    busy: boolean;
+    onToggle: (sinkId: string) => void;
+    onSetDefault: () => void;
+}) {
+    const internal = destinations.filter(dest => !destinationIsExternal(dest.reach));
+    const external = destinations.filter(dest => destinationIsExternal(dest.reach));
+    const selectedInternal = internal.filter(dest => selected.has(dest.sinkId)).length;
+    const selectedExternal = external.filter(dest => selected.has(dest.sinkId)).length;
+
+    return (
+        <fieldset className={styles.picker}>
+            <legend className={styles.picker_legend}>Publish to</legend>
+            {internal.length > 0 && (
+                <div className={styles.picker_group}>
+                    <div className={styles.picker_group_title}>Internal / Admin</div>
+                    {internal.map(dest => (
+                        <DestinationOption
+                            key={dest.sinkId}
+                            dest={dest}
+                            external={false}
+                            checked={selected.has(dest.sinkId)}
+                            disabled={busy}
+                            onToggle={onToggle}
+                        />
+                    ))}
+                </div>
+            )}
+            {external.length > 0 && (
+                <div className={`${styles.picker_group} ${styles.picker_group_external}`}>
+                    <div className={styles.picker_group_title}>External / Public</div>
+                    {external.map(dest => (
+                        <DestinationOption
+                            key={dest.sinkId}
+                            dest={dest}
+                            external
+                            checked={selected.has(dest.sinkId)}
+                            disabled={busy}
+                            onToggle={onToggle}
+                        />
+                    ))}
+                </div>
+            )}
+            <div className={styles.publish_summary}>
+                {selectedInternal === 0 && selectedExternal === 0
+                    ? 'No destinations selected'
+                    : (
+                        <>
+                            {selectedExternal > 0 && <AlertTriangle size={14} aria-hidden className={styles.summary_warn} />}
+                            Publishing to {selectedInternal} internal · {selectedExternal} external
+                        </>
+                    )}
+            </div>
+            <Button variant="ghost" size="xs" disabled={busy} onClick={onSetDefault}>
+                Set as default for this type
+            </Button>
+        </fieldset>
+    );
+}
+
+/**
+ * The decision rail of a pending review card: the destination picker (when the
+ * item's type publishes to destinations and sinks are eligible) plus the Approve
+ * / Edit / Reject actions. The eligible destinations are SECONDARY data, lazily
+ * fetched per card after mount, so they never block the queue render; an item
+ * with no eligible destinations shows the plain Approve action unchanged. The
+ * selection seeds from standing policy (`defaultSelected`) — the operator's saved
+ * per-type default — which the curator confirms or overrides before approving,
+ * the human gate doubling as the mandated-subset selector. An approval whose
+ * selection includes any external/public sink is routed through a confirmation
+ * modal first; internal-only approval and rejection commit immediately.
  *
  * @param props.item - The pending curation envelope.
- * @param props.busyId - The id of the row currently deciding, or null.
+ * @param props.busyId - The id of the card currently deciding, or null.
  * @param props.onApprove - Approve the item with the curator's selected destinations.
  * @param props.onReject - Reject the item.
  * @param props.onEdit - Open the inline editor for the item.
  * @param props.onSetDefault - Save the current selection as the type's default.
- * @returns The pending-row action controls.
+ * @returns The decision rail controls.
  */
 function PendingActions({ item, busyId, onApprove, onReject, onEdit, onSetDefault }: {
     item: ICurationItemView;
@@ -221,10 +430,11 @@ function PendingActions({ item, busyId, onApprove, onReject, onEdit, onSetDefaul
     // null while the lazy fetch is in flight; an empty array means "no picker".
     const [destinations, setDestinations] = useState<ICurationEligibleDestination[] | null>(null);
     const [selected, setSelected] = useState<Set<string>>(new Set());
+    const { open, close } = useModal();
 
     // Fetch the item's eligible destinations once after mount and seed the
     // selection from standing policy. A `cancelled` guard drops a late resolve if
-    // the row unmounts (e.g. the queue refetched) so it cannot set stale state.
+    // the card unmounts (e.g. the queue refetched) so it cannot set stale state.
     useEffect(() => {
         let cancelled = false;
         listDestinations(item.id)
@@ -260,38 +470,68 @@ function PendingActions({ item, busyId, onApprove, onReject, onEdit, onSetDefaul
     const busy = busyId === item.id;
     const blockedByOther = busyId !== null && busyId !== item.id;
     const hasPicker = destinations !== null && destinations.length > 0;
-    // Eligibility is unknown until this row's fetch settles (destinations === null);
+    // Eligibility is unknown until this card's fetch settles (destinations === null);
     // block approval during that window so a fast click cannot take the classic
     // path and silently skip the publish destinations the picker would have selected.
     const destinationsLoading = destinations === null;
-    const approveDestinations = hasPicker
-        ? Array.from(selected).map((sinkId): ICurationDestinationSelection => ({ sinkId }))
-        : undefined;
+    // A destinations-enabled item must target at least one sink: approving with an
+    // empty selection would commit the decision while publishing nowhere — a silent
+    // no-op the operator did not intend. Block Approve until a destination is picked.
+    const noDestinationSelected = hasPicker && selected.size === 0;
+
+    // The external/public sinks in the current selection — the channels the
+    // confirmation gate names, and the test for whether the gate fires at all.
+    const selectedExternal = useMemo(
+        () => (destinations ?? []).filter(dest => selected.has(dest.sinkId) && destinationIsExternal(dest.reach)),
+        [destinations, selected]
+    );
+
+    // Commit the approval with the curator's selection (or undefined when there
+    // is no picker, preserving the classic single-effect approve).
+    const commitApprove = useCallback(() => {
+        const approveDestinations = hasPicker
+            ? Array.from(selected).map((sinkId): ICurationDestinationSelection => ({ sinkId }))
+            : undefined;
+        onApprove(item.id, approveDestinations);
+    }, [hasPicker, selected, onApprove, item.id]);
+
+    // Approve, but gate any external/public fan-out behind explicit confirmation.
+    // Internal-only approvals (and items with no picker) commit immediately — the
+    // friction lands only where the effect is irreversible.
+    const handleApprove = useCallback(() => {
+        if (selectedExternal.length === 0) {
+            commitApprove();
+            return;
+        }
+        const modalId = `curation-publish-${item.id}`;
+        open({
+            id: modalId,
+            title: 'Confirm external publish',
+            size: 'sm',
+            content: (
+                <PublishConfirm
+                    channels={selectedExternal}
+                    onCancel={() => close(modalId)}
+                    onConfirm={() => { close(modalId); commitApprove(); }}
+                />
+            )
+        });
+    }, [selectedExternal, commitApprove, open, close, item.id]);
 
     return (
-        <Stack gap="sm">
-            {destinations !== null && destinations.length > 0 && (
-                <fieldset className={styles.destination_picker}>
-                    <legend className={styles.destination_legend}>Publish to</legend>
-                    {destinations.map((dest) => (
-                        <label key={dest.sinkId} className={styles.destination_option}>
-                            <input
-                                type="checkbox"
-                                checked={selected.has(dest.sinkId)}
-                                disabled={busy}
-                                onChange={() => toggle(dest.sinkId)}
-                            />
-                            <span className={styles.destination_label}>{dest.label ?? dest.sinkId}</span>
-                            <Badge tone="info">{dest.reach.egress}/{dest.reach.audience}</Badge>
-                        </label>
-                    ))}
-                    <Button variant="ghost" size="xs" disabled={busy} onClick={() => onSetDefault(item.id, Array.from(selected))}>
-                        Set as default for this type
-                    </Button>
-                </fieldset>
+        <Stack gap="md">
+            {destinationsLoading && <div className={styles.rail_hint}>Loading destinations…</div>}
+            {hasPicker && (
+                <DestinationPicker
+                    destinations={destinations}
+                    selected={selected}
+                    busy={busy}
+                    onToggle={toggle}
+                    onSetDefault={() => onSetDefault(item.id, Array.from(selected))}
+                />
             )}
-            <div className={styles.row_actions}>
-                <Button variant="primary" size="sm" loading={busy} disabled={blockedByOther || destinationsLoading} onClick={() => onApprove(item.id, approveDestinations)}>
+            <div className={styles.actions}>
+                <Button variant="primary" size="sm" loading={busy} disabled={blockedByOther || destinationsLoading || noDestinationSelected} onClick={handleApprove}>
                     <Check size={16} /> Approve
                 </Button>
                 {item.preview.editable && (
@@ -299,11 +539,65 @@ function PendingActions({ item, busyId, onApprove, onReject, onEdit, onSetDefaul
                         <Pencil size={16} /> Edit
                     </Button>
                 )}
-                <Button variant="danger" size="sm" disabled={blockedByOther} onClick={() => onReject(item.id)}>
+                <Button variant="danger" size="sm" className={styles.action_reject} loading={busy} disabled={blockedByOther} onClick={() => onReject(item.id)}>
                     <X size={16} /> Reject
                 </Button>
             </div>
         </Stack>
+    );
+}
+
+/**
+ * One pending item as a focused review card: the content (title, provider/source
+ * metadata, held-since, and the expandable preview) beside a decision rail. The
+ * two-region split gives the content readable width and hands the destination
+ * picker a column of its own, the room the old table cell never had — which is
+ * why the multilingual sink labels no longer wrap to eight lines. On a narrow
+ * container the regions stack, the rail dropping below the content.
+ *
+ * @param props.item - The pending curation envelope.
+ * @param props.busyId - The id of the card currently deciding, or null.
+ * @param props.onApprove - Approve the item with the curator's selected destinations.
+ * @param props.onReject - Reject the item.
+ * @param props.onEdit - Open the inline editor for the item.
+ * @param props.onSetDefault - Save the current selection as the type's default.
+ * @returns The review card.
+ */
+function PendingCard({ item, busyId, onApprove, onReject, onEdit, onSetDefault }: {
+    item: ICurationItemView;
+    busyId: string | null;
+    onApprove: (id: string, destinations?: ICurationDestinationSelection[]) => void;
+    onReject: (id: string) => void;
+    onEdit: (item: ICurationItemView) => void;
+    onSetDefault: (id: string, sinkIds: string[]) => void;
+}) {
+    return (
+        <Card padding="lg" className={styles.review_card}>
+            <div className={styles.review_grid}>
+                <div className={styles.review_content}>
+                    <div className={styles.review_meta}>
+                        <div className={styles.review_meta_head}>
+                            <span className={styles.review_title}>{item.preview.title ?? item.typeId}</span>
+                            {item.preview.editable && <Badge tone="info">editable</Badge>}
+                        </div>
+                        <div className={styles.review_submeta}>
+                            {item.providerId}{item.source ? ` · ${item.source}` : ''} · held <ClientTime date={item.createdAt} format="datetime" />
+                        </div>
+                    </div>
+                    <CurationPreview preview={item.preview} expandable />
+                </div>
+                <div className={styles.review_rail}>
+                    <PendingActions
+                        item={item}
+                        busyId={busyId}
+                        onApprove={onApprove}
+                        onReject={onReject}
+                        onEdit={onEdit}
+                        onSetDefault={onSetDefault}
+                    />
+                </div>
+            </div>
+        </Card>
     );
 }
 
@@ -442,49 +736,52 @@ export function CurationQueue({ onChanged }: { onChanged: () => void }) {
             {loading
                 ? <div className={styles.placeholder}>Loading…</div>
                 : items.length === 0
-                    ? <div className={styles.placeholder}>{isHistory ? 'No curation decisions yet.' : 'Nothing is awaiting curation.'}</div>
-                    : (
-                        <div className={`table-scroll ${styles.curation_table}`}>
-                            <Table>
-                                <Thead>
-                                    <Tr>
-                                        <Th width="shrink">Held</Th>
-                                        <Th width="shrink">Type</Th>
-                                        <Th>Preview</Th>
-                                        <Th width="shrink">Decision</Th>
-                                    </Tr>
-                                </Thead>
-                                <Tbody>
-                                    {items.map(item => (
-                                        <Tr key={item.id}>
-                                            <Td muted data-label="Held"><ClientTime date={item.createdAt} format="datetime" /></Td>
-                                            <Td data-label="Type">
-                                                <div className={styles.tool_name}>{item.preview.title ?? item.typeId}</div>
-                                                <div className={styles.tool_desc}>
-                                                    {item.providerId}{item.source ? ` · ${item.source}` : ''}
-                                                </div>
-                                            </Td>
-                                            <Td data-label="Preview"><CurationPreview preview={item.preview} /></Td>
-                                            <Td data-label="Decision">
-                                                {isHistory
-                                                    ? <CurationDecision item={item} />
-                                                    : (
-                                                        <PendingActions
-                                                            item={item}
-                                                            busyId={busyId}
-                                                            onApprove={(id, destinations) => { void resolve(id, 'approve', destinations); }}
-                                                            onReject={(id) => { void resolve(id, 'reject'); }}
-                                                            onEdit={openEditor}
-                                                            onSetDefault={(id, sinkIds) => { void setDefault(id, sinkIds); }}
-                                                        />
-                                                    )}
-                                            </Td>
+                    ? <div className={styles.placeholder}>{isHistory ? 'No curation decisions yet.' : 'Queue clear — nothing awaiting review.'}</div>
+                    : isHistory
+                        ? (
+                            <div className={`table-scroll ${styles.curation_table}`}>
+                                <Table>
+                                    <Thead>
+                                        <Tr>
+                                            <Th width="shrink">Held</Th>
+                                            <Th width="shrink">Type</Th>
+                                            <Th>Preview</Th>
+                                            <Th width="shrink">Decision</Th>
                                         </Tr>
-                                    ))}
-                                </Tbody>
-                            </Table>
-                        </div>
-                    )}
+                                    </Thead>
+                                    <Tbody>
+                                        {items.map(item => (
+                                            <Tr key={item.id}>
+                                                <Td muted data-label="Held"><ClientTime date={item.createdAt} format="datetime" /></Td>
+                                                <Td data-label="Type">
+                                                    <div className={styles.tool_name}>{item.preview.title ?? item.typeId}</div>
+                                                    <div className={styles.tool_desc}>
+                                                        {item.providerId}{item.source ? ` · ${item.source}` : ''}
+                                                    </div>
+                                                </Td>
+                                                <Td data-label="Preview"><CurationPreview preview={item.preview} /></Td>
+                                                <Td data-label="Decision"><CurationDecision item={item} /></Td>
+                                            </Tr>
+                                        ))}
+                                    </Tbody>
+                                </Table>
+                            </div>
+                        )
+                        : (
+                            <Stack gap="md">
+                                {items.map(item => (
+                                    <PendingCard
+                                        key={item.id}
+                                        item={item}
+                                        busyId={busyId}
+                                        onApprove={(id, destinations) => { void resolve(id, 'approve', destinations); }}
+                                        onReject={(id) => { void resolve(id, 'reject'); }}
+                                        onEdit={openEditor}
+                                        onSetDefault={(id, sinkIds) => { void setDefault(id, sinkIds); }}
+                                    />
+                                ))}
+                            </Stack>
+                        )}
         </Stack>
     );
 }

--- a/src/frontend/app/(core)/system/curation/page.module.scss
+++ b/src/frontend/app/(core)/system/curation/page.module.scss
@@ -84,27 +84,131 @@
     color: var(--color-text-subtle);
 }
 
-/* Destination picker: the publish sinks a curator selects when approving a
-   destinations-enabled item. Grouped in a fieldset for accessible labelling. */
-.destination_picker {
+/* Pending review card: one held item presented as a focused work item rather
+   than a table row. Establishes a container so the inner content|rail split
+   responds to the card's own width — correct inside slideouts and modals, not
+   just the full viewport. */
+.review_card {
+    container-type: inline-size;
+    container-name: review-card;
+}
+
+/* Content beside decision rail. Single column by default (narrow containers);
+   the rail drops below the content. Widens to two columns once the card has the
+   room, giving the destination picker a column of its own. */
+.review_grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--gap-lg);
+}
+
+@container review-card (min-width: #{$breakpoint-mobile-lg}) {
+    .review_grid {
+        grid-template-columns: minmax(0, 1fr) var(--max-width-xs);
+    }
+}
+
+/* Content region: metadata header then the expandable preview. min-width:0 lets
+   long unbroken body text wrap instead of forcing the grid column wider. */
+.review_content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+    min-width: 0;
+}
+
+.review_meta {
     display: flex;
     flex-direction: column;
     gap: var(--gap-2xs);
+}
+
+.review_meta_head {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    flex-wrap: wrap;
+}
+
+.review_title {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text);
+}
+
+.review_submeta {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+}
+
+/* Decision rail. Stacked above the content it follows on narrow cards (top
+   divider); becomes a true side rail with a left divider once two columns fit. */
+.review_rail {
+    display: flex;
+    flex-direction: column;
+    padding-top: var(--gap-md);
+    border-top: var(--border-width-thin) solid var(--color-border);
+}
+
+@container review-card (min-width: #{$breakpoint-mobile-lg}) {
+    .review_rail {
+        padding-top: 0;
+        padding-left: var(--gap-lg);
+        border-top: none;
+        border-left: var(--border-width-thin) solid var(--color-border);
+    }
+}
+
+/* Secondary hint while a card's eligible destinations are still loading. */
+.rail_hint {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+}
+
+/* Destination picker: the publish sinks a curator selects when approving a
+   destinations-enabled item. Grouped in a fieldset for accessible labelling,
+   then split into internal and external sub-groups so exposure is preattentive. */
+.picker {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
     margin: 0;
+    padding: 0;
+    border: none;
+}
+
+.picker_legend {
+    padding: 0;
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-muted);
+}
+
+/* One reach group (internal or external). The external variant is tinted amber
+   so a public destination never reads as a calm, default-safe choice. */
+.picker_group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
     padding: var(--padding-sm);
     border: var(--border-width-thin) solid var(--color-border);
     border-radius: var(--radius-md);
     background: var(--color-surface-muted);
 }
 
-.destination_legend {
-    padding: 0 var(--gap-2xs);
+.picker_group_external {
+    border-color: var(--color-warning);
+    background: var(--color-warning-alpha-15);
+}
+
+.picker_group_title {
     font-size: var(--font-size-caption);
     font-weight: var(--font-weight-semibold);
+    letter-spacing: var(--letter-spacing-wide);
+    text-transform: uppercase;
     color: var(--color-text-muted);
 }
 
-.destination_option {
+.dest_option {
     display: flex;
     align-items: center;
     gap: var(--gap-xs);
@@ -113,13 +217,74 @@
     cursor: pointer;
 }
 
-.destination_option input {
+.dest_option input {
     accent-color: var(--color-primary);
 }
 
+.dest_icon {
+    flex: 0 0 auto;
+    color: var(--color-text-muted);
+}
+
 /* Sink label grows so the reach badge sits flush at the row's end. */
-.destination_label {
+.dest_label {
     flex: 1 1 auto;
+    min-width: 0;
+}
+
+/* Live summary of the current selection's blast radius, above the actions. */
+.publish_summary {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-2xs);
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+}
+
+.summary_warn {
+    flex: 0 0 auto;
+    color: var(--color-warning);
+}
+
+/* Decision actions. Reject is pushed to the far end so the destructive button is
+   never adjacent to Approve — a Fitts's-law gap against the mis-click. */
+.actions {
+    display: flex;
+    gap: var(--gap-sm);
+    align-items: center;
+    flex-wrap: wrap;
+    margin-top: var(--gap-md);
+}
+
+.action_reject {
+    margin-left: auto;
+}
+
+/* External-publish confirmation modal: the warning banner and the named list of
+   public channels the approval will fire. */
+.confirm_warning {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    color: var(--color-warning-text);
+    font-size: var(--font-size-body-sm);
+}
+
+.confirm_list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.confirm_item {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text);
 }
 
 /* Per-destination delivery outcomes shown on a decided item in history. */

--- a/src/frontend/app/(core)/system/plugins/PluginsManagementPage.module.scss
+++ b/src/frontend/app/(core)/system/plugins/PluginsManagementPage.module.scss
@@ -184,51 +184,6 @@
     color: var(--color-primary);
 }
 
-/* Toggle Switch */
-.toggle {
-    position: relative;
-    width: var(--spacing-12);
-    height: var(--spacing-9);
-    border-radius: var(--spacing-9);
-    border: none;
-    cursor: pointer;
-    transition: background-color var(--transition-fast);
-    padding: 0;
-}
-
-.toggle:disabled {
-    opacity: var(--button-disabled-opacity);
-    cursor: not-allowed;
-}
-
-.toggle_on {
-    background: var(--color-success);
-}
-
-.toggle_off {
-    background: var(--color-border);
-}
-
-.toggle_loading {
-    opacity: 0.6;
-}
-
-.toggle_thumb {
-    position: absolute;
-    top: var(--spacing-1);
-    left: var(--spacing-1);
-    width: var(--spacing-7);
-    height: var(--spacing-7);
-    border-radius: var(--radius-full);
-    background: var(--color-white);
-    box-shadow: var(--shadow-sm);
-    transition: transform var(--transition-fast);
-}
-
-.toggle_on .toggle_thumb {
-    transform: translateX(var(--spacing-5));
-}
-
 /* Details Row */
 .details_row td {
     padding: 0;

--- a/src/frontend/app/(core)/system/plugins/page.tsx
+++ b/src/frontend/app/(core)/system/plugins/page.tsx
@@ -5,41 +5,10 @@ import { ChevronDown, ChevronRight, Download, Trash2, Settings, AlertCircle } fr
 import { Page, Stack } from '../../../../components/layout';
 import { Badge } from '../../../../components/ui/Badge';
 import { Button } from '../../../../components/ui/Button';
+import { Switch } from '../../../../components/ui/Switch';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../components/ui/Table';
 import type { IPluginInfo } from '@/types';
 import styles from './PluginsManagementPage.module.scss';
-
-/**
- * Toggle switch component for boolean state changes.
- *
- * Displays a sliding toggle control with loading state feedback.
- * Used for enable/disable plugin actions without confirmation dialogs.
- *
- * @param props - Component props
- * @param props.enabled - Current toggle state
- * @param props.onChange - Callback when toggle is clicked
- * @param props.disabled - Whether the toggle is interactive
- * @param props.loading - Whether an operation is in progress
- */
-function Toggle({ enabled, onChange, disabled, loading }: {
-    enabled: boolean;
-    onChange: () => void;
-    disabled?: boolean;
-    loading?: boolean;
-}) {
-    return (
-        <button
-            type="button"
-            role="switch"
-            aria-checked={enabled}
-            onClick={onChange}
-            disabled={disabled || loading}
-            className={`${styles.toggle} ${enabled ? styles.toggle_on : styles.toggle_off} ${loading ? styles.toggle_loading : ''}`}
-        >
-            <span className={styles.toggle_thumb} />
-        </button>
-    );
-}
 
 /**
  * Plugin row component for the management table.
@@ -103,11 +72,11 @@ function PluginRow({ pluginInfo, onInstall, onUninstall, onToggleEnabled, isLoad
                 </Td>
                 <Td className={styles.cell_enabled}>
                     {metadata.installed && (
-                        <Toggle
-                            enabled={metadata.enabled}
-                            onChange={() => onToggleEnabled(manifest.id, !metadata.enabled)}
-                            disabled={isLoading}
-                            loading={isThisLoading}
+                        <Switch
+                            on={metadata.enabled}
+                            onChange={(next) => onToggleEnabled(manifest.id, next)}
+                            disabled={isLoading || isThisLoading}
+                            aria-label={`${metadata.enabled ? 'Disable' : 'Enable'} ${manifest.title}`}
                         />
                     )}
                 </Td>

--- a/src/frontend/components/ui/ModalProvider/ModalProvider.tsx
+++ b/src/frontend/components/ui/ModalProvider/ModalProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useCallback, useContext, useEffect, useId, useMemo, useState, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { cn } from '../../../lib/cn';
 import { useAppDispatch } from '../../../store/hooks';
@@ -224,6 +224,72 @@ const sizeClass: Record<ModalSize, string> = {
  */
 function ModalRenderer({ descriptor, onClose }: { descriptor: ModalDescriptor; onClose: () => void }) {
     const { id, title, content, size = 'md', dismissible = true } = descriptor;
+    const dialogRef = useRef<HTMLDivElement>(null);
+    // The parent passes a fresh `onClose` arrow each render; holding it in a ref
+    // lets the focus effect run once on mount (not re-fire and steal focus on every
+    // parent re-render) while still calling the latest handler.
+    const onCloseRef = useRef(onClose);
+    onCloseRef.current = onClose;
+
+    /**
+     * Trap keyboard focus inside the dialog while it is open and restore it to the
+     * triggering element on close. Without this, Tab walks out of the dialog to the
+     * page behind it and Escape does nothing — unacceptable for a safety-critical
+     * confirm (e.g. the irreversible external-publish gate) that the operator may be
+     * driving entirely from the keyboard. Initial focus is only moved when React's
+     * own `autoFocus` has not already placed it inside the dialog, so an explicit
+     * default-focus target (the confirm dialog's Cancel button) is preserved.
+     */
+    useEffect(() => {
+        const dialog = dialogRef.current;
+        if (!dialog) {
+            return;
+        }
+        const previouslyFocused = document.activeElement as HTMLElement | null;
+        const focusable = (): HTMLElement[] => Array.from(
+            dialog.querySelectorAll<HTMLElement>(
+                'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+            )
+        );
+
+        if (!dialog.contains(document.activeElement)) {
+            (focusable()[0] ?? dialog).focus();
+        }
+
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                if (dismissible) {
+                    event.stopPropagation();
+                    onCloseRef.current();
+                }
+                return;
+            }
+            if (event.key !== 'Tab') {
+                return;
+            }
+            const items = focusable();
+            if (items.length === 0) {
+                event.preventDefault();
+                return;
+            }
+            const first = items[0];
+            const last = items[items.length - 1];
+            const active = document.activeElement;
+            if (event.shiftKey && (active === first || !dialog.contains(active))) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && active === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        };
+
+        dialog.addEventListener('keydown', onKeyDown);
+        return () => {
+            dialog.removeEventListener('keydown', onKeyDown);
+            previouslyFocused?.focus?.();
+        };
+    }, [dismissible]);
 
     /**
      * Handles backdrop click events to close dismissible modals.
@@ -247,7 +313,7 @@ function ModalRenderer({ descriptor, onClose }: { descriptor: ModalDescriptor; o
             className={styles.backdrop}
             onClick={handleBackdropClick}
         >
-            <div className={cn(styles.dialog, sizeClass[size])}>
+            <div ref={dialogRef} tabIndex={-1} className={cn(styles.dialog, sizeClass[size])}>
                 <header className={styles.dialog__header}>
                     {title && <h2 id={`${id}-title`}>{title}</h2>}
                     {dismissible && (

--- a/src/frontend/modules/scheduler/components/SchedulerMonitor/SchedulerMonitor.module.scss
+++ b/src/frontend/modules/scheduler/components/SchedulerMonitor/SchedulerMonitor.module.scss
@@ -163,51 +163,6 @@
     border-color: var(--color-border-hover);
 }
 
-/* Toggle Switch */
-.toggle {
-    position: relative;
-    width: var(--spacing-12);
-    height: var(--spacing-9);
-    border-radius: var(--spacing-9);
-    border: none;
-    cursor: pointer;
-    transition: background-color var(--transition-fast);
-    padding: 0;
-}
-
-.toggle:disabled {
-    opacity: var(--button-disabled-opacity);
-    cursor: not-allowed;
-}
-
-.toggle_on {
-    background: var(--color-success);
-}
-
-.toggle_off {
-    background: var(--color-border);
-}
-
-.toggle_loading {
-    opacity: 0.6;
-}
-
-.toggle_thumb {
-    position: absolute;
-    top: var(--spacing-1);
-    left: var(--spacing-1);
-    width: var(--spacing-7);
-    height: var(--spacing-7);
-    border-radius: var(--radius-full);
-    background: var(--color-white);
-    box-shadow: var(--shadow-sm);
-    transition: transform var(--transition-fast);
-}
-
-.toggle_on .toggle_thumb {
-    transform: translateX(var(--spacing-5));
-}
-
 /* Details Row */
 .details_content {
     padding: var(--spacing-6);

--- a/src/frontend/modules/scheduler/components/SchedulerMonitor/SchedulerMonitor.tsx
+++ b/src/frontend/modules/scheduler/components/SchedulerMonitor/SchedulerMonitor.tsx
@@ -19,6 +19,7 @@ import { ChevronDown, ChevronRight, AlertCircle } from 'lucide-react';
 import { Page, Stack } from '../../../../components/layout';
 import { Badge } from '../../../../components/ui/Badge';
 import { Input } from '../../../../components/ui/Input';
+import { Switch } from '../../../../components/ui/Switch';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../components/ui/Table';
 import { ClientTime } from '../../../../components/ui/ClientTime';
 import { getSchedulerStatus, getSchedulerHealth, updateSchedulerJob } from '../../api';
@@ -32,32 +33,6 @@ interface Props {
     title?: string;
     /** Hide the stats bar (useful when embedding in other pages) */
     hideStats?: boolean;
-}
-
-/**
- * Toggle switch component for boolean state changes.
- *
- * Displays a sliding toggle control with loading state feedback.
- * Used for enable/disable job actions without confirmation dialogs.
- */
-function Toggle({ enabled, onChange, disabled, loading }: {
-    enabled: boolean;
-    onChange: () => void;
-    disabled?: boolean;
-    loading?: boolean;
-}) {
-    return (
-        <button
-            type="button"
-            role="switch"
-            aria-checked={enabled}
-            onClick={onChange}
-            disabled={disabled || loading}
-            className={`${styles.toggle} ${enabled ? styles.toggle_on : styles.toggle_off} ${loading ? styles.toggle_loading : ''}`}
-        >
-            <span className={styles.toggle_thumb} />
-        </button>
-    );
 }
 
 /**
@@ -142,11 +117,11 @@ function JobRow({ job, onToggleEnabled, onScheduleChange, isLoading, loadingJobN
                     )}
                 </Td>
                 <Td className={styles.cell_enabled}>
-                    <Toggle
-                        enabled={job.enabled}
-                        onChange={() => onToggleEnabled(job.name, !job.enabled)}
-                        disabled={isLoading}
-                        loading={isThisLoading}
+                    <Switch
+                        on={job.enabled}
+                        onChange={(next) => onToggleEnabled(job.name, next)}
+                        disabled={isLoading || isThisLoading}
+                        aria-label={`${job.enabled ? 'Disable' : 'Enable'} ${job.name}`}
                     />
                 </Td>
             </Tr>


### PR DESCRIPTION
## Curation review-card redesign
Pending items render as master-detail review cards with a decision rail (destination picker + Approve/Edit/Reject). Destinations are grouped into calm internal/admin vs amber external/public, and any approval whose selection includes an external/public destination is gated behind an explicit, irreversible-publish confirmation. History remains a read-only audit table.

Review fixes applied on top of the redesign:
- Reject button now guards against double-submit (`loading` during its own in-flight reject).
- Approve is disabled when a picker is shown but no destination is selected (no silent publish-nowhere approval).
- Confirmation dialog states the **external-only** channel count so it doesn't imply total reach.

## Switch rollout (core admin)
`/system/scheduler` and `/system/plugins` now use the core `Switch` component. The duplicate local `Toggle` components and their orphaned `.toggle*` SCSS were removed from both.

## Modal accessibility
`ModalProvider` now traps Tab/Shift+Tab within the dialog, closes on Escape (dismissible modals only), and restores focus to the triggering element on close — while preserving React's `autoFocus` so the confirm dialog still lands on Cancel.

## AI query transcripts
Adds transcript-segment types (`IAiTranscriptSegment`) and wires AI query history and the QueryTab to record and render query transcripts.

Full `tsc --noEmit` passes.