### PR TITLE
feat(account-history): per-account TRON transaction ingestion into ClickHouse

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delphian/tronrelic-types",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "description": "Core type definitions for the TronRelic platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/types/src/account-history/IAccountHistoryService.ts
+++ b/packages/types/src/account-history/IAccountHistoryService.ts
@@ -1,0 +1,240 @@
+/**
+ * @fileoverview Published contract for the account-history module.
+ *
+ * The account-history module ingests the full transaction history of explicitly
+ * tracked TRON accounts into ClickHouse, pull-based and independent of the
+ * forward block-sync pipeline. This file is the single cross-component surface:
+ * the module publishes `IAccountHistoryService` on the service registry under
+ * `'account-history'`, so other modules (constructor DI) and plugins (registry
+ * `get`/`watch`) reach tracked accounts, ingestion control, and history reads
+ * without touching the module's collections or ClickHouse table directly.
+ *
+ * Reads return `IBlockTransaction` — the source-independent domain contract —
+ * so consumers never couple to the persistence row shape or to TronGrid.
+ */
+
+import type { IBlockTransaction } from '../blockchain/IBlockTransaction.js';
+
+/**
+ * Lifecycle state of one account's backfill.
+ *
+ * Typed as a closed union because these are the states the admin surface and
+ * the scheduler tick branch on; a new state would be a deliberate contract
+ * change, not silent drift.
+ */
+export type AccountIngestionStatus = 'queued' | 'running' | 'paused' | 'complete' | 'failed';
+
+/**
+ * An account the operator has asked the platform to track.
+ *
+ * Identity is the base58 address; `paused` is the per-account operational brake
+ * that stops this account's backfill without affecting the others. Tracking is
+ * admin-managed because the module is always-on (a core module cannot be
+ * toggled off), so the tracked set is the real control surface.
+ */
+export interface ITrackedAccount {
+    /** Base58 TRON address. Stable identity across restarts and the cursor key. */
+    address: string;
+    /** Optional human label for the admin list; has no effect on ingestion. */
+    label?: string;
+    /** When true the ingestion tick skips this account, leaving its cursor intact. */
+    paused: boolean;
+    /** When the account was first added to the tracked set. */
+    addedAt: Date;
+    /** Last time the tracked-account record itself was modified. */
+    updatedAt: Date;
+}
+
+/**
+ * Resumable backfill progress for one account.
+ *
+ * The cursor is TronGrid's opaque `fingerprint`; the timestamps describe how far
+ * back the walk has reached. There is no percentage — fingerprint paging never
+ * reveals an account's total transaction count up front, so progress is
+ * expressed as absolute counts plus the oldest point reached, never a fraction.
+ */
+export interface IAccountIngestionProgress {
+    /** Base58 address this progress record belongs to. */
+    address: string;
+    /** Current lifecycle state of the backfill. */
+    status: AccountIngestionStatus;
+    /**
+     * Opaque TronGrid fingerprint for the next page to fetch. Absent before the
+     * first tick and once the walk is complete (no more pages).
+     */
+    cursorFingerprint?: string;
+    /** Oldest block time reached walking history backward; advances each tick. */
+    oldestTimestampReached?: Date;
+    /** Newest block time observed on the first page; the leading edge of history. */
+    newestTimestampSeen?: Date;
+    /** Total rows written to ClickHouse for this account so far. */
+    rowsIngested: number;
+    /** When the ingestion tick last touched this account. */
+    lastRunAt?: Date;
+    /** Message from the most recent failed tick, cleared on the next success. */
+    lastError?: string;
+}
+
+/**
+ * Operator-tunable pacing for the ingestion job.
+ *
+ * These dials throttle ingestion *down* — they cannot exceed the shared TronGrid
+ * rate limiter that protects live block sync. `ingestionEnabled` is the
+ * module-level brake that makes the scheduler tick a no-op without unregistering
+ * the job; the cron cadence itself is owned by the scheduler, not these settings.
+ */
+export interface IAccountHistorySettings {
+    /** Master switch; when false the ingestion tick returns immediately. */
+    ingestionEnabled: boolean;
+    /** TronGrid pages pulled per account per tick — the primary speed/load dial. */
+    pagesPerTick: number;
+    /** How many tracked accounts advance per tick (round-robin, least-recent first). */
+    accountsPerTick: number;
+}
+
+/**
+ * One row of the admin stats table: a tracked account paired with its progress.
+ */
+export interface IAccountHistoryAccountStats {
+    /** The tracked-account record. */
+    account: ITrackedAccount;
+    /** Its current backfill progress, or a zeroed record if ingestion never ran. */
+    progress: IAccountIngestionProgress;
+}
+
+/**
+ * Full snapshot powering the admin page and the live-stats WebSocket payload.
+ */
+export interface IAccountHistoryStats {
+    /** Current pacing settings. */
+    settings: IAccountHistorySettings;
+    /** Per-account progress rows. */
+    accounts: IAccountHistoryAccountStats[];
+    /** Module-level rollups for the dashboard header. */
+    totals: {
+        /** Number of accounts in the tracked set. */
+        trackedAccounts: number;
+        /** Total rows ingested across all accounts. */
+        rowsIngested: number;
+        /** Accounts whose backfill has reached the end of available history. */
+        completeAccounts: number;
+        /** Accounts whose last tick failed. */
+        failedAccounts: number;
+    };
+}
+
+/**
+ * Input for adding an account to the tracked set.
+ */
+export interface IAddTrackedAccountInput {
+    /** Base58 TRON address to begin tracking. */
+    address: string;
+    /** Optional human label for the admin list. */
+    label?: string;
+}
+
+/**
+ * Parameters for a paged read of an account's stored history.
+ */
+export interface IAccountTransactionQuery {
+    /** Base58 address whose history to read. */
+    address: string;
+    /** Page size; the service clamps to a sane maximum. */
+    limit?: number;
+    /** Row offset for pagination. */
+    offset?: number;
+}
+
+/**
+ * A page of an account's stored transactions.
+ */
+export interface IAccountTransactionPage {
+    /** Source-independent transaction projections, newest first. */
+    transactions: IBlockTransaction[];
+    /** Total rows stored for the account, for pagination math. */
+    total: number;
+}
+
+/**
+ * The central service every account-history surface routes through.
+ *
+ * All access — admin controllers, the scheduler tick, and external consumers —
+ * goes through this interface; the ClickHouse table and the Mongo tracked-account
+ * and progress collections are reached only here. Published on the service
+ * registry as `'account-history'`.
+ */
+export interface IAccountHistoryService {
+    /**
+     * Begin tracking an account. Idempotent on address: re-adding an existing
+     * account updates its label rather than duplicating it.
+     *
+     * @param input - Address (and optional label) to track.
+     * @returns The tracked-account record, new or updated.
+     */
+    addTrackedAccount(input: IAddTrackedAccountInput): Promise<ITrackedAccount>;
+
+    /**
+     * Stop tracking an account and discard its progress cursor. Stored
+     * transactions in ClickHouse are retained — removal stops future ingestion,
+     * it does not purge history.
+     *
+     * @param address - Base58 address to stop tracking.
+     */
+    removeTrackedAccount(address: string): Promise<void>;
+
+    /**
+     * Pause or resume a single account's backfill without removing it. A paused
+     * account keeps its cursor so it resumes exactly where it left off.
+     *
+     * @param address - Base58 address to toggle.
+     * @param paused - True to pause, false to resume.
+     * @returns The updated tracked-account record.
+     */
+    setAccountPaused(address: string, paused: boolean): Promise<ITrackedAccount>;
+
+    /**
+     * List the tracked set for the admin surface.
+     *
+     * @returns All tracked accounts, oldest first.
+     */
+    listTrackedAccounts(): Promise<ITrackedAccount[]>;
+
+    /**
+     * Read current pacing settings.
+     *
+     * @returns The effective settings, seeded with defaults on first read.
+     */
+    getSettings(): Promise<IAccountHistorySettings>;
+
+    /**
+     * Update pacing settings. Only supplied fields change.
+     *
+     * @param patch - Partial settings to merge.
+     * @returns The settings after the merge.
+     */
+    updateSettings(patch: Partial<IAccountHistorySettings>): Promise<IAccountHistorySettings>;
+
+    /**
+     * Build the full stats snapshot for the admin page and live broadcasts.
+     *
+     * @returns Settings, per-account progress, and rollups.
+     */
+    getStats(): Promise<IAccountHistoryStats>;
+
+    /**
+     * Read a page of an account's stored history from ClickHouse.
+     *
+     * @param query - Address and pagination window.
+     * @returns A page of source-independent transactions plus the total count.
+     */
+    getTransactions(query: IAccountTransactionQuery): Promise<IAccountTransactionPage>;
+
+    /**
+     * Advance ingestion by one bounded slice: pick the least-recently-advanced
+     * unpaused accounts (up to `accountsPerTick`), pull up to `pagesPerTick`
+     * pages each, write rows, and persist the advanced cursors. Invoked by the
+     * scheduler job; also callable for a manual operator-triggered run. A no-op
+     * when `ingestionEnabled` is false or no provider is available.
+     */
+    runIngestionTick(): Promise<void>;
+}

--- a/packages/types/src/account-history/index.ts
+++ b/packages/types/src/account-history/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Barrel for the account-history domain contracts.
+ *
+ * Re-exports the published service interface and its DTOs so the root types
+ * index can surface them with a single explicit export line.
+ */
+
+export type {
+    AccountIngestionStatus,
+    ITrackedAccount,
+    IAccountIngestionProgress,
+    IAccountHistorySettings,
+    IAccountHistoryAccountStats,
+    IAccountHistoryStats,
+    IAddTrackedAccountInput,
+    IAccountTransactionQuery,
+    IAccountTransactionPage,
+    IAccountHistoryService
+} from './IAccountHistoryService.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -70,6 +70,7 @@ export type { ITronGridService, ITronGridAccountResponse, ITronGridAccountPermis
 export type { ITrc10, ITrc10FrozenSupply } from './trc10/index.js';
 export type { IBlockStats, IBlock, IBlockTransaction, IBlockTransactionParty, IBlockTransactionContract, IResourceUsage, IBlockchainService, ITransactionTimeseriesPoint, IOverviewTimeseriesPoint, OverviewTimeseriesWindow, ITransactionDetailService } from './blockchain/index.js';
 export type { IToolsService, IAddressConversionResult, IAddressValidationResult } from './tools/index.js';
+export type { AccountIngestionStatus, ITrackedAccount, IAccountIngestionProgress, IAccountHistorySettings, IAccountHistoryAccountStats, IAccountHistoryStats, IAddTrackedAccountInput, IAccountTransactionQuery, IAccountTransactionPage, IAccountHistoryService } from './account-history/index.js';
 export type { IAiTool, IAiToolInputSchema, IAiConversationMessage, IAiProvider, IAiStreamChunk, IAiQueryRecord, AiQueryMode, IAiQueryOptions, IAiQueryResult, IModelInfo, ISavedPrompt, IAiTranscriptSegment, IAiThinkingSegment, IAiTextSegment, IAiToolUseSegment, IAiToolResultSegment } from './ai-tools/index.js';
 export { AI_TOOL_NAME_PATTERN } from './ai-tools/index.js';
 export { UNTRUSTED_CONTENT_NOTICE, UNTRUSTED_CONTENT_SYSTEM_CLAUSE, wrapUntrustedToolResult } from './ai-tools/index.js';

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -40,6 +40,7 @@ import { PagesModule } from './modules/pages/index.js';
 import { WidgetsModule } from './modules/widgets/index.js';
 import { IdentityModule } from './modules/identity/index.js';
 import { TrafficModule } from './modules/traffic/index.js';
+import { AccountHistoryModule } from './modules/account-history/index.js';
 import { ToolsModule } from './modules/tools/index.js';
 import { AiToolsModule } from './modules/ai-tools/index.js';
 import { CurationModule } from './modules/curation/index.js';
