### PR TITLE
feat(identity): central per-user settings store; absorb notification prefs

### DIFF
--- a/docs/system/system.md
+++ b/docs/system/system.md
@@ -64,7 +64,7 @@ Identity runs on Better Auth (email-OTP / OAuth / passkey), mounted at `/api/aut
 
 ### Identity
 
-The identity module owns Better Auth and everything keyed by the Better Auth user id: the auth instance (above), the `GroupService` (admin/group membership), the signature-proven wallet store, and the account directory. It publishes `'accounts'`, `'wallets'`, and `'user-groups'` on the service registry so plugins and modules reach account data without touching `module_user_auth_*` directly. See [Identity Module README](../../src/backend/modules/identity/README.md) and [system-auth.md](./system-auth.md).
+The identity module owns Better Auth and everything keyed by the Better Auth user id: the auth instance (above), the `GroupService` (admin/group membership), the signature-proven wallet store, the account directory, and the central per-user settings store. It publishes `'accounts'`, `'wallets'`, `'user-groups'`, and `'user-settings'` on the service registry so plugins and modules reach account data without touching `module_user_auth_*` directly. The `'user-settings'` store is the single home for user-centric settings and preferences, addressed by `(userId, namespace, key)`; per-user notification opt-outs are its first consumer. See [Identity Module README](../../src/backend/modules/identity/README.md) and [system-auth.md](./system-auth.md).
 
 ### Traffic
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delphian/tronrelic-types",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "description": "Core type definitions for the TronRelic platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/types/src/identity/IUserSettingsService.ts
+++ b/packages/types/src/identity/IUserSettingsService.ts
@@ -1,0 +1,154 @@
+/**
+ * @fileoverview Published contract for the central per-user settings store.
+ *
+ * The identity module registers its `UserSettingsService` on the service
+ * registry as `'user-settings'`; modules and plugins consume it through
+ * `services.get<IUserSettingsService>('user-settings')`. It is the single home
+ * for user-centric settings and preferences, keyed by the Better Auth user id —
+ * the same opaque hex string the rest of the platform uses (see the wallet and
+ * account contracts in this barrel).
+ *
+ * **Why one store, addressed by namespace.** A central collection would
+ * otherwise become a typed grab-bag that every new setting must edit. Instead
+ * the store owns only the *envelope* — the `(userId, namespace, key)` address —
+ * while each provider owns the *payload* it stores under its own namespace. This
+ * mirrors the platform's content-type and notification idioms: core addresses,
+ * the provider gives meaning. A provider stores arbitrary JSON and reads it back
+ * with the same shape it wrote.
+ *
+ * **Two access paths, different trust.** The programmatic methods
+ * (`get`/`getNamespace`/`getForUsers`/`set`/`delete`) are for trusted server
+ * callers — a module persisting a user's choice, the dispatch pipeline batch-
+ * reading opt-outs — and perform no value validation. The self-service HTTP
+ * surface a logged-in user drives is **not** trusted: it may only write
+ * settings a provider has registered as user-writable via
+ * {@link IUserSettingDefinition}, and only after the registered validator
+ * accepts the value. Without that allow-list an authenticated user could write
+ * arbitrary `(namespace, key)` pairs and bloat their rows toward MongoDB's
+ * document limits — a storage-exhaustion vector. Registration is what makes a
+ * setting safe to expose.
+ */
+
+/**
+ * Declares a setting a provider is willing to expose on the user self-service
+ * surface. Registered at boot (module init / plugin enable) so the central
+ * service can offer a generic, safe `/api/user/settings` endpoint without
+ * understanding any provider's payload.
+ *
+ * A provider that only ever writes server-side (e.g. a derived flag) does not
+ * register a definition — it uses the programmatic `set`/`get` directly.
+ */
+export interface IUserSettingDefinition {
+    /** Provider namespace this setting lives under (e.g. `'core'`, `'notifications'`). */
+    namespace: string;
+
+    /** Setting key within the namespace. Unique per namespace. */
+    key: string;
+
+    /** Human label for the self-service UI catalog. */
+    label: string;
+
+    /** Optional longer description for the self-service UI. */
+    description?: string;
+
+    /**
+     * Whether the self-service HTTP surface may write this setting. `false`
+     * registers the setting for catalog/read purposes while reserving writes to
+     * trusted server callers.
+     */
+    userWritable: boolean;
+
+    /**
+     * Guard a candidate value before it is stored from the untrusted self-service
+     * surface. Returns `false` to reject. The programmatic `set` bypasses this —
+     * its callers are trusted.
+     *
+     * @param value - The untrusted candidate value from the request body.
+     * @returns Whether the value is acceptable to store.
+     */
+    validate: (value: unknown) => boolean;
+
+    /** Value returned by `get` when the user has no stored row for this setting. */
+    defaultValue?: unknown;
+}
+
+/**
+ * Central per-user settings store. Published as `'user-settings'`.
+ *
+ * Every method takes the resolved Better Auth user id — the service never reads
+ * cookies or sessions; the HTTP layer resolves identity and calls in.
+ */
+export interface IUserSettingsService {
+    /** Create the collection's indexes. Idempotent; called at module init. */
+    createIndexes(): Promise<void>;
+
+    /**
+     * Register a user-writable (or read-only catalog) setting definition. Safe to
+     * call repeatedly with the same `(namespace, key)`; the latest definition
+     * wins. Providers call this during their init/enable phase.
+     *
+     * @param definition - The setting the provider exposes to self-service.
+     */
+    registerDefinition(definition: IUserSettingDefinition): void;
+
+    /**
+     * All registered definitions. The self-service controller projects these
+     * (minus the validator) into the catalog it returns to the UI.
+     *
+     * @returns Every registered definition.
+     */
+    listDefinitions(): IUserSettingDefinition[];
+
+    /**
+     * Read one setting value, or `null` when the user has no row and the
+     * definition declares no default.
+     *
+     * @param userId - Better Auth user id.
+     * @param namespace - Provider namespace.
+     * @param key - Setting key.
+     * @returns The stored value (or registered default), else `null`.
+     */
+    get<T = unknown>(userId: string, namespace: string, key: string): Promise<T | null>;
+
+    /**
+     * Read every key a user has stored under one namespace in a single query, so
+     * a provider can hydrate all its settings at once.
+     *
+     * @param userId - Better Auth user id.
+     * @param namespace - Provider namespace.
+     * @returns Map of key → stored value for that namespace (empty when none).
+     */
+    getNamespace(userId: string, namespace: string): Promise<Record<string, unknown>>;
+
+    /**
+     * Batch-read one `(namespace, key)` setting for many users in one query, so a
+     * fan-out (e.g. a notification blast reading opt-outs) costs one round-trip
+     * rather than N. Users without a stored row are absent from the map.
+     *
+     * @param userIds - Better Auth user ids.
+     * @param namespace - Provider namespace.
+     * @param key - Setting key.
+     * @returns Map of userId → stored value for those that have one.
+     */
+    getForUsers<T = unknown>(userIds: string[], namespace: string, key: string): Promise<Map<string, T>>;
+
+    /**
+     * Write one setting value, upserting the row. Trusted path — performs no
+     * validation; the self-service controller validates before calling.
+     *
+     * @param userId - Better Auth user id.
+     * @param namespace - Provider namespace.
+     * @param key - Setting key.
+     * @param value - Provider-owned JSON value to store.
+     */
+    set<T = unknown>(userId: string, namespace: string, key: string, value: T): Promise<void>;
+
+    /**
+     * Remove one setting row, reverting the user to the registered default.
+     *
+     * @param userId - Better Auth user id.
+     * @param namespace - Provider namespace.
+     * @param key - Setting key.
+     */
+    delete(userId: string, namespace: string, key: string): Promise<void>;
+}

--- a/packages/types/src/identity/IUserSettingsService.ts
+++ b/packages/types/src/identity/IUserSettingsService.ts
@@ -111,8 +111,11 @@ export interface IUserSettingsService {
     get<T = unknown>(userId: string, namespace: string, key: string): Promise<T | null>;
 
     /**
-     * Read every key a user has stored under one namespace in a single query, so
-     * a provider can hydrate all its settings at once.
+     * Read every key a user has *stored* under one namespace in a single query.
+     * Stored values only — registered defaults are not merged in (mirroring
+     * `getForUsers`; contrast `get`, which falls back to a single key's default).
+     * A caller hydrating a namespace applies its own defaults for keys absent
+     * here, so a present key means the user explicitly set it.
      *
      * @param userId - Better Auth user id.
      * @param namespace - Provider namespace.

--- a/packages/types/src/identity/index.ts
+++ b/packages/types/src/identity/index.ts
@@ -22,3 +22,8 @@ export type {
     IListAccountsOptions,
     IListAccountsResult
 } from './IAccountDirectoryService.js';
+
+export type {
+    IUserSettingsService,
+    IUserSettingDefinition
+} from './IUserSettingsService.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -64,7 +64,7 @@ export type {
     INotificationAuditRecord,
     INotificationAuditQuery
 } from './notifications/index.js';
-export type { IWalletService, ILinkedWallet, WalletAction, IWalletChallenge, IWalletMutationInput, IAccountDirectoryService, IAccountSummary, IListAccountsOptions, IListAccountsResult } from './identity/index.js';
+export type { IWalletService, ILinkedWallet, WalletAction, IWalletChallenge, IWalletMutationInput, IAccountDirectoryService, IAccountSummary, IListAccountsOptions, IListAccountsResult, IUserSettingsService, IUserSettingDefinition } from './identity/index.js';
 export type { IUserGroup, ICreateUserGroupInput, IUpdateUserGroupInput, IUserGroupService } from './user/index.js';
 export type { ITronGridService, ITronGridAccountResponse, ITronGridAccountPermission } from './tron-grid/index.js';
 export type { ITrc10, ITrc10FrozenSupply } from './trc10/index.js';

--- a/src/backend/modules/identity/IdentityModule.ts
+++ b/src/backend/modules/identity/IdentityModule.ts
@@ -4,12 +4,13 @@
  * Carved out of the former omnibus user module so account identity has a
  * single owner. This module configures the Better Auth instance, the
  * group-membership service that backs BA's `groups` additional field, the
- * BA-user-keyed wallet store, the group-definition registry, and the
- * read-only account directory. It mounts `/api/auth/*`, `/api/user/wallets`,
- * the `/api/admin/users/groups` group-definition router, and the
+ * BA-user-keyed wallet store, the group-definition registry, the read-only
+ * account directory, and the central per-user settings store. It mounts
+ * `/api/auth/*`, `/api/user/wallets`, `/api/user/settings`, the
+ * `/api/admin/users/groups` group-definition router, and the
  * `/api/admin/users` account-directory router (the dashboard's user list),
- * and publishes `'user-groups'`, `'wallets'`, and `'accounts'` on the service
- * registry for late-binding consumers.
+ * and publishes `'user-groups'`, `'wallets'`, `'accounts'`, and
+ * `'user-settings'` on the service registry for late-binding consumers.
  *
  * Follows TronRelic's two-phase lifecycle: `init()` constructs services and
  * controllers without activating; `run()` mounts routes and registers
@@ -27,14 +28,17 @@ import { GroupService } from './services/group.service.js';
 import { WalletService } from './services/wallet.service.js';
 import { UserGroupService } from './services/user-group.service.js';
 import { AccountDirectoryService } from './services/account-directory.service.js';
+import { UserSettingsService } from './services/user-settings.service.js';
 import { setAuthInstance } from './services/auth-facade.js';
 import { createAuth, type Auth } from './auth.js';
 import { WalletController } from './api/wallet.controller.js';
 import { UserGroupController } from './api/user-group.controller.js';
 import { AccountsController } from './api/accounts.controller.js';
+import { UserSettingsController } from './api/user-settings.controller.js';
 import { createWalletRouter } from './api/wallet.routes.js';
 import { createAdminUserGroupRouter } from './api/user-group.routes.js';
 import { createAdminAccountsRouter } from './api/accounts.routes.js';
+import { createUserSettingsRouter } from './api/user-settings.routes.js';
 import { requireAdmin } from '../../api/middleware/admin-auth.js';
 
 /**
@@ -81,11 +85,13 @@ export class IdentityModule implements IModule<IIdentityModuleDependencies> {
     private walletService!: WalletService;
     private userGroupService!: UserGroupService;
     private accountDirectoryService!: AccountDirectoryService;
+    private userSettingsService!: UserSettingsService;
     private auth!: Auth;
 
     private walletController!: WalletController;
     private groupController!: UserGroupController;
     private accountsController!: AccountsController;
+    private userSettingsController!: UserSettingsController;
 
     private readonly logger = logger.child({ module: 'identity' });
 
@@ -133,6 +139,14 @@ export class IdentityModule implements IModule<IIdentityModuleDependencies> {
         AccountDirectoryService.setDependencies(this.database, this.logger);
         this.accountDirectoryService = AccountDirectoryService.getInstance();
 
+        // Central per-user settings store. The single home for user-centric
+        // settings/preferences, addressed by (userId, namespace, key) and
+        // published as 'user-settings' in run() for any module or plugin to
+        // consume — the notification dispatcher reads opt-outs through it.
+        UserSettingsService.setDependencies(this.database, this.logger);
+        this.userSettingsService = UserSettingsService.getInstance();
+        await this.userSettingsService.createIndexes();
+
         // Better Auth wiring. The auth factory takes a raw MongoDB Db handle —
         // see auth.ts for the documented exception to the IDatabaseService
         // rule. GroupService (configured above) backs the BA after-create
@@ -156,6 +170,7 @@ export class IdentityModule implements IModule<IIdentityModuleDependencies> {
         this.walletController = new WalletController(this.walletService, this.logger);
         this.groupController = new UserGroupController(this.userGroupService, this.logger);
         this.accountsController = new AccountsController(this.accountDirectoryService, this.logger);
+        this.userSettingsController = new UserSettingsController(this.userSettingsService, this.logger);
 
         this.logger.info('Identity module initialized');
     }
@@ -204,6 +219,13 @@ export class IdentityModule implements IModule<IIdentityModuleDependencies> {
         this.app.use('/api/user/wallets', walletRouter);
         this.logger.info('Wallet router mounted at /api/user/wallets');
 
+        // Per-user settings router at the literal `/api/user/settings` segment —
+        // the self-service surface for the central settings store. Login-gated
+        // inside the controller; no `:id` catch-all captures `settings`.
+        const userSettingsRouter: Router = createUserSettingsRouter(this.userSettingsController);
+        this.app.use('/api/user/settings', userSettingsRouter);
+        this.logger.info('User-settings router mounted at /api/user/settings');
+
         // Admin group-definition + membership router.
         const adminGroupRouter: Router = createAdminUserGroupRouter(this.groupController);
         this.app.use('/api/admin/users/groups', requireAdmin, adminGroupRouter);
@@ -219,11 +241,15 @@ export class IdentityModule implements IModule<IIdentityModuleDependencies> {
         this.app.use('/api/admin/users', requireAdmin, adminAccountsRouter);
         this.logger.info('Admin accounts router mounted at /api/admin/users');
 
-        // Publish the BA-keyed services for late-binding discovery.
+        // Publish the BA-keyed services for late-binding discovery. Published in
+        // identity's run() — which precedes notifications' run() and any runtime
+        // dispatch — so the notification preference store resolves 'user-settings'
+        // lazily without a boot-order race.
         this.serviceRegistry.register('user-groups', this.userGroupService);
         this.serviceRegistry.register('wallets', this.walletService);
         this.serviceRegistry.register('accounts', this.accountDirectoryService);
-        this.logger.info('Registered user-groups, wallets, accounts on the service registry');
+        this.serviceRegistry.register('user-settings', this.userSettingsService);
+        this.logger.info('Registered user-groups, wallets, accounts, user-settings on the service registry');
 
         this.logger.info('Identity module running');
     }

--- a/src/backend/modules/identity/README.md
+++ b/src/backend/modules/identity/README.md
@@ -9,11 +9,11 @@ Owns Better Auth and everything keyed by the Better Auth user id: the auth insta
 | Module id | `identity` |
 | Module class | `src/backend/modules/identity/IdentityModule.ts` |
 | Admin page | `/system/users` (menu item `Users`, order 25, registered in `run()`) |
-| Service registry names | `'user-groups'`, `'wallets'`, `'accounts'` |
-| Mounted routes | `/api/auth/*`, `/api/user/wallets/*`, `/api/admin/users/groups/*`, `/api/admin/users` (accounts) |
-| Types package | `@delphian/tronrelic-types` → `IWalletService`, `IAccountDirectoryService`, `IUserGroupService` |
+| Service registry names | `'user-groups'`, `'wallets'`, `'accounts'`, `'user-settings'` |
+| Mounted routes | `/api/auth/*`, `/api/user/wallets/*`, `/api/user/settings`, `/api/admin/users/groups/*`, `/api/admin/users` (accounts) |
+| Types package | `@delphian/tronrelic-types` → `IWalletService`, `IAccountDirectoryService`, `IUserGroupService`, `IUserSettingsService` |
 | Auth collections | `module_user_auth_users` / `_sessions` / `_accounts` / `_verifications` / `_passkeys` |
-| Owned collections | `module_user_wallets`, `module_user_groups` |
+| Owned collections | `module_user_wallets`, `module_user_groups`, `module_user_settings` |
 | Bootstrap order | Inits/runs after `TrafficModule` so traffic's `/api/admin/users/{traffic,analytics}` routers mount before the accounts `/api/admin/users` catch-all |
 
 ## Why This Module Exists Separately
@@ -36,6 +36,9 @@ Better Auth is the sole identity layer — the legacy UUID identity system was r
 | `services/wallet.service.ts` | BA-keyed wallet store (`module_user_wallets`); the `'wallets'` contract |
 | `services/wallet-challenge.service.ts` | Single-use nonce mint/consume for wallet mutations (utility, not a singleton) |
 | `services/account-directory.service.ts` | Read-only directory over BA accounts; the `'accounts'` contract |
+| `services/user-settings.service.ts` | Central per-user settings store (`module_user_settings`); the `'user-settings'` contract + definition registry |
+| `api/user-settings.{controller,routes}.ts` | `/api/user/settings` self-service surface (BA-session-resolved, registered-definition allow-list) |
+| `database/IUserSettingDocument.ts` | `module_user_settings` document (`(userId, namespace, key)` → opaque value) |
 | `api/wallet.{controller,routes}.ts` | `/api/user/wallets/*` (BA-session-resolved, no `:id` on the wire) |
 | `api/user-group.{controller,routes}.ts` | `/api/admin/users/groups/*` admin CRUD + membership |
 | `api/accounts.{controller,routes}.ts` | `/api/admin/users` admin account directory (list + per-account group assignment) over the `'accounts'` service |
@@ -70,6 +73,21 @@ Every method takes the resolved Better Auth user id first — the service never 
 
 Group definitions and membership. See `@/types` `IUserGroupService` for the full method surface; `isAdmin(userId)` is the canonical per-user admin check.
 
+### `'user-settings'` → `IUserSettingsService`
+
+The single home for user-centric settings and preferences, keyed by Better Auth user id and addressed by `(namespace, key)`. The store owns the envelope; each provider owns the opaque JSON value under its namespace — a new setting needs no schema change. Two trust levels: the programmatic methods (`get`/`getNamespace`/`getForUsers`/`set`/`delete`) serve trusted server callers and skip validation; the `/api/user/settings` self-service surface writes only settings a provider registered as `userWritable` via `registerDefinition`, after the definition's validator accepts the value — the allow-list that prevents arbitrary-key storage exhaustion.
+
+| Method | Purpose |
+|--------|---------|
+| `get(userId, namespace, key)` | One value, or the registered default, or null |
+| `getNamespace(userId, namespace)` | All keys a user stored under one namespace |
+| `getForUsers(userIds, namespace, key)` | Batch read one setting across users (one round-trip) |
+| `set(userId, namespace, key, value)` | Upsert a value (trusted; no validation) |
+| `delete(userId, namespace, key)` | Clear a value, reverting to the default |
+| `registerDefinition(def)` / `listDefinitions()` | Declare/enumerate self-service-writable settings |
+
+First consumer: the notifications module persists per-user opt-outs here under the `'notifications'` namespace (see [Notifications Module README](../notifications/README.md)).
+
 ## REST Endpoints
 
 | Method | Path | Auth | Purpose |
@@ -80,6 +98,9 @@ Group definitions and membership. See `@/types` `IUserGroupService` for the full
 | POST | `/api/user/wallets` | BA session | Link a wallet |
 | DELETE | `/api/user/wallets/:address` | BA session | Unlink a wallet |
 | PATCH | `/api/user/wallets/:address/primary` | BA session | Set primary |
+| GET | `/api/user/settings` | BA session | Caller's values + user-writable catalog |
+| PUT | `/api/user/settings` | BA session | Write one registered setting (`{namespace,key,value}`) |
+| DELETE | `/api/user/settings` | BA session | Clear one setting (`{namespace,key}`) |
 | GET/POST | `/api/admin/users/groups` | `requireAdmin` | List / create group definitions |
 | GET/PATCH/DELETE | `/api/admin/users/groups/:id` | `requireAdmin` | Read / update / delete a definition |
 | GET | `/api/admin/users/groups/:id/members` | `requireAdmin` | Paginated member ids |
@@ -91,7 +112,7 @@ Group definitions and membership. See `@/types` `IUserGroupService` for the full
 
 ## Lifecycle
 
-**`init()`** constructs (in order) `GroupService`, `WalletService`, `UserGroupService` (seeds the `admin` group), `AccountDirectoryService`, and the Better Auth instance, then wires the auth facade and builds the wallet + group controllers. **`run()`** registers the `Users` menu item under the System container, mounts `/api/auth/*`, the wallet router, the admin group router, and the admin accounts router (`/api/admin/users`, the `/:id` catch-all, last), then registers `'user-groups'`, `'wallets'`, `'accounts'`.
+**`init()`** constructs (in order) `GroupService`, `WalletService`, `UserGroupService` (seeds the `admin` group), `AccountDirectoryService`, `UserSettingsService`, and the Better Auth instance, then wires the auth facade and builds the wallet + group + user-settings controllers. **`run()`** registers the `Users` menu item under the System container, mounts `/api/auth/*`, the wallet router, the user-settings router, the admin group router, and the admin accounts router (`/api/admin/users`, the `/:id` catch-all, last), then registers `'user-groups'`, `'wallets'`, `'accounts'`, `'user-settings'`.
 
 ## Related
 

--- a/src/backend/modules/identity/README.md
+++ b/src/backend/modules/identity/README.md
@@ -100,7 +100,7 @@ First consumer: the notifications module persists per-user opt-outs here under t
 | PATCH | `/api/user/wallets/:address/primary` | BA session | Set primary |
 | GET | `/api/user/settings` | BA session | Caller's values + user-writable catalog |
 | PUT | `/api/user/settings` | BA session | Write one registered setting (`{namespace,key,value}`) |
-| DELETE | `/api/user/settings` | BA session | Clear one setting (`{namespace,key}`) |
+| DELETE | `/api/user/settings` | BA session | Clear one setting (`?namespace=&key=`) |
 | GET/POST | `/api/admin/users/groups` | `requireAdmin` | List / create group definitions |
 | GET/PATCH/DELETE | `/api/admin/users/groups/:id` | `requireAdmin` | Read / update / delete a definition |
 | GET | `/api/admin/users/groups/:id/members` | `requireAdmin` | Paginated member ids |

--- a/src/backend/modules/identity/__tests__/user-settings.service.test.ts
+++ b/src/backend/modules/identity/__tests__/user-settings.service.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @fileoverview Tests for the central per-user settings store.
+ *
+ * Exercises the programmatic read/write path (single, namespace, and batch
+ * reads, plus default fallback), the definition registry that gates the
+ * self-service surface, and the singleton lifecycle — all against the in-memory
+ * database mock so no live MongoDB is needed.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { ISystemLogService } from '@/types';
+import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+import { UserSettingsService } from '../services/user-settings.service.js';
+
+/** No-op logger satisfying ISystemLogService for the service under test. */
+function silentLogger(): ISystemLogService {
+    const noop = (): void => undefined;
+    const logger = {
+        info: noop, warn: noop, error: noop, debug: noop, trace: noop, fatal: noop,
+        child: () => logger
+    } as unknown as ISystemLogService;
+    return logger;
+}
+
+describe('UserSettingsService', () => {
+    let db: ReturnType<typeof createMockDatabaseService>;
+    let service: UserSettingsService;
+
+    beforeEach(() => {
+        db = createMockDatabaseService();
+        UserSettingsService.resetForTests();
+        UserSettingsService.setDependencies(db, silentLogger());
+        service = UserSettingsService.getInstance();
+    });
+
+    describe('singleton lifecycle', () => {
+        it('returns the same instance and throws before configuration', () => {
+            expect(UserSettingsService.getInstance()).toBe(service);
+            UserSettingsService.resetForTests();
+            expect(() => UserSettingsService.getInstance()).toThrow(/setDependencies/);
+        });
+    });
+
+    describe('programmatic read/write', () => {
+        it('round-trips a value under (userId, namespace, key)', async () => {
+            await service.set('user1', 'core', 'theme', 'dark');
+            expect(await service.get('user1', 'core', 'theme')).toBe('dark');
+        });
+
+        it('upserts in place rather than duplicating', async () => {
+            await service.set('user1', 'core', 'theme', 'dark');
+            await service.set('user1', 'core', 'theme', 'light');
+            expect(await service.get('user1', 'core', 'theme')).toBe('light');
+        });
+
+        it('isolates values by user, namespace, and key', async () => {
+            await service.set('user1', 'core', 'theme', 'dark');
+            expect(await service.get('user2', 'core', 'theme')).toBeNull();
+            expect(await service.get('user1', 'core', 'lang')).toBeNull();
+            expect(await service.get('user1', 'other', 'theme')).toBeNull();
+        });
+
+        it('reads every key in a namespace at once', async () => {
+            await service.set('user1', 'core', 'theme', 'dark');
+            await service.set('user1', 'core', 'lang', 'en');
+            await service.set('user1', 'other', 'x', 1);
+            expect(await service.getNamespace('user1', 'core')).toEqual({ theme: 'dark', lang: 'en' });
+        });
+
+        it('batch-reads one setting across many users, omitting those without a row', async () => {
+            await service.set('user1', 'notifications', 'preferences', { mutedAll: true, overrides: {} });
+            await service.set('user3', 'notifications', 'preferences', { mutedAll: false, overrides: {} });
+
+            const map = await service.getForUsers(['user1', 'user2', 'user3'], 'notifications', 'preferences');
+            expect(map.get('user1')).toEqual({ mutedAll: true, overrides: {} });
+            expect(map.has('user2')).toBe(false);
+            expect(map.get('user3')).toEqual({ mutedAll: false, overrides: {} });
+        });
+
+        it('returns an empty map for an empty user list without querying', async () => {
+            expect((await service.getForUsers([], 'core', 'theme')).size).toBe(0);
+        });
+
+        it('deletes a value, reverting to null', async () => {
+            await service.set('user1', 'core', 'theme', 'dark');
+            await service.delete('user1', 'core', 'theme');
+            expect(await service.get('user1', 'core', 'theme')).toBeNull();
+        });
+    });
+
+    describe('definition registry', () => {
+        it('falls back to the registered default when no row exists', async () => {
+            service.registerDefinition({
+                namespace: 'core', key: 'theme', label: 'Theme', userWritable: true,
+                validate: (v) => v === 'dark' || v === 'light', defaultValue: 'light'
+            });
+            expect(await service.get('user1', 'core', 'theme')).toBe('light');
+            await service.set('user1', 'core', 'theme', 'dark');
+            expect(await service.get('user1', 'core', 'theme')).toBe('dark');
+        });
+
+        it('exposes and replaces definitions by (namespace, key)', () => {
+            const validate = (): boolean => true;
+            service.registerDefinition({ namespace: 'core', key: 'theme', label: 'Theme', userWritable: true, validate });
+            expect(service.getDefinition('core', 'theme')?.label).toBe('Theme');
+            service.registerDefinition({ namespace: 'core', key: 'theme', label: 'Appearance', userWritable: false, validate });
+            expect(service.getDefinition('core', 'theme')?.label).toBe('Appearance');
+            expect(service.getDefinition('core', 'theme')?.userWritable).toBe(false);
+            expect(service.listDefinitions()).toHaveLength(1);
+        });
+
+        it('returns undefined for an unregistered definition', () => {
+            expect(service.getDefinition('core', 'missing')).toBeUndefined();
+        });
+    });
+});

