### PR TITLE
feat(account-history): forward-sync observability + menu submenu pattern

### DIFF
--- a/docs/frontend/frontend.md
+++ b/docs/frontend/frontend.md
@@ -28,6 +28,10 @@ Page structure is built from layout primitives in `components/layout/`. They pro
 | `<Grid>` | `gap="sm\|md\|lg"`, `columns="2\|3\|responsive"` | Grid layout |
 | `<Section>` | `gap="sm\|md\|lg"` | Content section with spacing |
 
+### Admin Page Tab Rows Use the Menu Submenu Pattern
+
+A core or module admin page's in-page tab row (e.g. `/system/account-history`) must be a menu — not a hand-rolled `<button>` array, a `.segmented-control` strip, or a per-page `styles.tab` row. Those are **not authorized** for this surface; the menu Submenu Pattern is the only permitted approach. Register the tabs as nodes in the page's own menu namespace (memory-only, `requiresAdmin` per node), fetch that namespace tree SSR-first, and render it with `MenuNavClient` in submenu mode (`onItemSelect` drives `activeTab`, `activeUrl` highlights). This inherits per-user gating, ordering, and live `menu:update` refresh, and lets a plugin contribute a tab. Reference implementation: `/system/account-history`. See [Submenu Pattern](../../src/backend/modules/menu/README.md#submenu-pattern-namespaced-tab-rows).
+
 ### Container Queries, Not Viewport Media Queries
 
 Component responsiveness uses `container-type: inline-size` and `@container` queries so a component adapts to whatever container it lives in (sidebar, modal, full page, plugin widget, slideout). Reserve `@media` queries for global layout in `app/layout.tsx` only. Breakpoint variables (`$breakpoint-mobile-md`, etc.) live in `app/breakpoints` and must be interpolated as `#{$breakpoint-mobile-md}` inside `@container` rules. See [ui-responsive-design.md](./ui/ui-responsive-design.md).
@@ -72,6 +76,7 @@ Before committing a UI component or plugin page:
 - [ ] Icons from `lucide-react`; ARIA labels on icon-only buttons; visible focus states; semantic HTML (`<button>`, `<nav>`, `<ul>`)
 - [ ] Timestamps render via `<ClientTime>`; no `window`/`document`/`localStorage` in render body (only in `useEffect`)
 - [ ] Backend URLs read via `getServerConfig()` (SSR) or `getRuntimeConfig()` (client) — never `process.env.*` and never `NEXT_PUBLIC_*`
+- [ ] In-page admin tab rows use the menu Submenu Pattern (`MenuNavClient` + a menu namespace), not a hand-rolled strip
 - [ ] Tested in multiple contexts (full page, slideout, modal, mobile container width)
 
 ## Further Reading

--- a/docs/frontend/ui/ui-components.md
+++ b/docs/frontend/ui/ui-components.md
@@ -22,7 +22,7 @@ Source: [components/layout/](../../../src/frontend/components/layout/). Export b
 | `<Grid>` | Grid container; `gap`, `columns="2\|3\|responsive"` | [Grid](../../../src/frontend/components/layout/Grid/) |
 | `<Section>` | Content section with internal `gap` spacing | [Section](../../../src/frontend/components/layout/Section/) |
 | `<MainHeader>` | Site header: database-driven `MenuNav`, logo, wallet/theme controls (server component) | [MainHeader](../../../src/frontend/components/layout/MainHeader/) |
-| `MenuNavSSR` / `MenuNavClient` | SSR-first navigation fed by the backend Menu module; hydrates into a client menu with hamburger support | [MenuNav](../../../src/frontend/components/layout/MenuNav/) |
+| `MenuNavSSR` / `MenuNavClient` | SSR-first navigation fed by the backend Menu module; hydrates into a client menu with hamburger support. `MenuNavClient` (submenu mode) is also the **required** renderer for a core/module admin page's in-page tab row — see [Submenu Pattern](../../../src/backend/modules/menu/README.md#submenu-pattern-namespaced-tab-rows) | [MenuNav](../../../src/frontend/components/layout/MenuNav/) |
 | `<BlockTicker>` | Compact real-time block ticker; follows SSR + Live Updates with Redux hydration | [BlockTicker](../../../src/frontend/components/layout/BlockTicker/) |
 
 See [ui.md](./ui.md) and [frontend.md](../frontend.md#component-first-layout-architecture) for the decision hierarchy (layout components > utility classes > raw divs).
@@ -75,6 +75,8 @@ See [react.md](../react/react.md#context-provider-system) for composition order 
 ## Styling Utility Classes (Not Components)
 
 For one-off visual treatments, use the utility classes in [globals.scss](../../../src/frontend/app/globals.scss): `.chip`, `.pill`, `.segmented-control`, `.stat-grid`, `.stat-card__label/value/delta`, `.alert`, `.text-muted`, `.text-subtle`, `.link`, `.live-indicator`, `.table-row--flash`. Prefer the React primitives above; these utilities exist for legacy call sites and rare compositional needs. `.btn` and `.badge` are *not* global utilities — they live in `Button.module.css` and `Badge.module.css` and are reachable only through `<Button>` / `<Badge>`.
+
+`.segmented-control` is **not** authorized for a core/module admin page's in-page tab row — those must use the menu Submenu Pattern (`MenuNavClient` backed by a menu namespace), the only authorized pattern for that surface. See [Submenu Pattern](../../../src/backend/modules/menu/README.md#submenu-pattern-namespaced-tab-rows). The utility remains fine for non-navigational toggles (e.g. a chart's range switch).
 
 ## When To Add A New Component
 

--- a/packages/types/src/account-history/IAccountHistoryService.ts
+++ b/packages/types/src/account-history/IAccountHistoryService.ts
@@ -65,12 +65,31 @@ export interface IAccountIngestionProgress {
     cursorFingerprint?: string;
     /** Oldest block time reached walking history backward; advances each tick. */
     oldestTimestampReached?: Date;
-    /** Newest block time observed on the first page; the leading edge of history. */
+    /**
+     * Freshness watermark: the newest block time the account is known current to.
+     * Seeded by the backfill's first page and advanced by forward sync as new
+     * transactions land, so it answers "how up to date is this account?" — the
+     * single most useful signal for a `complete` account.
+     */
     newestTimestampSeen?: Date;
     /** Total rows written to ClickHouse for this account so far. */
     rowsIngested: number;
-    /** When the ingestion tick last touched this account. */
+    /** When the ingestion tick (backfill or forward sync) last touched this account. */
     lastRunAt?: Date;
+    /**
+     * When forward sync last refreshed this `complete` account, distinct from
+     * {@link lastRunAt} so the admin can tell a forward refresh from the original
+     * backfill advance. Absent until the first forward sync runs.
+     */
+    lastForwardRunAt?: Date;
+    /**
+     * True when a `complete` account is mid-drain — forward sync hit the per-tick
+     * page cap on a backlog larger than one tick and is catching up across ticks.
+     * Derived from the presence of a forward continuation cursor; the raw cursor
+     * fingerprints are never exposed. Lets the admin distinguish "complete and
+     * current" from "complete but still catching up".
+     */
+    catchingUp?: boolean;
     /** Message from the most recent failed tick, cleared on the next success. */
     lastError?: string;
 }
@@ -120,6 +139,19 @@ export interface IAccountHistoryStats {
         completeAccounts: number;
         /** Accounts whose last tick failed. */
         failedAccounts: number;
+        /**
+         * Completed accounts currently mid-drain in forward sync (catching up on a
+         * backlog larger than one tick). A non-zero value tells the operator the
+         * forward pass is behind and may warrant a higher page cap or cadence.
+         */
+        catchingUpAccounts: number;
+        /**
+         * The stalest freshness watermark across completed accounts — the minimum
+         * {@link IAccountIngestionProgress.newestTimestampSeen}. Every completed
+         * account is current at least to this point, so it is the fleet-wide
+         * freshness floor for the header. Absent when no account is complete.
+         */
+        oldestNewestTimestamp?: Date;
     };
 }
 

--- a/src/backend/modules/account-history/AccountHistoryModule.ts
+++ b/src/backend/modules/account-history/AccountHistoryModule.ts
@@ -83,6 +83,25 @@ const FORWARD_SYNC_CRON = '*/5 * * * *';
 const FORWARD_SYNC_JOB = 'account-history:forward-sync';
 
 /**
+ * Dedicated menu namespace for the page's in-page tab row. Kept out of `main`
+ * so the tabs never leak into the global nav chrome — only the page's own
+ * `MenuNavClient` reads this namespace (menu module's Submenu Pattern).
+ */
+const SUBMENU_NAMESPACE = 'account-history';
+
+/**
+ * The in-page tab row, declared as menu nodes rather than a hand-rolled button
+ * array so the row inherits per-user gating, ordering, and live `menu:update`
+ * refresh from the menu service. Each `url` carries a `?tab=` the client reads
+ * to drive the active panel; the route is identical across tabs.
+ */
+const SUBMENU_TABS: ReadonlyArray<{ label: string; tab: string; icon: string; order: number }> = [
+    { label: 'Tracked Accounts', tab: 'accounts', icon: 'List', order: 0 },
+    { label: 'Ingestion Settings', tab: 'settings', icon: 'Settings', order: 1 },
+    { label: 'Schedules', tab: 'schedules', icon: 'CalendarClock', order: 2 }
+];
+
+/**
  * Two-phase core module wiring the account-history service, job, API, and menu.
  */
 export class AccountHistoryModule implements IModule<IAccountHistoryModuleDependencies> {
@@ -155,6 +174,7 @@ export class AccountHistoryModule implements IModule<IAccountHistoryModuleDepend
             await this.menuService.create({
                 namespace: 'main',
                 label: 'Account History',
+                description: 'Track TRON accounts, backfill their full history into ClickHouse, and keep completed accounts current with forward sync.',
                 url: '/system/account-history',
                 icon: 'History',
                 order: 27,
@@ -162,9 +182,28 @@ export class AccountHistoryModule implements IModule<IAccountHistoryModuleDepend
                 enabled: true
             });
             this.logger.info('Account-history menu item registered under the System container');
+
+            // Register the in-page tab row as a namespaced menu (Submenu Pattern).
+            // The nodes are memory-only and live outside the System container, so
+            // the container's non-bypassable `requiresAdmin` force does not reach
+            // them — the module sets `requiresAdmin` per node itself. The page
+            // renders this namespace with MenuNavClient instead of hand-rolling tabs.
+            for (const tab of SUBMENU_TABS) {
+                await this.menuService.create({
+                    namespace: SUBMENU_NAMESPACE,
+                    label: tab.label,
+                    url: `/system/account-history?tab=${tab.tab}`,
+                    icon: tab.icon,
+                    order: tab.order,
+                    parent: null,
+                    enabled: true,
+                    requiresAdmin: true
+                });
+            }
+            this.logger.info('Account-history submenu tab nodes registered');
         } catch (error) {
-            this.logger.error({ error }, 'Failed to register account-history menu item');
-            throw new Error(`Failed to register account-history menu item: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            this.logger.error({ error }, 'Failed to register account-history menu items');
+            throw new Error(`Failed to register account-history menu items: ${error instanceof Error ? error.message : 'Unknown error'}`);
         }
 
         const router: Router = createAccountHistoryRouter(this.controller);

--- a/src/backend/modules/account-history/README.md
+++ b/src/backend/modules/account-history/README.md
@@ -8,7 +8,7 @@ Ingests the full transaction history of operator-tracked TRON accounts into Clic
 |---------|-------|
 | Module id | `account-history` |
 | Module class | `src/backend/modules/account-history/AccountHistoryModule.ts` |
-| Admin page | `/system/account-history` (menu item `Account History`, order 27, registered in `run()`) |
+| Admin page | `/system/account-history` — System-container item `Account History` (order 27); in-page tabs registered as the `account-history` menu namespace (menu module's Submenu Pattern), rendered with `MenuNavClient`. All in `run()`. |
 | Service registry name | `'account-history'` → `IAccountHistoryService` |
 | Mounted routes | `/api/admin/system/account-history/*` (`createAdminRateLimiter` + `requireAdmin`); `/api/account-history/me/progress` (`requireLogin`, ownership-scoped) |
 | Auto-enrollment | Registers a `'core'` handler on the `http.walletLinked` hook — a user verifying a wallet auto-enrolls it (`label: 'user-verified'`) |
@@ -104,6 +104,8 @@ The backward backfill only walks *down* and permanently excludes `complete` acco
 The watermark advances only when a drain fully reaches known territory (a row at or below it). When a tick hits the per-tick page cap first — a backlog larger than one tick can hold — the endpoint is left *mid-drain*: its continuation fingerprint is persisted (`forwardTxCursor` / `forwardTrc20Cursor`) and the next tick resumes draining downward from there. The newest timestamp seen is held in `forwardPendingNewest` and promoted to the watermark only once both endpoints reach known territory, so the watermark never moves past rows a capped tick left un-fetched — the silent gap an immediate advance would create. While an account is mid-drain, an endpoint that is not itself draining is skipped rather than re-walked, so its fresh arrivals cannot push the shared pending watermark past the still-draining endpoint's un-fetched rows; those arrivals are caught on the next clean cycle. A high-volume account therefore drains over several ticks with **no data loss** — raising `pagesPerTick` or the job cadence only makes it drain faster.
 
 The poll never flips an account to `failed` — that would re-admit it to the backward backfill (which filters on `status !== 'complete'`) and, with cursors cleared at completion, trigger a full re-walk that double-counts; on error it keeps `complete`, persists the drain state, and the next tick resumes from it.
+
+**Admin visibility.** Forward sync is legible on `/system/account-history` without reading Mongo. `newestTimestampSeen` is the per-account freshness watermark ("Newest tx" column); a `catchingUp` boolean (derived from a parked forward continuation cursor, never the raw fingerprint) tags a completed account still draining a backlog; `lastForwardRunAt` records the last forward refresh, distinct from the frozen backfill `lastRunAt`. `getStats().totals` rolls these into `catchingUpAccounts` and `oldestNewestTimestamp` (the freshness floor across completed accounts) for the page header. The `POST /ingest/forward/run` endpoint is wired to a "Run forward sync" button so an operator can force a refresh without waiting for the cron.
 
 ## Storage
 

--- a/src/backend/modules/account-history/__tests__/account-history.test.ts
+++ b/src/backend/modules/account-history/__tests__/account-history.test.ts
@@ -108,10 +108,11 @@ describe('AccountHistoryModule', () => {
         const module = new AccountHistoryModule();
 
         const hookRegistry = createHookRegistryMock();
+        const menuService = createMenuMock();
         await module.init({
             database: createMockDatabaseService(),
             app: app as never,
-            menuService: createMenuMock(),
+            menuService,
             scheduler,
             clickhouse: undefined,
             serviceRegistry,
@@ -134,6 +135,17 @@ describe('AccountHistoryModule', () => {
         expect(scheduler.register).toHaveBeenCalledWith('account-history:ingest', expect.any(String), expect.any(Function));
         expect(scheduler.register).toHaveBeenCalledWith('account-history:forward-sync', expect.any(String), expect.any(Function));
         expect(serviceRegistry.has('account-history')).toBe(true);
+
+        // The System-container entry plus the three in-page tab nodes (the
+        // Submenu Pattern): tabs live in their own namespace, outside the System
+        // container, so the module sets `requiresAdmin` on them explicitly.
+        expect(menuService.create).toHaveBeenCalledWith(expect.objectContaining({ namespace: 'main', label: 'Account History' }));
+        expect(menuService.create).toHaveBeenCalledWith(expect.objectContaining({
+            namespace: 'account-history',
+            url: '/system/account-history?tab=accounts',
+            requiresAdmin: true
+        }));
+        expect(menuService.create).toHaveBeenCalledTimes(4);
         expect(hookRegistry.register).toHaveBeenCalledWith(
             'core',
             expect.objectContaining({ id: 'http.walletLinked' }),
@@ -298,6 +310,9 @@ describe('AccountHistoryService', () => {
         expect(progress.status).toBe('complete');
         expect(progress.rowsIngested).toBe(101);
         expect(new Date(progress.newestTimestampSeen).getTime()).toBe(newer.getTime());
+        // Forward sync records its own refresh timestamp, distinct from the frozen
+        // backfill `lastRunAt`, so the admin can read a "last refresh" fact.
+        expect(progress.lastForwardRunAt).toBeDefined();
     });
 
     it('runForwardSyncTick resumes a capped drain across ticks and advances the watermark only once known territory is reached', async () => {
@@ -384,6 +399,62 @@ describe('AccountHistoryService', () => {
 
         await service.runForwardSyncTick();
         expect(provider.fetchPage).not.toHaveBeenCalled();
+    });
+
+    it('getStats rolls up catching-up accounts, the freshness floor, and per-account catchingUp', async () => {
+        AccountHistoryService.resetForTests();
+        const database = createMockDatabaseService();
+        const draining = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
+        const current = 'TLa2f6VPqDgRE67v7c1pj7iGwsizZ1jGfX';
+        const jan = new Date('2024-01-01T00:00:00.000Z');
+        const feb = new Date('2024-02-01T00:00:00.000Z');
+        database.getCollectionData(TRACKED_COLLECTION).push({ address: draining, paused: false, addedAt: jan, updatedAt: jan });
+        database.getCollectionData(TRACKED_COLLECTION).push({ address: current, paused: false, addedAt: jan, updatedAt: jan });
+        // `draining` is mid-drain (a forward cursor is parked) and its leading edge
+        // sits at `feb`; `current` is fully caught up at `jan`. The freshness floor
+        // is the older of the two watermarks (`jan`).
+        database.getCollectionData(PROGRESS_COLLECTION).push({
+            address: draining, status: 'complete', newestTimestampSeen: feb,
+            nativeComplete: true, trc20Complete: true, forwardTxCursor: 'fp-resume', rowsIngested: 200
+        });
+        database.getCollectionData(PROGRESS_COLLECTION).push({
+            address: current, status: 'complete', newestTimestampSeen: jan,
+            nativeComplete: true, trc20Complete: true, rowsIngested: 50
+        });
+
+        AccountHistoryService.setDependencies({
+            database, clickhouse: undefined, provider: null, emitter: undefined, logger: createSilentLogger()
+        });
+        const service = AccountHistoryService.getInstance();
+
+        const stats = await service.getStats();
+
+        expect(stats.totals.completeAccounts).toBe(2);
+        expect(stats.totals.catchingUpAccounts).toBe(1);
+        expect(new Date(stats.totals.oldestNewestTimestamp!).getTime()).toBe(jan.getTime());
+
+        const drainingStats = stats.accounts.find((a) => a.account.address === draining);
+        const currentStats = stats.accounts.find((a) => a.account.address === current);
+        expect(drainingStats?.progress.catchingUp).toBe(true);
+        expect(currentStats?.progress.catchingUp).toBe(false);
+    });
+
+    it('getStats omits the freshness floor when no account is complete', async () => {
+        AccountHistoryService.resetForTests();
+        const database = createMockDatabaseService();
+        const now = new Date('2024-01-01T00:00:00.000Z');
+        database.getCollectionData(TRACKED_COLLECTION).push({ address: VALID_ADDRESS, paused: false, addedAt: now, updatedAt: now });
+        database.getCollectionData(PROGRESS_COLLECTION).push({ address: VALID_ADDRESS, status: 'queued', rowsIngested: 0 });
+        AccountHistoryService.setDependencies({
+            database, clickhouse: undefined, provider: null, emitter: undefined, logger: createSilentLogger()
+        });
+        const service = AccountHistoryService.getInstance();
+
+        const stats = await service.getStats();
+
+        expect(stats.totals.completeAccounts).toBe(0);
+        expect(stats.totals.catchingUpAccounts).toBe(0);
+        expect(stats.totals.oldestNewestTimestamp).toBeUndefined();
     });
 });
 

--- a/src/backend/modules/account-history/database/index.ts
+++ b/src/backend/modules/account-history/database/index.ts
@@ -94,8 +94,16 @@ export interface IAccountProgressDoc {
     forwardPendingNewest?: Date;
     /** Total rows written to ClickHouse for this account. */
     rowsIngested: number;
-    /** When the ingestion tick last touched this account; drives round-robin ordering. */
+    /** When any tick (backfill or forward sync) last touched this account; drives backfill round-robin ordering. */
     lastRunAt?: Date;
+    /**
+     * When forward sync last refreshed this completed account. Set alongside
+     * `lastRunAt` by the forward pass and drives the forward round-robin (stalest
+     * first), so a never-refreshed completed account — `lastForwardRunAt` absent —
+     * sorts ahead of one refreshed recently. Surfaced to the admin as a distinct
+     * "last refresh" fact separate from the original backfill advance.
+     */
+    lastForwardRunAt?: Date;
     /** Message from the most recent failed tick; cleared on the next success. */
     lastError?: string;
 }

--- a/src/backend/modules/account-history/services/account-history.service.ts
+++ b/src/backend/modules/account-history/services/account-history.service.ts
@@ -316,6 +316,18 @@ export class AccountHistoryService implements IAccountHistoryService {
             progress: AccountHistoryService.toProgress(account.address, progressByAddress.get(account.address))
         }));
 