@@ -239,6 +240,7 @@ interface BootstrapContext {
         widgets: WidgetsModule;
         identity: IdentityModule;
         traffic: TrafficModule;
+        accountHistory: AccountHistoryModule;
         tools: ToolsModule;
         notifications: NotificationsModule;
         curation: CurationModule;
@@ -384,6 +386,7 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     const widgetsModule = new WidgetsModule();
     const identityModule = new IdentityModule();
     const trafficModule = new TrafficModule();
+    const accountHistoryModule = new AccountHistoryModule();
     const toolsModule = new ToolsModule();
     const notificationsModule = new NotificationsModule();
     const curationModule = new CurationModule();
@@ -398,6 +401,10 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     const schedulerService = schedulerModule.getSchedulerService();
     await identityModule.init(sharedDeps);
     await trafficModule.init({ ...sharedDeps, scheduler: schedulerService, clickhouse });
+    // Account-history: pull-based per-account transaction backfill into ClickHouse.
+    // Receives the scheduler service (for its bounded ingestion job) and clickhouse
+    // (its store); no-ops ingestion when clickhouse is absent. Independent of block sync.
+    await accountHistoryModule.init({ ...sharedDeps, scheduler: schedulerService, clickhouse });
     await toolsModule.init(sharedDeps);
     // Notifications module: builds the category/channel registries, preference,
     // policy, and audit stores. Inits before ai-tools so its run() (which
@@ -448,6 +455,7 @@ async function bootstrapInit(): Promise<BootstrapContext> {
             widgets: widgetsModule,
             identity: identityModule,
             traffic: trafficModule,
+            accountHistory: accountHistoryModule,
             tools: toolsModule,
             notifications: notificationsModule,
             curation: curationModule,
@@ -502,6 +510,9 @@ async function bootstrapRun(ctx: BootstrapContext): Promise<void> {
     // ticking), so the relay job is registered before the scheduler activates.
     await modules.syndication.run();
     await modules.aiTools.run();
+    // Account-history runs before scheduler (which runs last and starts ticking),
+    // so its `account-history:ingest` job is registered before the scheduler activates.
+    await modules.accountHistory.run();
     await modules.scheduler.run();
 
     // Mount the hook-system introspection endpoint. The route is

--- a/src/backend/modules/account-history/AccountHistoryModule.ts
+++ b/src/backend/modules/account-history/AccountHistoryModule.ts
@@ -1,0 +1,173 @@
+/**
+ * @fileoverview AccountHistoryModule — pull-based per-account transaction ingest.
+ *
+ * Tracks the full transaction history of operator-chosen TRON accounts into
+ * ClickHouse, independent of the forward block-sync pipeline. It owns one
+ * service (`IAccountHistoryService`, published as `'account-history'`), a bounded
+ * scheduler ingestion job, an admin API, and a `/system/account-history` menu
+ * entry. The module is always-on (a core module cannot be toggled), so the
+ * tracked set and the `ingestionEnabled` setting are the real control surface;
+ * it degrades to a no-op when ClickHouse is absent.
+ */
+
+import type { Express, Router } from 'express';
+import type {
+    IClickHouseService,
+    IDatabaseService,
+    IMenuService,
+    IModule,
+    IModuleMetadata,
+    ISchedulerService,
+    IServiceRegistry,
+    IWebSocketService
+} from '@/types';
+import { logger } from '../../lib/logger.js';
+import { MAIN_SYSTEM_CONTAINER_ID } from '../menu/index.js';
+import { requireAdmin } from '../../api/middleware/admin-auth.js';
+import { createAdminRateLimiter } from '../../api/middleware/rate-limit.js';
+import { WebSocketService } from '../../services/websocket.service.js';
+import { AccountHistoryService } from './services/account-history.service.js';
+import { AccountHistoryController } from './api/account-history.controller.js';
+import { createAccountHistoryRouter } from './api/account-history.routes.js';
+import { TronGridAccountHistoryProvider } from './providers/trongrid-account-history.provider.js';
+
+/**
+ * Dependencies the account-history module requires at bootstrap.
+ */
+export interface IAccountHistoryModuleDependencies {
+    /** Core database for the control collections. */
+    database: IDatabaseService;
+    /** Express app the module mounts its admin router onto. */
+    app: Express;
+    /** Menu service for the System-container admin entry. */
+    menuService: IMenuService;
+    /** Scheduler for the recurring ingestion job; null disables the job. */
+    scheduler: ISchedulerService | null;
+    /** ClickHouse store; undefined makes ingestion and reads no-ops. */
+    clickhouse: IClickHouseService | undefined;
+    /** Service registry for publishing `'account-history'`. */
+    serviceRegistry: IServiceRegistry;
+}
+
+/**
+ * Cron for the ingestion job. Every two minutes keeps backfills moving while
+ * staying gentle on the shared TronGrid budget; operators retune it from the
+ * scheduler (and see it on the module's Schedules tab).
+ */
+const INGESTION_CRON = '*/2 * * * *';
+
+/** Scheduler job name; the `account-history:` prefix scopes the module's Schedules tab. */
+const INGESTION_JOB = 'account-history:ingest';
+
+/**
+ * Two-phase core module wiring the account-history service, job, API, and menu.
+ */
+export class AccountHistoryModule implements IModule<IAccountHistoryModuleDependencies> {
+    readonly metadata: IModuleMetadata = {
+        id: 'account-history',
+        name: 'Account History',
+        version: '1.0.0',
+        description: 'Pull-based per-account TRON transaction history ingested into ClickHouse'
+    };
+
+    private app!: Express;
+    private menuService!: IMenuService;
+    private scheduler!: ISchedulerService | null;
+    private serviceRegistry!: IServiceRegistry;
+    private service!: AccountHistoryService;
+    private controller!: AccountHistoryController;
+
+    private readonly logger = logger.child({ module: 'account-history' });
+
+    /**
+     * Phase 1: create the service and controller; do not mount routes.
+     *
+     * @param dependencies - Injected collaborators.
+     */
+    async init(dependencies: IAccountHistoryModuleDependencies): Promise<void> {
+        this.logger.info('Initializing account-history module...');
+
+        this.app = dependencies.app;
+        this.menuService = dependencies.menuService;
+        this.scheduler = dependencies.scheduler;
+        this.serviceRegistry = dependencies.serviceRegistry;
+
+        const provider = new TronGridAccountHistoryProvider();
+        const emitter = AccountHistoryModule.resolveEmitter();
+
+        AccountHistoryService.setDependencies({
+            database: dependencies.database,
+            clickhouse: dependencies.clickhouse,
+            provider,
+            emitter,
+            logger: this.logger
+        });
+        this.service = AccountHistoryService.getInstance();
+        await this.service.ensureIndexes();
+
+        this.controller = new AccountHistoryController(this.service, this.logger);
+
+        this.logger.info('Account-history module initialized');
+    }
+
+    /**
+     * Phase 2: register the menu entry, mount the admin router, register the
+     * ingestion job, and publish the service for late-binding consumers.
+     */
+    async run(): Promise<void> {
+        this.logger.info('Running account-history module...');
+
+        try {
+            await this.menuService.create({
+                namespace: 'main',
+                label: 'Account History',
+                url: '/system/account-history',
+                icon: 'History',
+                order: 27,
+                parent: MAIN_SYSTEM_CONTAINER_ID,
+                enabled: true
+            });
+            this.logger.info('Account-history menu item registered under the System container');
+        } catch (error) {
+            this.logger.error({ error }, 'Failed to register account-history menu item');
+            throw new Error(`Failed to register account-history menu item: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+
+        const router: Router = createAccountHistoryRouter(this.controller);
+        this.app.use(
+            '/api/admin/system/account-history',
+            createAdminRateLimiter('account-history-admin'),
+            requireAdmin,
+            router
+        );
+        this.logger.info('Account-history admin router mounted at /api/admin/system/account-history');
+
+        if (this.scheduler) {
+            this.scheduler.register(INGESTION_JOB, INGESTION_CRON, async () => {
+                await this.service.runIngestionTick();
+            });
+            this.logger.info('Account-history ingestion job registered');
+        } else {
+            this.logger.info('Scheduler disabled — account-history ingestion job not registered');
+        }
+
+        this.serviceRegistry.register('account-history', this.service);
+        this.logger.info('Registered account-history on the service registry');
+
+        this.logger.info('Account-history module running');
+    }
+
+    /**
+     * Resolve the WebSocket emitter for live stats, tolerating a deployment with
+     * WebSockets disabled (the emitter's own guard makes `emit` a no-op there).
+     *
+     * @returns The shared WebSocket service, or undefined if unavailable.
+     */
+    private static resolveEmitter(): IWebSocketService | undefined {
+        try {
+            return WebSocketService.getInstance();
+        } catch {
+            return undefined;
+        }
+    }
+}

--- a/src/backend/modules/account-history/README.md
+++ b/src/backend/modules/account-history/README.md
@@ -1,0 +1,90 @@
+# Account History Module
+
+Ingests the full transaction history of operator-tracked TRON accounts into ClickHouse, pull-based and independent of the forward block-sync pipeline. Backfills are bounded per scheduler tick and resumable, so a million-transaction account spreads over many ticks without a long-lived process and resumes after a restart.
+
+## Agent Quick Surface
+
+| Surface | Value |
+|---------|-------|
+| Module id | `account-history` |
+| Module class | `src/backend/modules/account-history/AccountHistoryModule.ts` |
+| Admin page | `/system/account-history` (menu item `Account History`, order 27, registered in `run()`) |
+| Service registry name | `'account-history'` → `IAccountHistoryService` |
+| Mounted routes | `/api/admin/system/account-history/*` (`createAdminRateLimiter` + `requireAdmin`) |
+| Scheduler job | `account-history:ingest` (default `*/2 * * * *`) |
+| WebSocket event | `account-history:stats` (global broadcast; has a case in `WebSocketService.emit()`) |
+| Types package | `@delphian/tronrelic-types` → `IAccountHistoryService` and its DTOs |
+| ClickHouse table | `account_transactions` (ReplacingMergeTree) |
+| Mongo collections | `module_account-history_tracked`, `module_account-history_progress`, `module_account-history_settings` |
+| Provider seam | `IAccountHistoryProvider` (v1 impl: `TronGridAccountHistoryProvider`) |
+| Bootstrap order | Inits after the scheduler service is available; runs alongside other modules before `loadPlugins` |
+
+## Why It Is a Module (Not a Plugin)
+
+By the module-vs-plugin matrix this feature is plugin-shaped (the app runs without it). It is built as a module at the operator's explicit request: a self-contained, always-on core component. The consequence is that it cannot be toggled off — so the **tracked set** and the `ingestionEnabled` **setting** are the control surface a plugin's enable/disable would otherwise provide.
+
+## Source Map
+
+| Path | Responsibility |
+|------|----------------|
+| `AccountHistoryModule.ts` | Two-phase lifecycle; creates the service, mounts the router, registers the job and menu, publishes `'account-history'` |
+| `services/account-history.service.ts` | `AccountHistoryService` singleton — the single authority; tracked set, cursors, settings, ingestion loop, ClickHouse reads, live-stats emit |
+| `providers/IAccountHistoryProvider.ts` | The data-source seam the service depends on (never TronGrid directly) |
+| `providers/trongrid-account-history.provider.ts` | v1 TronGrid provider + `toAccountTransactionRow` ClickHouse projector |
+| `api/account-history.controller.ts` | Thin HTTP handlers delegating to the service |
+| `api/account-history.routes.ts` | Router factory (guards applied at mount) |
+| `database/index.ts` | Collection/table constants, Mongo doc shapes, ClickHouse row shape, TronGrid item shape |
+| `lib/clickhouse-datetime.ts` | `DateTime64(3)` (de)serialization helpers |
+| `migrations/001_create_account_transactions_table.ts` | ClickHouse table DDL (`target: 'clickhouse'`) |
+
+## Data Source Coverage
+
+The v1 provider uses TronGrid's `/v1/accounts/{addr}/transactions` endpoint, which returns **every** transaction type — native TRX, TRC10, staking, delegation, and contract calls (TRC20 transfers appear as `TriggerSmartContract`). One endpoint covers "all transaction types". The TRC20-specific endpoint is intentionally unused: it only adds decoded token amounts, which the source-independent `IBlockTransaction` contract does not model.
+
+**Limitation:** TronGrid fingerprint paging cannot reach the deepest history of very large accounts. The provider seam exists so a future archive-node or paid full-history source is a provider swap, not a service rewrite. Treat TronGrid as the v1 source the seam is designed to outgrow.
+
+## Published Contract — `'account-history'` → `IAccountHistoryService`
+
+| Method | Purpose |
+|--------|---------|
+| `addTrackedAccount({ address, label? })` | Begin tracking (idempotent on address) |
+| `removeTrackedAccount(address)` | Stop tracking; retains stored history |
+| `setAccountPaused(address, paused)` | Pause/resume one account, preserving its cursor |
+| `listTrackedAccounts()` | The tracked set, oldest first |
+| `getSettings()` / `updateSettings(patch)` | Read / merge pacing (`ingestionEnabled`, `pagesPerTick`, `accountsPerTick`) |
+| `getStats()` | Settings + per-account progress + rollups (admin page and live payload) |
+| `getTransactions({ address, limit?, offset? })` | Paged history read returning `IBlockTransaction[]` |
+| `runIngestionTick()` | Advance ingestion one bounded slice (scheduler + manual trigger) |
+
+Consume from a plugin via `context.services.watch('account-history', ...)`; from a module via constructor DI or the registry.
+
+## REST Endpoints (`requireAdmin`)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/admin/system/account-history/stats` | Full stats snapshot |
+| GET/PATCH | `/api/admin/system/account-history/settings` | Read / update pacing |
+| POST | `/api/admin/system/account-history/ingest/run` | Manual ingestion tick |
+| GET/POST | `/api/admin/system/account-history/accounts` | List / add tracked accounts |
+| GET | `/api/admin/system/account-history/accounts/:address/transactions` | Paged history |
+| PATCH | `/api/admin/system/account-history/accounts/:address/paused` | Pause/resume |
+| DELETE | `/api/admin/system/account-history/accounts/:address` | Stop tracking |
+
+## Ingestion Contract
+
+`runIngestionTick()` selects the least-recently-advanced unpaused, not-complete accounts (up to `accountsPerTick`), pulls up to `pagesPerTick` provider pages each, writes rows to ClickHouse, and advances each account's fingerprint cursor **only after a clean write** — a failed tick leaves the cursor untouched so the next tick retries the same page. ReplacingMergeTree keyed `(account, timestamp, tx_id)` absorbs the overlaps fingerprint paging produces, so re-ingest is idempotent. The pacing dials throttle *down* only — they cannot exceed the shared TronGrid rate limiter that protects live block sync.
+
+Progress is expressed as absolute counts plus the oldest timestamp reached, never a percentage: fingerprint paging never reveals an account's total transaction count up front.
+
+## Storage
+
+**ClickHouse `account_transactions`** — `ReplacingMergeTree(ingested_at)`, `PARTITION BY toYYYYMM(timestamp)`, `ORDER BY (account, timestamp, tx_id)`. Columns flatten `IBlockTransaction` plus `account` and `ingested_at`. No TTL — account history is the product.
+
+**Mongo control collections** — `tracked` (the set, unique `address`), `progress` (resumable cursor per address, unique `address`), `settings` (singleton, keyed `settings`).
+
+## Related
+
+- [system-database.md](../../../../docs/system/system-database.md) — `IDatabaseService` access
+- [system-database-migrations.md](../../../../docs/system/system-database-migrations.md) — ClickHouse-targeted migrations
+- [Traffic Module README](../traffic/README.md) — the sibling ClickHouse consumer this mirrors
+- [system-domain-types.md](../../../../docs/system/system-domain-types.md) — why reads return `IBlockTransaction`

--- a/src/backend/modules/account-history/README.md
+++ b/src/backend/modules/account-history/README.md
@@ -39,9 +39,14 @@ By the module-vs-plugin matrix this feature is plugin-shaped (the app runs witho
 
 ## Data Source Coverage
 
-The v1 provider uses TronGrid's `/v1/accounts/{addr}/transactions` endpoint, which returns **every** transaction type — native TRX, TRC10, staking, delegation, and contract calls (TRC20 transfers appear as `TriggerSmartContract`). One endpoint covers "all transaction types". The TRC20-specific endpoint is intentionally unused: it only adds decoded token amounts, which the source-independent `IBlockTransaction` contract does not model.
+The provider walks **both** TronGrid account endpoints, because neither alone is complete:
 
-**Limitation:** TronGrid fingerprint paging cannot reach the deepest history of very large accounts. The provider seam exists so a future archive-node or paid full-history source is a provider swap, not a service rewrite. Treat TronGrid as the v1 source the seam is designed to outgrow.
+- `/v1/accounts/{addr}/transactions` (source `tx`) — native TRX, TRC10, staking, delegation, raw contract calls, and *outbound* TRC20 (the account is the native caller).
+- `/v1/accounts/{addr}/transactions/trc20` (source `trc20`) — decoded token transfers indexed by participant, capturing *inbound* TRC20 the native endpoint omits (an inbound transfer's recipient lives only inside the contract call data, never as a native party), with the token amount.
+
+Each endpoint has its own fingerprint cursor; an account is marked `complete` only when **both** exhaust. TRC20 amount/symbol/decimals are stored in dedicated columns (carried through the normalized transaction's `contract.parameters`), so `IBlockTransaction` stays unextended. An outbound TRC20 transfer is stored as two rows — the native call (`tx`) and the decoded transfer (`trc20`); reads suppress the redundant native row when a `trc20` row exists for the same tx.
+
+**Limitation:** TronGrid fingerprint paging cannot reach the deepest history of very large accounts. The provider seam exists so a future archive-node or paid full-history source is a provider swap, not a service rewrite.
 
 ## Published Contract — `'account-history'` → `IAccountHistoryService`
 
@@ -72,13 +77,13 @@ Consume from a plugin via `context.services.watch('account-history', ...)`; from
 
 ## Ingestion Contract
 
-`runIngestionTick()` selects the least-recently-advanced unpaused, not-complete accounts (up to `accountsPerTick`), pulls up to `pagesPerTick` provider pages each, writes rows to ClickHouse, and advances each account's fingerprint cursor **only after a clean write** — a failed tick leaves the cursor untouched so the next tick retries the same page. ReplacingMergeTree keyed `(account, timestamp, tx_id)` absorbs the overlaps fingerprint paging produces, so re-ingest is idempotent. The pacing dials throttle *down* only — they cannot exceed the shared TronGrid rate limiter that protects live block sync.
+`runIngestionTick()` selects the least-recently-advanced unpaused, not-complete accounts (up to `accountsPerTick`) and, for each, walks both endpoints (`tx` then `trc20`) up to `pagesPerTick` pages each, writing rows to ClickHouse and advancing **each endpoint's own cursor** after every clean write. A failed tick persists each cursor at its last cleanly-written page so the next tick resumes without re-counting or re-fetching. An account becomes `complete` only when both endpoints exhaust. ReplacingMergeTree keyed `(account, timestamp, tx_id, source, to_address)` absorbs paging/retry overlaps, so re-ingest is idempotent. The pacing dials throttle *down* only — they cannot exceed the shared TronGrid rate limiter that protects live block sync.
 
 Progress is expressed as absolute counts plus the oldest timestamp reached, never a percentage: fingerprint paging never reveals an account's total transaction count up front.
 
 ## Storage
 
-**ClickHouse `account_transactions`** — `ReplacingMergeTree(ingested_at)`, `PARTITION BY toYYYYMM(timestamp)`, `ORDER BY (account, timestamp, tx_id)`. Columns flatten `IBlockTransaction` plus `account` and `ingested_at`. No TTL — account history is the product.
+**ClickHouse `account_transactions`** — `ReplacingMergeTree(ingested_at)`, `PARTITION BY toYYYYMM(timestamp)`, `ORDER BY (account, timestamp, tx_id, source, to_address)`. Columns flatten `IBlockTransaction` plus `account`, `source`, the TRC20 `token_amount`/`token_symbol`/`token_decimals`, and `ingested_at`. No TTL — account history is the product.
 
 **Mongo control collections** — `tracked` (the set, unique `address`), `progress` (resumable cursor per address, unique `address`), `settings` (singleton, keyed `settings`).
 

--- a/src/backend/modules/account-history/__tests__/account-history.test.ts
+++ b/src/backend/modules/account-history/__tests__/account-history.test.ts
@@ -169,7 +169,7 @@ describe('AccountHistoryService', () => {
 });
 
 describe('toAccountTransactionRow', () => {
-    it('projects a transaction into a flat ClickHouse row with null-coalesced optionals', () => {
+    it('projects a native transaction into a flat ClickHouse row with null token columns', () => {
         const tx: IBlockTransaction = {
             txId: 'abc',
             blockNumber: 100,
@@ -181,16 +181,40 @@ describe('toAccountTransactionRow', () => {
             contract: { address: 'Tcontract', method: '0xa9059cbb' },
             memo: null
         };
-        const row = toAccountTransactionRow('Tacct', tx, '2024-01-01 00:00:00.000', '2024-06-01 00:00:00.000');
+        const row = toAccountTransactionRow('Tacct', tx, 'tx', '2024-01-01 00:00:00.000', '2024-06-01 00:00:00.000');
 
         expect(row.account).toBe('Tacct');
         expect(row.tx_id).toBe('abc');
+        expect(row.source).toBe('tx');
         expect(row.type).toBe('TriggerSmartContract');
         expect(row.contract_address).toBe('Tcontract');
         expect(row.contract_method).toBe('0xa9059cbb');
         expect(row.amount_sun).toBeNull();
         expect(row.energy_consumed).toBeNull();
+        expect(row.token_amount).toBeNull();
+        expect(row.token_symbol).toBeNull();
         expect(row.memo).toBeNull();
         expect(row.ingested_at).toBe('2024-06-01 00:00:00.000');
+    });
+
+    it('lifts TRC20 token detail from contract.parameters into dedicated columns', () => {
+        const tx: IBlockTransaction = {
+            txId: 'def',
+            blockNumber: 0,
+            timestamp: new Date('2024-01-02T00:00:00.000Z'),
+            type: 'TriggerSmartContract',
+            status: 'SUCCESS',
+            from: { address: 'Tsender' },
+            to: { address: 'Trecipient' },
+            contract: { address: 'Ttoken', method: 'transfer', parameters: { value: '1000000', symbol: 'USDT', decimals: 6 } },
+            memo: null
+        };
+        const row = toAccountTransactionRow('Tacct', tx, 'trc20', '2024-01-02 00:00:00.000', '2024-06-01 00:00:00.000');
+
+        expect(row.source).toBe('trc20');
+        expect(row.token_amount).toBe('1000000');
+        expect(row.token_symbol).toBe('USDT');
+        expect(row.token_decimals).toBe(6);
+        expect(row.contract_address).toBe('Ttoken');
     });
 });

--- a/src/backend/modules/account-history/__tests__/account-history.test.ts
+++ b/src/backend/modules/account-history/__tests__/account-history.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @fileoverview Tests for the account-history module.
+ *
+ * Covers the two-phase module lifecycle (metadata, init/run phase separation,
+ * route mounting, scheduler registration, service publication) and the service's
+ * source-of-truth behaviors that don't depend on seeded collection data: pacing
+ * defaults and clamping, address validation, the ClickHouse-absent no-ops, and
+ * the pure ClickHouse-row projection.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IBlockTransaction, IMenuService, ISchedulerService, ISystemLogService } from '@/types';
+import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+import { createMockServiceRegistry } from '../../../tests/vitest/mocks/service-registry.js';
+import { AccountHistoryModule } from '../AccountHistoryModule.js';
+import { AccountHistoryService } from '../services/account-history.service.js';
+import { toAccountTransactionRow } from '../providers/trongrid-account-history.provider.js';
+import type { IAccountHistoryProvider } from '../providers/IAccountHistoryProvider.js';
+
+/** A real base58 TRON address (the USDT contract) for validation-passing cases. */
+const VALID_ADDRESS = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
+
+/**
+ * A no-op logger satisfying ISystemLogService for tests that don't assert on logs.
+ *
+ * @returns A logger whose methods do nothing and whose `child` returns itself.
+ */
+function createSilentLogger(): ISystemLogService {
+    const logger = {
+        info() {}, warn() {}, error() {}, debug() {}, trace() {}, fatal() {},
+        child() { return logger; }
+    };
+    return logger as unknown as ISystemLogService;
+}
+
+/**
+ * Build a menu-service mock whose `create` resolves, for module-run assertions.
+ *
+ * @returns A mock IMenuService.
+ */
+function createMenuMock(): IMenuService {
+    return { create: vi.fn().mockResolvedValue({ id: 'menu-node' }) } as unknown as IMenuService;
+}
+
+/**
+ * Build a scheduler mock recording job registrations.
+ *
+ * @returns A mock ISchedulerService.
+ */
+function createSchedulerMock(): ISchedulerService {
+    return {
+        register: vi.fn(),
+        disable: vi.fn().mockResolvedValue(undefined),
+        unregister: vi.fn().mockResolvedValue(undefined)
+    } as unknown as ISchedulerService;
+}
+
+describe('AccountHistoryModule', () => {
+    beforeEach(() => {
+        AccountHistoryService.resetForTests();
+    });
+
+    it('exposes correct metadata', () => {
+        const module = new AccountHistoryModule();
+        expect(module.metadata.id).toBe('account-history');
+        expect(module.metadata.name).toBe('Account History');
+        expect(module.metadata.version).toBe('1.0.0');
+    });
+
+    it('does not mount routes during init()', async () => {
+        const app = { use: vi.fn() };
+        const module = new AccountHistoryModule();
+        await module.init({
+            database: createMockDatabaseService(),
+            app: app as never,
+            menuService: createMenuMock(),
+            scheduler: createSchedulerMock(),
+            clickhouse: undefined,
+            serviceRegistry: createMockServiceRegistry()
+        });
+        expect(app.use).not.toHaveBeenCalled();
+    });
+
+    it('throws if run() is called before init()', async () => {
+        const module = new AccountHistoryModule();
+        await expect(module.run()).rejects.toThrow();
+    });
+
+    it('mounts routes, registers the ingestion job, and publishes the service during run()', async () => {
+        const app = { use: vi.fn() };
+        const scheduler = createSchedulerMock();
+        const serviceRegistry = createMockServiceRegistry();
+        const module = new AccountHistoryModule();
+
+        await module.init({
+            database: createMockDatabaseService(),
+            app: app as never,
+            menuService: createMenuMock(),
+            scheduler,
+            clickhouse: undefined,
+            serviceRegistry
+        });
+        await module.run();
+
+        expect(app.use).toHaveBeenCalledWith(
+            '/api/admin/system/account-history',
+            expect.anything(),
+            expect.anything(),
+            expect.any(Function)
+        );
+        expect(scheduler.register).toHaveBeenCalledWith('account-history:ingest', expect.any(String), expect.any(Function));
+        expect(serviceRegistry.has('account-history')).toBe(true);
+    });
+});
+
+describe('AccountHistoryService', () => {
+    /**
+     * Configure a fresh service with the given provider and no ClickHouse.
+     *
+     * @param provider - The provider to inject, or null.
+     * @returns The configured service instance.
+     */
+    function buildService(provider: IAccountHistoryProvider | null) {
+        AccountHistoryService.resetForTests();
+        AccountHistoryService.setDependencies({
+            database: createMockDatabaseService(),
+            clickhouse: undefined,
+            provider,
+            emitter: undefined,
+            logger: createSilentLogger()
+        });
+        return AccountHistoryService.getInstance();
+    }
+
+    beforeEach(() => {
+        AccountHistoryService.resetForTests();
+    });
+
+    it('returns default pacing settings when none are stored', async () => {
+        const service = buildService(null);
+        const settings = await service.getSettings();
+        expect(settings).toEqual({ ingestionEnabled: true, pagesPerTick: 5, accountsPerTick: 3 });
+    });
+
+    it('clamps non-positive pacing dials to at least 1', async () => {
+        const service = buildService(null);
+        const settings = await service.updateSettings({ pagesPerTick: 0, accountsPerTick: -4 });
+        expect(settings.pagesPerTick).toBe(1);
+        expect(settings.accountsPerTick).toBe(1);
+    });
+
+    it('rejects a non-base58 tracked address', async () => {
+        const service = buildService(null);
+        await expect(service.addTrackedAccount({ address: 'not-an-address' })).rejects.toThrow();
+    });
+
+    it('returns an empty page when ClickHouse is unavailable', async () => {
+        const service = buildService(null);
+        const page = await service.getTransactions({ address: VALID_ADDRESS });
+        expect(page).toEqual({ transactions: [], total: 0 });
+    });
+
+    it('runIngestionTick is a no-op without ClickHouse and never calls the provider', async () => {
+        const provider: IAccountHistoryProvider = { id: 'test', fetchPage: vi.fn() };
+        const service = buildService(provider);
+        await service.runIngestionTick();
+        expect(provider.fetchPage).not.toHaveBeenCalled();
+    });
+});
+
+describe('toAccountTransactionRow', () => {
+    it('projects a transaction into a flat ClickHouse row with null-coalesced optionals', () => {
+        const tx: IBlockTransaction = {
+            txId: 'abc',
+            blockNumber: 100,
+            timestamp: new Date('2024-01-01T00:00:00.000Z'),
+            type: 'TriggerSmartContract',
+            status: 'SUCCESS',
+            from: { address: 'Tfrom' },
+            to: { address: 'Tto' },
+            contract: { address: 'Tcontract', method: '0xa9059cbb' },
+            memo: null
+        };
+        const row = toAccountTransactionRow('Tacct', tx, '2024-01-01 00:00:00.000', '2024-06-01 00:00:00.000');
+
+        expect(row.account).toBe('Tacct');
+        expect(row.tx_id).toBe('abc');
+        expect(row.type).toBe('TriggerSmartContract');
+        expect(row.contract_address).toBe('Tcontract');
+        expect(row.contract_method).toBe('0xa9059cbb');
+        expect(row.amount_sun).toBeNull();
+        expect(row.energy_consumed).toBeNull();
+        expect(row.memo).toBeNull();
+        expect(row.ingested_at).toBe('2024-06-01 00:00:00.000');
+    });
+});

--- a/src/backend/modules/account-history/api/account-history.controller.ts
+++ b/src/backend/modules/account-history/api/account-history.controller.ts
@@ -1,0 +1,151 @@
+/**
+ * @fileoverview Thin HTTP layer for the account-history admin API.
+ *
+ * Every handler does request plumbing only — parse input, call one
+ * `IAccountHistoryService` method, shape the response — so all behavior lives
+ * behind the central service. Responses are the raw resource or, on failure,
+ * `{ error, message }`, matching the platform's controller convention.
+ */
+
+import type { Request, Response } from 'express';
+import type { IAccountHistoryService, ISystemLogService } from '@/types';
+
+/**
+ * Admin controller for tracked accounts, pacing settings, stats, history reads,
+ * and manual ingestion triggering.
+ */
+export class AccountHistoryController {
+    /**
+     * @param service - The central account-history service (all heavy lifting).
+     * @param logger - Scoped logger for handler-level error reporting.
+     */
+    constructor(
+        private readonly service: IAccountHistoryService,
+        private readonly logger: ISystemLogService
+    ) {}
+
+    /**
+     * GET /accounts — list the tracked set.
+     */
+    listTrackedAccounts = async (_req: Request, res: Response): Promise<void> => {
+        try {
+            const accounts = await this.service.listTrackedAccounts();
+            res.json({ accounts });
+        } catch (error) {
+            this.fail(res, 500, 'Failed to list tracked accounts', error);
+        }
+    };
+
+    /**
+     * POST /accounts — begin tracking an account. Body: `{ address, label? }`.
+     */
+    addTrackedAccount = async (req: Request, res: Response): Promise<void> => {
+        try {
+            const { address, label } = req.body ?? {};
+            const account = await this.service.addTrackedAccount({ address, label });
+            res.status(201).json(account);
+        } catch (error) {
+            this.fail(res, 400, 'Failed to add tracked account', error);
+        }
+    };
+
+    /**
+     * DELETE /accounts/:address — stop tracking (retains stored history).
+     */
+    removeTrackedAccount = async (req: Request, res: Response): Promise<void> => {
+        try {
+            await this.service.removeTrackedAccount(req.params.address);
+            res.status(204).end();
+        } catch (error) {
+            this.fail(res, 400, 'Failed to remove tracked account', error);
+        }
+    };
+
+    /**
+     * PATCH /accounts/:address/paused — pause or resume one account. Body: `{ paused }`.
+     */
+    setAccountPaused = async (req: Request, res: Response): Promise<void> => {
+        try {
+            const paused = Boolean(req.body?.paused);
+            const account = await this.service.setAccountPaused(req.params.address, paused);
+            res.json(account);
+        } catch (error) {
+            this.fail(res, 400, 'Failed to update account pause state', error);
+        }
+    };
+
+    /**
+     * GET /accounts/:address/transactions — paged history read. Query: `limit`, `offset`.
+     */
+    getTransactions = async (req: Request, res: Response): Promise<void> => {
+        try {
+            const limit = req.query.limit ? parseInt(String(req.query.limit), 10) : undefined;
+            const offset = req.query.offset ? parseInt(String(req.query.offset), 10) : undefined;
+            const page = await this.service.getTransactions({ address: req.params.address, limit, offset });
+            res.json(page);
+        } catch (error) {
+            this.fail(res, 400, 'Failed to read account transactions', error);
+        }
+    };
+
+    /**
+     * GET /settings — current pacing settings.
+     */
+    getSettings = async (_req: Request, res: Response): Promise<void> => {
+        try {
+            const settings = await this.service.getSettings();
+            res.json(settings);
+        } catch (error) {
+            this.fail(res, 500, 'Failed to read settings', error);
+        }
+    };
+
+    /**
+     * PATCH /settings — merge pacing settings. Body: partial settings.
+     */
+    updateSettings = async (req: Request, res: Response): Promise<void> => {
+        try {
+            const settings = await this.service.updateSettings(req.body ?? {});
+            res.json(settings);
+        } catch (error) {
+            this.fail(res, 400, 'Failed to update settings', error);
+        }
+    };
+
+    /**
+     * GET /stats — full stats snapshot (settings, per-account progress, totals).
+     */
+    getStats = async (_req: Request, res: Response): Promise<void> => {
+        try {
+            const stats = await this.service.getStats();
+            res.json(stats);
+        } catch (error) {
+            this.fail(res, 500, 'Failed to read stats', error);
+        }
+    };
+
+    /**
+     * POST /ingest/run — manually advance ingestion by one bounded tick.
+     */
+    runIngestion = async (_req: Request, res: Response): Promise<void> => {
+        try {
+            await this.service.runIngestionTick();
+            res.status(202).json({ started: true });
+        } catch (error) {
+            this.fail(res, 500, 'Failed to run ingestion tick', error);
+        }
+    };
+
+    /**
+     * Log and emit a uniform error response.
+     *
+     * @param res - The response to write.
+     * @param status - HTTP status code.
+     * @param error - Human-facing summary; also the log message.
+     * @param cause - The caught error, surfaced as `message`.
+     */
+    private fail(res: Response, status: number, error: string, cause: unknown): void {
+        this.logger.error({ error: cause }, error);
+        res.status(status).json({ error, message: cause instanceof Error ? cause.message : 'Unknown error' });
+    }
+}

--- a/src/backend/modules/account-history/api/account-history.routes.ts
+++ b/src/backend/modules/account-history/api/account-history.routes.ts
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Express router factory for the account-history admin API.
+ *
+ * The factory wires routes to controller handlers only; `requireAdmin` and the
+ * admin rate limiter are applied at mount time in the module's `run()`, matching
+ * the platform convention. Static segments are declared before the dynamic
+ * `:address` routes so they are not shadowed.
+ */
+
+import { Router } from 'express';
+import type { AccountHistoryController } from './account-history.controller.js';
+
+/**
+ * Build the account-history admin router.
+ *
+ * @param controller - The controller whose handlers back each route.
+ * @returns A configured Express router (unmounted, unguarded).
+ */
+export function createAccountHistoryRouter(controller: AccountHistoryController): Router {
+    const router = Router();
+
+    router.get('/stats', controller.getStats);
+    router.get('/settings', controller.getSettings);
+    router.patch('/settings', controller.updateSettings);
+    router.post('/ingest/run', controller.runIngestion);
+
+    router.get('/accounts', controller.listTrackedAccounts);
+    router.post('/accounts', controller.addTrackedAccount);
+    router.get('/accounts/:address/transactions', controller.getTransactions);
+    router.patch('/accounts/:address/paused', controller.setAccountPaused);
+    router.delete('/accounts/:address', controller.removeTrackedAccount);
+
+    return router;
+}

--- a/src/backend/modules/account-history/database/index.ts
+++ b/src/backend/modules/account-history/database/index.ts
@@ -1,0 +1,162 @@
+/**
+ * @fileoverview Persistence shapes for the account-history module.
+ *
+ * Three MongoDB collections hold control state — the tracked set, per-account
+ * resumable progress, and the singleton pacing settings — and one ClickHouse
+ * row shape holds the ingested transactions. These are implementation
+ * artifacts, not cross-component contracts, so they live in the module (in
+ * core) rather than the types package; the published contract is
+ * `IAccountHistoryService` in `@/types`. Collection names are manually prefixed
+ * `module_account-history_*` per the module namespace convention.
+ */
+
+/** Physical MongoDB collection holding the operator-managed tracked set. */
+export const TRACKED_COLLECTION = 'module_account-history_tracked';
+
+/** Physical MongoDB collection holding per-account resumable ingestion progress. */
+export const PROGRESS_COLLECTION = 'module_account-history_progress';
+
+/** Physical MongoDB collection holding the singleton pacing settings document. */
+export const SETTINGS_COLLECTION = 'module_account-history_settings';
+
+/** ClickHouse table holding ingested per-account transactions. */
+export const TRANSACTIONS_TABLE = 'account_transactions';
+
+/** Fixed discriminator for the singleton settings document. */
+export const SETTINGS_KEY = 'settings';
+
+/**
+ * Stored tracked-account record. Mirrors the public `ITrackedAccount` shape with
+ * `addedAt`/`updatedAt` persisted as `Date`.
+ */
+export interface ITrackedAccountDoc {
+    /** Base58 TRON address; unique within the collection. */
+    address: string;
+    /** Optional human label for the admin list. */
+    label?: string;
+    /** When true the ingestion tick skips this account. */
+    paused: boolean;
+    /** When the account was first added to the tracked set. */
+    addedAt: Date;
+    /** Last time this record was modified. */
+    updatedAt: Date;
+}
+
+/**
+ * Stored per-account ingestion progress / resumable cursor. One document per
+ * tracked address, upserted as each tick advances the backfill.
+ */
+export interface IAccountProgressDoc {
+    /** Base58 address this progress belongs to; unique within the collection. */
+    address: string;
+    /** Lifecycle state of the backfill. */
+    status: 'queued' | 'running' | 'paused' | 'complete' | 'failed';
+    /** Opaque TronGrid fingerprint for the next page; absent before first run or at completion. */
+    cursorFingerprint?: string;
+    /** Oldest block time reached walking history backward. */
+    oldestTimestampReached?: Date;
+    /** Newest block time observed on the first page. */
+    newestTimestampSeen?: Date;
+    /** Total rows written to ClickHouse for this account. */
+    rowsIngested: number;
+    /** When the ingestion tick last touched this account; drives round-robin ordering. */
+    lastRunAt?: Date;
+    /** Message from the most recent failed tick; cleared on the next success. */
+    lastError?: string;
+}
+
+/**
+ * Stored pacing settings. A single document discriminated by `key: SETTINGS_KEY`.
+ */
+export interface IAccountHistorySettingsDoc {
+    /** Fixed discriminator so the singleton is addressable by `{ key }`. */
+    key: string;
+    /** Master switch; when false the ingestion tick is a no-op. */
+    ingestionEnabled: boolean;
+    /** TronGrid pages pulled per account per tick. */
+    pagesPerTick: number;
+    /** Tracked accounts advanced per tick (round-robin). */
+    accountsPerTick: number;
+}
+
+/**
+ * One row of the ClickHouse `account_transactions` table — a flat projection of
+ * `IBlockTransaction` plus the per-account key and the ReplacingMergeTree
+ * version column. Numeric fields are sun amounts and resource units; timestamps
+ * are ClickHouse `DateTime64(3)` strings produced by `formatClickHouseDateTime64Utc`.
+ */
+export interface IAccountTransactionRow extends Record<string, unknown> {
+    /** Tracked account this row was ingested for; part of the dedup key. */
+    account: string;
+    /** Transaction hash. */
+    tx_id: string;
+    /** Including block height. */
+    block_number: number;
+    /** Block execution time as a ClickHouse datetime string. */
+    timestamp: string;
+    /** Native contract type, e.g. `TransferContract`. */
+    type: string;
+    /** Native execution result, e.g. `SUCCESS`. */
+    status: string;
+    /** Base58 sender. */
+    from_address: string;
+    /** Base58 recipient. */
+    to_address: string;
+    /** Native TRX moved, in sun; null when the type carries no native value. */
+    amount_sun: number | null;
+    /** Total TRX burned, in sun; null when unknown. */
+    fee_sun: number | null;
+    /** Energy units consumed; null when unknown. */
+    energy_consumed: number | null;
+    /** TRX burned for energy, in sun; null when unknown. */
+    energy_fee_sun: number | null;
+    /** Bandwidth units consumed; null when unknown. */
+    bandwidth_consumed: number | null;
+    /** TRX burned for bandwidth, in sun; null when unknown. */
+    bandwidth_fee_sun: number | null;
+    /** Base58 contract address for contract calls (token contract for TRC20); null otherwise. */
+    contract_address: string | null;
+    /** Decoded method selector/name; null when not a contract call. */
+    contract_method: string | null;
+    /** Decoded memo (hex of `raw_data.data`); null when none. */
+    memo: string | null;
+    /** Ingestion time; the ReplacingMergeTree version column. */
+    ingested_at: string;
+}
+
+/**
+ * Minimal shape of a TronGrid account-transaction item the provider reads. The
+ * v1 REST API returns the full java-tron transaction envelope; the provider
+ * touches only these fields, all optional because TronGrid omits what a given
+ * transaction type does not carry.
+ */
+export interface ITronGridAccountTx {
+    /** Transaction hash. */
+    txID?: string;
+    /** Including block height. */
+    blockNumber?: number;
+    /** Block time in epoch milliseconds. */
+    block_timestamp?: number;
+    /** Raw transaction body: contracts and optional memo data. */
+    raw_data?: {
+        contract?: Array<{
+            type?: string;
+            parameter?: { value?: Record<string, unknown> };
+        }>;
+        data?: string;
+    };
+    /** Execution result records; `ret[0].contractRet` is the status. */
+    ret?: Array<{ contractRet?: string }>;
+    /** Total TRX burned, in sun. */
+    fee?: number;
+    /** Energy units consumed (total). */
+    energy_usage_total?: number;
+    /** Energy units drawn from the account's own resources. */
+    energy_usage?: number;
+    /** TRX burned for energy, in sun. */
+    energy_fee?: number;
+    /** Bandwidth units consumed. */
+    net_usage?: number;
+    /** TRX burned for bandwidth, in sun. */
+    net_fee?: number;
+}

--- a/src/backend/modules/account-history/database/index.ts
+++ b/src/backend/modules/account-history/database/index.ts
@@ -26,6 +26,14 @@ export const TRANSACTIONS_TABLE = 'account_transactions';
 export const SETTINGS_KEY = 'settings';
 
 /**
+ * Which TronGrid account endpoint a stored row came from. `'tx'` is the general
+ * `/transactions` endpoint (native TRX, TRC10, staking, raw contract calls);
+ * `'trc20'` is `/transactions/trc20` (decoded token transfers, including inbound
+ * ones the general endpoint omits). Part of the ClickHouse dedup key.
+ */
+export type AccountTxSource = 'tx' | 'trc20';
+
+/**
  * Stored tracked-account record. Mirrors the public `ITrackedAccount` shape with
  * `addedAt`/`updatedAt` persisted as `Date`.
  */
@@ -49,10 +57,16 @@ export interface ITrackedAccountDoc {
 export interface IAccountProgressDoc {
     /** Base58 address this progress belongs to; unique within the collection. */
     address: string;
-    /** Lifecycle state of the backfill. */
+    /** Lifecycle state of the backfill; `complete` only once BOTH endpoints exhaust. */
     status: 'queued' | 'running' | 'paused' | 'complete' | 'failed';
-    /** Opaque TronGrid fingerprint for the next page; absent before first run or at completion. */
+    /** Opaque fingerprint for the next general `/transactions` page; absent before first run or when that endpoint is exhausted. */
     cursorFingerprint?: string;
+    /** Opaque fingerprint for the next `/transactions/trc20` page; absent before first run or when that endpoint is exhausted. */
+    trc20CursorFingerprint?: string;
+    /** True once the general `/transactions` walk has reached the end of available history. */
+    nativeComplete?: boolean;
+    /** True once the `/transactions/trc20` walk has reached the end of available history. */
+    trc20Complete?: boolean;
     /** Oldest block time reached walking history backward. */
     oldestTimestampReached?: Date;
     /** Newest block time observed on the first page. */
@@ -90,7 +104,9 @@ export interface IAccountTransactionRow extends Record<string, unknown> {
     account: string;
     /** Transaction hash. */
     tx_id: string;
-    /** Including block height. */
+    /** Which TronGrid endpoint produced this row (`'tx'` or `'trc20'`); part of the dedup key. */
+    source: AccountTxSource;
+    /** Including block height (0 when the source endpoint omits it, e.g. trc20). */
     block_number: number;
     /** Block execution time as a ClickHouse datetime string. */
     timestamp: string;
@@ -118,7 +134,13 @@ export interface IAccountTransactionRow extends Record<string, unknown> {
     contract_address: string | null;
     /** Decoded method selector/name; null when not a contract call. */
     contract_method: string | null;
-    /** Decoded memo (hex of `raw_data.data`); null when none. */
+    /** Raw TRC20 token amount as an integer string (decimals unapplied); null for non-token rows. */
+    token_amount: string | null;
+    /** TRC20 token symbol from the transfer's token_info; null for non-token rows. */
+    token_symbol: string | null;
+    /** TRC20 token decimals from the transfer's token_info; null for non-token rows. */
+    token_decimals: number | null;
+    /** Decoded UTF-8 memo from `raw_data.data`; null when none. */
     memo: string | null;
     /** Ingestion time; the ReplacingMergeTree version column. */
     ingested_at: string;
@@ -159,4 +181,36 @@ export interface ITronGridAccountTx {
     net_usage?: number;
     /** TRX burned for bandwidth, in sun. */
     net_fee?: number;
+}
+
+/**
+ * Minimal shape of a TronGrid TRC20 transfer item the provider reads from the
+ * `/v1/accounts/{addr}/transactions/trc20` endpoint. This endpoint indexes by
+ * token-transfer participant, so it returns transfers the account *received*
+ * (which the native `/transactions` endpoint omits, since the recipient is only
+ * inside the contract call data). Fields are optional because TronGrid omits
+ * unknowns; the decoded `value` carries the raw token amount.
+ */
+export interface ITronGridTrc20Tx {
+    /** Hash of the transaction carrying the transfer. */
+    transaction_id?: string;
+    /** Block time in epoch milliseconds. */
+    block_timestamp?: number;
+    /** Base58 sender of the token transfer. */
+    from?: string;
+    /** Base58 recipient of the token transfer. */
+    to?: string;
+    /** Raw token amount as an integer string (decimals unapplied). */
+    value?: string;
+    /** Event type, e.g. `'Transfer'` / `'Approval'`. */
+    type?: string;
+    /** Token contract metadata. */
+    token_info?: {
+        /** Base58 token contract address. */
+        address?: string;
+        /** Token symbol, e.g. `USDT`. */
+        symbol?: string;
+        /** Token decimals. */
+        decimals?: number;
+    };
 }

--- a/src/backend/modules/account-history/index.ts
+++ b/src/backend/modules/account-history/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @fileoverview Public API for the account-history module.
+ *
+ * Bootstrap constructs and wires the module through these exports; the published
+ * runtime contract is `IAccountHistoryService` in `@/types`, consumed via the
+ * `'account-history'` service-registry name.
+ */
+
+export { AccountHistoryModule } from './AccountHistoryModule.js';
+export type { IAccountHistoryModuleDependencies } from './AccountHistoryModule.js';
+export { AccountHistoryService } from './services/account-history.service.js';
+export type { IAccountHistoryServiceDependencies } from './services/account-history.service.js';
+export type { IAccountHistoryProvider, IAccountHistoryPageResult, IAccountHistoryFetchOptions } from './providers/IAccountHistoryProvider.js';
+export { TronGridAccountHistoryProvider } from './providers/trongrid-account-history.provider.js';

--- a/src/backend/modules/account-history/lib/clickhouse-datetime.ts
+++ b/src/backend/modules/account-history/lib/clickhouse-datetime.ts
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview ClickHouse `DateTime64(3, 'UTC')` (de)serialization helpers.
+ *
+ * The `@clickhouse/client` JSONEachRow path does not reliably accept a JS `Date`
+ * for a `DateTime64` column — an ISO string with `T`/`Z` can be rejected or
+ * misparsed. ClickHouse's native `YYYY-MM-DD HH:MM:SS.sss` form is unambiguous,
+ * so account-history writes timestamps in that form and reads them back through
+ * the inverse. This mirrors the proven private helpers in the traffic module;
+ * it is duplicated here rather than imported because those are file-private to
+ * traffic and exporting them would couple two modules through an implementation
+ * detail.
+ */
+
+/**
+ * Left-pad a number to a fixed width so each date component has a stable length.
+ *
+ * @param value - The numeric component to pad.
+ * @param width - Target string width.
+ * @returns Zero-padded string of at least `width` characters.
+ */
+function pad(value: number, width: number): string {
+    return String(value).padStart(width, '0');
+}
+
+/**
+ * Render a `Date` as ClickHouse's native millisecond UTC datetime literal.
+ *
+ * Used for every timestamp written to the `account_transactions` table and for
+ * binding time-range query parameters parsed with `parseDateTimeBestEffort`.
+ *
+ * @param date - The instant to format (interpreted in UTC).
+ * @returns A `YYYY-MM-DD HH:MM:SS.sss` string.
+ */
+export function formatClickHouseDateTime64Utc(date: Date): string {
+    return (
+        `${pad(date.getUTCFullYear(), 4)}-${pad(date.getUTCMonth() + 1, 2)}-${pad(date.getUTCDate(), 2)} ` +
+        `${pad(date.getUTCHours(), 2)}:${pad(date.getUTCMinutes(), 2)}:${pad(date.getUTCSeconds(), 2)}.${pad(date.getUTCMilliseconds(), 3)}`
+    );
+}
+
+/**
+ * Inverse of {@link formatClickHouseDateTime64Utc}.
+ *
+ * Falls back to `new Date(value)` for any unrecognized form so a future
+ * ClickHouse driver upgrade that normalizes timestamps to ISO does not break
+ * reads silently.
+ *
+ * @param value - A ClickHouse datetime string from a query result.
+ * @returns The parsed `Date`.
+ */
+export function parseClickHouseDateTime64Utc(value: string): Date {
+    const match = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z?$/.exec(value);
+    if (!match) {
+        return new Date(value);
+    }
+    const [, year, month, day, hour, minute, second, milliseconds = '0'] = match;
+    return new Date(Date.UTC(
+        Number(year),
+        Number(month) - 1,
+        Number(day),
+        Number(hour),
+        Number(minute),
+        Number(second),
+        Number(milliseconds.padEnd(3, '0'))
+    ));
+}

--- a/src/backend/modules/account-history/migrations/001_create_account_transactions_table.ts
+++ b/src/backend/modules/account-history/migrations/001_create_account_transactions_table.ts
@@ -1,13 +1,23 @@
 /**
  * @fileoverview Migration: create the ClickHouse `account_transactions` table.
  *
- * Account backfills append a row per (tracked account, transaction). The table
- * is a `ReplacingMergeTree` keyed by `(account, timestamp, tx_id)` so the
- * inevitable overlaps from fingerprint paging and tick retries collapse to one
- * row instead of duplicating — idempotency for free. It is ordered for the
- * dominant read (one account's history newest-first) and partitioned by month
- * so range scans touch few partitions. No TTL: account history is the product,
- * not ephemeral analytics, so rows are retained until an operator drops them.
+ * Account backfills append a row per (tracked account, transaction, source). The
+ * table is a `ReplacingMergeTree` keyed by
+ * `(account, timestamp, tx_id, source, to_address)` so the inevitable overlaps
+ * from fingerprint paging and tick retries collapse to one row instead of
+ * duplicating — idempotency for free. `to_address` is in the key so a batch TRC20
+ * transaction (multiple Transfer events sharing one tx_id, to different
+ * recipients) keeps a distinct row per recipient instead of collapsing. `source`
+ * (`'tx'` for the
+ * native/TRC10/contract endpoint, `'trc20'` for the token-transfer endpoint) is in
+ * the key because an outbound TRC20 transfer surfaces in *both* endpoints with
+ * different shapes for the same tx_id; keeping them as distinct rows is lossless
+ * (the native call and the decoded transfer-with-amount are different views) and
+ * deterministic, where a shared key would nondeterministically clobber one shape.
+ * It is ordered for the dominant read (one account's history newest-first) and
+ * partitioned by month so range scans touch few partitions. No TTL: account
+ * history is the product, not ephemeral analytics, so rows are retained until an
+ * operator drops them.
  */
 
 import type { IMigration, IMigrationContext } from '@/types';
@@ -38,6 +48,7 @@ export const migration: IMigration = {
             CREATE TABLE IF NOT EXISTS account_transactions (
                 account String,
                 tx_id String,
+                source LowCardinality(String),
                 block_number UInt64,
                 timestamp DateTime64(3, 'UTC'),
 
@@ -56,13 +67,18 @@ export const migration: IMigration = {
 
                 contract_address Nullable(String),
                 contract_method Nullable(String),
+
+                token_amount Nullable(String),
+                token_symbol LowCardinality(Nullable(String)),
+                token_decimals Nullable(UInt8),
+
                 memo Nullable(String),
 
                 ingested_at DateTime64(3, 'UTC')
             )
             ENGINE = ReplacingMergeTree(ingested_at)
             PARTITION BY toYYYYMM(timestamp)
-            ORDER BY (account, timestamp, tx_id)
+            ORDER BY (account, timestamp, tx_id, source, to_address)
         `);
 
         console.log('[Migration account-history:001] Created ClickHouse account_transactions table');

--- a/src/backend/modules/account-history/migrations/001_create_account_transactions_table.ts
+++ b/src/backend/modules/account-history/migrations/001_create_account_transactions_table.ts
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Migration: create the ClickHouse `account_transactions` table.
+ *
+ * Account backfills append a row per (tracked account, transaction). The table
+ * is a `ReplacingMergeTree` keyed by `(account, timestamp, tx_id)` so the
+ * inevitable overlaps from fingerprint paging and tick retries collapse to one
+ * row instead of duplicating — idempotency for free. It is ordered for the
+ * dominant read (one account's history newest-first) and partitioned by month
+ * so range scans touch few partitions. No TTL: account history is the product,
+ * not ephemeral analytics, so rows are retained until an operator drops them.
+ */
+
+import type { IMigration, IMigrationContext } from '@/types';
+
+export const migration: IMigration = {
+    id: '001_create_account_transactions_table',
+    description:
+        'Create the ClickHouse account_transactions ReplacingMergeTree table that stores ' +
+        'the full per-account transaction history ingested by the account-history module. ' +
+        'Keyed (account, timestamp, tx_id) for idempotent re-ingest and ordered for ' +
+        'per-account newest-first reads; partitioned by month, no TTL.',
+    target: 'clickhouse',
+    dependencies: [],
+
+    /**
+     * Create the table when ClickHouse is configured; no-op otherwise.
+     *
+     * @param context - Migration context; `clickhouse` is undefined when the
+     *   deployment has no ClickHouse, in which case account-history is inert.
+     */
+    async up(context: IMigrationContext): Promise<void> {
+        if (!context.clickhouse) {
+            console.log('[Migration account-history:001] ClickHouse not configured — skipping account_transactions table creation');
+            return;
+        }
+
+        await context.clickhouse.exec(`
+            CREATE TABLE IF NOT EXISTS account_transactions (
+                account String,
+                tx_id String,
+                block_number UInt64,
+                timestamp DateTime64(3, 'UTC'),
+
+                type LowCardinality(String),
+                status LowCardinality(String),
+
+                from_address String,
+                to_address String,
+
+                amount_sun Nullable(Int64),
+                fee_sun Nullable(Int64),
+                energy_consumed Nullable(Int64),
+                energy_fee_sun Nullable(Int64),
+                bandwidth_consumed Nullable(Int64),
+                bandwidth_fee_sun Nullable(Int64),
+
+                contract_address Nullable(String),
+                contract_method Nullable(String),
+                memo Nullable(String),
+
+                ingested_at DateTime64(3, 'UTC')
+            )
+            ENGINE = ReplacingMergeTree(ingested_at)
+            PARTITION BY toYYYYMM(timestamp)
+            ORDER BY (account, timestamp, tx_id)
+        `);
+
+        console.log('[Migration account-history:001] Created ClickHouse account_transactions table');
+    }
+};

--- a/src/backend/modules/account-history/providers/IAccountHistoryProvider.ts
+++ b/src/backend/modules/account-history/providers/IAccountHistoryProvider.ts
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview The provider seam that decouples ingestion from its data source.
+ *
+ * The service depends on this interface, never on TronGrid directly, so swapping
+ * to an archive node or a paid full-history source later is a provider change,
+ * not a service rewrite. TronGrid's fingerprint paging cannot reach the deepest
+ * history of million-transaction accounts, so treat the v1 TronGrid provider as
+ * a starting point the seam is designed to outgrow.
+ */
+
+import type { IBlockTransaction } from '@/types';
+
+/**
+ * One page of an account's history plus the cursor to continue.
+ *
+ * `transactions` are source-independent projections. `nextFingerprint` is the
+ * opaque cursor for the following page; its absence means the provider has no
+ * more pages to give (end of reachable history).
+ */
+export interface IAccountHistoryPageResult {
+    /** The page's transactions, normalized to the domain contract. */
+    transactions: IBlockTransaction[];
+    /** Opaque cursor for the next page; undefined when paging is exhausted. */
+    nextFingerprint?: string;
+}
+
+/**
+ * Options for fetching a single page of an account's history.
+ */
+export interface IAccountHistoryFetchOptions {
+    /** Maximum transactions to return in this page (provider clamps to its own ceiling). */
+    limit: number;
+    /** Opaque cursor from the previous page; omit to start from the newest. */
+    fingerprint?: string;
+}
+
+/**
+ * A source of an account's full transaction history, walked one page at a time.
+ */
+export interface IAccountHistoryProvider {
+    /** Stable identifier for logs and audit (e.g. `'trongrid'`). */
+    readonly id: string;
+
+    /**
+     * Fetch one page of every transaction type the account participated in.
+     *
+     * @param address - Base58 account address to read.
+     * @param options - Page size and continuation cursor.
+     * @returns The page plus the cursor for the next call.
+     */
+    fetchPage(address: string, options: IAccountHistoryFetchOptions): Promise<IAccountHistoryPageResult>;
+}

--- a/src/backend/modules/account-history/providers/IAccountHistoryProvider.ts
+++ b/src/backend/modules/account-history/providers/IAccountHistoryProvider.ts
@@ -9,6 +9,7 @@
  */
 
 import type { IBlockTransaction } from '@/types';
+import type { AccountTxSource } from '../database/index.js';
 
 /**
  * One page of an account's history plus the cursor to continue.
@@ -28,6 +29,8 @@ export interface IAccountHistoryPageResult {
  * Options for fetching a single page of an account's history.
  */
 export interface IAccountHistoryFetchOptions {
+    /** Which endpoint to read: `'tx'` (native/TRC10/contract) or `'trc20'` (token transfers). */
+    source: AccountTxSource;
     /** Maximum transactions to return in this page (provider clamps to its own ceiling). */
     limit: number;
     /** Opaque cursor from the previous page; omit to start from the newest. */

--- a/src/backend/modules/account-history/providers/trongrid-account-history.provider.ts
+++ b/src/backend/modules/account-history/providers/trongrid-account-history.provider.ts
@@ -1,0 +1,151 @@
+/**
+ * @fileoverview TronGrid implementation of the account-history provider seam.
+ *
+ * Walks an account's history through TronGrid's `/v1/accounts/{addr}/transactions`
+ * endpoint, which returns *every* transaction type — native TRX, TRC10, staking,
+ * delegation, and contract calls (TRC20 transfers surface as TriggerSmartContract).
+ * One endpoint therefore covers "all transaction types"; the TRC20-specific
+ * endpoint is intentionally not used because it only adds decoded token amounts,
+ * which `IBlockTransaction` does not model.
+ *
+ * Calls route through the shared `TronGridClient` singleton so this backfill
+ * inherits the global rate limiter and rotating keys — sharing the TronGrid
+ * budget with live block sync rather than competing with it. Each raw item is
+ * normalized to `IBlockTransaction` via the blockchain module's pure parsers, so
+ * the account-history and block-sync pipelines interpret a contract identically.
+ */
+
+import type { IBlockTransaction } from '@/types';
+import { TronGridClient } from '../../blockchain/tron-grid.client.js';
+import {
+    normalizeContractType,
+    resolveOwnerAddress,
+    resolveRecipient,
+    resolveAmounts,
+    describeContract
+} from '../../blockchain/transaction-parse.js';
+import type { IAccountTransactionRow, ITronGridAccountTx } from '../database/index.js';
+import type { IAccountHistoryFetchOptions, IAccountHistoryPageResult, IAccountHistoryProvider } from './IAccountHistoryProvider.js';
+
+/** TronGrid's hard ceiling on page size for the account-transactions endpoint. */
+const MAX_PAGE_SIZE = 200;
+
+/**
+ * Reads account history from TronGrid behind the provider seam.
+ */
+export class TronGridAccountHistoryProvider implements IAccountHistoryProvider {
+    /** Stable provider id for audit/logs. */
+    readonly id = 'trongrid';
+
+    /**
+     * Fetch one page of all-type transactions for an account and normalize them.
+     *
+     * @param address - Base58 account address.
+     * @param options - Page size and continuation fingerprint.
+     * @returns Normalized transactions plus the next-page cursor.
+     */
+    async fetchPage(address: string, options: IAccountHistoryFetchOptions): Promise<IAccountHistoryPageResult> {
+        const params: Record<string, string | number | boolean> = {
+            only_confirmed: true,
+            limit: Math.min(Math.max(1, options.limit), MAX_PAGE_SIZE),
+            order_by: 'block_timestamp,desc'
+        };
+        if (options.fingerprint) {
+            params.fingerprint = options.fingerprint;
+        }
+
+        const response = await TronGridClient.getInstance().getAccountTransactions<{
+            data?: ITronGridAccountTx[];
+            meta?: { fingerprint?: string };
+        }>(address, params);
+
+        const items = response?.data ?? [];
+        const transactions = items.map((item) => TronGridAccountHistoryProvider.toBlockTransaction(item));
+
+        const result: IAccountHistoryPageResult = {
+            transactions,
+            nextFingerprint: response?.meta?.fingerprint
+        };
+        return result;
+    }
+
+    /**
+     * Map one raw TronGrid account-transaction item to the source-independent
+     * domain contract, reusing the blockchain module's parsers so field meaning
+     * never drifts from the sync pipeline.
+     *
+     * @param item - Raw TronGrid transaction envelope.
+     * @returns The normalized transaction.
+     */
+    private static toBlockTransaction(item: ITronGridAccountTx): IBlockTransaction {
+        const contract0 = item.raw_data?.contract?.[0];
+        const rawType = contract0?.type;
+        const value = contract0?.parameter?.value ?? {};
+
+        const normalized = normalizeContractType(rawType);
+        const from = resolveOwnerAddress(value);
+        const to = resolveRecipient(normalized, value, from);
+        const { rawAmountSun } = resolveAmounts(normalized, value);
+
+        const isContractCall = normalized === 'TriggerSmartContract' || normalized === 'CreateSmartContract';
+        const details = isContractCall ? describeContract(normalized, value) : undefined;
+
+        const hasEnergy = item.energy_usage_total !== undefined || item.energy_usage !== undefined || item.energy_fee !== undefined;
+        const hasBandwidth = item.net_usage !== undefined || item.net_fee !== undefined;
+
+        const transaction: IBlockTransaction = {
+            txId: item.txID ?? '',
+            blockNumber: item.blockNumber ?? 0,
+            timestamp: new Date(item.block_timestamp ?? 0),
+            type: rawType ?? 'Unknown',
+            status: item.ret?.[0]?.contractRet ?? 'UNKNOWN',
+            from: { address: from },
+            to: { address: to },
+            amountSun: rawAmountSun > 0 ? rawAmountSun : undefined,
+            feeSun: typeof item.fee === 'number' ? item.fee : undefined,
+            energy: hasEnergy
+                ? { consumed: item.energy_usage_total ?? item.energy_usage ?? 0, feeSun: item.energy_fee ?? 0 }
+                : undefined,
+            bandwidth: hasBandwidth
+                ? { consumed: item.net_usage ?? 0, feeSun: item.net_fee ?? 0 }
+                : undefined,
+            contract: details ? { address: details.address, method: details.method, parameters: details.parameters } : undefined,
+            memo: item.raw_data?.data ?? null
+        };
+        return transaction;
+    }
+}
+
+/**
+ * Project a normalized transaction into a flat ClickHouse row for a given
+ * tracked account. Kept beside the provider because it inverts the same mapping;
+ * the service calls it for every fetched transaction before insert.
+ *
+ * @param account - The tracked account this row is ingested for (dedup key).
+ * @param tx - The normalized transaction.
+ * @param ingestedAt - Formatted ClickHouse datetime used as the ReplacingMergeTree version.
+ * @returns The ClickHouse row.
+ */
+export function toAccountTransactionRow(account: string, tx: IBlockTransaction, timestamp: string, ingestedAt: string): IAccountTransactionRow {
+    const row: IAccountTransactionRow = {
+        account,
+        tx_id: tx.txId,
+        block_number: tx.blockNumber,
+        timestamp,
+        type: tx.type,
+        status: tx.status,
+        from_address: tx.from.address,
+        to_address: tx.to.address,
+        amount_sun: tx.amountSun ?? null,
+        fee_sun: tx.feeSun ?? null,
+        energy_consumed: tx.energy?.consumed ?? null,
+        energy_fee_sun: tx.energy?.feeSun ?? null,
+        bandwidth_consumed: tx.bandwidth?.consumed ?? null,
+        bandwidth_fee_sun: tx.bandwidth?.feeSun ?? null,
+        contract_address: tx.contract?.address ?? null,
+        contract_method: tx.contract?.method ?? null,
+        memo: tx.memo ?? null,
+        ingested_at: ingestedAt
+    };
+    return row;
+}

--- a/src/backend/modules/account-history/providers/trongrid-account-history.provider.ts
+++ b/src/backend/modules/account-history/providers/trongrid-account-history.provider.ts
@@ -1,16 +1,24 @@
 /**
  * @fileoverview TronGrid implementation of the account-history provider seam.
  *
- * Walks an account's history through TronGrid's `/v1/accounts/{addr}/transactions`
- * endpoint, which returns *every* transaction type — native TRX, TRC10, staking,
- * delegation, and contract calls (TRC20 transfers surface as TriggerSmartContract).
- * One endpoint therefore covers "all transaction types"; the TRC20-specific
- * endpoint is intentionally not used because it only adds decoded token amounts,
- * which `IBlockTransaction` does not model.
+ * Walks an account's history through BOTH TronGrid account endpoints, because
+ * neither alone is complete:
+ *   - `/v1/accounts/{addr}/transactions` (`source: 'tx'`) — native TRX, TRC10,
+ *     staking, delegation, and raw contract calls. It indexes by the native
+ *     transaction parties (owner/to), so it includes *outbound* TRC20 transfers
+ *     (the account is the caller) but NOT inbound ones (the recipient is only
+ *     inside the encoded call data, never a native party).
+ *   - `/v1/accounts/{addr}/transactions/trc20` (`source: 'trc20'`) — decoded
+ *     token transfers indexed by token-transfer participant, so it captures the
+ *     inbound TRC20 transfers the native endpoint omits, with the token amount.
+ * The service walks both with separate cursors and marks an account complete only
+ * when both exhaust. TRC20 token amount/symbol/decimals ride in the normalized
+ * transaction's `contract.parameters` (the open decoded-ABI-args domain), so
+ * `IBlockTransaction` itself stays unextended.
  *
  * Calls route through the shared `TronGridClient` singleton so this backfill
  * inherits the global rate limiter and rotating keys — sharing the TronGrid
- * budget with live block sync rather than competing with it. Each raw item is
+ * budget with live block sync rather than competing with it. Native items are
  * normalized to `IBlockTransaction` via the blockchain module's pure parsers, so
  * the account-history and block-sync pipelines interpret a contract identically.
  */
@@ -24,7 +32,7 @@ import {
     resolveAmounts,
     describeContract
 } from '../../blockchain/transaction-parse.js';
-import type { IAccountTransactionRow, ITronGridAccountTx } from '../database/index.js';
+import type { AccountTxSource, IAccountTransactionRow, ITronGridAccountTx, ITronGridTrc20Tx } from '../database/index.js';
 import type { IAccountHistoryFetchOptions, IAccountHistoryPageResult, IAccountHistoryProvider } from './IAccountHistoryProvider.js';
 
 /** TronGrid's hard ceiling on page size for the account-transactions endpoint. */
@@ -38,10 +46,12 @@ export class TronGridAccountHistoryProvider implements IAccountHistoryProvider {
     readonly id = 'trongrid';
 
     /**
-     * Fetch one page of all-type transactions for an account and normalize them.
+     * Fetch one page from the requested endpoint and normalize it. The `source`
+     * selects which TronGrid endpoint to read; each carries its own fingerprint
+     * cursor, tracked separately by the service.
      *
      * @param address - Base58 account address.
-     * @param options - Page size and continuation fingerprint.
+     * @param options - Endpoint source, page size, and continuation fingerprint.
      * @returns Normalized transactions plus the next-page cursor.
      */
     async fetchPage(address: string, options: IAccountHistoryFetchOptions): Promise<IAccountHistoryPageResult> {
@@ -54,19 +64,26 @@ export class TronGridAccountHistoryProvider implements IAccountHistoryProvider {
             params.fingerprint = options.fingerprint;
         }
 
-        const response = await TronGridClient.getInstance().getAccountTransactions<{
+        const client = TronGridClient.getInstance();
+        if (options.source === 'trc20') {
+            const response = await client.getTrc20Transactions<{
+                data?: ITronGridTrc20Tx[];
+                meta?: { fingerprint?: string };
+            }>(address, params);
+            const items = response?.data ?? [];
+            const transactions = items
+                .filter((item) => (item.type ?? 'Transfer') === 'Transfer')
+                .map((item) => TronGridAccountHistoryProvider.toBlockTransactionFromTrc20(item));
+            return { transactions, nextFingerprint: response?.meta?.fingerprint };
+        }
+
+        const response = await client.getAccountTransactions<{
             data?: ITronGridAccountTx[];
             meta?: { fingerprint?: string };
         }>(address, params);
-
         const items = response?.data ?? [];
         const transactions = items.map((item) => TronGridAccountHistoryProvider.toBlockTransaction(item));
-
-        const result: IAccountHistoryPageResult = {
-            transactions,
-            nextFingerprint: response?.meta?.fingerprint
-        };
-        return result;
+        return { transactions, nextFingerprint: response?.meta?.fingerprint };
     }
 
     /**
@@ -110,7 +127,41 @@ export class TronGridAccountHistoryProvider implements IAccountHistoryProvider {
                 ? { consumed: item.net_usage ?? 0, feeSun: item.net_fee ?? 0 }
                 : undefined,
             contract: details ? { address: details.address, method: details.method, parameters: details.parameters } : undefined,
-            memo: item.raw_data?.data ?? null
+            memo: TronGridClient.decodeMemo(item.raw_data?.data)
+        };
+        return transaction;
+    }
+
+    /**
+     * Map one decoded TRC20 transfer to the domain contract. The token contract,
+     * amount, symbol, and decimals ride in `contract.parameters` (the open
+     * decoded-ABI-args domain) so `IBlockTransaction` stays unextended; the
+     * service lifts them into dedicated ClickHouse columns. The trc20 endpoint
+     * returns only confirmed transfers and omits block number and native result,
+     * so status is `SUCCESS` and block number 0.
+     *
+     * @param item - Raw TronGrid TRC20 transfer item.
+     * @returns The normalized transaction.
+     */
+    private static toBlockTransactionFromTrc20(item: ITronGridTrc20Tx): IBlockTransaction {
+        const transaction: IBlockTransaction = {
+            txId: item.transaction_id ?? '',
+            blockNumber: 0,
+            timestamp: new Date(item.block_timestamp ?? 0),
+            type: 'TriggerSmartContract',
+            status: 'SUCCESS',
+            from: { address: item.from ?? 'unknown' },
+            to: { address: item.to ?? 'unknown' },
+            contract: {
+                address: item.token_info?.address ?? 'unknown',
+                method: 'transfer',
+                parameters: {
+                    value: item.value ?? '0',
+                    symbol: item.token_info?.symbol,
+                    decimals: item.token_info?.decimals
+                }
+            },
+            memo: null
         };
         return transaction;
     }
@@ -118,18 +169,29 @@ export class TronGridAccountHistoryProvider implements IAccountHistoryProvider {
 
 /**
  * Project a normalized transaction into a flat ClickHouse row for a given
- * tracked account. Kept beside the provider because it inverts the same mapping;
- * the service calls it for every fetched transaction before insert.
+ * tracked account and source. Kept beside the provider because it inverts the
+ * same mapping; the service calls it for every fetched transaction before insert.
+ * For `trc20` rows the token amount/symbol/decimals are lifted out of
+ * `contract.parameters` (where the trc20 mapper placed them) into dedicated
+ * columns; for `tx` rows the token columns are null.
  *
  * @param account - The tracked account this row is ingested for (dedup key).
  * @param tx - The normalized transaction.
+ * @param source - Which endpoint produced it (`'tx'` or `'trc20'`); part of the dedup key.
+ * @param timestamp - Formatted ClickHouse datetime for the transaction's block time.
  * @param ingestedAt - Formatted ClickHouse datetime used as the ReplacingMergeTree version.
  * @returns The ClickHouse row.
  */
-export function toAccountTransactionRow(account: string, tx: IBlockTransaction, timestamp: string, ingestedAt: string): IAccountTransactionRow {
+export function toAccountTransactionRow(account: string, tx: IBlockTransaction, source: AccountTxSource, timestamp: string, ingestedAt: string): IAccountTransactionRow {
+    const params = source === 'trc20' ? tx.contract?.parameters : undefined;
+    const tokenAmount = params && params.value != null ? String(params.value) : null;
+    const tokenSymbol = params && typeof params.symbol === 'string' ? params.symbol : null;
+    const tokenDecimals = params && typeof params.decimals === 'number' ? params.decimals : null;
+
     const row: IAccountTransactionRow = {
         account,
         tx_id: tx.txId,
+        source,
         block_number: tx.blockNumber,
         timestamp,
         type: tx.type,
@@ -144,6 +206,9 @@ export function toAccountTransactionRow(account: string, tx: IBlockTransaction, 
         bandwidth_fee_sun: tx.bandwidth?.feeSun ?? null,
         contract_address: tx.contract?.address ?? null,
         contract_method: tx.contract?.method ?? null,
+        token_amount: tokenAmount,
+        token_symbol: tokenSymbol,
+        token_decimals: tokenDecimals,
         memo: tx.memo ?? null,
         ingested_at: ingestedAt
     };

--- a/src/backend/modules/account-history/services/account-history.service.ts
+++ b/src/backend/modules/account-history/services/account-history.service.ts
@@ -1,0 +1,664 @@
+/**
+ * @fileoverview AccountHistoryService — the single authority for account history.
+ *
+ * Every surface (admin controllers, the scheduler tick, registry consumers)
+ * routes through this singleton; the ClickHouse table and the Mongo control
+ * collections are reached only here. It owns the tracked set, the resumable
+ * per-account cursors, the pacing settings, the ingestion loop, and the
+ * ClickHouse reads — and it degrades to a no-op when ClickHouse or a provider
+ * is absent, so an always-on core module never crashes a ClickHouse-less deploy.
+ *
+ * Ingestion is deliberately bounded per tick (pages-per-tick × accounts-per-tick)
+ * and advances the least-recently-touched accounts first, so a million-row
+ * backfill spreads over many ticks without a long-lived process and resumes
+ * exactly where it left off after a restart.
+ */
+
+import type {
+    IAccountHistoryService,
+    IAccountHistorySettings,
+    IAccountHistoryStats,
+    IAccountHistoryAccountStats,
+    IAccountIngestionProgress,
+    IAccountTransactionPage,
+    IAccountTransactionQuery,
+    IAddTrackedAccountInput,
+    ITrackedAccount,
+    IBlockTransaction,
+    IClickHouseService,
+    IDatabaseService,
+    ISystemLogService,
+    IWebSocketService
+} from '@/types';
+import {
+    PROGRESS_COLLECTION,
+    SETTINGS_COLLECTION,
+    SETTINGS_KEY,
+    TRACKED_COLLECTION,
+    TRANSACTIONS_TABLE,
+    type IAccountHistorySettingsDoc,
+    type IAccountProgressDoc,
+    type IAccountTransactionRow,
+    type ITrackedAccountDoc
+} from '../database/index.js';
+import type { IAccountHistoryProvider } from '../providers/IAccountHistoryProvider.js';
+import { toAccountTransactionRow } from '../providers/trongrid-account-history.provider.js';
+import { formatClickHouseDateTime64Utc, parseClickHouseDateTime64Utc } from '../lib/clickhouse-datetime.js';
+
+/** Default pacing applied on first read; gentle enough to share the TronGrid budget. */
+const DEFAULT_SETTINGS: IAccountHistorySettings = {
+    ingestionEnabled: true,
+    pagesPerTick: 5,
+    accountsPerTick: 3
+};
+
+/** Page size requested from the provider; TronGrid's per-call maximum. */
+const PROVIDER_PAGE_LIMIT = 200;
+
+/** Maximum rows a single history read returns, to protect the caller. */
+const MAX_READ_LIMIT = 500;
+
+/** Base58 TRON mainnet address shape: leading `T`, 34 chars total. */
+const TRON_ADDRESS_PATTERN = /^T[1-9A-HJ-NP-Za-km-z]{33}$/;
+
+/** WebSocket event name for live ingestion stats; must have a case in WebSocketService.emit(). */
+const STATS_EVENT = 'account-history:stats';
+
+/**
+ * Dependencies injected once at bootstrap. ClickHouse and the provider are
+ * nullable because a deployment may lack ClickHouse, and the provider seam may
+ * be unconfigured — either way ingestion no-ops rather than throwing.
+ */
+export interface IAccountHistoryServiceDependencies {
+    /** Core database for the control collections. */
+    database: IDatabaseService;
+    /** ClickHouse store for transactions; undefined disables ingestion and reads. */
+    clickhouse: IClickHouseService | undefined;
+    /** History data source behind the provider seam; null disables ingestion. */
+    provider: IAccountHistoryProvider | null;
+    /** Optional emitter for live stats; undefined silently skips broadcasts. */
+    emitter: IWebSocketService | undefined;
+    /** Scoped logger. */
+    logger: ISystemLogService;
+}
+
+/**
+ * Singleton implementation of the published `'account-history'` service.
+ */
+export class AccountHistoryService implements IAccountHistoryService {
+    private static instance: AccountHistoryService | undefined;
+
+    private readonly database: IDatabaseService;
+    private readonly clickhouse: IClickHouseService | undefined;
+    private readonly provider: IAccountHistoryProvider | null;
+    private readonly emitter: IWebSocketService | undefined;
+    private readonly logger: ISystemLogService;
+
+    /** Guards against overlapping ingestion ticks (cron + manual trigger racing). */
+    private ticking = false;
+
+    /**
+     * @param deps - Injected collaborators; stored for the singleton's lifetime.
+     */
+    private constructor(deps: IAccountHistoryServiceDependencies) {
+        this.database = deps.database;
+        this.clickhouse = deps.clickhouse;
+        this.provider = deps.provider;
+        this.emitter = deps.emitter;
+        this.logger = deps.logger;
+    }
+
+    /**
+     * Configure the singleton once at bootstrap. Subsequent calls are ignored so
+     * every caller shares one instance and one set of collaborators.
+     *
+     * @param deps - The injected dependencies.
+     */
+    public static setDependencies(deps: IAccountHistoryServiceDependencies): void {
+        if (!AccountHistoryService.instance) {
+            AccountHistoryService.instance = new AccountHistoryService(deps);
+        }
+    }
+
+    /**
+     * Retrieve the configured singleton.
+     *
+     * @returns The shared instance.
+     * @throws If accessed before {@link setDependencies}.
+     */
+    public static getInstance(): AccountHistoryService {
+        if (!AccountHistoryService.instance) {
+            throw new Error('AccountHistoryService.setDependencies() must be called before getInstance()');
+        }
+        return AccountHistoryService.instance;
+    }
+
+    /**
+     * Reset the singleton. Test-only seam so suites can reconfigure dependencies.
+     */
+    public static resetForTests(): void {
+        AccountHistoryService.instance = undefined;
+    }
+
+    /**
+     * Create the unique indexes the control collections rely on for upsert-by-
+     * address. Called from module `init()`; safe to run repeatedly.
+     */
+    public async ensureIndexes(): Promise<void> {
+        await this.database.createIndex(TRACKED_COLLECTION, { address: 1 }, { unique: true });
+        await this.database.createIndex(PROGRESS_COLLECTION, { address: 1 }, { unique: true });
+        await this.database.createIndex(SETTINGS_COLLECTION, { key: 1 }, { unique: true });
+    }
+
+    /**
+     * Begin tracking an account (idempotent on address). Re-adding updates the
+     * label and ensures a queued progress record exists so the next tick picks
+     * it up.
+     *
+     * @param input - Address and optional label.
+     * @returns The tracked-account record.
+     */
+    public async addTrackedAccount(input: IAddTrackedAccountInput): Promise<ITrackedAccount> {
+        const address = String(input.address ?? '').trim();
+        if (!TRON_ADDRESS_PATTERN.test(address)) {
+            throw new Error('address must be a base58 TRON address (T...)');
+        }
+
+        const now = new Date();
+        const collection = this.database.getCollection<ITrackedAccountDoc>(TRACKED_COLLECTION);
+        await collection.updateOne(
+            { address },
+            {
+                $set: { label: input.label, updatedAt: now },
+                $setOnInsert: { address, paused: false, addedAt: now }
+            },
+            { upsert: true }
+        );
+
+        await this.ensureProgress(address);
+        const doc = await collection.findOne({ address });
+        const tracked = AccountHistoryService.toTrackedAccount(doc!);
+        return tracked;
+    }
+
+    /**
+     * Stop tracking an account and discard its cursor. Stored ClickHouse rows are
+     * retained — this stops future ingestion, it does not purge history.
+     *
+     * @param address - Base58 address to stop tracking.
+     */
+    public async removeTrackedAccount(address: string): Promise<void> {
+        await this.database.getCollection<ITrackedAccountDoc>(TRACKED_COLLECTION).deleteOne({ address });
+        await this.database.getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION).deleteOne({ address });
+    }
+
+    /**
+     * Pause or resume one account without removing it; the cursor is preserved so
+     * a resumed account continues from where it stopped.
+     *
+     * @param address - Base58 address to toggle.
+     * @param paused - True to pause, false to resume.
+     * @returns The updated tracked-account record.
+     */
+    public async setAccountPaused(address: string, paused: boolean): Promise<ITrackedAccount> {
+        const collection = this.database.getCollection<ITrackedAccountDoc>(TRACKED_COLLECTION);
+        const result = await collection.findOneAndUpdate(
+            { address },
+            { $set: { paused, updatedAt: new Date() } },
+            { returnDocument: 'after' }
+        );
+        const doc = (result && 'value' in result ? result.value : result) as ITrackedAccountDoc | null;
+        if (!doc) {
+            throw new Error(`account ${address} is not tracked`);
+        }
+        await this.setProgressStatus(address, paused ? 'paused' : 'queued');
+        const tracked = AccountHistoryService.toTrackedAccount(doc);
+        return tracked;
+    }
+
+    /**
+     * List the tracked set for the admin surface, oldest first.
+     *
+     * @returns All tracked accounts.
+     */
+    public async listTrackedAccounts(): Promise<ITrackedAccount[]> {
+        const docs = await this.database
+            .getCollection<ITrackedAccountDoc>(TRACKED_COLLECTION)
+            .find({})
+            .sort({ addedAt: 1 })
+            .toArray();
+        const accounts = docs.map(AccountHistoryService.toTrackedAccount);
+        return accounts;
+    }
+
+    /**
+     * Read pacing settings, seeding defaults on first access.
+     *
+     * @returns The effective settings.
+     */
+    public async getSettings(): Promise<IAccountHistorySettings> {
+        const doc = await this.database
+            .getCollection<IAccountHistorySettingsDoc>(SETTINGS_COLLECTION)
+            .findOne({ key: SETTINGS_KEY });
+        const settings: IAccountHistorySettings = doc
+            ? { ingestionEnabled: doc.ingestionEnabled, pagesPerTick: doc.pagesPerTick, accountsPerTick: doc.accountsPerTick }
+            : { ...DEFAULT_SETTINGS };
+        return settings;
+    }
+
+    /**
+     * Merge a partial settings update, clamping the numeric dials to sane floors
+     * so an operator cannot stall ingestion with a zero or negative value.
+     *
+     * @param patch - Fields to change.
+     * @returns The settings after the merge.
+     */
+    public async updateSettings(patch: Partial<IAccountHistorySettings>): Promise<IAccountHistorySettings> {
+        const current = await this.getSettings();
+        const next: IAccountHistorySettings = {
+            ingestionEnabled: patch.ingestionEnabled ?? current.ingestionEnabled,
+            pagesPerTick: Math.max(1, Math.floor(patch.pagesPerTick ?? current.pagesPerTick)),
+            accountsPerTick: Math.max(1, Math.floor(patch.accountsPerTick ?? current.accountsPerTick))
+        };
+        await this.database.getCollection<IAccountHistorySettingsDoc>(SETTINGS_COLLECTION).updateOne(
+            { key: SETTINGS_KEY },
+            { $set: { ...next, key: SETTINGS_KEY } },
+            { upsert: true }
+        );
+        return next;
+    }
+
+    /**
+     * Assemble the full stats snapshot powering the admin page and live broadcasts.
+     *
+     * @returns Settings, per-account progress rows, and rollups.
+     */
+    public async getStats(): Promise<IAccountHistoryStats> {
+        const [settings, accounts, progressDocs] = await Promise.all([
+            this.getSettings(),
+            this.listTrackedAccounts(),
+            this.database.getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION).find({}).toArray()
+        ]);
+
+        const progressByAddress = new Map<string, IAccountProgressDoc>();
+        for (const doc of progressDocs) {
+            progressByAddress.set(doc.address, doc);
+        }
+
+        const accountStats: IAccountHistoryAccountStats[] = accounts.map((account) => ({
+            account,
+            progress: AccountHistoryService.toProgress(account.address, progressByAddress.get(account.address))
+        }));
+
+        const stats: IAccountHistoryStats = {
+            settings,
+            accounts: accountStats,
+            totals: {
+                trackedAccounts: accounts.length,
+                rowsIngested: accountStats.reduce((sum, a) => sum + a.progress.rowsIngested, 0),
+                completeAccounts: accountStats.filter((a) => a.progress.status === 'complete').length,
+                failedAccounts: accountStats.filter((a) => a.progress.status === 'failed').length
+            }
+        };
+        return stats;
+    }
+
+    /**
+     * Read a page of an account's stored history from ClickHouse, newest first.
+     * Returns an empty page when ClickHouse is not configured.
+     *
+     * @param query - Address and pagination window.
+     * @returns A page of source-independent transactions and the total count.
+     */
+    public async getTransactions(query: IAccountTransactionQuery): Promise<IAccountTransactionPage> {
+        const address = String(query.address ?? '').trim();
+        if (!TRON_ADDRESS_PATTERN.test(address)) {
+            throw new Error('address must be a base58 TRON address (T...)');
+        }
+        if (!this.clickhouse) {
+            return { transactions: [], total: 0 };
+        }
+
+        const limit = Math.min(Math.max(1, Math.floor(query.limit ?? 50)), MAX_READ_LIMIT);
+        const offset = Math.max(0, Math.floor(query.offset ?? 0));
+
+        const rows = await this.clickhouse.query<IAccountTransactionRow>(
+            `SELECT account, tx_id, block_number, timestamp, type, status, from_address, to_address,
+                    amount_sun, fee_sun, energy_consumed, energy_fee_sun, bandwidth_consumed, bandwidth_fee_sun,
+                    contract_address, contract_method, memo
+             FROM ${TRANSACTIONS_TABLE} FINAL
+             WHERE account = {address:String}
+             ORDER BY timestamp DESC
+             LIMIT {limit:UInt32} OFFSET {offset:UInt32}`,
+            { address, limit, offset }
+        );
+
+        const countRows = await this.clickhouse.query<{ total: string | number }>(
+            `SELECT count(DISTINCT tx_id) AS total FROM ${TRANSACTIONS_TABLE} WHERE account = {address:String}`,
+            { address }
+        );
+
+        const page: IAccountTransactionPage = {
+            transactions: rows.map(AccountHistoryService.rowToBlockTransaction),
+            total: Number(countRows[0]?.total ?? 0)
+        };
+        return page;
+    }
+
+    /**
+     * Advance ingestion by one bounded slice. Picks the least-recently-advanced
+     * unpaused, not-complete accounts (up to `accountsPerTick`), pulls up to
+     * `pagesPerTick` pages each, writes rows, and persists cursors. No-op when
+     * disabled, when ClickHouse or the provider is absent, or when a tick is
+     * already running.
+     */
+    public async runIngestionTick(): Promise<void> {
+        if (this.ticking) {
+            this.logger.debug('Account-history ingestion already running — skipping overlapping tick');
+            return;
+        }
+
+        // The whole tick body — settings read, account selection, and the
+        // broadcast — runs inside one try so a setup failure (not just a
+        // per-account fetch/write, which ingestAccount self-catches) is logged
+        // with account-history context. It is rethrown so the scheduler still
+        // records the run as failed in its execution history.
+        this.ticking = true;
+        try {
+            const settings = await this.getSettings();
+            if (!settings.ingestionEnabled) {
+                this.logger.debug('Account-history ingestion disabled — tick is a no-op');
+                return;
+            }
+            if (!this.clickhouse || !this.provider) {
+                this.logger.info('Account-history ingestion skipped — ClickHouse or provider unavailable');
+                return;
+            }
+
+            const candidates = await this.selectAccountsForTick(settings.accountsPerTick);
+            for (const address of candidates) {
+                await this.ingestAccount(address, settings.pagesPerTick);
+            }
+            await this.broadcastStats();
+        } catch (error) {
+            this.logger.error(
+                { error: error instanceof Error ? error.message : 'Unknown error' },
+                'Account-history ingestion tick failed'
+            );
+            throw error;
+        } finally {
+            this.ticking = false;
+        }
+    }
+
+    /**
+     * Choose which accounts advance this tick: unpaused and not yet complete,
+     * ordered by least-recently-advanced so coverage rotates fairly.
+     *
+     * @param accountsPerTick - Maximum accounts to return.
+     * @returns Base58 addresses to ingest this tick.
+     */
+    private async selectAccountsForTick(accountsPerTick: number): Promise<string[]> {
+        const tracked = await this.database
+            .getCollection<ITrackedAccountDoc>(TRACKED_COLLECTION)
+            .find({ paused: { $ne: true } })
+            .toArray();
+        if (tracked.length === 0) {
+            return [];
+        }
+
+        const progressDocs = await this.database
+            .getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION)
+            .find({ address: { $in: tracked.map((t) => t.address) } })
+            .toArray();
+        const progressByAddress = new Map<string, IAccountProgressDoc>();
+        for (const doc of progressDocs) {
+            progressByAddress.set(doc.address, doc);
+        }
+
+        const eligible = tracked.filter((t) => progressByAddress.get(t.address)?.status !== 'complete');
+        eligible.sort((a, b) => {
+            const aRun = progressByAddress.get(a.address)?.lastRunAt?.getTime() ?? 0;
+            const bRun = progressByAddress.get(b.address)?.lastRunAt?.getTime() ?? 0;
+            return aRun - bRun;
+        });
+
+        const selected = eligible.slice(0, accountsPerTick).map((t) => t.address);
+        return selected;
+    }
+
+    /**
+     * Walk up to `pages` pages for one account, writing each page to ClickHouse
+     * and advancing the cursor only after a clean write. On error the cursor is
+     * left untouched so the next tick retries the same page.
+     *
+     * @param address - Base58 account to ingest.
+     * @param pages - Maximum pages to pull this tick.
+     */
+    private async ingestAccount(address: string, pages: number): Promise<void> {
+        const progress = await this.ensureProgress(address);
+        await this.patchProgress(address, { status: 'running', lastRunAt: new Date(), lastError: undefined });
+
+        let fingerprint = progress.cursorFingerprint;
+        let rowsThisTick = 0;
+        let oldest = progress.oldestTimestampReached;
+        let newest = progress.newestTimestampSeen;
+
+        try {
+            for (let page = 0; page < pages; page++) {
+                const result = await this.provider!.fetchPage(address, { limit: PROVIDER_PAGE_LIMIT, fingerprint });
+                if (result.transactions.length > 0) {
+                    await this.writeTransactions(address, result.transactions);
+                    rowsThisTick += result.transactions.length;
+                    for (const tx of result.transactions) {
+                        if (!newest || tx.timestamp > newest) {
+                            newest = tx.timestamp;
+                        }
+                        if (!oldest || tx.timestamp < oldest) {
+                            oldest = tx.timestamp;
+                        }
+                    }
+                }
+
+                fingerprint = result.nextFingerprint;
+                if (!fingerprint) {
+                    await this.patchProgress(address, {
+                        status: 'complete',
+                        cursorFingerprint: undefined,
+                        rowsIngested: progress.rowsIngested + rowsThisTick,
+                        oldestTimestampReached: oldest,
+                        newestTimestampSeen: newest
+                    });
+                    this.logger.info({ address, rowsThisTick }, 'Account-history backfill complete for account');
+                    return;
+                }
+            }
+
+            await this.patchProgress(address, {
+                status: 'queued',
+                cursorFingerprint: fingerprint,
+                rowsIngested: progress.rowsIngested + rowsThisTick,
+                oldestTimestampReached: oldest,
+                newestTimestampSeen: newest
+            });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Unknown error';
+            this.logger.error({ address, error: message }, 'Account-history ingestion failed for account');
+            await this.patchProgress(address, {
+                status: 'failed',
+                lastError: message,
+                rowsIngested: progress.rowsIngested + rowsThisTick,
+                oldestTimestampReached: oldest,
+                newestTimestampSeen: newest
+            });
+        }
+    }
+
+    /**
+     * Project and insert a page of transactions into ClickHouse. ReplacingMergeTree
+     * makes the insert idempotent on `(account, timestamp, tx_id)`.
+     *
+     * @param address - The tracked account these rows belong to.
+     * @param transactions - Normalized transactions to store.
+     */
+    private async writeTransactions(address: string, transactions: IBlockTransaction[]): Promise<void> {
+        const ingestedAt = formatClickHouseDateTime64Utc(new Date());
+        const rows = transactions.map((tx) =>
+            toAccountTransactionRow(address, tx, formatClickHouseDateTime64Utc(tx.timestamp), ingestedAt)
+        );
+        await this.clickhouse!.insert<IAccountTransactionRow>(TRANSACTIONS_TABLE, rows);
+    }
+
+    /**
+     * Ensure a progress document exists for an account, creating a queued one if
+     * absent, and return the current state.
+     *
+     * @param address - Base58 address.
+     * @returns The existing or newly created progress document.
+     */
+    private async ensureProgress(address: string): Promise<IAccountProgressDoc> {
+        const collection = this.database.getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION);
+        const existing = await collection.findOne({ address });
+        if (existing) {
+            return existing;
+        }
+        const fresh: IAccountProgressDoc = { address, status: 'queued', rowsIngested: 0 };
+        await collection.updateOne({ address }, { $setOnInsert: fresh }, { upsert: true });
+        return fresh;
+    }
+
+    /**
+     * Apply a partial update to a progress document.
+     *
+     * @param address - Base58 address.
+     * @param patch - Fields to set; `undefined` values are unset.
+     */
+    private async patchProgress(address: string, patch: Partial<IAccountProgressDoc>): Promise<void> {
+        const set: Record<string, unknown> = {};
+        const unset: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(patch)) {
+            if (value === undefined) {
+                unset[key] = '';
+            } else {
+                set[key] = value;
+            }
+        }
+        const update: Record<string, unknown> = {};
+        if (Object.keys(set).length > 0) {
+            update.$set = set;
+        }
+        if (Object.keys(unset).length > 0) {
+            update.$unset = unset;
+        }
+        await this.database.getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION).updateOne({ address }, update, { upsert: true });
+    }
+
+    /**
+     * Force a progress status, used when pausing/resuming an account.
+     *
+     * @param address - Base58 address.
+     * @param status - The status to set.
+     */
+    private async setProgressStatus(address: string, status: IAccountProgressDoc['status']): Promise<void> {
+        await this.ensureProgress(address);
+        await this.patchProgress(address, { status });
+    }
+
+    /**
+     * Broadcast the current stats snapshot to admin listeners. Silently skipped
+     * when no emitter is wired.
+     */
+    private async broadcastStats(): Promise<void> {
+        if (!this.emitter) {
+            return;
+        }
+        const stats = await this.getStats();
+        this.emitter.emit({ event: STATS_EVENT, payload: stats });
+    }
+
+    /**
+     * Convert a stored tracked-account document to the public shape.
+     *
+     * @param doc - The Mongo document.
+     * @returns The public tracked-account record.
+     */
+    private static toTrackedAccount(doc: ITrackedAccountDoc): ITrackedAccount {
+        return {
+            address: doc.address,
+            label: doc.label,
+            paused: Boolean(doc.paused),
+            addedAt: doc.addedAt,
+            updatedAt: doc.updatedAt
+        };
+    }
+
+    /**
+     * Convert a stored progress document (or its absence) to the public shape,
+     * yielding a zeroed `queued` record when ingestion never ran for the account.
+     *
+     * @param address - Base58 address the progress belongs to.
+     * @param doc - The Mongo document, or undefined.
+     * @returns The public progress record.
+     */
+    private static toProgress(address: string, doc: IAccountProgressDoc | undefined): IAccountIngestionProgress {
+        if (!doc) {
+            return { address, status: 'queued', rowsIngested: 0 };
+        }
+        return {
+            address,
+            status: doc.status,
+            cursorFingerprint: doc.cursorFingerprint,
+            oldestTimestampReached: doc.oldestTimestampReached,
+            newestTimestampSeen: doc.newestTimestampSeen,
+            rowsIngested: doc.rowsIngested,
+            lastRunAt: doc.lastRunAt,
+            lastError: doc.lastError
+        };
+    }
+
+    /**
+     * Convert a ClickHouse row back to the source-independent domain contract,
+     * coercing the driver's string-encoded Int64 columns to numbers and parsing
+     * the native datetime literal.
+     *
+     * @param row - A ClickHouse result row.
+     * @returns The transaction projection.
+     */
+    private static rowToBlockTransaction(row: IAccountTransactionRow): IBlockTransaction {
+        const num = (value: unknown): number | undefined => {
+            if (value === null || value === undefined) {
+                return undefined;
+            }
+            const parsed = Number(value);
+            return Number.isFinite(parsed) ? parsed : undefined;
+        };
+
+        const energyConsumed = num(row.energy_consumed);
+        const energyFee = num(row.energy_fee_sun);
+        const bandwidthConsumed = num(row.bandwidth_consumed);
+        const bandwidthFee = num(row.bandwidth_fee_sun);
+
+        const transaction: IBlockTransaction = {
+            txId: String(row.tx_id),
+            blockNumber: Number(row.block_number ?? 0),
+            timestamp: parseClickHouseDateTime64Utc(String(row.timestamp)),
+            type: String(row.type),
+            status: String(row.status),
+            from: { address: String(row.from_address) },
+            to: { address: String(row.to_address) },
+            amountSun: num(row.amount_sun),
+            feeSun: num(row.fee_sun),
+            energy: energyConsumed !== undefined || energyFee !== undefined
+                ? { consumed: energyConsumed ?? 0, feeSun: energyFee ?? 0 }
+                : undefined,
+            bandwidth: bandwidthConsumed !== undefined || bandwidthFee !== undefined
+                ? { consumed: bandwidthConsumed ?? 0, feeSun: bandwidthFee ?? 0 }
+                : undefined,
+            contract: row.contract_address
+                ? { address: String(row.contract_address), method: row.contract_method ? String(row.contract_method) : undefined }
+                : undefined,
+            memo: row.memo === null || row.memo === undefined ? null : String(row.memo)
+        };
+        return transaction;
+    }
+}

--- a/src/backend/modules/account-history/services/account-history.service.ts
+++ b/src/backend/modules/account-history/services/account-history.service.ts
@@ -36,6 +36,7 @@ import {
     SETTINGS_KEY,
     TRACKED_COLLECTION,
     TRANSACTIONS_TABLE,
+    type AccountTxSource,
     type IAccountHistorySettingsDoc,
     type IAccountProgressDoc,
     type IAccountTransactionRow,
@@ -63,6 +64,28 @@ const TRON_ADDRESS_PATTERN = /^T[1-9A-HJ-NP-Za-km-z]{33}$/;
 
 /** WebSocket event name for live ingestion stats; must have a case in WebSocketService.emit(). */
 const STATS_EVENT = 'account-history:stats';
+
+/**
+ * Mutable per-tick state threaded through the two endpoint walks for one account,
+ * so both `'tx'` and `'trc20'` advance into a single combined progress record
+ * (two cursors, two completion flags, shared counts and timestamp bounds).
+ */
+interface IIngestWalkState {
+    /** Cursor for the native `/transactions` endpoint. */
+    nativeCursor?: string;
+    /** Cursor for the `/transactions/trc20` endpoint. */
+    trc20Cursor?: string;
+    /** Whether the native endpoint has reached the end of history. */
+    nativeComplete: boolean;
+    /** Whether the trc20 endpoint has reached the end of history. */
+    trc20Complete: boolean;
+    /** Running total rows written across both endpoints. */
+    rowsIngested: number;
+    /** Oldest block time reached so far. */
+    oldest?: Date;
+    /** Newest block time seen so far. */
+    newest?: Date;
+}
 
 /**
  * Dependencies injected once at bootstrap. ClickHouse and the provider are
@@ -322,19 +345,30 @@ export class AccountHistoryService implements IAccountHistoryService {
         const limit = Math.min(Math.max(1, Math.floor(query.limit ?? 50)), MAX_READ_LIMIT);
         const offset = Math.max(0, Math.floor(query.offset ?? 0));
 
+        // An outbound TRC20 transfer lands as both a native call row ('tx') and a
+        // decoded transfer row ('trc20') with the same tx_id; the trc20 row is the
+        // richer view, so suppress the native twin on read. The filter drops only a
+        // 'tx' row whose tx_id also has a 'trc20' row — native-only transactions and
+        // every (batch-distinct) trc20 row are preserved.
+        const dedupeFilter =
+            `NOT (source = 'tx' AND tx_id IN (
+                 SELECT tx_id FROM ${TRANSACTIONS_TABLE} WHERE account = {address:String} AND source = 'trc20'
+             ))`;
+
         const rows = await this.clickhouse.query<IAccountTransactionRow>(
-            `SELECT account, tx_id, block_number, timestamp, type, status, from_address, to_address,
+            `SELECT account, tx_id, source, block_number, timestamp, type, status, from_address, to_address,
                     amount_sun, fee_sun, energy_consumed, energy_fee_sun, bandwidth_consumed, bandwidth_fee_sun,
-                    contract_address, contract_method, memo
+                    contract_address, contract_method, token_amount, token_symbol, token_decimals, memo
              FROM ${TRANSACTIONS_TABLE} FINAL
-             WHERE account = {address:String}
+             WHERE account = {address:String} AND ${dedupeFilter}
              ORDER BY timestamp DESC
              LIMIT {limit:UInt32} OFFSET {offset:UInt32}`,
             { address, limit, offset }
         );
 
         const countRows = await this.clickhouse.query<{ total: string | number }>(
-            `SELECT count(DISTINCT tx_id) AS total FROM ${TRANSACTIONS_TABLE} WHERE account = {address:String}`,
+            `SELECT count() AS total FROM ${TRANSACTIONS_TABLE} FINAL
+             WHERE account = {address:String} AND ${dedupeFilter}`,
             { address }
         );
 
@@ -428,85 +462,141 @@ export class AccountHistoryService implements IAccountHistoryService {
     }
 
     /**
-     * Walk up to `pages` pages for one account, writing each page to ClickHouse
-     * and advancing the cursor only after a clean write. On error the cursor is
-     * left untouched so the next tick retries the same page.
+     * Advance one account this tick by walking BOTH TronGrid endpoints — the
+     * general `/transactions` (`'tx'`) and `/transactions/trc20` (`'trc20'`) —
+     * each up to `pages` pages with its own cursor, and marking the account
+     * `complete` only once both endpoints are exhausted. Walking both is required
+     * for full coverage: the native endpoint omits *inbound* TRC20 transfers
+     * (the account is only the decoded recipient, not a native party), which the
+     * trc20 endpoint supplies. On error each cursor is persisted at its last
+     * cleanly-written page so the next tick resumes without re-counting or
+     * re-fetching what already landed.
      *
      * @param address - Base58 account to ingest.
-     * @param pages - Maximum pages to pull this tick.
+     * @param pages - Maximum pages to pull per endpoint this tick.
      */
     private async ingestAccount(address: string, pages: number): Promise<void> {
         const progress = await this.ensureProgress(address);
         await this.patchProgress(address, { status: 'running', lastRunAt: new Date(), lastError: undefined });
 
-        let fingerprint = progress.cursorFingerprint;
-        let rowsThisTick = 0;
-        let oldest = progress.oldestTimestampReached;
-        let newest = progress.newestTimestampSeen;
+        const state: IIngestWalkState = {
+            nativeCursor: progress.cursorFingerprint,
+            trc20Cursor: progress.trc20CursorFingerprint,
+            nativeComplete: progress.nativeComplete ?? false,
+            trc20Complete: progress.trc20Complete ?? false,
+            rowsIngested: progress.rowsIngested,
+            oldest: progress.oldestTimestampReached,
+            newest: progress.newestTimestampSeen
+        };
 
         try {
-            for (let page = 0; page < pages; page++) {
-                const result = await this.provider!.fetchPage(address, { limit: PROVIDER_PAGE_LIMIT, fingerprint });
-                if (result.transactions.length > 0) {
-                    await this.writeTransactions(address, result.transactions);
-                    rowsThisTick += result.transactions.length;
-                    for (const tx of result.transactions) {
-                        if (!newest || tx.timestamp > newest) {
-                            newest = tx.timestamp;
-                        }
-                        if (!oldest || tx.timestamp < oldest) {
-                            oldest = tx.timestamp;
-                        }
-                    }
-                }
-
-                fingerprint = result.nextFingerprint;
-                if (!fingerprint) {
-                    await this.patchProgress(address, {
-                        status: 'complete',
-                        cursorFingerprint: undefined,
-                        rowsIngested: progress.rowsIngested + rowsThisTick,
-                        oldestTimestampReached: oldest,
-                        newestTimestampSeen: newest
-                    });
-                    this.logger.info({ address, rowsThisTick }, 'Account-history backfill complete for account');
-                    return;
-                }
+            if (!state.nativeComplete) {
+                await this.walkSource(address, 'tx', pages, state);
+            }
+            if (!state.trc20Complete) {
+                await this.walkSource(address, 'trc20', pages, state);
             }
 
+            const done = state.nativeComplete && state.trc20Complete;
             await this.patchProgress(address, {
-                status: 'queued',
-                cursorFingerprint: fingerprint,
-                rowsIngested: progress.rowsIngested + rowsThisTick,
-                oldestTimestampReached: oldest,
-                newestTimestampSeen: newest
+                status: done ? 'complete' : 'queued',
+                cursorFingerprint: state.nativeComplete ? undefined : state.nativeCursor,
+                trc20CursorFingerprint: state.trc20Complete ? undefined : state.trc20Cursor,
+                nativeComplete: state.nativeComplete,
+                trc20Complete: state.trc20Complete,
+                rowsIngested: state.rowsIngested,
+                oldestTimestampReached: state.oldest,
+                newestTimestampSeen: state.newest
             });
+            if (done) {
+                this.logger.info({ address, rowsIngested: state.rowsIngested }, 'Account-history backfill complete for account (both endpoints exhausted)');
+            }
         } catch (error) {
             const message = error instanceof Error ? error.message : 'Unknown error';
             this.logger.error({ address, error: message }, 'Account-history ingestion failed for account');
             await this.patchProgress(address, {
                 status: 'failed',
                 lastError: message,
-                rowsIngested: progress.rowsIngested + rowsThisTick,
-                oldestTimestampReached: oldest,
-                newestTimestampSeen: newest
+                cursorFingerprint: state.nativeCursor,
+                trc20CursorFingerprint: state.trc20Cursor,
+                nativeComplete: state.nativeComplete,
+                trc20Complete: state.trc20Complete,
+                rowsIngested: state.rowsIngested,
+                oldestTimestampReached: state.oldest,
+                newestTimestampSeen: state.newest
             });
         }
     }
 
     /**
-     * Project and insert a page of transactions into ClickHouse. ReplacingMergeTree
-     * makes the insert idempotent on `(account, timestamp, tx_id)`.
+     * Walk one endpoint's pages, writing each page to ClickHouse and advancing
+     * that endpoint's cursor in `state` after every clean write. Mutates `state`
+     * in place (cursor, completion flag, counts, timestamp bounds) so the caller
+     * can persist a single combined progress record. A throw propagates to the
+     * caller's catch with `state` reflecting everything written so far.
+     *
+     * @param address - Base58 account being ingested.
+     * @param source - Which endpoint to walk (`'tx'` or `'trc20'`).
+     * @param pages - Maximum pages to pull this tick.
+     * @param state - Mutable per-tick walk state, updated in place.
+     */
+    private async walkSource(address: string, source: AccountTxSource, pages: number, state: IIngestWalkState): Promise<void> {
+        let fingerprint = source === 'tx' ? state.nativeCursor : state.trc20Cursor;
+
+        for (let page = 0; page < pages; page++) {
+            const result = await this.provider!.fetchPage(address, { source, limit: PROVIDER_PAGE_LIMIT, fingerprint });
+            if (result.transactions.length > 0) {
+                await this.writeTransactions(address, source, result.transactions);
+                state.rowsIngested += result.transactions.length;
+                for (const tx of result.transactions) {
+                    if (!state.newest || tx.timestamp > state.newest) {
+                        state.newest = tx.timestamp;
+                    }
+                    if (!state.oldest || tx.timestamp < state.oldest) {
+                        state.oldest = tx.timestamp;
+                    }
+                }
+            }
+
+            fingerprint = result.nextFingerprint;
+            if (source === 'tx') {
+                state.nativeCursor = fingerprint;
+            } else {
+                state.trc20Cursor = fingerprint;
+            }
+
+            if (!fingerprint) {
+                if (source === 'tx') {
+                    state.nativeComplete = true;
+                } else {
+                    state.trc20Complete = true;
+                }
+                return;
+            }
+        }
+    }
+
+    /**
+     * Project and insert a page of transactions from one endpoint into ClickHouse.
+     * ReplacingMergeTree makes the insert idempotent on the full sort key
+     * `(account, timestamp, tx_id, source, to_address)`.
      *
      * @param address - The tracked account these rows belong to.
+     * @param source - Which endpoint produced them (part of the dedup key).
      * @param transactions - Normalized transactions to store.
      */
-    private async writeTransactions(address: string, transactions: IBlockTransaction[]): Promise<void> {
+    private async writeTransactions(address: string, source: AccountTxSource, transactions: IBlockTransaction[]): Promise<void> {
         const ingestedAt = formatClickHouseDateTime64Utc(new Date());
         const rows = transactions.map((tx) =>
-            toAccountTransactionRow(address, tx, formatClickHouseDateTime64Utc(tx.timestamp), ingestedAt)
+            toAccountTransactionRow(address, tx, source, formatClickHouseDateTime64Utc(tx.timestamp), ingestedAt)
         );
-        await this.clickhouse!.insert<IAccountTransactionRow>(TRANSACTIONS_TABLE, rows);
+        // Wait for the durable commit before the caller advances the fingerprint
+        // cursor. With the default async_insert / wait_for_async_insert:0, a later
+        // flush failure would surface only in the error poller — after the cursor
+        // has already moved past these rows, permanently skipping the page. A throw
+        // here keeps the cursor on the failed page so the next tick re-fetches and
+        // (idempotently, via ReplacingMergeTree) re-writes it.
+        await this.clickhouse!.insert<IAccountTransactionRow>(TRANSACTIONS_TABLE, rows, { waitForCommit: true });
     }
 
     /**
@@ -518,13 +608,13 @@ export class AccountHistoryService implements IAccountHistoryService {
      */
     private async ensureProgress(address: string): Promise<IAccountProgressDoc> {
         const collection = this.database.getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION);
-        const existing = await collection.findOne({ address });
-        if (existing) {
-            return existing;
-        }
-        const fresh: IAccountProgressDoc = { address, status: 'queued', rowsIngested: 0 };
-        await collection.updateOne({ address }, { $setOnInsert: fresh }, { upsert: true });
-        return fresh;
+        const result = await collection.findOneAndUpdate(
+            { address },
+            { $setOnInsert: { address, status: 'queued', rowsIngested: 0 } },
+            { upsert: true, returnDocument: 'after' }
+        );
+        const doc = (result && 'value' in result ? result.value : result) as IAccountProgressDoc;
+        return doc;
     }
 
     /**
@@ -554,26 +644,41 @@ export class AccountHistoryService implements IAccountHistoryService {
     }
 
     /**
-     * Force a progress status, used when pausing/resuming an account.
+     * Force a progress status, used when pausing/resuming an account. A
+     * `complete` backfill is never reopened: overwriting it to `queued` on
+     * resume would re-include the account in the next tick (which filters on
+     * `status !== 'complete'`) and, with the cursor cleared at completion,
+     * trigger a full re-walk that re-fetches the whole history and double-counts
+     * `rowsIngested`. The admin badge reads `account.paused` for the paused
+     * label, so a paused completed account still displays as paused without
+     * losing its terminal status.
      *
      * @param address - Base58 address.
      * @param status - The status to set.
      */
     private async setProgressStatus(address: string, status: IAccountProgressDoc['status']): Promise<void> {
-        await this.ensureProgress(address);
+        const progress = await this.ensureProgress(address);
+        if (progress.status === 'complete') {
+            return;
+        }
         await this.patchProgress(address, { status });
     }
 
     /**
-     * Broadcast the current stats snapshot to admin listeners. Silently skipped
-     * when no emitter is wired.
+     * Nudge admin listeners to refetch stats after an ingestion tick. Emits only
+     * a timestamp, never the snapshot itself: this event is broadcast to every
+     * connected socket (anonymous visitors included) with no room or auth gate,
+     * while the {@link getStats} snapshot carries tracked-account addresses,
+     * labels, and ingestion errors that the REST surface guards behind
+     * `requireAdmin`. Admin clients refetch over that gated endpoint on this
+     * signal, mirroring the `curation:changed` / `menu:update` nudges. Silently
+     * skipped when no emitter is wired.
      */
     private async broadcastStats(): Promise<void> {
         if (!this.emitter) {
             return;
         }
-        const stats = await this.getStats();
-        this.emitter.emit({ event: STATS_EVENT, payload: stats });
+        this.emitter.emit({ event: STATS_EVENT, payload: { at: Date.now() } });
     }
 
     /**
@@ -638,6 +743,26 @@ export class AccountHistoryService implements IAccountHistoryService {
         const bandwidthConsumed = num(row.bandwidth_consumed);
         const bandwidthFee = num(row.bandwidth_fee_sun);
 
+        // Rehydrate TRC20 token detail into contract.parameters (the open decoded-
+        // ABI-args domain), mirroring how the trc20 provider mapping stored it, so
+        // consumers get the token amount/symbol/decimals without IBlockTransaction
+        // carrying token-specific fields.
+        const tokenParameters = row.token_amount != null
+            ? {
+                value: String(row.token_amount),
+                symbol: row.token_symbol ?? undefined,
+                decimals: row.token_decimals ?? undefined
+            }
+            : undefined;
+
+        const contract = row.contract_address
+            ? {
+                address: String(row.contract_address),
+                method: row.contract_method ? String(row.contract_method) : undefined,
+                parameters: tokenParameters
+            }
+            : undefined;
+
         const transaction: IBlockTransaction = {
             txId: String(row.tx_id),
             blockNumber: Number(row.block_number ?? 0),
@@ -654,9 +779,7 @@ export class AccountHistoryService implements IAccountHistoryService {
             bandwidth: bandwidthConsumed !== undefined || bandwidthFee !== undefined
                 ? { consumed: bandwidthConsumed ?? 0, feeSun: bandwidthFee ?? 0 }
                 : undefined,
-            contract: row.contract_address
-                ? { address: String(row.contract_address), method: row.contract_method ? String(row.contract_method) : undefined }
-                : undefined,
+            contract,
             memo: row.memo === null || row.memo === undefined ? null : String(row.memo)
         };
         return transaction;

--- a/src/backend/modules/blockchain/tron-grid.client.ts
+++ b/src/backend/modules/blockchain/tron-grid.client.ts
@@ -696,6 +696,32 @@ export class TronGridClient {
     }
 
     /**
+     * Fetch paginated native/contract transactions for an account via the v1 REST API.
+     *
+     * Covers every non-TRC20 transaction type — native TRX transfers, TRC10,
+     * staking/delegation, and raw contract calls — that the account participated
+     * in. Pair this with `getTrc20Transactions` to assemble an account's complete
+     * history; the account-history module walks both, fingerprint-paged.
+     *
+     * Routed through the same `enqueueRequest` throttle and rotating-key headers
+     * as every other call, so a long account backfill shares the global TronGrid
+     * rate budget rather than competing with live block sync.
+     *
+     * @param base58Address - Account address in base58 format.
+     * @param params - Query parameters (`only_confirmed`, `limit`, `fingerprint`, optional `min_timestamp`/`max_timestamp`).
+     * @returns Raw response data with transactions and pagination metadata (`meta.fingerprint`).
+     */
+    async getAccountTransactions<T>(base58Address: string, params: Record<string, string | number | boolean>): Promise<T> {
+        return enqueueRequest(async () => {
+            const response = await httpClient.get<T>(
+                `${BASE_URL}/v1/accounts/${base58Address}/transactions`,
+                { params, headers: buildHeaders(), timeout: 15000 }
+            );
+            return response.data;
+        });
+    }
+
+    /**
      * Execute a read-only smart contract call via triggerconstantcontract.
      *
      * No gas cost — used for querying contract state (e.g. allowance, balanceOf).

--- a/src/backend/services/websocket.service.ts
+++ b/src/backend/services/websocket.service.ts
@@ -369,11 +369,14 @@ export class WebSocketService implements IWebSocketService {
       case 'ai-tools:approvals-changed':
       case 'curation:changed':
       case 'content:published':
+      case 'account-history:stats':
         // Admin-dashboard refetch nudges from the AI tool governor, the curation
-        // service, and the internal publish sink. The /system/ai-tools,
-        // /system/curation, and publish surfaces subscribe on the shared socket
-        // without joining a room, so these broadcast globally; payloads carry
-        // only a timestamp, count, or published-item summary, never governed data.
+        // service, the internal publish sink, and the account-history ingestion
+        // tick. The /system/ai-tools, /system/curation, publish, and
+        // /system/account-history surfaces subscribe on the shared socket without
+        // joining a room, so these broadcast globally; payloads carry only a
+        // timestamp, count, ingestion-progress snapshot, or item summary, never
+        // governed data.
         this.io.emit(event.event, event.payload);
         break;
       case 'toast':

--- a/src/backend/services/websocket.service.ts
+++ b/src/backend/services/websocket.service.ts
@@ -375,8 +375,8 @@ export class WebSocketService implements IWebSocketService {
         // tick. The /system/ai-tools, /system/curation, publish, and
         // /system/account-history surfaces subscribe on the shared socket without
         // joining a room, so these broadcast globally; payloads carry only a
-        // timestamp, count, ingestion-progress snapshot, or item summary, never
-        // governed data.
+        // timestamp, count, or item summary, never governed data — each surface
+        // refetches the protected detail over its requireAdmin REST endpoint.
         this.io.emit(event.event, event.payload);
         break;
       case 'toast':

--- a/src/frontend/app/(core)/system/account-history/AccountsTab.tsx
+++ b/src/frontend/app/(core)/system/account-history/AccountsTab.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+/**
+ * @fileoverview Tracked-accounts tab for /system/account-history.
+ *
+ * The control surface a plugin's enable/disable would otherwise provide: add or
+ * remove tracked accounts, pause/resume an individual backfill, and watch
+ * per-account progress. Stats are owned by the page (fed live off the
+ * `account-history:stats` socket event) and passed in; mutations call back via
+ * `onChanged` so the page refetches. Like the sibling system surfaces this is an
+ * admin client surface, not SSR-first public content.
+ */
+
+import { useState, useCallback } from 'react';
+import { Plus, Play, Trash2, Pause, PlayCircle } from 'lucide-react';
+import { Stack } from '../../../../components/layout';
+import { Button } from '../../../../components/ui/Button';
+import { Badge } from '../../../../components/ui/Badge';
+import { Input } from '../../../../components/ui/Input';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../components/ui/Table';
+import { ClientTime } from '../../../../components/ui/ClientTime';
+import { useToast } from '../../../../components/ui/ToastProvider';
+import {
+    addTrackedAccount,
+    removeTrackedAccount,
+    setAccountPaused,
+    runIngestion,
+    type IAccountHistoryStatsView,
+    type AccountIngestionStatus
+} from '../../../../modules/account-history';
+import styles from './page.module.scss';
+
+/**
+ * Map a backfill status to a Badge tone so an operator reads progress at a glance.
+ *
+ * @param status - The account's ingestion status.
+ * @returns The Badge tone.
+ */
+function statusTone(status: AccountIngestionStatus): 'success' | 'danger' | 'warning' | 'info' | 'neutral' {
+    switch (status) {
+        case 'complete': return 'success';
+        case 'failed': return 'danger';
+        case 'running': return 'warning';
+        case 'paused': return 'neutral';
+        default: return 'info';
+    }
+}
+
+/**
+ * Tracked-accounts tab content.
+ *
+ * @param props.stats - The current stats snapshot, or null before first load.
+ * @param props.onChanged - Called after a mutation so the page refetches stats.
+ * @returns The tab.
+ */
+export function AccountsTab({ stats, onChanged }: { stats: IAccountHistoryStatsView | null; onChanged: () => void }) {
+    const [address, setAddress] = useState('');
+    const [label, setLabel] = useState('');
+    const [busy, setBusy] = useState(false);
+    const { push } = useToast();
+
+    const add = useCallback(async () => {
+        setBusy(true);
+        try {
+            await addTrackedAccount(address.trim(), label.trim() || undefined);
+            setAddress('');
+            setLabel('');
+            push({ tone: 'success', title: 'Account tracked' });
+            onChanged();
+        } catch (err) {
+            push({ tone: 'danger', title: 'Failed to add account', description: err instanceof Error ? err.message : String(err) });
+        } finally {
+            setBusy(false);
+        }
+    }, [address, label, onChanged, push]);
+
+    const remove = useCallback(async (addr: string) => {
+        try {
+            await removeTrackedAccount(addr);
+            push({ tone: 'info', title: 'Account removed', description: 'Stored history is retained.' });
+            onChanged();
+        } catch (err) {
+            push({ tone: 'danger', title: 'Failed to remove account', description: err instanceof Error ? err.message : String(err) });
+        }
+    }, [onChanged, push]);
+
+    const togglePause = useCallback(async (addr: string, paused: boolean) => {
+        try {
+            await setAccountPaused(addr, paused);
+            onChanged();
+        } catch (err) {
+            push({ tone: 'danger', title: 'Failed to update account', description: err instanceof Error ? err.message : String(err) });
+        }
+    }, [onChanged, push]);
+
+    const runNow = useCallback(async () => {
+        try {
+            await runIngestion();
+            push({ tone: 'success', title: 'Ingestion tick started' });
+        } catch (err) {
+            push({ tone: 'danger', title: 'Failed to run ingestion', description: err instanceof Error ? err.message : String(err) });
+        }
+    }, [push]);
+
+    const accounts = stats?.accounts ?? [];
+
+    return (
+        <Stack gap="md">
+            <div className={styles.toolbar}>
+                <Input
+                    value={address}
+                    onChange={(event) => setAddress(event.target.value)}
+                    placeholder="TRON address (T...)"
+                    aria-label="Account address to track"
+                    disabled={busy}
+                />
+                <Input
+                    value={label}
+                    onChange={(event) => setLabel(event.target.value)}
+                    placeholder="Label (optional)"
+                    aria-label="Account label"
+                    disabled={busy}
+                />
+                <Button variant="primary" size="sm" loading={busy} disabled={!address.trim()} onClick={() => { void add(); }}>
+                    <Plus size={16} /> Track
+                </Button>
+                <Button variant="secondary" size="sm" onClick={() => { void runNow(); }}>
+                    <Play size={16} /> Run now
+                </Button>
+            </div>
+
+            <p className="text-muted" style={{ margin: 0, fontSize: 'var(--font-size-body-sm)' }}>
+                Backfill walks each account&apos;s full history newest-first, bounded per tick. Progress shows rows ingested and how far
+                back the cursor has reached — there is no percentage, since the total transaction count is unknown until the walk ends.
+            </p>
+
+            {accounts.length === 0
+                ? <div className="text-muted">No accounts tracked yet.</div>
+                : (
+                    <div className="table-scroll">
+                        <Table>
+                            <Thead>
+                                <Tr>
+                                    <Th>Account</Th>
+                                    <Th width="shrink">Status</Th>
+                                    <Th width="shrink">Rows</Th>
+                                    <Th width="shrink">Oldest reached</Th>
+                                    <Th width="shrink">Last run</Th>
+                                    <Th width="shrink">Actions</Th>
+                                </Tr>
+                            </Thead>
+                            <Tbody>
+                                {accounts.map(({ account, progress }) => (
+                                    <Tr key={account.address} hasError={progress.status === 'failed'}>
+                                        <Td data-label="Account">
+                                            <div className={styles.account_addr}>{account.label ?? account.address}</div>
+                                            {account.label && <div className="text-muted">{account.address}</div>}
+                                            {progress.lastError && <div className={styles.account_error}>{progress.lastError}</div>}
+                                        </Td>
+                                        <Td data-label="Status">
+                                            <Badge tone={statusTone(progress.status)}>{account.paused ? 'paused' : progress.status}</Badge>
+                                        </Td>
+                                        <Td data-label="Rows" muted>{progress.rowsIngested.toLocaleString()}</Td>
+                                        <Td data-label="Oldest reached" muted>
+                                            {progress.oldestTimestampReached ? <ClientTime date={progress.oldestTimestampReached} format="datetime" /> : '—'}
+                                        </Td>
+                                        <Td data-label="Last run" muted>
+                                            {progress.lastRunAt ? <ClientTime date={progress.lastRunAt} format="datetime" /> : '—'}
+                                        </Td>
+                                        <Td data-label="Actions">
+                                            <div className={styles.row_actions}>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="xs"
+                                                    onClick={() => { void togglePause(account.address, !account.paused); }}
+                                                    aria-label={account.paused ? 'Resume account' : 'Pause account'}
+                                                >
+                                                    {account.paused ? <PlayCircle size={14} /> : <Pause size={14} />}
+                                                    {account.paused ? 'Resume' : 'Pause'}
+                                                </Button>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="xs"
+                                                    onClick={() => { void remove(account.address); }}
+                                                    aria-label="Remove account"
+                                                >
+                                                    <Trash2 size={14} /> Remove
+                                                </Button>
+                                            </div>
+                                        </Td>
+                                    </Tr>
+                                ))}
+                            </Tbody>
+                        </Table>
+                    </div>
+                )}
+        </Stack>
+    );
+}

--- a/src/frontend/app/(core)/system/account-history/SettingsTab.tsx
+++ b/src/frontend/app/(core)/system/account-history/SettingsTab.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+/**
+ * @fileoverview Ingestion-settings tab for /system/account-history.
+ *
+ * The pacing dials: a master ingestion switch plus pages-per-tick and
+ * accounts-per-tick. These throttle ingestion *down* only — they cannot exceed
+ * the shared TronGrid rate limiter that protects live block sync, so turning
+ * them up never pulls faster than the global budget allows. The cron cadence
+ * itself lives on the Schedules tab (owned by the scheduler), not here.
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import { Save } from 'lucide-react';
+import { Stack } from '../../../../components/layout';
+import { Button } from '../../../../components/ui/Button';
+import { Input } from '../../../../components/ui/Input';
+import { Switch } from '../../../../components/ui/Switch';
+import { useToast } from '../../../../components/ui/ToastProvider';
+import { getSettings, updateSettings, type IAccountHistorySettings } from '../../../../modules/account-history';
+import styles from './page.module.scss';
+
+/**
+ * Ingestion-settings tab content.
+ *
+ * @returns The tab.
+ */
+export function SettingsTab() {
+    const [settings, setSettings] = useState<IAccountHistorySettings | null>(null);
+    const [saving, setSaving] = useState(false);
+    const { push } = useToast();
+
+    useEffect(() => {
+        let cancelled = false;
+        getSettings()
+            .then((next) => { if (!cancelled) setSettings(next); })
+            .catch((err) => {
+                if (!cancelled) push({ tone: 'danger', title: 'Failed to load settings', description: err instanceof Error ? err.message : String(err) });
+            });
+        return () => { cancelled = true; };
+    }, [push]);
+
+    const patch = useCallback((change: Partial<IAccountHistorySettings>) => {
+        setSettings((prev) => (prev ? { ...prev, ...change } : prev));
+    }, []);
+
+    const save = useCallback(async () => {
+        if (!settings) {
+            return;
+        }
+        setSaving(true);
+        try {
+            const next = await updateSettings(settings);
+            setSettings(next);
+            push({ tone: 'success', title: 'Settings saved' });
+        } catch (err) {
+            push({ tone: 'danger', title: 'Failed to save settings', description: err instanceof Error ? err.message : String(err) });
+        } finally {
+            setSaving(false);
+        }
+    }, [settings, push]);
+
+    if (!settings) {
+        return <div className="text-muted">Loading settings…</div>;
+    }
+
+    return (
+        <Stack gap="lg">
+            <div className={styles.setting_row}>
+                <div>
+                    <div className={styles.setting_label}>Ingestion enabled</div>
+                    <div className="text-muted">Master switch. When off, the scheduled tick is a no-op and no account advances.</div>
+                </div>
+                <Switch on={settings.ingestionEnabled} onChange={(next) => patch({ ingestionEnabled: next })} aria-label="Toggle ingestion" />
+            </div>
+
+            <div className={styles.setting_row}>
+                <div>
+                    <div className={styles.setting_label}>Pages per tick</div>
+                    <div className="text-muted">TronGrid pages (200 tx each) pulled per account each tick — the primary speed/load dial.</div>
+                </div>
+                <Input
+                    type="number"
+                    min={1}
+                    value={settings.pagesPerTick}
+                    onChange={(event) => patch({ pagesPerTick: Number(event.target.value) })}
+                    aria-label="Pages per tick"
+                    className={styles.number_input}
+                />
+            </div>
+
+            <div className={styles.setting_row}>
+                <div>
+                    <div className={styles.setting_label}>Accounts per tick</div>
+                    <div className="text-muted">How many tracked accounts advance each tick (round-robin, least-recent first).</div>
+                </div>
+                <Input
+                    type="number"
+                    min={1}
+                    value={settings.accountsPerTick}
+                    onChange={(event) => patch({ accountsPerTick: Number(event.target.value) })}
+                    aria-label="Accounts per tick"
+                    className={styles.number_input}
+                />
+            </div>
+
+            <p className="text-muted" style={{ margin: 0, fontSize: 'var(--font-size-body-sm)' }}>
+                These dials throttle ingestion down only. They cannot exceed the shared TronGrid rate limiter that protects live block
+                sync — past that ceiling, higher values just mean the tick waits in the throttle queue rather than pulling faster.
+            </p>
+
+            <div>
+                <Button variant="primary" size="sm" loading={saving} onClick={() => { void save(); }}>
+                    <Save size={16} /> Save settings
+                </Button>
+            </div>
+        </Stack>
+    );
+}

--- a/src/frontend/app/(core)/system/account-history/page.module.scss
+++ b/src/frontend/app/(core)/system/account-history/page.module.scss
@@ -1,0 +1,56 @@
+/**
+ * Scoped styles for the /system/account-history admin surface. Layout and state
+ * only — colors, spacing, and typography flow through design tokens.
+ */
+
+.summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--gap-sm);
+}
+
+.content {
+    margin-top: var(--gap-md);
+}
+
+.toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--gap-sm);
+}
+
+.row_actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--gap-xs);
+}
+
+.account_addr {
+    font-weight: var(--font-weight-medium);
+    word-break: break-all;
+}
+
+.account_error {
+    margin-top: var(--gap-2xs);
+    color: var(--color-danger);
+    font-size: var(--font-size-caption);
+}
+
+.setting_row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--gap-md);
+}
+
+.setting_label {
+    font-weight: var(--font-weight-semibold);
+}
+
+.number_input {
+    max-width: var(--max-width-xs);
+    width: 8ch;
+}

--- a/src/frontend/app/(core)/system/account-history/page.tsx
+++ b/src/frontend/app/(core)/system/account-history/page.tsx
@@ -8,9 +8,10 @@
  * jobs, a filtered view of the one scheduler authority via SchedulerMonitor).
  * Admin-gated by the /system layout; a client component fetching over the
  * cookie-authenticated admin API. Ingestion stats stay live off the
- * `account-history:stats` WebSocket broadcast — the snapshot the backend emits
- * after each tick replaces local state directly, with the gated REST feed as the
- * initial load and refetch path.
+ * `account-history:stats` WebSocket nudge — a timestamp-only signal the backend
+ * emits after each tick that triggers a refetch over the requireAdmin REST feed.
+ * The snapshot itself is never sent over the socket: it carries admin-only data
+ * and the broadcast reaches every connected client.
  */
 
 import { useEffect, useState, useCallback } from 'react';
@@ -66,14 +67,17 @@ export default function AccountHistoryAdminPage() {
         void loadStats();
     }, [loadStats]);
 
-    // The backend emits the full stats snapshot after each ingestion tick, so the
-    // table updates live without polling. The payload is the snapshot itself.
+    // The backend emits a timestamp-only nudge after each ingestion tick (the
+    // snapshot carries admin-only data and the broadcast reaches every socket),
+    // so refetch the full stats over the requireAdmin REST endpoint on the
+    // signal rather than trusting the socket payload — mirroring how the
+    // /system/curation page refetches on `curation:changed`.
     useEffect(() => {
         const socket = getSocket();
-        const onStats = (payload: IAccountHistoryStatsView) => { setStats(payload); };
+        const onStats = () => { void loadStats(); };
         socket.on('account-history:stats', onStats);
         return () => { socket.off('account-history:stats', onStats); };
-    }, []);
+    }, [loadStats]);
 
     return (
         <Page>

--- a/src/frontend/app/(core)/system/account-history/page.tsx
+++ b/src/frontend/app/(core)/system/account-history/page.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+/**
+ * @fileoverview /system/account-history — admin surface for per-account history.
+ *
+ * Three tabs: tracked accounts (the control surface, with live per-account
+ * progress), ingestion settings (pacing), and schedules (the module's scheduler
+ * jobs, a filtered view of the one scheduler authority via SchedulerMonitor).
+ * Admin-gated by the /system layout; a client component fetching over the
+ * cookie-authenticated admin API. Ingestion stats stay live off the
+ * `account-history:stats` WebSocket broadcast — the snapshot the backend emits
+ * after each tick replaces local state directly, with the gated REST feed as the
+ * initial load and refetch path.
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import { Page, PageHeader } from '../../../../components/layout';
+import { Badge } from '../../../../components/ui/Badge';
+import { getSocket } from '../../../../lib/socketClient';
+import { SchedulerMonitor, type SchedulerJob } from '../../../../modules/scheduler';
+import { getStats, type IAccountHistoryStatsView } from '../../../../modules/account-history';
+import { AccountsTab } from './AccountsTab';
+import { SettingsTab } from './SettingsTab';
+import styles from './page.module.scss';
+
+/** The page's three tab ids. */
+type TabId = 'accounts' | 'settings' | 'schedules';
+
+/** Tab definitions in display order. */
+const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
+    { id: 'accounts', label: 'Tracked Accounts' },
+    { id: 'settings', label: 'Ingestion Settings' },
+    { id: 'schedules', label: 'Schedules' }
+];
+
+/**
+ * Predicate selecting only this module's scheduler jobs for the Schedules tab —
+ * the same scheduler authority as /system/scheduler, filtered by name prefix so
+ * edits here and there can never drift.
+ *
+ * @param job - A scheduler job.
+ * @returns True for `account-history:`-prefixed jobs.
+ */
+function isAccountHistoryJob(job: SchedulerJob): boolean {
+    return job.name.startsWith('account-history:');
+}
+
+/**
+ * Account-history admin page.
+ *
+ * @returns The page.
+ */
+export default function AccountHistoryAdminPage() {
+    const [activeTab, setActiveTab] = useState<TabId>('accounts');
+    const [stats, setStats] = useState<IAccountHistoryStatsView | null>(null);
+
+    const loadStats = useCallback(async () => {
+        try {
+            setStats(await getStats());
+        } catch {
+            /* primary data load failure surfaces on the empty table; leave stats as-is */
+        }
+    }, []);
+
+    useEffect(() => {
+        void loadStats();
+    }, [loadStats]);
+
+    // The backend emits the full stats snapshot after each ingestion tick, so the
+    // table updates live without polling. The payload is the snapshot itself.
+    useEffect(() => {
+        const socket = getSocket();
+        const onStats = (payload: IAccountHistoryStatsView) => { setStats(payload); };
+        socket.on('account-history:stats', onStats);
+        return () => { socket.off('account-history:stats', onStats); };
+    }, []);
+
+    return (
+        <Page>
+            <PageHeader
+                title="Account History"
+                subtitle="Track specific TRON accounts and backfill their full transaction history into ClickHouse."
+            />
+
+            {stats && (
+                <div className={styles.summary}>
+                    <Badge tone="info">{stats.totals.trackedAccounts} tracked</Badge>
+                    <Badge tone="neutral">{stats.totals.rowsIngested.toLocaleString()} rows</Badge>
+                    {stats.totals.completeAccounts > 0 && <Badge tone="success">{stats.totals.completeAccounts} complete</Badge>}
+                    {stats.totals.failedAccounts > 0 && <Badge tone="danger">{stats.totals.failedAccounts} failed</Badge>}
+                </div>
+            )}
+
+            <div className="segmented-control" role="tablist" aria-label="Account history sections">
+                {TABS.map((tab) => (
+                    <button
+                        key={tab.id}
+                        type="button"
+                        role="tab"
+                        aria-selected={activeTab === tab.id}
+                        className={activeTab === tab.id ? 'is-active' : undefined}
+                        onClick={() => setActiveTab(tab.id)}
+                    >
+                        {tab.label}
+                    </button>
+                ))}
+            </div>
+
+            <div className={styles.content}>
+                {activeTab === 'accounts' && <AccountsTab stats={stats} onChanged={loadStats} />}
+                {activeTab === 'settings' && <SettingsTab />}
+                {activeTab === 'schedules' && <SchedulerMonitor jobFilter={isAccountHistoryJob} title="Account History Schedules" />}
+            </div>
+        </Page>
+    );
+}

--- a/src/frontend/modules/account-history/api/client.ts
+++ b/src/frontend/modules/account-history/api/client.ts
@@ -96,12 +96,16 @@ export interface IAccountTransactionPageView {
  *
  * @param response - The fetch response.
  * @param what - A short verb phrase naming the action, for the error message.
- * @returns The parsed JSON body.
+ * @returns The parsed JSON body, or `undefined` for a 204 No Content response
+ *          (e.g. a successful DELETE) which carries no body to parse.
  */
 async function parse<T>(response: Response, what: string): Promise<T> {
     if (!response.ok) {
         const body = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
         throw new Error(body.error || `Failed to ${what} (HTTP ${response.status})`);
+    }
+    if (response.status === 204) {
+        return undefined as T;
     }
     return response.json() as Promise<T>;
 }

--- a/src/frontend/modules/account-history/api/client.ts
+++ b/src/frontend/modules/account-history/api/client.ts
@@ -1,0 +1,204 @@
+/**
+ * @fileoverview Admin API client for the account-history module.
+ *
+ * Thin fetch wrappers over `/api/admin/system/account-history/*`. Same-origin
+ * calls carry the Better Auth session cookie automatically, which the backend's
+ * `requireAdmin` middleware consults — no token plumbing here. Every function
+ * throws on a non-2xx response so callers surface the failure in the UI.
+ *
+ * The view types redeclare the published DTOs' `Date` fields as ISO strings,
+ * because both the REST responses and the `account-history:stats` WebSocket
+ * payload arrive as JSON (dates serialized to strings). This mirrors the
+ * curation client's view-type convention.
+ */
+
+import type { IAccountHistorySettings, AccountIngestionStatus } from '@/types';
+
+/** Base path for every account-history admin endpoint. */
+const BASE = '/api/admin/system/account-history';
+
+export type { IAccountHistorySettings, AccountIngestionStatus } from '@/types';
+
+/**
+ * A tracked account as serialized over the wire (dates as ISO strings).
+ */
+export interface ITrackedAccountView {
+    address: string;
+    label?: string;
+    paused: boolean;
+    addedAt: string;
+    updatedAt: string;
+}
+
+/**
+ * Per-account ingestion progress as serialized over the wire.
+ */
+export interface IAccountIngestionProgressView {
+    address: string;
+    status: AccountIngestionStatus;
+    cursorFingerprint?: string;
+    oldestTimestampReached?: string;
+    newestTimestampSeen?: string;
+    rowsIngested: number;
+    lastRunAt?: string;
+    lastError?: string;
+}
+
+/**
+ * One stats row: a tracked account paired with its progress.
+ */
+export interface IAccountHistoryAccountStatsView {
+    account: ITrackedAccountView;
+    progress: IAccountIngestionProgressView;
+}
+
+/**
+ * The full stats snapshot powering the admin page and the live WebSocket payload.
+ */
+export interface IAccountHistoryStatsView {
+    settings: IAccountHistorySettings;
+    accounts: IAccountHistoryAccountStatsView[];
+    totals: {
+        trackedAccounts: number;
+        rowsIngested: number;
+        completeAccounts: number;
+        failedAccounts: number;
+    };
+}
+
+/**
+ * One stored transaction as serialized over the wire (timestamp as ISO string).
+ */
+export interface IAccountTransactionView {
+    txId: string;
+    blockNumber: number;
+    timestamp: string;
+    type: string;
+    status: string;
+    from: { address: string };
+    to: { address: string };
+    amountSun?: number;
+    feeSun?: number;
+    contract?: { address: string; method?: string };
+    memo?: string | null;
+}
+
+/**
+ * A page of an account's stored history.
+ */
+export interface IAccountTransactionPageView {
+    transactions: IAccountTransactionView[];
+    total: number;
+}
+
+/**
+ * Parse a fetch response, throwing a descriptive error on a non-2xx status.
+ *
+ * @param response - The fetch response.
+ * @param what - A short verb phrase naming the action, for the error message.
+ * @returns The parsed JSON body.
+ */
+async function parse<T>(response: Response, what: string): Promise<T> {
+    if (!response.ok) {
+        const body = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
+        throw new Error(body.error || `Failed to ${what} (HTTP ${response.status})`);
+    }
+    return response.json() as Promise<T>;
+}
+
+/**
+ * Fetch the full stats snapshot (settings, per-account progress, totals).
+ *
+ * @returns The stats snapshot.
+ */
+export async function getStats(): Promise<IAccountHistoryStatsView> {
+    return parse<IAccountHistoryStatsView>(await fetch(`${BASE}/stats`), 'load account-history stats');
+}
+
+/**
+ * Add an account to the tracked set.
+ *
+ * @param address - Base58 TRON address to track.
+ * @param label - Optional human label.
+ * @returns Resolves when tracked.
+ */
+export async function addTrackedAccount(address: string, label?: string): Promise<void> {
+    await parse(await fetch(`${BASE}/accounts`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address, label })
+    }), 'add tracked account');
+}
+
+/**
+ * Stop tracking an account (retains stored history).
+ *
+ * @param address - Base58 address to remove.
+ * @returns Resolves when removed.
+ */
+export async function removeTrackedAccount(address: string): Promise<void> {
+    await parse(await fetch(`${BASE}/accounts/${encodeURIComponent(address)}`, { method: 'DELETE' }), 'remove tracked account');
+}
+
+/**
+ * Pause or resume one account's backfill.
+ *
+ * @param address - Base58 address.
+ * @param paused - True to pause, false to resume.
+ * @returns Resolves when updated.
+ */
+export async function setAccountPaused(address: string, paused: boolean): Promise<void> {
+    await parse(await fetch(`${BASE}/accounts/${encodeURIComponent(address)}/paused`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ paused })
+    }), 'update account pause state');
+}
+
+/**
+ * Read current pacing settings.
+ *
+ * @returns The settings.
+ */
+export async function getSettings(): Promise<IAccountHistorySettings> {
+    return parse<IAccountHistorySettings>(await fetch(`${BASE}/settings`), 'load settings');
+}
+
+/**
+ * Merge a partial settings update.
+ *
+ * @param patch - Fields to change.
+ * @returns The settings after the merge.
+ */
+export async function updateSettings(patch: Partial<IAccountHistorySettings>): Promise<IAccountHistorySettings> {
+    return parse<IAccountHistorySettings>(await fetch(`${BASE}/settings`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch)
+    }), 'update settings');
+}
+
+/**
+ * Trigger one manual ingestion tick.
+ *
+ * @returns Resolves when the tick has been requested.
+ */
+export async function runIngestion(): Promise<void> {
+    await parse(await fetch(`${BASE}/ingest/run`, { method: 'POST' }), 'run ingestion');
+}
+
+/**
+ * Read a page of an account's stored history.
+ *
+ * @param address - Base58 address.
+ * @param limit - Page size.
+ * @param offset - Row offset.
+ * @returns The page of transactions and the total count.
+ */
+export async function getTransactions(address: string, limit = 50, offset = 0): Promise<IAccountTransactionPageView> {
+    const query = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+    return parse<IAccountTransactionPageView>(
+        await fetch(`${BASE}/accounts/${encodeURIComponent(address)}/transactions?${query.toString()}`),
+        'load account transactions'
+    );
+}

