### PR TITLE
feat(profile): split /profile into Profile and Wallets tabs

### DIFF
--- a/src/backend/modules/identity/IdentityModule.ts
+++ b/src/backend/modules/identity/IdentityModule.ts
@@ -72,6 +72,28 @@ export interface IIdentityModuleDependencies {
 }
 
 /**
+ * Dedicated menu namespace for the `/profile` hub's in-page tab row. Kept out of
+ * `main` so the tabs never leak into the global nav chrome — only the profile
+ * page's own `MenuNavClient` reads this namespace (menu module's Submenu
+ * Pattern). The route is identical across tabs; each node carries a `?tab=` the
+ * client reads to drive the active panel.
+ */
+const PROFILE_SUBMENU_NAMESPACE = 'profile';
+
+/**
+ * The profile hub's tab row, declared as menu nodes rather than a hand-rolled
+ * button array so the row inherits ordering and live `menu:update` refresh from
+ * the menu service. The nodes carry no `requiresAdmin`/`requiresGroups` gate:
+ * `/profile` is login-gated by the route's `ProfileAuthGate`, and every signed-in
+ * visitor sees both tabs. Keeping the namespace out of `main` is what hides the
+ * tabs from global nav — not a per-node gate.
+ */
+const PROFILE_SUBMENU_TABS: ReadonlyArray<{ label: string; tab: string; icon: string; order: number }> = [
+    { label: 'Profile', tab: 'profile', icon: 'User', order: 0 },
+    { label: 'Wallets', tab: 'wallets', icon: 'Wallet', order: 1 }
+];
+
+/**
  * Better Auth identity module.
  */
 export class IdentityModule implements IModule<IIdentityModuleDependencies> {
@@ -208,6 +230,26 @@ export class IdentityModule implements IModule<IIdentityModuleDependencies> {
             });
 
             this.logger.info('Users menu item registered under the System container');
