### PR TITLE
fix(menu): drop stale dependency from migration 005

### DIFF
--- a/src/backend/modules/menu/migrations/005_remove_accounts_menu_node.ts
+++ b/src/backend/modules/menu/migrations/005_remove_accounts_menu_node.ts
@@ -35,7 +35,7 @@ import type { IMigration, IMigrationContext } from '@/types';
 export const migration: IMigration = {
     id: '005_remove_accounts_menu_node',
     description: 'Delete the persisted Accounts (/accounts) main-namespace menu node and its override after the public accounts feature was removed.',
-    dependencies: ['module:menu:004_merge_system_namespace_into_main'],
+    dependencies: [],
 
     async up(context: IMigrationContext): Promise<void> {
         const nodes = context.database.getCollection('menu_nodes');


### PR DESCRIPTION
## Why

PR #366 added menu migration `005_remove_accounts_menu_node` with a hard dependency on `module:menu:004_merge_system_namespace_into_main`. The production image's smoke-boot health check then crashed during migration scanning:

```
Migration 'module:menu:005_remove_accounts_menu_node' depends on
'module:menu:004_merge_system_namespace_into_main', but that migration was not
found on disk and has no completed record in the migrations collection.
```

Root cause: `004` fails to load at runtime. It imports `../constants.js`, but the backend is bundled into a single `dist/backend/index.js` while migration files stay standalone for dynamic scanning — so `constants.js` is never emitted as its own file and `004.js` hits `ERR_MODULE_NOT_FOUND` and is skipped. That skip was harmless until `005` depended on `004`, turning it into an unsatisfied dependency that throws in `topologicalSort` and aborts `DatabaseModule.init()`.

## What

Remove the dependency. `005` has no genuine ordering relationship with `004` — `004` merges the legacy `system` namespace, `005` deletes a `main`-namespace node; they are independent in any order. The dependency was an over-applied chaining convention, not a requirement.

The underlying `004` packaging gap is pre-existing and benign (prod ran `004` historically and records it complete; a fresh environment has no `system`-namespace nodes for it to merge) and is left for a separate follow-up.