+        // The freshness floor: the stalest leading edge among completed accounts.
+        // Computed over completed accounts only — forward sync (which advances the
+        // watermark) applies only to them, so an in-progress account's partial
+        // watermark would understate the fleet's caught-up freshness. Undefined
+        // when nothing is complete yet, so the header omits the rollup.
+        const completeWatermarks = accountStats
+            .filter((a) => a.progress.status === 'complete' && a.progress.newestTimestampSeen)
+            .map((a) => a.progress.newestTimestampSeen!.getTime());
+        const oldestNewestTimestamp = completeWatermarks.length > 0
+            ? new Date(Math.min(...completeWatermarks))
+            : undefined;
+
         const stats: IAccountHistoryStats = {
             settings,
             accounts: accountStats,
@@ -323,7 +335,9 @@ export class AccountHistoryService implements IAccountHistoryService {
                 trackedAccounts: accounts.length,
                 rowsIngested: accountStats.reduce((sum, a) => sum + a.progress.rowsIngested, 0),
                 completeAccounts: accountStats.filter((a) => a.progress.status === 'complete').length,
-                failedAccounts: accountStats.filter((a) => a.progress.status === 'failed').length
+                failedAccounts: accountStats.filter((a) => a.progress.status === 'failed').length,
+                catchingUpAccounts: accountStats.filter((a) => a.progress.catchingUp).length,
+                oldestNewestTimestamp
             }
         };
         return stats;