+
+            // Register the /profile hub's in-page tab row as a namespaced menu
+            // (menu module's Submenu Pattern). Memory-only nodes outside the
+            // System container, so the container's non-bypassable requiresAdmin
+            // force does not reach them — and we deliberately set no gate: the
+            // route's ProfileAuthGate already requires login, and both tabs are
+            // visible to every signed-in account. The page renders this namespace
+            // with MenuNavClient instead of hand-rolling tabs.
+            for (const tab of PROFILE_SUBMENU_TABS) {
+                await this.menuService.create({
+                    namespace: PROFILE_SUBMENU_NAMESPACE,
+                    label: tab.label,
+                    url: `/profile?tab=${tab.tab}`,
+                    icon: tab.icon,
+                    order: tab.order,
+                    parent: null,
+                    enabled: true
+                });
+            }
+            this.logger.info('Profile submenu tab nodes registered');
         } catch (error) {
             this.logger.error({ error }, 'Failed to register users menu item');
             throw new Error(`Failed to register users menu item: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/src/frontend/app/(core)/profile/page.tsx
+++ b/src/frontend/app/(core)/profile/page.tsx
@@ -10,6 +10,7 @@
 
 import { headers } from 'next/headers';
 import type { Metadata } from 'next';
+import type { MenuNodeSerialized } from '@/shared';
 import type { IAccountIngestionProgress, ILinkedWallet } from '@/types';
 import { getServerSideApiUrlWithPath } from '../../../lib/api-url';
 import { getServerSession } from '../../../modules/user/lib/session-server';
@@ -19,6 +20,13 @@ import { ProfileView } from '../../../modules/user/components/ProfileView';
 export const metadata: Metadata = {
     title: 'Profile'
 };
+
+/**
+ * Namespace holding the profile hub's tab nodes (Profile, Wallets), registered
+ * by the identity module. Kept out of `main` so the tabs never appear in the
+ * global nav — only this page's `MenuNavClient` reads it.
+ */
+const SUBMENU_NAMESPACE = 'profile';
 
 /**
  * Fetch the signed-in account's linked wallets during SSR, forwarding the
@@ -82,22 +90,65 @@ async function fetchInitialProgress(apiUrl: string): Promise<IAccountIngestionPr
 }
 
 /**
+ * Fetch the profile hub's tab row (the `profile` menu namespace) during SSR so
+ * the submenu paints with the page instead of after a client round-trip. The
+ * nodes carry no gate, but the cookie is forwarded for parity with other
+ * Submenu Pattern fetches and to keep behaviour identical if a gate is added
+ * later. On any failure it degrades to an empty tree — the page still renders,
+ * just without the tab row until a live `menu:update` refetch repopulates it.
+ *
+ * @param apiUrl - The resolved backend API base (already includes `/api`).
+ * @returns The namespace root nodes and the tree snapshot timestamp.
+ */
+async function fetchSubmenu(apiUrl: string): Promise<{ roots: MenuNodeSerialized[]; generatedAt: string }> {
+    const fallback = { roots: [] as MenuNodeSerialized[], generatedAt: new Date().toISOString() };
+    try {
+        const reqHeaders = await headers();
+        const cookie = reqHeaders.get('cookie');
+        const response = await fetch(`${apiUrl}/menu?namespace=${SUBMENU_NAMESPACE}`, {
+            cache: 'no-store',
+            headers: cookie ? { Cookie: cookie } : undefined
+        });
+        if (!response.ok) {
+            return fallback;
+        }
+        const data = await response.json() as { tree?: { roots?: MenuNodeSerialized[]; generatedAt?: string } };
+        return {
+            roots: data.tree?.roots ?? [],
+            generatedAt: data.tree?.generatedAt ?? fallback.generatedAt
+        };
+    } catch {
+        return fallback;
+    }
+}
+
+/**
  * Profile page server component.
  *
+ * @param props - Next.js route props.
+ * @param props.searchParams - The `?tab=` deep link (a Promise in Next.js 15+),
+ *   read SSR-first to seed the initially active tab so a refreshed, bookmarked,
+ *   or shared link opens on the selected panel instead of falling back to Profile.
  * @returns The SSR-rendered hub for a logged-in visitor, or null to defer to
  *   the route's sign-in gate when there is no session.
  */
-export default async function ProfilePage() {
+export default async function ProfilePage({
+    searchParams
+}: {
+    searchParams: Promise<{ tab?: string }>;
+}) {
     const session = await getServerSession();
     if (!session) {
         return null;
     }
 
     const apiUrl = getServerSideApiUrlWithPath();
-    const [initialWallets, initialProgress] = await Promise.all([
+    const [initialWallets, initialProgress, submenu] = await Promise.all([
         fetchInitialWallets(apiUrl),
-        fetchInitialProgress(apiUrl)
+        fetchInitialProgress(apiUrl),
+        fetchSubmenu(apiUrl)
     ]);
+    const { tab } = await searchParams;
 
     return (
         <Page>
@@ -111,6 +162,9 @@ export default async function ProfilePage() {
                 }}
                 initialWallets={initialWallets}
                 initialProgress={initialProgress}
+                submenuTree={submenu.roots}
+                submenuGeneratedAt={submenu.generatedAt}
+                initialTab={tab}
             />
         </Page>
     );

--- a/src/frontend/modules/user/components/ProfileView/ProfileView.module.scss
+++ b/src/frontend/modules/user/components/ProfileView/ProfileView.module.scss
@@ -8,6 +8,10 @@
 
 @use '../../../../app/breakpoints' as *;
 
+.submenu {
+    border-bottom: var(--border-width-thin) solid var(--color-border);
+}
+
 .account {
     display: flex;
     align-items: center;

--- a/src/frontend/modules/user/components/ProfileView/ProfileView.tsx
+++ b/src/frontend/modules/user/components/ProfileView/ProfileView.tsx
@@ -15,16 +15,37 @@
 import { useCallback, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { LogOut, ShieldCheck } from 'lucide-react';
+import type { MenuNodeSerialized } from '@/shared';
 import { Card } from '../../../../components/ui/Card';
 import { Button } from '../../../../components/ui/Button';
 import { Badge } from '../../../../components/ui/Badge';
 import { Stack, Section } from '../../../../components/layout';
+import { MenuNavClient } from '../../../../components/layout/MenuNav/MenuNavClient';
 import { useToast } from '../../../../components/ui/ToastProvider';
 import { PreferencesPanel } from '../../../notifications';
 import { signOut } from '../../lib/auth-client';
 import { WalletManager } from '../WalletManager';
 import type { IAccountIngestionProgress, ILinkedWallet } from '@/types';
 import styles from './ProfileView.module.scss';
+
+/** The hub's tab ids; the `?tab=` value carried by each submenu node. */
+type ProfileTabId = 'profile' | 'wallets';
+
+/** The menu namespace the identity module registers the tab nodes under. */
+const SUBMENU_NAMESPACE = 'profile';
+
+/**
+ * Resolve a submenu node's `?tab=` value (or the SSR `initialTab`) to a known
+ * tab id, defaulting to `profile` for an unrecognized or missing value so a
+ * malformed node or stale link can never leave the hub on a blank panel.
+ *
+ * @param value - A `?tab=` query value or a full node url carrying one.
+ * @returns The matching tab id.
+ */
+function resolveTab(value: string | undefined): ProfileTabId {
+    const tab = value?.match(/[?&]tab=([^&]+)/)?.[1] ?? value;
+    return tab === 'wallets' ? 'wallets' : 'profile';
+}
 
 /**
  * The identity fields the hub needs to render. A trimmed projection of the
@@ -59,6 +80,24 @@ export interface IProfileViewProps {
      * wallets, seeding the per-wallet status badges so they paint without a flash.
      */
     initialProgress: IAccountIngestionProgress[];
+
+    /**
+     * SSR-fetched tab row nodes (Profile, Wallets) for the hub's submenu. Driving
+     * the row through the menu service rather than a hand-rolled button array
+     * gives it ordering and live `menu:update` refresh, and lets a plugin
+     * contribute a tab by registering into the `profile` namespace.
+     */
+    submenuTree: MenuNodeSerialized[];
+
+    /** Snapshot timestamp of the submenu tree, seeded onto the menu Redux slice. */
+    submenuGeneratedAt: string;
+
+    /**
+     * The `?tab=` value from the request URL, read SSR-first in `page.tsx` so a
+     * refreshed, bookmarked, or shared deep link opens on the right panel. An
+     * unknown or absent value resolves to `profile`.
+     */
+    initialTab?: string;
 }
 
 /**
@@ -77,10 +116,36 @@ function identityLabel(identity: IProfileIdentity): string {
  *
  * @param props - {@link IProfileViewProps}.
  */
-export function ProfileView({ identity, initialWallets, initialProgress }: IProfileViewProps) {
+export function ProfileView({
+    identity,
+    initialWallets,
+    initialProgress,
+    submenuTree,
+    submenuGeneratedAt,
+    initialTab
+}: IProfileViewProps) {
     const router = useRouter();
     const { push } = useToast();
     const [signingOut, setSigningOut] = useState(false);
+    const [activeTab, setActiveTab] = useState<ProfileTabId>(resolveTab(initialTab));
+
+    /**
+     * Activate the clicked tab and keep its URL a real deep link.
+     *
+     * `MenuNavClient` suppresses the <Link> navigation when `onItemSelect` is set,
+     * so without this the address bar would never reflect the selected tab and a
+     * refresh or shared link would fall back to the Profile panel. Rewrite the
+     * address in place with `history.replaceState` — no server round-trip — so the
+     * registered `?tab=` URLs become true deep links that `page.tsx` reads
+     * SSR-first to seed the panel on next load.
+     *
+     * @param item - The clicked submenu node, carrying its `?tab=` url.
+     */
+    const handleTabSelect = useCallback((item: MenuNodeSerialized): void => {
+        const tab = resolveTab(item.url);
+        setActiveTab(tab);
+        window.history.replaceState(null, '', `/profile?tab=${tab}`);
+    }, []);
 
     /**
      * Sign the user out, then refresh so the route's auth gate re-evaluates and
@@ -105,41 +170,57 @@ export function ProfileView({ identity, initialWallets, initialProgress }: IProf
 
     return (
         <Stack gap="lg">
-            <Section gap="sm">
-                <h2>Account</h2>
-                <Card>
-                    <div className={styles.account}>
-                        <div className={styles.identity}>
-                            <span className="text-muted">Signed in as</span>
-                            <strong className={styles.identity_value}>{identityLabel(identity)}</strong>
-                            {identity.emailVerified && (
-                                <Badge tone="success">
-                                    <ShieldCheck size={14} aria-hidden /> Email verified
-                                </Badge>
-                            )}
-                        </div>
-                        <Button
-                            variant="danger"
-                            size="sm"
-                            icon={<LogOut size={18} aria-hidden />}
-                            onClick={handleSignOut}
-                            loading={signingOut}
-                        >
-                            Sign out
-                        </Button>
-                    </div>
-                </Card>
-            </Section>
+            <div className={styles.submenu}>
+                <MenuNavClient
+                    namespace={SUBMENU_NAMESPACE}
+                    items={submenuTree}
+                    generatedAt={submenuGeneratedAt}
+                    ariaLabel="Profile sections"
+                    activeUrl={`/profile?tab=${activeTab}`}
+                    onItemSelect={handleTabSelect}
+                />
+            </div>
 
-            <Section gap="sm">
-                <h2>Wallets</h2>
-                <WalletManager initialWallets={initialWallets} initialProgress={initialProgress} />
-            </Section>
+            {activeTab === 'profile' && (
+                <>
+                    <Section gap="sm">
+                        <h2>Account</h2>
+                        <Card>
+                            <div className={styles.account}>
+                                <div className={styles.identity}>
+                                    <span className="text-muted">Signed in as</span>
+                                    <strong className={styles.identity_value}>{identityLabel(identity)}</strong>
+                                    {identity.emailVerified && (
+                                        <Badge tone="success">
+                                            <ShieldCheck size={14} aria-hidden /> Email verified
+                                        </Badge>
+                                    )}
+                                </div>
+                                <Button
+                                    variant="danger"
+                                    size="sm"
+                                    icon={<LogOut size={18} aria-hidden />}
+                                    onClick={handleSignOut}
+                                    loading={signingOut}
+                                >
+                                    Sign out
+                                </Button>
+                            </div>
+                        </Card>
+                    </Section>
 
-            <Section gap="sm">
-                <h2>Notifications</h2>
-                <PreferencesPanel />
-            </Section>
+                    <Section gap="sm">
+                        <h2>Notifications</h2>
+                        <PreferencesPanel />
+                    </Section>
+                </>
+            )}
+
+            {activeTab === 'wallets' && (
+                <Section gap="sm">
+                    <WalletManager initialWallets={initialWallets} initialProgress={initialProgress} />
+                </Section>
+            )}
         </Stack>
     );
 }

--- a/src/frontend/modules/user/components/ProfileView/ProfileView.tsx
+++ b/src/frontend/modules/user/components/ProfileView/ProfileView.tsx
@@ -39,11 +39,18 @@ const SUBMENU_NAMESPACE = 'profile';
  * tab id, defaulting to `profile` for an unrecognized or missing value so a
  * malformed node or stale link can never leave the hub on a blank panel.
  *
- * @param value - A `?tab=` query value or a full node url carrying one.
+ * Next.js parses a repeated query key (`/profile?tab=wallets&tab=profile`) into
+ * a `string[]`, so the SSR `initialTab` can arrive as an array even though the
+ * route types it as a string. Collapse that to the first entry before parsing,
+ * so a crafted URL falls back to the default tab instead of throwing on `.match`.
+ *
+ * @param value - A `?tab=` query value, a full node url carrying one, or the
+ *   repeated-key array Next.js may hand the SSR `initialTab`.
  * @returns The matching tab id.
  */
-function resolveTab(value: string | undefined): ProfileTabId {
-    const tab = value?.match(/[?&]tab=([^&]+)/)?.[1] ?? value;
+function resolveTab(value: string | string[] | undefined): ProfileTabId {
+    const raw = Array.isArray(value) ? value[0] : value;
+    const tab = raw?.match(/[?&]tab=([^&]+)/)?.[1] ?? raw;
     return tab === 'wallets' ? 'wallets' : 'profile';
 }
 
@@ -181,46 +188,40 @@ export function ProfileView({
                 />
             </div>
 
-            {activeTab === 'profile' && (
-                <>
-                    <Section gap="sm">
-                        <h2>Account</h2>
-                        <Card>
-                            <div className={styles.account}>
-                                <div className={styles.identity}>
-                                    <span className="text-muted">Signed in as</span>
-                                    <strong className={styles.identity_value}>{identityLabel(identity)}</strong>
-                                    {identity.emailVerified && (
-                                        <Badge tone="success">
-                                            <ShieldCheck size={14} aria-hidden /> Email verified
-                                        </Badge>
-                                    )}
-                                </div>
-                                <Button
-                                    variant="danger"
-                                    size="sm"
-                                    icon={<LogOut size={18} aria-hidden />}
-                                    onClick={handleSignOut}
-                                    loading={signingOut}
-                                >
-                                    Sign out
-                                </Button>
-                            </div>
-                        </Card>
-                    </Section>
+            <Section gap="sm" style={{ display: activeTab === 'profile' ? undefined : 'none' }}>
+                <h2>Account</h2>
+                <Card>
+                    <div className={styles.account}>
+                        <div className={styles.identity}>
+                            <span className="text-muted">Signed in as</span>
+                            <strong className={styles.identity_value}>{identityLabel(identity)}</strong>
+                            {identity.emailVerified && (
+                                <Badge tone="success">
+                                    <ShieldCheck size={14} aria-hidden /> Email verified
+                                </Badge>
+                            )}
+                        </div>
+                        <Button
+                            variant="danger"
+                            size="sm"
+                            icon={<LogOut size={18} aria-hidden />}
+                            onClick={handleSignOut}
+                            loading={signingOut}
+                        >
+                            Sign out
+                        </Button>
+                    </div>
+                </Card>
+            </Section>
 
-                    <Section gap="sm">
-                        <h2>Notifications</h2>
-                        <PreferencesPanel />
-                    </Section>
-                </>
-            )}
+            <Section gap="sm" style={{ display: activeTab === 'profile' ? undefined : 'none' }}>
+                <h2>Notifications</h2>
+                <PreferencesPanel />
+            </Section>
 
-            {activeTab === 'wallets' && (
-                <Section gap="sm">
-                    <WalletManager initialWallets={initialWallets} initialProgress={initialProgress} />
-                </Section>
-            )}
+            <Section gap="sm" style={{ display: activeTab === 'wallets' ? undefined : 'none' }}>
+                <WalletManager initialWallets={initialWallets} initialProgress={initialProgress} />
+            </Section>
         </Stack>
     );
 }


### PR DESCRIPTION
Splits the `/profile` hub into two tabs using the menu module's Submenu Pattern (mirroring `/system/account-history`), so the wallet management surface lives on its own tab instead of stacking below account and notifications.

## What changed

- **Identity module** registers a memory-only `profile` menu namespace with two tab nodes — `Profile` → `/profile?tab=profile` and `Wallets` → `/profile?tab=wallets`. The nodes carry no `requiresAdmin`/`requiresGroups` gate: the route's `ProfileAuthGate` already enforces login, and keeping the namespace out of `main` is what hides the tabs from global nav.
- **`/profile` page** fetches that namespace SSR-first (cookie forwarded) and reads `?tab=` from `searchParams` to seed the active panel, so refreshed/bookmarked/shared deep links open on the right tab.
- **`ProfileView`** becomes the tabbed shell: renders `MenuNavClient` in submenu mode (`activeUrl` + `onItemSelect`, with `history.replaceState` keeping `?tab=` a real deep link). Tab **Profile** = Account + Notifications; tab **Wallets** = `WalletManager`.

## Why the Submenu Pattern

A per-user profile is not ephemeral from the menu's perspective — `/profile` is a static singleton route resolved from the session, and the two tabs are a fixed set identical for every visitor. Driving the row through the menu service (vs a hand-rolled button array) inherits ordering and live `menu:update` refresh, and lets a plugin contribute a tab into the `profile` namespace later.

Backend and frontend type-check clean (`typecheck:backend` + `typecheck:frontend`).