--- a/src/frontend/modules/account-history/index.ts
+++ b/src/frontend/modules/account-history/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @fileoverview Public surface of the frontend account-history module — the admin
+ * API client for tracked accounts, pacing settings, stats, and history reads.
+ * Consumers import from the module root.
+ */
+
+export * from './api/client';


### PR DESCRIPTION
## Why

We need to track the full transaction history of specific TRON accounts (some with millions of transactions) in ClickHouse, ingested gradually to avoid overloading data sources. No existing service does this — the block-sync pipeline only walks blocks forward, never an individual account's history.

## What

A new always-on core **`account-history`** module: pull-based per-account backfill into ClickHouse, independent of block sync.

- **Types** (`packages/types`, 4.16.0 → 4.17.0): `IAccountHistoryService` + DTOs, published on the registry as `'account-history'`. Reads return the source-independent `IBlockTransaction` (not extended — token specifics stay in the module-local ClickHouse row, per the admission test).
- **Provider seam** `IAccountHistoryProvider` with a TronGrid v1 impl using the general account-transactions endpoint (covers all types; TRC20 surfaces as `TriggerSmartContract`). Routes through the shared rate-limited `TronGridClient` so the backfill shares the global budget with live block sync; `getAccountTransactions` added to that client.
- **`AccountHistoryService`** singleton — the single authority: tracked set, resumable per-account fingerprint cursors, pacing settings, a bounded round-robin ingestion tick (advances cursor only after a clean write), ClickHouse reads, and live-stats emit. Setup and per-account failures are logged via `SystemLogService` and surfaced on the admin page.
- **Storage**: `account_transactions` `ReplacingMergeTree(ingested_at)`, ordered `(account, timestamp, tx_id)` for idempotent re-ingest; `target: 'clickhouse'` migration.
- **Wiring**: bootstrap init/run; `account-history:stats` case added to `WebSocketService.emit()`.
- **Frontend** `/system/account-history`: tracked-accounts, ingestion-settings, and schedules tabs (the schedules tab is a `SchedulerMonitor` filtered to `account-history:` jobs — one scheduler authority, filtered view), with live stats over WebSocket.

Pacing dials throttle ingestion *down* only; the shared TronGrid limiter remains the ceiling. Degrades to a no-op when ClickHouse is absent.

Verified: types/backend/frontend typecheck clean; module + service tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)