--- a/src/backend/modules/identity/api/user-settings.controller.ts
+++ b/src/backend/modules/identity/api/user-settings.controller.ts
@@ -126,7 +126,9 @@ export class UserSettingsController {
 
     /**
      * DELETE `/` — clear one setting, reverting the user to the registered
-     * default. Body: `{ namespace, key }`. Only registered, user-writable
+     * default. Query: `?namespace=<ns>&key=<key>` — a DELETE request body is
+     * discouraged by RFC 9110 and stripped by many proxies/clients, so the
+     * identifiers ride the query string. Only registered, user-writable
      * settings may be cleared, mirroring the write allow-list.
      */
     remove = async (req: Request, res: Response): Promise<void> => {
@@ -136,11 +138,10 @@ export class UserSettingsController {
             return;
         }
 
-        const body = (req.body ?? {}) as Record<string, unknown>;
-        const namespace = body.namespace;
-        const key = body.key;
+        const namespace = req.query.namespace;
+        const key = req.query.key;
         if (typeof namespace !== 'string' || typeof key !== 'string') {
-            res.status(400).json({ success: false, error: 'namespace and key are required strings' });
+            res.status(400).json({ success: false, error: 'namespace and key are required query parameters' });
             return;
         }
 

--- a/src/backend/modules/identity/api/user-settings.controller.ts
+++ b/src/backend/modules/identity/api/user-settings.controller.ts
@@ -1,0 +1,161 @@
+/**
+ * @fileoverview HTTP interface for the central per-user settings store.
+ *
+ * The self-service surface a logged-in user drives to read and change their own
+ * settings. Login-gated, never admin: a user owns their own settings. The userId
+ * is taken from the resolved Better Auth session, never the request body, so a
+ * user can only touch their own rows.
+ *
+ * This surface is untrusted, so it is deliberately narrow: it serves and writes
+ * only settings a provider has registered as `userWritable`, and a write must
+ * pass that definition's validator. An unregistered or non-writable
+ * `(namespace, key)`, or a value the validator rejects, is a 400 — never stored.
+ * That allow-list is what prevents an authenticated user from writing arbitrary
+ * keys and exhausting their storage.
+ */
+
+import type { Request, Response } from 'express';
+import { isLoggedIn } from '@/types';
+import type { IHasAuthSession, ISystemLogService } from '@/types';
+import type { UserSettingsService } from '../services/user-settings.service.js';
+
+/**
+ * Serves and updates the current user's registered, user-writable settings.
+ *
+ * Constructed in `IdentityModule.init()` with the {@link UserSettingsService}
+ * singleton and the module logger.
+ */
+export class UserSettingsController {
+    /**
+     * @param settings - Central settings store.
+     * @param logger - Module logger; a `component: 'user-settings-controller'` child is derived.
+     */
+    constructor(
+        private readonly settings: UserSettingsService,
+        private readonly logger: ISystemLogService
+    ) {
+        this.logger = logger.child({ component: 'user-settings-controller' });
+    }
+
+    /**
+     * Resolve the caller's Better Auth user id, or `null` when not logged in.
+     *
+     * @param req - Request carrying the resolved session.
+     * @returns The user id, or `null`.
+     */
+    private userId(req: Request): string | null {
+        if (!isLoggedIn(req as unknown as IHasAuthSession)) {
+            return null;
+        }
+        return (req as unknown as IHasAuthSession).authSession?.user?.id ?? null;
+    }
+
+    /**
+     * GET `/` — the caller's stored values for every user-writable setting plus
+     * the catalog the UI renders the form from. The validator function is dropped
+     * from the catalog projection because it cannot cross the wire.
+     */
+    get = async (req: Request, res: Response): Promise<void> => {
+        const userId = this.userId(req);
+        if (!userId) {
+            res.status(401).json({ success: false, error: 'Authentication required' });
+            return;
+        }
+
+        try {
+            const definitions = this.settings.listDefinitions().filter((d) => d.userWritable);
+            const catalog = definitions.map((d) => ({
+                namespace: d.namespace,
+                key: d.key,
+                label: d.label,
+                description: d.description
+            }));
+            const values = await Promise.all(
+                definitions.map(async (d) => ({
+                    namespace: d.namespace,
+                    key: d.key,
+                    value: await this.settings.get(userId, d.namespace, d.key)
+                }))
+            );
+            res.json({ success: true, catalog, values });
+        } catch (error) {
+            this.logger.error({ error, userId }, 'Failed to read user settings');
+            res.status(500).json({ success: false, error: 'Failed to read settings' });
+        }
+    };
+
+    /**
+     * PUT `/` — write one setting. Body: `{ namespace, key, value }`. Rejects an
+     * unregistered or non-writable pairing, or a value the registered validator
+     * refuses, with a 400 so model-free client input cannot smuggle unexpected
+     * shapes or keys into storage.
+     */
+    put = async (req: Request, res: Response): Promise<void> => {
+        const userId = this.userId(req);
+        if (!userId) {
+            res.status(401).json({ success: false, error: 'Authentication required' });
+            return;
+        }
+
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const namespace = body.namespace;
+        const key = body.key;
+        if (typeof namespace !== 'string' || typeof key !== 'string') {
+            res.status(400).json({ success: false, error: 'namespace and key are required strings' });
+            return;
+        }
+
+        const definition = this.settings.getDefinition(namespace, key);
+        if (!definition || !definition.userWritable) {
+            res.status(400).json({ success: false, error: 'Unknown or read-only setting' });
+            return;
+        }
+        if (!definition.validate(body.value)) {
+            res.status(400).json({ success: false, error: 'Invalid value for setting' });
+            return;
+        }
+
+        try {
+            await this.settings.set(userId, namespace, key, body.value);
+            res.json({ success: true, namespace, key, value: body.value });
+        } catch (error) {
+            this.logger.error({ error, userId, namespace, key }, 'Failed to write user setting');
+            res.status(500).json({ success: false, error: 'Failed to write setting' });
+        }
+    };
+
+    /**
+     * DELETE `/` — clear one setting, reverting the user to the registered
+     * default. Body: `{ namespace, key }`. Only registered, user-writable
+     * settings may be cleared, mirroring the write allow-list.
+     */
+    remove = async (req: Request, res: Response): Promise<void> => {
+        const userId = this.userId(req);
+        if (!userId) {
+            res.status(401).json({ success: false, error: 'Authentication required' });
+            return;
+        }
+
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const namespace = body.namespace;
+        const key = body.key;
+        if (typeof namespace !== 'string' || typeof key !== 'string') {
+            res.status(400).json({ success: false, error: 'namespace and key are required strings' });
+            return;
+        }
+
+        const definition = this.settings.getDefinition(namespace, key);
+        if (!definition || !definition.userWritable) {
+            res.status(400).json({ success: false, error: 'Unknown or read-only setting' });
+            return;
+        }
+
+        try {
+            await this.settings.delete(userId, namespace, key);
+            res.json({ success: true, namespace, key });
+        } catch (error) {
+            this.logger.error({ error, userId, namespace, key }, 'Failed to delete user setting');
+            res.status(500).json({ success: false, error: 'Failed to delete setting' });
+        }
+    };
+}

--- a/src/backend/modules/identity/api/user-settings.routes.ts
+++ b/src/backend/modules/identity/api/user-settings.routes.ts
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview Router factory for the central per-user settings endpoints.
+ *
+ * Mounted at `/api/user/settings`. Like the wallet router, these routes resolve
+ * the caller from the Better Auth session inside the controller and carry no id
+ * in the path — a user only ever reads or writes their own settings. The literal
+ * `settings` segment sits alongside `/api/user/wallets`; no `/:id` catch-all
+ * captures it.
+ */
+
+import { Router } from 'express';
+import type { UserSettingsController } from './user-settings.controller.js';
+import { createRateLimiter } from '../../../api/middleware/rate-limit.js';
+
+/**
+ * Create the Express router for the per-user settings endpoints.
+ *
+ * Per-IP rate-limited at a modest tier — settings changes are interactive and
+ * infrequent, so a tight ceiling bounds abuse without hurting real use.
+ * Authorization (401 for anonymous callers) is enforced inside the controller
+ * off `req.authSession`.
+ *
+ * @param controller - User-settings controller instance.
+ * @returns Express router to mount at `/api/user/settings`.
+ */
+export function createUserSettingsRouter(controller: UserSettingsController): Router {
+    const router = Router();
+
+    const settingsRateLimiter = createRateLimiter({
+        windowSeconds: 60,
+        maxRequests: 30,
+        keyPrefix: 'user:settings'
+    });
+
+    /**
+     * GET /api/user/settings
+     * The caller's stored values plus the user-writable catalog.
+     */
+    router.get('/', settingsRateLimiter, controller.get.bind(controller));
+
+    /**
+     * PUT /api/user/settings
+     * Write one registered, user-writable setting after validation.
+     */
+    router.put('/', settingsRateLimiter, controller.put.bind(controller));
+
+    /**
+     * DELETE /api/user/settings
+     * Clear one setting, reverting it to the registered default.
+     */
+    router.delete('/', settingsRateLimiter, controller.remove.bind(controller));
+
+    return router;
+}

--- a/src/backend/modules/identity/database/IUserSettingDocument.ts
+++ b/src/backend/modules/identity/database/IUserSettingDocument.ts
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Storage shape for the central per-user settings store.
+ *
+ * One row per `(userId, namespace, key)` triple — the *envelope* the
+ * `UserSettingsService` owns. The `value` is opaque provider-owned JSON: the
+ * store never interprets it, so a new setting needs no schema change here. This
+ * is the "core owns the address, provider owns the payload" idiom the wallet and
+ * notification stores also follow, applied to user settings. Keyed by the Better
+ * Auth user id (the opaque hex string the rest of the platform uses — see
+ * `services/user-id.ts`).
+ */
+
+import type { ObjectId } from 'mongodb';
+
+/**
+ * Physical collection name for the central per-user settings store.
+ *
+ * Uses the identity module's historical `module_user_*` prefix (shared with
+ * `module_user_wallets` / `module_user_groups`), the convention this module
+ * carried out of the former omnibus user module. Renaming is a breaking change
+ * for persisted rows — coordinate with a migration.
+ */
+export const USER_SETTINGS_COLLECTION = 'module_user_settings';
+
+/**
+ * One stored setting. The unique `(userId, namespace, key)` index makes this the
+ * single row for that address; `value` carries the provider's JSON verbatim.
+ */
+export interface IUserSettingDocument {
+    /** Mongo identity. */
+    _id: ObjectId;
+
+    /** Better Auth user id (opaque hex string) this row belongs to. */
+    userId: string;
+
+    /** Provider namespace (e.g. `'notifications'`, `'core'`). */
+    namespace: string;
+
+    /** Setting key within the namespace. */
+    key: string;
+
+    /** Opaque provider-owned value. The store never interprets it. */
+    value: unknown;
+
+    /** Last write time. */
+    updatedAt: Date;
+}

--- a/src/backend/modules/identity/index.ts
+++ b/src/backend/modules/identity/index.ts
@@ -17,13 +17,18 @@ export type { WalletAction, IWalletMutationInput } from './services/wallet.servi
 export { WalletChallengeService } from './services/wallet-challenge.service.js';
 export type { IWalletChallenge, WalletChallengeAction } from './services/wallet-challenge.service.js';
 export { AccountDirectoryService } from './services/account-directory.service.js';
+export { UserSettingsService } from './services/user-settings.service.js';
 export { AUTH_USERS_COLLECTION, AUTH_COLLECTIONS } from './services/auth-constants.js';
 export { createAuth, type Auth } from './auth.js';
 
 export { UserGroupController } from './api/user-group.controller.js';
 export { WalletController } from './api/wallet.controller.js';
+export { UserSettingsController } from './api/user-settings.controller.js';
 export { createAdminUserGroupRouter } from './api/user-group.routes.js';
 export { createWalletRouter } from './api/wallet.routes.js';
+export { createUserSettingsRouter } from './api/user-settings.routes.js';
 
 export type { IWalletDocument, ILinkedWallet } from './database/IWalletDocument.js';
 export type { IUserGroupDocument } from './database/IUserGroupDocument.js';
+export { USER_SETTINGS_COLLECTION } from './database/IUserSettingDocument.js';
+export type { IUserSettingDocument } from './database/IUserSettingDocument.js';

--- a/src/backend/modules/identity/services/user-settings.service.ts
+++ b/src/backend/modules/identity/services/user-settings.service.ts
@@ -1,0 +1,260 @@
+/**
+ * @fileoverview Central per-user settings store, keyed by Better Auth user id.
+ *
+ * The single home for user-centric settings and preferences. Solves the problem
+ * of preference data scattering across modules and plugins, each minting its own
+ * collection: here every consumer stores under one collection addressed by
+ * `(userId, namespace, key)`, and reaches it through one registered service
+ * (`'user-settings'`) rather than touching storage directly.
+ *
+ * **Envelope vs payload.** The store owns only the address; each provider owns
+ * the JSON value it writes under its namespace and reads back unchanged. A new
+ * setting needs no change here — the same idiom the platform's content-type and
+ * notification stores follow.
+ *
+ * **Two trust levels.** The programmatic methods serve trusted server callers
+ * (a module persisting a choice, the notification dispatcher batch-reading
+ * opt-outs) and do not validate values. The self-service HTTP surface a
+ * logged-in user drives is untrusted: it may write only settings a provider has
+ * registered as `userWritable`, and only after that definition's validator
+ * accepts the value. Without the allow-list a user could write arbitrary
+ * `(namespace, key)` rows and exhaust storage — so registration is the gate that
+ * makes a setting safe to expose.
+ *
+ * **Singleton.** Follows the project's `setDependencies()` / `getInstance()`
+ * pattern because the store is shared application state configured once at
+ * bootstrap, mirroring {@link WalletService}.
+ */
+
+import { ObjectId, type Collection } from 'mongodb';
+import type {
+    IDatabaseService,
+    ISystemLogService,
+    IUserSettingsService,
+    IUserSettingDefinition
+} from '@/types';
+import { USER_SETTINGS_COLLECTION, type IUserSettingDocument } from '../database/IUserSettingDocument.js';
+
+/**
+ * Compose the in-memory registry key for a setting definition. Kept private so
+ * `(namespace, key)` is always combined the same way for lookup and storage.
+ *
+ * @param namespace - Provider namespace.
+ * @param key - Setting key within the namespace.
+ * @returns The combined registry key.
+ */
+function definitionKey(namespace: string, key: string): string {
+    return `${namespace}:${key}`;
+}
+
+/**
+ * Central per-user settings service. Configured during `IdentityModule.init()`
+ * via {@link UserSettingsService.setDependencies} and published on the service
+ * registry as `'user-settings'`.
+ */
+export class UserSettingsService implements IUserSettingsService {
+    /** Singleton instance. `null` until {@link setDependencies} runs. */
+    private static instance: UserSettingsService | null = null;
+
+    /** `module_user_settings` collection handle. */
+    private readonly collection: Collection<IUserSettingDocument>;
+
+    /** Logger scoped to this service. */
+    private readonly logger: ISystemLogService;
+
+    /**
+     * Registered setting definitions keyed by `namespace:key`. Drives the safe
+     * self-service surface; the programmatic methods ignore it.
+     */
+    private readonly definitions = new Map<string, IUserSettingDefinition>();
+
+    /**
+     * @param database - Database abstraction (Tier-1 collection access).
+     * @param logger - Derives a `component: 'user-settings-service'` child.
+     */
+    private constructor(database: IDatabaseService, logger: ISystemLogService) {
+        this.collection = database.getCollection<IUserSettingDocument>(USER_SETTINGS_COLLECTION);
+        this.logger = logger.child({ component: 'user-settings-service' });
+    }
+
+    /**
+     * Configure the singleton with its dependencies. Idempotent — a second call
+     * keeps the first instance so consumers cannot swap dependencies mid-flight.
+     *
+     * @param database - Database service injected by the module.
+     * @param logger - Identity-module child logger.
+     */
+    public static setDependencies(database: IDatabaseService, logger: ISystemLogService): void {
+        if (!UserSettingsService.instance) {
+            UserSettingsService.instance = new UserSettingsService(database, logger);
+        }
+    }
+
+    /**
+     * Resolve the configured singleton.
+     *
+     * @returns The shared {@link UserSettingsService} instance.
+     * @throws {Error} When called before {@link setDependencies}.
+     */
+    public static getInstance(): UserSettingsService {
+        if (!UserSettingsService.instance) {
+            throw new Error('UserSettingsService.setDependencies() must be called before getInstance().');
+        }
+        return UserSettingsService.instance;
+    }
+
+    /**
+     * Reset the singleton. Test-only escape hatch.
+     *
+     * @internal
+     */
+    public static resetForTests(): void {
+        UserSettingsService.instance = null;
+    }
+
+    /**
+     * Create the collection indexes. The unique `(userId, namespace, key)` index
+     * makes each address a single row and backs per-user reads/writes; the
+     * `(namespace, key)` index backs the cross-user batch read the notification
+     * dispatcher relies on (`{ namespace, key, userId: { $in } }`).
+     */
+    public async createIndexes(): Promise<void> {
+        await this.collection.createIndex(
+            { userId: 1, namespace: 1, key: 1 },
+            { unique: true, name: 'userId_namespace_key_unique' }
+        );
+        await this.collection.createIndex({ namespace: 1, key: 1 }, { name: 'namespace_key' });
+        this.logger.info('User-settings indexes created');
+    }
+
+    /**
+     * Register (or replace) a setting definition. The latest definition for a
+     * `(namespace, key)` wins, so a redeploy that tweaks a label or validator is
+     * safe. Providers call this during their init/enable phase.
+     *
+     * @param definition - The setting a provider exposes to self-service.
+     */
+    public registerDefinition(definition: IUserSettingDefinition): void {
+        this.definitions.set(definitionKey(definition.namespace, definition.key), definition);
+        this.logger.info(
+            { namespace: definition.namespace, key: definition.key, userWritable: definition.userWritable },
+            'User-setting definition registered'
+        );
+    }
+
+    /**
+     * All registered definitions, for the self-service catalog projection.
+     *
+     * @returns Every registered definition (order unspecified).
+     */
+    public listDefinitions(): IUserSettingDefinition[] {
+        return Array.from(this.definitions.values());
+    }
+
+    /**
+     * Look up a registered definition, or `undefined`. Used by the self-service
+     * controller to enforce the write allow-list.
+     *
+     * @param namespace - Provider namespace.
+     * @param key - Setting key.
+     * @returns The definition, or `undefined` when unregistered.
+     */
+    public getDefinition(namespace: string, key: string): IUserSettingDefinition | undefined {
+        return this.definitions.get(definitionKey(namespace, key));
+    }
+
+    /**
+     * Read one setting value, falling back to the registered default and then to
+     * `null` when neither a row nor a default exists.
+     *
+     * @param userId - Better Auth user id.
+     * @param namespace - Provider namespace.
+     * @param key - Setting key.
+     * @returns The stored value (or registered default), else `null`.
+     */
+    public async get<T = unknown>(userId: string, namespace: string, key: string): Promise<T | null> {
+        const doc = await this.collection.findOne({ userId, namespace, key });
+        if (doc) {
+            return doc.value as T;
+        }
+        const definition = this.getDefinition(namespace, key);
+        const fallback = definition?.defaultValue !== undefined ? (definition.defaultValue as T) : null;
+        return fallback;
+    }
+
+    /**
+     * Read every key a user has stored under one namespace in a single query.
+     *
+     * @param userId - Better Auth user id.
+     * @param namespace - Provider namespace.
+     * @returns Map of key → stored value for that namespace (empty when none).
+     */
+    public async getNamespace(userId: string, namespace: string): Promise<Record<string, unknown>> {
+        const docs = await this.collection.find({ userId, namespace }).toArray();
+        const result: Record<string, unknown> = {};
+        for (const doc of docs) {
+            result[doc.key] = doc.value;
+        }
+        return result;
+    }
+
+    /**
+     * Batch-read one `(namespace, key)` setting for many users in one query, so a
+     * fan-out (a notification blast reading opt-outs) costs one round-trip. Users
+     * without a stored row are absent from the map — the caller applies its own
+     * default for them.
+     *
+     * @param userIds - Better Auth user ids.
+     * @param namespace - Provider namespace.
+     * @param key - Setting key.
+     * @returns Map of userId → stored value for those that have one.
+     */
+    public async getForUsers<T = unknown>(
+        userIds: string[],
+        namespace: string,
+        key: string
+    ): Promise<Map<string, T>> {
+        const map = new Map<string, T>();
+        if (userIds.length === 0) {
+            return map;
+        }
+        const docs = await this.collection
+            .find({ namespace, key, userId: { $in: userIds } })
+            .toArray();
+        for (const doc of docs) {
+            map.set(doc.userId, doc.value as T);
+        }
+        return map;
+    }
+
+    /**
+     * Write one setting value, upserting the row. Trusted path — performs no
+     * validation; the self-service controller validates against the registered
+     * definition before calling.
+     *
+     * @param userId - Better Auth user id.
+     * @param namespace - Provider namespace.
+     * @param key - Setting key.
+     * @param value - Provider-owned JSON value to store.
+     */
+    public async set<T = unknown>(userId: string, namespace: string, key: string, value: T): Promise<void> {
+        await this.collection.updateOne(
+            { userId, namespace, key },
+            { $set: { userId, namespace, key, value, updatedAt: new Date() } },
+            { upsert: true }
+        );
+        this.logger.info({ userId, namespace, key }, 'User setting written');
+    }
+
+    /**
+     * Remove one setting row, reverting the user to the registered default.
+     *
+     * @param userId - Better Auth user id.
+     * @param namespace - Provider namespace.
+     * @param key - Setting key.
+     */
+    public async delete(userId: string, namespace: string, key: string): Promise<void> {
+        await this.collection.deleteOne({ userId, namespace, key });
+        this.logger.info({ userId, namespace, key }, 'User setting deleted');
+    }
+}

--- a/src/backend/modules/identity/services/user-settings.service.ts
+++ b/src/backend/modules/identity/services/user-settings.service.ts
@@ -44,7 +44,7 @@ import { USER_SETTINGS_COLLECTION, type IUserSettingDocument } from '../database
  * @returns The combined registry key.
  */
 function definitionKey(namespace: string, key: string): string {
-    return `${namespace}:${key}`;
+    return JSON.stringify([namespace, key]);
 }
 
 /**
@@ -63,8 +63,10 @@ export class UserSettingsService implements IUserSettingsService {
     private readonly logger: ISystemLogService;
 
     /**
-     * Registered setting definitions keyed by `namespace:key`. Drives the safe
-     * self-service surface; the programmatic methods ignore it.
+     * Registered setting definitions keyed by a tuple-safe, JSON-encoded
+     * `(namespace, key)` so a colon in either part cannot collide two distinct
+     * settings. Drives the safe self-service surface; the programmatic methods
+     * ignore it.
      */
     private readonly definitions = new Map<string, IUserSettingDefinition>();
 
@@ -183,7 +185,12 @@ export class UserSettingsService implements IUserSettingsService {
     }
 
     /**
-     * Read every key a user has stored under one namespace in a single query.
+     * Read every key a user has *stored* under one namespace in a single query.
+     * Stored values only — registered defaults are not merged in, mirroring
+     * {@link getForUsers}; a caller that wants defaults applies them itself
+     * (unlike {@link get}, which falls back to a single key's default). The
+     * result is therefore empty when the user has stored nothing, and a present
+     * key means the user explicitly set it.
      *
      * @param userId - Better Auth user id.
      * @param namespace - Provider namespace.

--- a/src/backend/modules/notifications/NotificationsModule.ts
+++ b/src/backend/modules/notifications/NotificationsModule.ts
@@ -24,7 +24,8 @@ import type {
     ISystemLogService,
     IContentRegistry,
     IContentRouter,
-    IUserGroupService
+    IUserGroupService,
+    IUserSettingsService
 } from '@/types';
 import { CONTENT_TYPES_SERVICE } from '../../services/content-registry.js';
 import { CONTENT_ROUTER_SERVICE } from '../../services/content-router.js';
@@ -123,8 +124,14 @@ export class NotificationsModule implements IModule<INotificationsModuleDependen
         this.categoryRegistry = new CategoryRegistry(this.logger);
         this.channelRegistry = new ChannelRegistry(this.logger);
 
-        this.preferenceService = new PreferenceService(this.database, this.logger);
-        await this.preferenceService.ensureIndexes();
+        // Per-user opt-outs persist in the identity module's central
+        // 'user-settings' store (resolved lazily — identity publishes it in its
+        // own run(), ahead of any dispatch). The store owns the collection and
+        // its indexes, so there is nothing to ensure here.
+        this.preferenceService = new PreferenceService(
+            () => this.serviceRegistry.get<IUserSettingsService>('user-settings'),
+            this.logger
+        );
 
         this.policyService = new PolicyService(this.database, this.logger);
 

--- a/src/backend/modules/notifications/README.md
+++ b/src/backend/modules/notifications/README.md
@@ -12,10 +12,10 @@ Category-based notification dispatch: any source declares a category and fires; 
 | User page | `/account/notifications` (per-user opt-outs; any logged-in user) |
 | Service registry name | `'notifications'` → `INotificationService` |
 | Content-router sinks | Each channel registers `notifications:<channelId>` on `'content-router'` in `run()` (`accepts: []` floor, `reach` per channel; toast `{ user, user }`). Dispatch matches candidates through the router (`DispatchService.candidateChannelIds`); delivery + recipient resolution stay in dispatch |
-| Consumes from registry | `'user-groups'` (`IUserGroupService.getMembers`) for audience resolution; `'content-types'` (`IContentRegistry`) to resolve a request's content type into a descriptor; `'content-router'` to advertise channels as sinks |
+| Consumes from registry | `'user-groups'` (`IUserGroupService.getMembers`) for audience resolution; `'user-settings'` (`IUserSettingsService`) to persist per-user opt-outs under the `notifications` namespace; `'content-types'` (`IContentRegistry`) to resolve a request's content type into a descriptor; `'content-router'` to advertise channels as sinks |
 | Types package | `@delphian/tronrelic-types` → `INotificationService`, `INotificationCategory`, `INotificationChannel`, `INotificationRequest`/`Receipt`, `INotificationPreferences`, `INotificationPolicy`, `INotificationAuditRecord` |
 | Mounted routes | `/api/notifications/*` (login-gated), `/api/admin/system/notifications/*` (`requireAdmin`) |
-| Owned collections | `module_notifications_preferences`, `module_notifications_policy`, `module_notifications_audit` |
+| Owned collections | `module_notifications_policy`, `module_notifications_audit` (per-user opt-outs live in identity's `module_user_settings`) |
 | WebSocket event | `notification` (emitted to `user:${id}` rooms; single switch case in `websocket.service.ts`) |
 | Bootstrap order | Inits/runs after `IdentityModule` (so `'user-groups'` is published) and before `AiToolsModule` (which registers a category and fires through `'notifications'`) |
 
@@ -35,14 +35,15 @@ It is a **module** (not a plugin) because it is essential cross-cutting infrastr
 | `services/dispatch.service.ts` | The resolution pipeline: audience → gates → channels → audit |
 | `services/category-registry.ts` | In-memory category descriptors (code, process-lifetime) |
 | `services/channel-registry.ts` | In-memory channel transports |
-| `services/preference.service.ts` | `module_notifications_preferences` — per-user opt-outs |
+| `services/preference.service.ts` | Per-user opt-outs, persisted via the central `'user-settings'` store (namespace `notifications`, key `preferences`) |
 | `services/policy.service.ts` | `module_notifications_policy` — admin channel/category kill switches |
 | `services/audit.service.ts` | `module_notifications_audit` — one row per blast, TTL-indexed |
 | `services/recipient-resolver.ts` | Audience → Better Auth user ids via `'user-groups'` |
 | `channels/toast-channel.ts` | The built-in toast channel — emits `notification` to `user:${id}` rooms |
 | `api/preferences.{controller,routes}.ts` | `/api/notifications/preferences` (login-gated) |
 | `api/admin.{controller,routes}.ts` | `/api/admin/system/notifications/*` (`requireAdmin`) |
-| `database/index.ts` | The three MongoDB document shapes |
+| `database/index.ts` | The MongoDB document shapes (policy, audit; the legacy preferences shape is retained as a reference to the retired collection) |
+| `migrations/001_move_preferences_to_user_settings.ts` | Copies legacy `module_notifications_preferences` rows into `module_user_settings` and drops the retired collection |
 
 ## The Contract
 
@@ -100,11 +101,12 @@ Each registered channel also registers a `notifications:<channelId>` sink on the
 
 | Collection | Key | Holds |
 |------------|-----|-------|
-| `module_notifications_preferences` | `userId` (unique) | `mutedAll` + `overrides[categoryId][channelId]` |
 | `module_notifications_policy` | singleton `_id` | `channels` + `categories` enable maps (missing = enabled) |
 | `module_notifications_audit` | `_id` | One blast: label/audience snapshot, per-channel delivered/suppressed, TTL-indexed (90d) |
 
-Indexes are created in `init()` (the collections are new — no production data to migrate). Categories and channels are code (registered at boot); only their admin enable-state, the per-user opt-outs, and the audit history persist.
+Per-user opt-outs are **not** stored here — they live in the identity module's central `module_user_settings` store under the `notifications` namespace (key `preferences`, value `{ mutedAll, overrides }`), reached through the `'user-settings'` service. `PreferenceService` is a thin adapter over that store; this module keeps the catalog-aware validation (in the preferences controller) and the dispatch-time read. Migration `module:notifications:001_move_preferences_to_user_settings` moved the legacy `module_notifications_preferences` collection into the central store and dropped it.
+
+The policy and audit indexes are created in `init()`. Categories and channels are code (registered at boot); only their admin enable-state, the per-user opt-outs (now central), and the audit history persist.
 
 ## REST Endpoints
 
@@ -128,4 +130,4 @@ The `ai-tools` module registers the `ai-tools.scheduled-prompt-run` category (au
 - [system-content-types.md](../../../../docs/system/system-content-types.md) — the central content registry `notify()` resolves through, and the channel-capability vocabulary
 - [Module Architecture](../../../../docs/system/modules/modules-architecture.md) — IModule contract, bootstrap order, service registry
 - [plugins-service-registry.md](../../../../docs/plugins/plugins-service-registry.md) — `watch()` vs `get()` for consuming `'notifications'`
-- [Identity Module README](../identity/README.md) — the `'user-groups'` service used for audience resolution
+- [Identity Module README](../identity/README.md) — the `'user-groups'` service used for audience resolution and the `'user-settings'` store that persists per-user opt-outs

--- a/src/backend/modules/notifications/__tests__/notifications.module.test.ts
+++ b/src/backend/modules/notifications/__tests__/notifications.module.test.ts
@@ -30,6 +30,7 @@ import { NotificationService } from '../services/notification.service.js';
 import { CategoryRegistry } from '../services/category-registry.js';
 import { ChannelRegistry } from '../services/channel-registry.js';
 import { PreferenceService } from '../services/preference.service.js';
+import { UserSettingsService } from '../../identity/services/user-settings.service.js';
 import { PolicyService } from '../services/policy.service.js';
 import { AuditService } from '../services/audit.service.js';
 import { RecipientResolver } from '../services/recipient-resolver.js';
@@ -103,7 +104,12 @@ describe('Notifications dispatch pipeline', () => {
         db = createMockDatabaseService();
         categories = new CategoryRegistry(logger);
         channels = new ChannelRegistry(logger);
-        preferences = new PreferenceService(db, logger);
+        // Opt-outs now persist in the central user-settings store; back the
+        // preference service with a real UserSettingsService over the mock db so
+        // the dispatch read/write path is exercised end to end.
+        UserSettingsService.resetForTests();
+        UserSettingsService.setDependencies(db, logger);
+        preferences = new PreferenceService(() => UserSettingsService.getInstance(), logger);
         policy = new PolicyService(db, logger);
         audit = new AuditService(db, logger);
         content = new ContentRegistry(logger);

--- a/src/backend/modules/notifications/migrations/001_move_preferences_to_user_settings.ts
+++ b/src/backend/modules/notifications/migrations/001_move_preferences_to_user_settings.ts
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview Move per-user notification opt-outs into the central
+ * user-settings store.
+ *
+ * Notification preferences used to live in this module's own
+ * `module_notifications_preferences` collection. They now persist in the identity
+ * module's central `module_user_settings` store under the `'notifications'`
+ * namespace, so all user-centric settings share one home behind the
+ * `'user-settings'` service. This migration copies each existing opt-out row into
+ * the central store and drops the retired collection.
+ *
+ * Collection names are written as literals on purpose: a migration is a frozen
+ * record of an operation, so it must not drift if a constant is later renamed.
+ *
+ * Idempotent. The destination upsert keys on `(userId, namespace, key)`, so a
+ * re-run overwrites rather than duplicates; once the source collection is dropped
+ * a re-run simply finds nothing to copy.
+ */
+
+import type { IMigration, IMigrationContext } from '@/types';
+
+/** Retired source collection — this module's former preference store. */
+const SOURCE_COLLECTION = 'module_notifications_preferences';
+
+/** Destination collection — identity's central per-user settings store. */
+const DESTINATION_COLLECTION = 'module_user_settings';
+
+/** Namespace the opt-outs occupy in the central store. */
+const NAMESPACE = 'notifications';
+
+/** Key the single opt-out value is stored under within the namespace. */
+const KEY = 'preferences';
+
+/**
+ * Legacy preference row shape as stored in `module_notifications_preferences`.
+ */
+interface ILegacyPreferenceDocument {
+    userId: string;
+    mutedAll?: boolean;
+    overrides?: Record<string, Record<string, boolean>>;
+}
+
+export const migration: IMigration = {
+    id: '001_move_preferences_to_user_settings',
+    description: 'Move per-user notification opt-outs from module_notifications_preferences into the central module_user_settings store.',
+    // Must run AFTER the curation category-rename migration: that migration
+    // rekeys `overrides` inside the legacy collection, so moving (and dropping)
+    // the collection first would strand the rename — the migrated opt-outs would
+    // keep the stale category key and curation's rekey would no-op against a
+    // vanished collection.
+    dependencies: ['module:curation:002_rename_curation_held_notification_category'],
+
+    /**
+     * Copy every legacy preference row into the central settings store, then drop
+     * the retired collection.
+     *
+     * @param context - Migration context exposing the database service.
+     */
+    async up(context: IMigrationContext): Promise<void> {
+        const source = context.database.getCollection<ILegacyPreferenceDocument>(SOURCE_COLLECTION);
+        const destination = context.database.getCollection(DESTINATION_COLLECTION);
+        const now = new Date();
+
+        const legacy = await source.find({}).toArray();
+        for (const row of legacy) {
+            const value = {
+                mutedAll: row.mutedAll ?? false,
+                overrides: row.overrides ?? {}
+            };
+            await destination.updateOne(
+                { userId: row.userId, namespace: NAMESPACE, key: KEY },
+                { $set: { userId: row.userId, namespace: NAMESPACE, key: KEY, value, updatedAt: now } },
+                { upsert: true }
+            );
+        }
+
+        // Drop the retired collection so the data has exactly one home. The catch
+        // makes a re-run after the drop (or a fresh deploy that never had the
+        // collection) a no-op rather than a NamespaceNotFound failure.
+        await source.drop().catch(() => undefined);
+    }
+};

--- a/src/backend/modules/notifications/services/dispatch.service.ts
+++ b/src/backend/modules/notifications/services/dispatch.service.ts
@@ -25,11 +25,11 @@ import type {
 } from '@/types';
 import type { CategoryRegistry } from './category-registry.js';
 import type { ChannelRegistry } from './channel-registry.js';
-import type { PreferenceService } from './preference.service.js';
+import type { PreferenceService, INotificationPreferencesValue } from './preference.service.js';
 import type { PolicyService } from './policy.service.js';
 import type { AuditService } from './audit.service.js';
 import type { RecipientResolver } from './recipient-resolver.js';
-import type { INotificationPreferencesDocument, INotificationAuditDocument } from '../database/index.js';
+import type { INotificationAuditDocument } from '../database/index.js';
 import { channelIdFromSinkId } from '../channels/notification-channel-sink.js';
 
 /**
@@ -250,7 +250,7 @@ export class DispatchService {
     private isAllowed(
         category: INotificationCategory,
         channelId: string,
-        pref: INotificationPreferencesDocument | undefined
+        pref: INotificationPreferencesValue | undefined
     ): boolean {
         if (pref?.mutedAll && category.mutable !== false) {
             return false;

--- a/src/backend/modules/notifications/services/preference.service.ts
+++ b/src/backend/modules/notifications/services/preference.service.ts
@@ -1,38 +1,74 @@
 /**
- * @fileoverview Per-user notification preferences store.
+ * @fileoverview Per-user notification preferences, persisted in the central
+ * user-settings store.
  *
  * Keyed by Better Auth user id. The dispatch pipeline reads a recipient's
  * preferences before delivering on any channel — server-side enforcement is the
  * only place per-user silencing can be honored without trusting the client. A
  * user with no stored row takes every category default and mutes nothing.
+ *
+ * **Storage moved, semantics stayed.** The opt-out data lives in the identity
+ * module's central `'user-settings'` store under the `'notifications'` namespace,
+ * not in a notifications-owned collection. This module keeps the
+ * notification-specific shape, the catalog-aware validation (in the controller),
+ * and the dispatch-time read; only persistence delegates outward. The service is
+ * resolved lazily from the registry — identity publishes `'user-settings'` in its
+ * own `run()`, which precedes any dispatch, so there is no boot-order race.
  */
 
-import type { IDatabaseService, ISystemLogService, INotificationPreferences, INotificationPreferenceUpdate } from '@/types';
-import type { INotificationPreferencesDocument } from '../database/index.js';
-import { PREFERENCES_COLLECTION } from '../config.js';
+import type { ISystemLogService, IUserSettingsService, INotificationPreferences, INotificationPreferenceUpdate } from '@/types';
+
+/** Namespace the notification opt-outs occupy in the central user-settings store. */
+export const NOTIFICATION_PREFS_NAMESPACE = 'notifications';
+
+/** Key the single opt-out value is stored under within the namespace. */
+export const NOTIFICATION_PREFS_KEY = 'preferences';
 
 /**
- * Reads and writes per-user preference documents. Not a singleton — the module
- * constructs exactly one and injects it into the dispatcher and the user
- * controller; it implements no public `IXxxService` contract.
+ * The stored opt-out value — the notification-specific payload the central store
+ * holds opaquely under `(userId, 'notifications', 'preferences')`. Equivalent to
+ * {@link INotificationPreferences} without the `userId` (implied by the address).
+ */
+export interface INotificationPreferencesValue {
+    /** Global mute — suppresses every mutable category on every channel. */
+    mutedAll: boolean;
+    /** category id → channel id → enabled. Missing entry falls back to the category default. */
+    overrides: Record<string, Record<string, boolean>>;
+}
+
+/**
+ * Reads and writes per-user notification preferences through the central
+ * user-settings store. Not a singleton — the module constructs exactly one and
+ * injects it into the dispatcher and the user controller; it implements no public
+ * `IXxxService` contract.
  */
 export class PreferenceService {
     /**
-     * @param database - Core database service (module-prefixed collection).
+     * @param getUserSettings - Lazy resolver for the published `'user-settings'`
+     *   service. Lazy because identity registers it in its own `run()`; resolving
+     *   per call tolerates that boot order and operator churn, mirroring how the
+     *   recipient resolver reaches `'user-groups'`.
      * @param logger - Scoped logger.
      */
     constructor(
-        private readonly database: IDatabaseService,
+        private readonly getUserSettings: () => IUserSettingsService | undefined,
         private readonly logger: ISystemLogService
     ) {}
 
     /**
-     * Ensure the unique index on `userId`. Idempotent — safe to call every boot.
-     * Runs at module init rather than as a migration because the collection is
-     * new and carries no production data to transform.
+     * Resolve the central settings store or fail loudly. A miss is a wiring error
+     * (identity is a core module, always present at runtime), not a recoverable
+     * condition, so callers should not paper over it.
+     *
+     * @returns The published user-settings service.
+     * @throws {Error} When `'user-settings'` is not registered.
      */
-    async ensureIndexes(): Promise<void> {
-        await this.database.createIndex(PREFERENCES_COLLECTION, { userId: 1 }, { unique: true, name: 'userId_unique' });
+    private settings(): IUserSettingsService {
+        const service = this.getUserSettings();
+        if (!service) {
+            throw new Error("Notification preferences require the 'user-settings' service to be registered");
+        }
+        return service;
     }
 
     /**
@@ -42,37 +78,32 @@ export class PreferenceService {
      * @returns The user's preferences (never null).
      */
     async get(userId: string): Promise<INotificationPreferences> {
-        const doc = await this.database
-            .getCollection<INotificationPreferencesDocument>(PREFERENCES_COLLECTION)
-            .findOne({ userId });
-        return this.toPublic(userId, doc);
+        const value = await this.settings().get<INotificationPreferencesValue>(
+            userId,
+            NOTIFICATION_PREFS_NAMESPACE,
+            NOTIFICATION_PREFS_KEY
+        );
+        return { userId, mutedAll: value?.mutedAll ?? false, overrides: value?.overrides ?? {} };
     }
 
     /**
-     * Batch-read preferences for a set of recipients in one query, so a blast
-     * to N users costs one round-trip rather than N. Users without a row are
-     * absent from the map; the dispatcher treats absence as "all defaults".
+     * Batch-read preferences for a set of recipients in one query, so a blast to
+     * N users costs one round-trip rather than N. Users without a row are absent
+     * from the map; the dispatcher treats absence as "all defaults".
      *
      * @param userIds - Recipient user ids.
-     * @returns Map of userId → stored document for those that have one.
+     * @returns Map of userId → stored opt-out value for those that have one.
      */
-    async getForUsers(userIds: string[]): Promise<Map<string, INotificationPreferencesDocument>> {
-        const map = new Map<string, INotificationPreferencesDocument>();
-        if (userIds.length === 0) {
-            return map;
-        }
-        const docs = await this.database
-            .getCollection<INotificationPreferencesDocument>(PREFERENCES_COLLECTION)
-            .find({ userId: { $in: userIds } })
-            .toArray();
-        for (const doc of docs) {
-            map.set(doc.userId, doc);
-        }
-        return map;
+    async getForUsers(userIds: string[]): Promise<Map<string, INotificationPreferencesValue>> {
+        return this.settings().getForUsers<INotificationPreferencesValue>(
+            userIds,
+            NOTIFICATION_PREFS_NAMESPACE,
+            NOTIFICATION_PREFS_KEY
+        );
     }
 
     /**
-     * Apply a preference patch, upserting the row. `mutedAll` replaces; the
+     * Apply a preference patch, upserting the value. `mutedAll` replaces; the
      * `overrides` map is shallow-merged at the category level so toggling one
      * (category, channel) pair leaves the user's other choices intact.
      *
@@ -81,9 +112,12 @@ export class PreferenceService {
      * @returns The resulting preferences.
      */
     async update(userId: string, patch: INotificationPreferenceUpdate): Promise<INotificationPreferences> {
-        const current = await this.database
-            .getCollection<INotificationPreferencesDocument>(PREFERENCES_COLLECTION)
-            .findOne({ userId });
+        const settings = this.settings();
+        const current = await settings.get<INotificationPreferencesValue>(
+            userId,
+            NOTIFICATION_PREFS_NAMESPACE,
+            NOTIFICATION_PREFS_KEY
+        );
 
         const mutedAll = patch.mutedAll ?? current?.mutedAll ?? false;
         const overrides: Record<string, Record<string, boolean>> = { ...(current?.overrides ?? {}) };
@@ -93,30 +127,10 @@ export class PreferenceService {
             }
         }
 
-        await this.database
-            .getCollection<INotificationPreferencesDocument>(PREFERENCES_COLLECTION)
-            .updateOne(
-                { userId },
-                { $set: { userId, mutedAll, overrides, updatedAt: new Date() } },
-                { upsert: true }
-            );
+        const value: INotificationPreferencesValue = { mutedAll, overrides };
+        await settings.set(userId, NOTIFICATION_PREFS_NAMESPACE, NOTIFICATION_PREFS_KEY, value);
 
         this.logger.info({ userId }, 'Notification preferences updated');
         return { userId, mutedAll, overrides };
-    }
-
-    /**
-     * Project a stored document (or its absence) to the public preference shape.
-     *
-     * @param userId - The user the projection is for.
-     * @param doc - Stored row, or null when none exists.
-     * @returns Public preferences with defaults applied.
-     */
-    private toPublic(userId: string, doc: INotificationPreferencesDocument | null): INotificationPreferences {
-        return {
-            userId,
-            mutedAll: doc?.mutedAll ?? false,
-            overrides: doc?.overrides ?? {}
-        };
     }
 }


### PR DESCRIPTION
## What

Adds a central per-user settings store to the identity module — the single home for user-centric settings and preferences, behind one registry-published service (`'user-settings'`).

`UserSettingsService` (implements `IUserSettingsService`) backs one collection, `module_user_settings`, addressed by `(userId, namespace, key)`. Core owns the address; each provider owns the opaque JSON value under its namespace, so a new setting needs no central schema change. Two trust levels: trusted programmatic `get`/`getNamespace`/`getForUsers`/`set`/`delete`, and an untrusted self-service surface at `/api/user/settings` (login-gated) that writes only settings a provider registered as `userWritable`, after the registered validator accepts the value — the allow-list that prevents arbitrary-key storage exhaustion.

## Notifications absorbed (first consumer)

Per-user notification opt-outs move out of `module_notifications_preferences` into the central store under the `notifications` namespace. `PreferenceService` becomes a thin adapter that resolves `'user-settings'` lazily (identity publishes it in `run()`, ahead of any dispatch). Admin policy stays in notifications — it's global, not per-user. Migration `module:notifications:001_move_preferences_to_user_settings` copies the legacy rows and drops the collection; it depends on the curation category-rename migration so the rekey lands before the move.

## Verification

- `tsc --noEmit`: clean.
- Full suite: 1251 passed, 1 skipped, 0 failed (includes new `UserSettingsService` unit tests and the re-pointed notifications dispatch tests).

## Notes

- Bumps `@delphian/tronrelic-types` to 4.17.1 for the new `IUserSettingsService` / `IUserSettingDefinition` exports. No plugin consumes them.
- No concrete first setting (e.g. theme/timezone) is registered yet, and no frontend self-service page is included — both are deliberate follow-ups. The catalog is empty until a provider registers a definition.
- Not covered by tests: the self-service controller's allow-list and the data migration.