@@ -680,10 +694,14 @@ export class AccountHistoryService implements IAccountHistoryService {
             progressByAddress.set(doc.address, doc);
         }
 
+        // Order by the forward-specific timestamp, not `lastRunAt`: for a completed
+        // account `lastRunAt` was frozen at backfill completion, so it cannot rotate
+        // forward freshness fairly. A never-forward-synced account (no
+        // `lastForwardRunAt`) sorts first, so it is refreshed soonest.
         const eligible = tracked.filter((t) => progressByAddress.get(t.address)?.status === 'complete');
         eligible.sort((a, b) => {
-            const aRun = progressByAddress.get(a.address)?.lastRunAt?.getTime() ?? 0;
-            const bRun = progressByAddress.get(b.address)?.lastRunAt?.getTime() ?? 0;
+            const aRun = progressByAddress.get(a.address)?.lastForwardRunAt?.getTime() ?? 0;
+            const bRun = progressByAddress.get(b.address)?.lastForwardRunAt?.getTime() ?? 0;
             return aRun - bRun;
         });
 
@@ -808,11 +826,17 @@ export class AccountHistoryService implements IAccountHistoryService {
             }
 
             const stillDraining = nextTxCursor !== undefined || nextTrc20Cursor !== undefined;
+            // One timestamp for both fields: `lastRunAt` keeps its "last touched by
+            // any tick" meaning (so the admin's primary column stays live for
+            // completed accounts), while `lastForwardRunAt` records the forward
+            // refresh specifically and drives the forward round-robin.
+            const now = new Date();
             const patch: Partial<IAccountProgressDoc> = {
                 forwardTxCursor: nextTxCursor,
                 forwardTrc20Cursor: nextTrc20Cursor,
                 rowsIngested: progress.rowsIngested + written,
-                lastRunAt: new Date(),
+                lastRunAt: now,
+                lastForwardRunAt: now,
                 lastError: undefined
             };
             if (stillDraining) {
@@ -836,12 +860,14 @@ export class AccountHistoryService implements IAccountHistoryService {
             // Keep status `complete`; never reopen the backfill (see method doc).
             // Persist the drain state so the next tick resumes; never promote the
             // watermark on a failed (partial) drain.
+            const now = new Date();
             await this.patchProgress(address, {
                 forwardTxCursor: nextTxCursor,
                 forwardTrc20Cursor: nextTrc20Cursor,
                 forwardPendingNewest: pendingNewest,
                 rowsIngested: progress.rowsIngested + written,
-                lastRunAt: new Date(),
+                lastRunAt: now,
+                lastForwardRunAt: now,
                 lastError: message
             });
         }
@@ -978,7 +1004,7 @@ export class AccountHistoryService implements IAccountHistoryService {
      */
     private static toProgress(address: string, doc: IAccountProgressDoc | undefined): IAccountIngestionProgress {
         if (!doc) {
-            return { address, status: 'queued', rowsIngested: 0 };
+            return { address, status: 'queued', rowsIngested: 0, catchingUp: false };
         }
         return {
             address,
@@ -988,6 +1014,11 @@ export class AccountHistoryService implements IAccountHistoryService {
             newestTimestampSeen: doc.newestTimestampSeen,
             rowsIngested: doc.rowsIngested,
             lastRunAt: doc.lastRunAt,
+            lastForwardRunAt: doc.lastForwardRunAt,
+            // Mid-drain iff a forward continuation cursor is parked on either
+            // endpoint. Surface only the boolean — the opaque fingerprints stay
+            // internal, but the operator still learns the account is catching up.
+            catchingUp: Boolean(doc.forwardTxCursor || doc.forwardTrc20Cursor),
             lastError: doc.lastError
         };
     }

--- a/src/backend/modules/account-history/services/account-history.service.ts
+++ b/src/backend/modules/account-history/services/account-history.service.ts
@@ -325,7 +325,7 @@ export class AccountHistoryService implements IAccountHistoryService {
             .filter((a) => a.progress.status === 'complete' && a.progress.newestTimestampSeen)
             .map((a) => a.progress.newestTimestampSeen!.getTime());
         const oldestNewestTimestamp = completeWatermarks.length > 0
-            ? new Date(Math.min(...completeWatermarks))
+            ? new Date(completeWatermarks.reduce((min, t) => Math.min(min, t), Infinity))
             : undefined;
 
         const stats: IAccountHistoryStats = {

--- a/src/backend/modules/menu/README.md
+++ b/src/backend/modules/menu/README.md
@@ -332,7 +332,9 @@ export const myPluginBackendPlugin = definePlugin({
 
 ## Submenu Pattern (Namespaced Tab Rows)
 
-An admin page's submenu — the in-page tab row on surfaces like `/system/traffic` or the AI assistant admin (query / history / tools / settings) — is just a menu. Pages historically hand-roll these as `<button>` arrays with local `activeTab` state, duplicating the same pattern across surfaces. Backing the row with the menu service instead inherits per-user gating, ordering, live `menu:update` refresh, and runtime extensibility: a *different* plugin can contribute a tab into the row by registering a node, which a hand-rolled array cannot offer.
+An admin page's submenu — the in-page tab row on a surface like `/system/account-history` (tracked accounts / settings / schedules) — is just a menu, and backing it with the menu service is **the only authorized pattern for core and module admin pages.** Hand-rolled `<button>` arrays with local `activeTab` state, bare `.segmented-control` strips, and per-page `styles.tab` rows are **not permitted** for these surfaces: they duplicate the same code across pages and forfeit the per-user gating, ordering, live `menu:update` refresh, and runtime extensibility the menu service provides — a *different* plugin can even contribute a tab into the row by registering a node, which a hand-rolled array cannot.
+
+**Reference implementation:** `/system/account-history`. `AccountHistoryModule.run()` registers the `account-history` namespace nodes; `AccountHistoryAdminClient.tsx` renders them with `MenuNavClient`. Copy that surface when building a new admin page's tab row.
 
 ### How It Works
 
@@ -352,30 +354,31 @@ The click decision is the caller's: omit `onItemSelect` and a tab navigates like
 ### Example
 
 ```typescript
-// Backend: register the tabs in the page's own namespace during `ready`.
-menuService.subscribe('ready', async () => {
-    await menuService.create({
-        namespace: 'ai-assistant',
-        label: 'Query',
-        url: '/system/plugins/ai-assistant?tab=query',
-        icon: 'Search',
-        order: 0,
-        parent: null,
-        enabled: true,
-        requiresAdmin: true // caller owns gating outside the System subtree
-    });
-    // ...history, tools, settings
+// Backend: register the tabs in the page's own namespace. A core module
+// registers in `run()` (the menu service is already up); a plugin registers in
+// a `menuService.subscribe('ready', ...)` callback. Memory-only, requiresAdmin
+// per node since the namespace sits outside the System container.
+await menuService.create({
+    namespace: 'account-history',
+    label: 'Tracked Accounts',
+    url: '/system/account-history?tab=accounts',
+    icon: 'List',
+    order: 0,
+    parent: null,
+    enabled: true,
+    requiresAdmin: true // caller owns gating outside the System subtree
 });
+// ...Ingestion Settings, Schedules
 ```
 
 ```tsx
-// Frontend (page client component): render the row as in-page tabs.
+// Frontend (core page client component): render the row as in-page tabs.
 <MenuNavClient
-    namespace="ai-assistant"
+    namespace="account-history"
     items={submenuTree}
     generatedAt={generatedAt}
-    activeUrl={`/system/plugins/ai-assistant?tab=${activeTab}`}
-    onItemSelect={(item) => setActiveTab(tabKeyFromUrl(item.url))}
+    activeUrl={`/system/account-history?tab=${activeTab}`}
+    onItemSelect={(item) => setActiveTab(tabFromUrl(item.url))}
 />
 ```
 

--- a/src/frontend/app/(core)/system/account-history/AccountHistoryAdminClient.tsx
+++ b/src/frontend/app/(core)/system/account-history/AccountHistoryAdminClient.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+/**
+ * @fileoverview Client shell for /system/account-history.
+ *
+ * Holds the interactive surface: the live stats snapshot, the in-page tab row,
+ * and the three tab panels (tracked accounts, ingestion settings, schedules).
+ * The tab row is the menu module's Submenu Pattern — a namespaced menu rendered
+ * with `MenuNavClient`, not a hand-rolled button array — so it inherits per-user
+ * gating, ordering, and live `menu:update` refresh. The server entry
+ * (`page.tsx`) fetches that namespace tree SSR-first and passes it in, mirroring
+ * how `MenuNavSSR` feeds `MenuNavClient`. Clicking a tab drives local state via
+ * `onItemSelect` rather than navigating; `activeUrl` highlights the active tab
+ * since the route is identical across them.
+ *
+ * Ingestion stats stay live off the `account-history:stats` WebSocket nudge — a
+ * timestamp-only signal the backend emits after each tick that triggers a
+ * refetch over the requireAdmin REST feed. The snapshot itself is never sent
+ * over the socket: it carries admin-only data and the broadcast reaches every
+ * connected client.
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import type { MenuNodeSerialized } from '@/shared';
+import { Page, PageHeader } from '../../../../components/layout';
+import { Badge } from '../../../../components/ui/Badge';
+import { ClientTime } from '../../../../components/ui/ClientTime';
+import { MenuNavClient } from '../../../../components/layout/MenuNav/MenuNavClient';
+import { getSocket } from '../../../../lib/socketClient';
+import { SchedulerMonitor, type SchedulerJob } from '../../../../modules/scheduler';
+import { getStats, type IAccountHistoryStatsView } from '../../../../modules/account-history';
+import { AccountsTab } from './AccountsTab';
+import { SettingsTab } from './SettingsTab';
+import styles from './page.module.scss';
+
+/** The page's three tab ids; the `?tab=` value carried by each submenu node. */
+type TabId = 'accounts' | 'settings' | 'schedules';
+
+/** The menu namespace the module registers the tab nodes under. */
+const SUBMENU_NAMESPACE = 'account-history';
+
+/**
+ * Props for the client shell.
+ */
+interface IAccountHistoryAdminClientProps {
+    /** SSR-fetched submenu nodes (the tab row), already gated for the admin. */
+    submenuTree: MenuNodeSerialized[];
+    /** Snapshot timestamp of the submenu tree, seeded onto the menu Redux slice. */
+    submenuGeneratedAt: string;
+}
+
+/**
+ * Predicate selecting only this module's scheduler jobs for the Schedules tab —
+ * the same scheduler authority as /system/scheduler, filtered by name prefix so
+ * edits here and there can never drift.
+ *
+ * @param job - A scheduler job.
+ * @returns True for `account-history:`-prefixed jobs.
+ */
+function isAccountHistoryJob(job: SchedulerJob): boolean {
+    return job.name.startsWith('account-history:');
+}
+
+/**
+ * Resolve a submenu node's `?tab=` value to a known TabId, defaulting to
+ * `accounts` for an unrecognized or missing value so a malformed node can never
+ * leave the page on a blank panel.
+ *
+ * @param url - The clicked node's url (e.g. `/system/account-history?tab=settings`).
+ * @returns The matching tab id.
+ */
+function tabFromUrl(url: string | undefined): TabId {
+    const tab = url?.match(/[?&]tab=([^&]+)/)?.[1];
+    return tab === 'settings' || tab === 'schedules' ? tab : 'accounts';
+}
+
+/**
+ * Account-history admin client shell.
+ *
+ * @param props - SSR submenu tree and its timestamp.
+ * @returns The page.
+ */
+export function AccountHistoryAdminClient({ submenuTree, submenuGeneratedAt }: IAccountHistoryAdminClientProps) {
+    const [activeTab, setActiveTab] = useState<TabId>('accounts');
+    const [stats, setStats] = useState<IAccountHistoryStatsView | null>(null);
+
+    const loadStats = useCallback(async () => {
+        try {
+            setStats(await getStats());
+        } catch {
+            /* primary data load failure surfaces on the empty table; leave stats as-is */
+        }
+    }, []);
+
+    useEffect(() => {
+        void loadStats();
+    }, [loadStats]);
+
+    // The backend emits a timestamp-only nudge after each ingestion tick (the
+    // snapshot carries admin-only data and the broadcast reaches every socket),
+    // so refetch the full stats over the requireAdmin REST endpoint on the
+    // signal rather than trusting the socket payload — mirroring how the
+    // /system/curation page refetches on `curation:changed`.
+    useEffect(() => {
+        const socket = getSocket();
+        const onStats = () => { void loadStats(); };
+        socket.on('account-history:stats', onStats);
+        return () => { socket.off('account-history:stats', onStats); };
+    }, [loadStats]);
+
+    return (
+        <Page>
+            <PageHeader
+                title="Account History"
+                subtitle="Track specific TRON accounts, backfill their full transaction history into ClickHouse, and keep completed accounts current with forward sync."
+            />
+
+            <p className={styles.intro}>
+                Two pull-based passes run on their own schedules, independent of the live block sync. A bounded <strong>backfill</strong>{' '}
+                walks each tracked account&apos;s full history newest-first until both TronGrid endpoints exhaust; once an account is
+                complete, <strong>forward sync</strong> keeps it current by appending transactions that land afterward. Use the tabs to
+                manage the tracked set, tune pacing, and edit the two schedules.
+            </p>
+
+            {stats && (
+                <div className={styles.summary}>
+                    <Badge tone="info">{stats.totals.trackedAccounts} tracked</Badge>
+                    <Badge tone="neutral">{stats.totals.rowsIngested.toLocaleString()} rows</Badge>
+                    {stats.totals.completeAccounts > 0 && <Badge tone="success">{stats.totals.completeAccounts} complete</Badge>}
+                    {stats.totals.catchingUpAccounts > 0 && <Badge tone="warning">{stats.totals.catchingUpAccounts} catching up</Badge>}
+                    {stats.totals.failedAccounts > 0 && <Badge tone="danger">{stats.totals.failedAccounts} failed</Badge>}
+                    {stats.totals.oldestNewestTimestamp && (
+                        <Badge tone="neutral">current to <ClientTime date={stats.totals.oldestNewestTimestamp} format="relative" /></Badge>
+                    )}
+                </div>
+            )}
+
+            <div className={styles.submenu}>
+                <MenuNavClient
+                    namespace={SUBMENU_NAMESPACE}
+                    items={submenuTree}
+                    generatedAt={submenuGeneratedAt}
+                    ariaLabel="Account history sections"
+                    activeUrl={`/system/account-history?tab=${activeTab}`}
+                    onItemSelect={(item) => setActiveTab(tabFromUrl(item.url))}
+                />
+            </div>
+
+            <div className={styles.content}>
+                {activeTab === 'accounts' && <AccountsTab stats={stats} onChanged={loadStats} />}
+                {activeTab === 'settings' && <SettingsTab />}
+                {activeTab === 'schedules' && <SchedulerMonitor jobFilter={isAccountHistoryJob} title="Account History Schedules" />}
+            </div>
+        </Page>
+    );
+}

--- a/src/frontend/app/(core)/system/account-history/AccountHistoryAdminClient.tsx
+++ b/src/frontend/app/(core)/system/account-history/AccountHistoryAdminClient.tsx
@@ -47,6 +47,12 @@ interface IAccountHistoryAdminClientProps {
     submenuTree: MenuNodeSerialized[];
     /** Snapshot timestamp of the submenu tree, seeded onto the menu Redux slice. */
     submenuGeneratedAt: string;
+    /**
+     * The `?tab=` value from the request URL, read SSR-first in `page.tsx` so a
+     * refreshed, bookmarked, or shared deep link opens on the right panel. An
+     * unknown or absent value resolves to `accounts`.
+     */
+    initialTab?: string;
 }
 
 /**
@@ -77,11 +83,13 @@ function tabFromUrl(url: string | undefined): TabId {
 /**
  * Account-history admin client shell.
  *
- * @param props - SSR submenu tree and its timestamp.
+ * @param props - SSR submenu tree, its timestamp, and the deep-linked initial tab.
  * @returns The page.
  */
-export function AccountHistoryAdminClient({ submenuTree, submenuGeneratedAt }: IAccountHistoryAdminClientProps) {
-    const [activeTab, setActiveTab] = useState<TabId>('accounts');
+export function AccountHistoryAdminClient({ submenuTree, submenuGeneratedAt, initialTab }: IAccountHistoryAdminClientProps) {
+    const [activeTab, setActiveTab] = useState<TabId>(
+        initialTab === 'settings' || initialTab === 'schedules' ? initialTab : 'accounts'
+    );
     const [stats, setStats] = useState<IAccountHistoryStatsView | null>(null);
 
     const loadStats = useCallback(async () => {
@@ -90,6 +98,25 @@ export function AccountHistoryAdminClient({ submenuTree, submenuGeneratedAt }: I
         } catch {
             /* primary data load failure surfaces on the empty table; leave stats as-is */
         }
+    }, []);
+
+    /**
+     * Activate the clicked tab and keep its URL a real deep link.
+     *
+     * `MenuNavClient` suppresses the <Link> navigation when `onItemSelect` is set
+     * (it preventDefaults the click), so without this the address bar would never
+     * reflect the selected tab and a refresh, bookmark, or shared link would fall
+     * back to the Accounts panel. Rewrite the address in place with
+     * `history.replaceState` — no server round-trip and no `useSearchParams`
+     * Suspense boundary — so the registered `?tab=` URLs become true deep links;
+     * `page.tsx` reads that value SSR-first to seed the panel on next load.
+     *
+     * @param item - The clicked submenu node, carrying its `?tab=` url.
+     */
+    const handleTabSelect = useCallback((item: MenuNodeSerialized) => {
+        const tab = tabFromUrl(item.url);
+        setActiveTab(tab);
+        window.history.replaceState(null, '', `/system/account-history?tab=${tab}`);
     }, []);
 
     useEffect(() => {
@@ -142,7 +169,7 @@ export function AccountHistoryAdminClient({ submenuTree, submenuGeneratedAt }: I
                     generatedAt={submenuGeneratedAt}
                     ariaLabel="Account history sections"
                     activeUrl={`/system/account-history?tab=${activeTab}`}
-                    onItemSelect={(item) => setActiveTab(tabFromUrl(item.url))}
+                    onItemSelect={handleTabSelect}
                 />
             </div>
 

--- a/src/frontend/app/(core)/system/account-history/AccountsTab.tsx
+++ b/src/frontend/app/(core)/system/account-history/AccountsTab.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useState, useCallback } from 'react';
-import { Plus, Play, Trash2, Pause, PlayCircle } from 'lucide-react';
+import { Plus, Play, Trash2, Pause, PlayCircle, RefreshCw } from 'lucide-react';
 import { Stack } from '../../../../components/layout';
 import { Button } from '../../../../components/ui/Button';
 import { Badge } from '../../../../components/ui/Badge';
@@ -25,6 +25,7 @@ import {
     removeTrackedAccount,
     setAccountPaused,
     runIngestion,
+    runForwardSync,
     type IAccountHistoryStatsView,
     type AccountIngestionStatus
 } from '../../../../modules/account-history';
@@ -96,9 +97,18 @@ export function AccountsTab({ stats, onChanged }: { stats: IAccountHistoryStatsV
     const runNow = useCallback(async () => {
         try {
             await runIngestion();
-            push({ tone: 'success', title: 'Ingestion tick started' });
+            push({ tone: 'success', title: 'Backfill tick started' });
         } catch (err) {
             push({ tone: 'danger', title: 'Failed to run ingestion', description: err instanceof Error ? err.message : String(err) });
+        }
+    }, [push]);
+
+    const runForwardNow = useCallback(async () => {
+        try {
+            await runForwardSync();
+            push({ tone: 'success', title: 'Forward-sync tick started', description: 'Refreshing completed accounts with new transactions.' });
+        } catch (err) {
+            push({ tone: 'danger', title: 'Failed to run forward sync', description: err instanceof Error ? err.message : String(err) });
         }
     }, [push]);
 
@@ -125,13 +135,17 @@ export function AccountsTab({ stats, onChanged }: { stats: IAccountHistoryStatsV
                     <Plus size={16} /> Track
                 </Button>
                 <Button variant="secondary" size="sm" onClick={() => { void runNow(); }}>
-                    <Play size={16} /> Run now
+                    <Play size={16} /> Run backfill
+                </Button>
+                <Button variant="secondary" size="sm" onClick={() => { void runForwardNow(); }}>
+                    <RefreshCw size={16} /> Run forward sync
                 </Button>
             </div>
 
             <p className="text-muted" style={{ margin: 0, fontSize: 'var(--font-size-body-sm)' }}>
-                Backfill walks each account&apos;s full history newest-first, bounded per tick. Progress shows rows ingested and how far
-                back the cursor has reached — there is no percentage, since the total transaction count is unknown until the walk ends.
+                Backfill walks each account&apos;s full history newest-first, bounded per tick — no percentage, since the total count is
+                unknown until the walk ends. Once complete, forward sync keeps the account current: &ldquo;Newest tx&rdquo; is the latest
+                transaction stored, and a <em>catching up</em> tag means forward sync is still draining a backlog larger than one tick.
             </p>
 
             {accounts.length === 0
@@ -145,6 +159,7 @@ export function AccountsTab({ stats, onChanged }: { stats: IAccountHistoryStatsV
                                     <Th width="shrink">Status</Th>
                                     <Th width="shrink">Rows</Th>
                                     <Th width="shrink">Oldest reached</Th>
+                                    <Th width="shrink">Newest tx</Th>
                                     <Th width="shrink">Last run</Th>
                                     <Th width="shrink">Actions</Th>
                                 </Tr>
@@ -158,14 +173,25 @@ export function AccountsTab({ stats, onChanged }: { stats: IAccountHistoryStatsV
                                             {progress.lastError && <div className={styles.account_error}>{progress.lastError}</div>}
                                         </Td>
                                         <Td data-label="Status">
-                                            <Badge tone={statusTone(progress.status)}>{account.paused ? 'paused' : progress.status}</Badge>
+                                            <div className={styles.badge_stack}>
+                                                <Badge tone={statusTone(progress.status)}>{account.paused ? 'paused' : progress.status}</Badge>
+                                                {progress.catchingUp && !account.paused && <Badge tone="warning">catching up</Badge>}
+                                            </div>
                                         </Td>
                                         <Td data-label="Rows" muted>{progress.rowsIngested.toLocaleString()}</Td>
                                         <Td data-label="Oldest reached" muted>
                                             {progress.oldestTimestampReached ? <ClientTime date={progress.oldestTimestampReached} format="datetime" /> : '—'}
                                         </Td>
+                                        <Td data-label="Newest tx" muted>
+                                            {progress.newestTimestampSeen ? <ClientTime date={progress.newestTimestampSeen} format="relative" /> : '—'}
+                                        </Td>
                                         <Td data-label="Last run" muted>
                                             {progress.lastRunAt ? <ClientTime date={progress.lastRunAt} format="datetime" /> : '—'}
+                                            {progress.lastForwardRunAt && (
+                                                <div className={styles.forward_run}>
+                                                    refreshed <ClientTime date={progress.lastForwardRunAt} format="relative" />
+                                                </div>
+                                            )}
                                         </Td>
                                         <Td data-label="Actions">
                                             <div className={styles.row_actions}>

--- a/src/frontend/app/(core)/system/account-history/SettingsTab.tsx
+++ b/src/frontend/app/(core)/system/account-history/SettingsTab.tsx
@@ -4,10 +4,12 @@
  * @fileoverview Ingestion-settings tab for /system/account-history.
  *
  * The pacing dials: a master ingestion switch plus pages-per-tick and
- * accounts-per-tick. These throttle ingestion *down* only — they cannot exceed
+ * accounts-per-tick. All three govern BOTH passes — the backward backfill and
+ * the forward sync that keeps completed accounts current — since both share one
+ * settings document. These throttle ingestion *down* only: they cannot exceed
  * the shared TronGrid rate limiter that protects live block sync, so turning
- * them up never pulls faster than the global budget allows. The cron cadence
- * itself lives on the Schedules tab (owned by the scheduler), not here.
+ * them up never pulls faster than the global budget allows. The two cron
+ * cadences live on the Schedules tab (owned by the scheduler), not here.
  */
 
 import { useEffect, useState, useCallback } from 'react';
@@ -69,7 +71,7 @@ export function SettingsTab() {
             <div className={styles.setting_row}>
                 <div>
                     <div className={styles.setting_label}>Ingestion enabled</div>
-                    <div className="text-muted">Master switch. When off, the scheduled tick is a no-op and no account advances.</div>
+                    <div className="text-muted">Master switch for both passes. When off, the backfill and forward-sync ticks are no-ops and no account advances or refreshes.</div>
                 </div>
                 <Switch on={settings.ingestionEnabled} onChange={(next) => patch({ ingestionEnabled: next })} aria-label="Toggle ingestion" />
             </div>
@@ -77,7 +79,7 @@ export function SettingsTab() {
             <div className={styles.setting_row}>
                 <div>
                     <div className={styles.setting_label}>Pages per tick</div>
-                    <div className="text-muted">TronGrid pages (200 tx each) pulled per account each tick — the primary speed/load dial.</div>
+                    <div className="text-muted">TronGrid pages (200 tx each) pulled per account each tick, for both backfill and forward sync — the primary speed/load dial. Raising it also lets forward sync drain a backlog faster.</div>
                 </div>
                 <Input
                     type="number"
@@ -92,7 +94,7 @@ export function SettingsTab() {
             <div className={styles.setting_row}>
                 <div>
                     <div className={styles.setting_label}>Accounts per tick</div>
-                    <div className="text-muted">How many tracked accounts advance each tick (round-robin, least-recent first).</div>
+                    <div className="text-muted">How many accounts each tick advances (round-robin, least-recent first) — backfill rotates not-yet-complete accounts, forward sync rotates completed ones.</div>
                 </div>
                 <Input
                     type="number"

--- a/src/frontend/app/(core)/system/account-history/page.module.scss
+++ b/src/frontend/app/(core)/system/account-history/page.module.scss
@@ -3,11 +3,23 @@
  * only — colors, spacing, and typography flow through design tokens.
  */
 
+.intro {
+    margin: 0;
+    max-width: var(--max-width-prose);
+    color: var(--color-text-muted);
+    font-size: var(--font-size-body-sm);
+    line-height: var(--line-height-relaxed);
+}
+
 .summary {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: var(--gap-sm);
+}
+
+.submenu {
+    margin-top: var(--gap-sm);
 }
 
 .content {
@@ -36,6 +48,19 @@
 .account_error {
     margin-top: var(--gap-2xs);
     color: var(--color-danger);
+    font-size: var(--font-size-caption);
+}
+
+.badge_stack {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--gap-2xs);
+}
+
+.forward_run {
+    margin-top: var(--gap-2xs);
+    color: var(--color-text-muted);
     font-size: var(--font-size-caption);
 }
 

--- a/src/frontend/app/(core)/system/account-history/page.tsx
+++ b/src/frontend/app/(core)/system/account-history/page.tsx
@@ -52,9 +52,18 @@ async function fetchSubmenu(): Promise<{ roots: MenuNodeSerialized[]; generatedA
 /**
  * Account-history admin page (server entry).
  *
+ * @param props - Next.js route props.
+ * @param props.searchParams - The `?tab=` deep link (a Promise in Next.js 15+),
+ *   read SSR-first to seed the initially active panel so a refreshed, bookmarked,
+ *   or shared link opens on the selected tab instead of falling back to Accounts.
  * @returns The client shell seeded with the SSR-fetched submenu tree.
  */
-export default async function AccountHistoryAdminPage() {
+export default async function AccountHistoryAdminPage({
+    searchParams
+}: {
+    searchParams: Promise<{ tab?: string }>;
+}) {
     const { roots, generatedAt } = await fetchSubmenu();
-    return <AccountHistoryAdminClient submenuTree={roots} submenuGeneratedAt={generatedAt} />;
+    const { tab } = await searchParams;
+    return <AccountHistoryAdminClient submenuTree={roots} submenuGeneratedAt={generatedAt} initialTab={tab} />;
 }

--- a/src/frontend/app/(core)/system/account-history/page.tsx
+++ b/src/frontend/app/(core)/system/account-history/page.tsx
@@ -1,120 +1,60 @@
-'use client';
-
 /**
- * @fileoverview /system/account-history — admin surface for per-account history.
+ * @fileoverview /system/account-history server entry.
  *
- * Three tabs: tracked accounts (the control surface, with live per-account
- * progress), ingestion settings (pacing), and schedules (the module's scheduler
- * jobs, a filtered view of the one scheduler authority via SchedulerMonitor).
- * Admin-gated by the /system layout; a client component fetching over the
- * cookie-authenticated admin API. Ingestion stats stay live off the
- * `account-history:stats` WebSocket nudge — a timestamp-only signal the backend
- * emits after each tick that triggers a refetch over the requireAdmin REST feed.
- * The snapshot itself is never sent over the socket: it carries admin-only data
- * and the broadcast reaches every connected client.
+ * Fetches the page's in-page tab row from the menu service SSR-first and hands
+ * it to the client shell. The tab row is a namespaced menu (menu module's
+ * Submenu Pattern), not a hand-rolled button array, so it inherits per-user
+ * gating, ordering, and live `menu:update` refresh. This server component
+ * fetches that namespace tree once — forwarding the admin's session cookie so
+ * the nodes' `requiresAdmin` gating resolves — exactly as `MenuNavSSR` feeds the
+ * global nav; the client shell then renders it with `MenuNavClient` and drives
+ * the active panel. Admin-gated by the /system layout.
  */
 
-import { useEffect, useState, useCallback } from 'react';
-import { Page, PageHeader } from '../../../../components/layout';
-import { Badge } from '../../../../components/ui/Badge';
-import { getSocket } from '../../../../lib/socketClient';
-import { SchedulerMonitor, type SchedulerJob } from '../../../../modules/scheduler';
-import { getStats, type IAccountHistoryStatsView } from '../../../../modules/account-history';
-import { AccountsTab } from './AccountsTab';
-import { SettingsTab } from './SettingsTab';
-import styles from './page.module.scss';
+import { cookies } from 'next/headers';
+import type { MenuNodeSerialized } from '@/shared';
+import { getServerSideApiUrl } from '../../../../lib/api-url';
+import { AccountHistoryAdminClient } from './AccountHistoryAdminClient';
 
-/** The page's three tab ids. */
-type TabId = 'accounts' | 'settings' | 'schedules';
-
-/** Tab definitions in display order. */
-const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
-    { id: 'accounts', label: 'Tracked Accounts' },
-    { id: 'settings', label: 'Ingestion Settings' },
-    { id: 'schedules', label: 'Schedules' }
-];
+/** Namespace holding the page's tab nodes; registered by AccountHistoryModule. */
+const SUBMENU_NAMESPACE = 'account-history';
 
 /**
- * Predicate selecting only this module's scheduler jobs for the Schedules tab —
- * the same scheduler authority as /system/scheduler, filtered by name prefix so
- * edits here and there can never drift.
+ * Fetch the submenu namespace tree from the menu API, forwarding the visitor's
+ * cookies so the backend's per-user `requiresAdmin` gating resolves for the
+ * admin. On any failure it returns an empty tree, mirroring `MenuNavSSR`'s
+ * graceful degradation — the page still renders, just without the tab row until
+ * a live `menu:update` refetch repopulates it.
  *
- * @param job - A scheduler job.
- * @returns True for `account-history:`-prefixed jobs.
+ * @returns The namespace root nodes and the tree snapshot timestamp.
  */
-function isAccountHistoryJob(job: SchedulerJob): boolean {
-    return job.name.startsWith('account-history:');
+async function fetchSubmenu(): Promise<{ roots: MenuNodeSerialized[]; generatedAt: string }> {
+    const fallback = { roots: [] as MenuNodeSerialized[], generatedAt: new Date().toISOString() };
+    try {
+        const cookieHeader = (await cookies()).toString();
+        const response = await fetch(`${getServerSideApiUrl()}/api/menu?namespace=${SUBMENU_NAMESPACE}`, {
+            cache: 'no-store',
+            headers: cookieHeader ? { Cookie: cookieHeader } : undefined
+        });
+        if (!response.ok) {
+            return fallback;
+        }
+        const data = await response.json() as { tree?: { roots?: MenuNodeSerialized[]; generatedAt?: string } };
+        return {
+            roots: data.tree?.roots ?? [],
+            generatedAt: data.tree?.generatedAt ?? fallback.generatedAt
+        };
+    } catch {
+        return fallback;
+    }
 }
 
 /**
- * Account-history admin page.
+ * Account-history admin page (server entry).
  *
- * @returns The page.
+ * @returns The client shell seeded with the SSR-fetched submenu tree.
  */
-export default function AccountHistoryAdminPage() {
-    const [activeTab, setActiveTab] = useState<TabId>('accounts');
-    const [stats, setStats] = useState<IAccountHistoryStatsView | null>(null);
-
-    const loadStats = useCallback(async () => {
-        try {
-            setStats(await getStats());
-        } catch {
-            /* primary data load failure surfaces on the empty table; leave stats as-is */
-        }
-    }, []);
-
-    useEffect(() => {
-        void loadStats();
-    }, [loadStats]);
-
-    // The backend emits a timestamp-only nudge after each ingestion tick (the
-    // snapshot carries admin-only data and the broadcast reaches every socket),
-    // so refetch the full stats over the requireAdmin REST endpoint on the
-    // signal rather than trusting the socket payload — mirroring how the
-    // /system/curation page refetches on `curation:changed`.
-    useEffect(() => {
-        const socket = getSocket();
-        const onStats = () => { void loadStats(); };
-        socket.on('account-history:stats', onStats);
-        return () => { socket.off('account-history:stats', onStats); };
-    }, [loadStats]);
-
-    return (
-        <Page>
-            <PageHeader
-                title="Account History"
-                subtitle="Track specific TRON accounts and backfill their full transaction history into ClickHouse."
-            />
-
-            {stats && (
-                <div className={styles.summary}>
-                    <Badge tone="info">{stats.totals.trackedAccounts} tracked</Badge>
-                    <Badge tone="neutral">{stats.totals.rowsIngested.toLocaleString()} rows</Badge>
-                    {stats.totals.completeAccounts > 0 && <Badge tone="success">{stats.totals.completeAccounts} complete</Badge>}
-                    {stats.totals.failedAccounts > 0 && <Badge tone="danger">{stats.totals.failedAccounts} failed</Badge>}
-                </div>
-            )}
-
-            <div className="segmented-control" role="tablist" aria-label="Account history sections">
-                {TABS.map((tab) => (
-                    <button
-                        key={tab.id}
-                        type="button"
-                        role="tab"
-                        aria-selected={activeTab === tab.id}
-                        className={activeTab === tab.id ? 'is-active' : undefined}
-                        onClick={() => setActiveTab(tab.id)}
-                    >
-                        {tab.label}
-                    </button>
-                ))}
-            </div>
-
-            <div className={styles.content}>
-                {activeTab === 'accounts' && <AccountsTab stats={stats} onChanged={loadStats} />}
-                {activeTab === 'settings' && <SettingsTab />}
-                {activeTab === 'schedules' && <SchedulerMonitor jobFilter={isAccountHistoryJob} title="Account History Schedules" />}
-            </div>
-        </Page>
-    );
+export default async function AccountHistoryAdminPage() {
+    const { roots, generatedAt } = await fetchSubmenu();
+    return <AccountHistoryAdminClient submenuTree={roots} submenuGeneratedAt={generatedAt} />;
 }

--- a/src/frontend/modules/account-history/api/client.ts
+++ b/src/frontend/modules/account-history/api/client.ts
@@ -41,6 +41,10 @@ export interface IAccountIngestionProgressView {
     newestTimestampSeen?: string;
     rowsIngested: number;
     lastRunAt?: string;
+    /** When forward sync last refreshed this completed account (ISO string). */
+    lastForwardRunAt?: string;
+    /** True when a completed account is mid-drain in forward sync (catching up). */
+    catchingUp?: boolean;
     lastError?: string;
 }
 
@@ -63,6 +67,10 @@ export interface IAccountHistoryStatsView {
         rowsIngested: number;
         completeAccounts: number;
         failedAccounts: number;
+        /** Completed accounts currently catching up across forward-sync ticks. */
+        catchingUpAccounts: number;
+        /** Stalest freshness watermark across completed accounts (ISO string). */
+        oldestNewestTimestamp?: string;
     };
 }
 
@@ -183,12 +191,24 @@ export async function updateSettings(patch: Partial<IAccountHistorySettings>): P
 }
 
 /**
- * Trigger one manual ingestion tick.
+ * Trigger one manual backfill ingestion tick.
  *
  * @returns Resolves when the tick has been requested.
  */
 export async function runIngestion(): Promise<void> {
     await parse(await fetch(`${BASE}/ingest/run`, { method: 'POST' }), 'run ingestion');
+}
+
+/**
+ * Trigger one manual forward-sync tick, refreshing completed accounts with
+ * transactions that arrived after their backfill finished. The backend endpoint
+ * has always existed; this surfaces it so an admin can force a freshness pass
+ * without waiting for the `account-history:forward-sync` cron.
+ *
+ * @returns Resolves when the tick has been requested.
+ */
+export async function runForwardSync(): Promise<void> {
+    await parse(await fetch(`${BASE}/ingest/forward/run`, { method: 'POST' }), 'run forward sync');
 }
 
 /**


### PR DESCRIPTION
## Summary

Improves the `/system/account-history` admin surface across three fronts.

**Forward-sync observability.** The forward-sync pipeline that keeps completed accounts current was previously invisible in the admin UI. This surfaces the per-account freshness watermark (`newestTimestampSeen`), a derived `catchingUp` flag for accounts still draining a backlog, and `lastForwardRunAt` (distinct from the frozen backfill `lastRunAt`), plus `catchingUpAccounts` and `oldestNewestTimestamp` rollups. The page gains a "Newest tx" column, catching-up badges, a "Run forward sync" button (wiring the pre-existing `POST /ingest/forward/run` endpoint that had no UI caller), and settings copy clarifying the pacing dials govern both the backfill and forward-sync passes.

**Menu Submenu Pattern adoption.** The in-page tab row migrates from the hand-rolled `.segmented-control` to the menu module's documented Submenu Pattern: a namespaced `account-history` menu registered by `AccountHistoryModule`, fetched SSR-first, and rendered with `MenuNavClient` in submenu mode. This makes the page the first and reference implementation of that pattern.

**Documentation policy.** Establishes the Submenu Pattern as the only authorized approach for core/module admin tab rows, surfaced from the docs a page author actually reads (`menu/README.md`, `frontend.md`, `ui-components.md`) where it was previously undiscoverable.

Types changes are additive optional fields; backend and frontend typechecks pass and the 19 module tests (2 new) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
