### PR TITLE
Add scheduler run-now endpoint, account-history tick selectors, valuation leg recovery

### DIFF
--- a/docs/system/system-api-scheduler.md
+++ b/docs/system/system-api-scheduler.md
@@ -15,6 +15,7 @@ Schedule changes via `PATCH` persist to MongoDB and survive restarts — operato
 | GET | `/admin/system/scheduler/status` | All jobs with last/next run, status, duration, error |
 | GET | `/admin/system/scheduler/health` | Global enabled flag, uptime, success rate, overdue jobs |
 | PATCH | `/admin/system/scheduler/job/:jobName` | Toggle `enabled` or update `schedule` (cron) |
+| POST | `/admin/system/scheduler/job/:jobName/run` | Run the job once now, outside its schedule |
 
 ## Response Reference
 
@@ -92,7 +93,28 @@ curl -X PATCH -H "X-Admin-Token: $TOKEN" -H "Content-Type: application/json" \
     http://localhost:4000/api/admin/system/scheduler/job/chain-parameters:fetch
 ```
 
-Changes apply on the next tick — they do not retroactively run a missed schedule.
+Changes apply on the next tick — they do not retroactively run a missed schedule. To run a job immediately, use the run endpoint below.
+
+### `POST /scheduler/job/:jobName/run`
+
+Triggers one out-of-schedule run of `:jobName` — the only way to exercise a low-frequency job before its next tick (e.g. forcing the 4-hourly `account-history:snapshot` for a newly tracked wallet). The job's `enabled` flag is ignored: a manual run executes the handler once and touches neither the cron task nor persisted config, so a disabled job can be run without re-enabling it.
+
+Returns `202` immediately (the run is fire-and-forget; the outcome lands in `scheduler_executions` and surfaces on the next `status` poll). `started` is `false` — not an error — when the job was already running, because single-flight is preserved server-side.
+
+```json
+{ "success": true, "started": true, "message": "Scheduler job account-history:snapshot run started" }
+```
+
+| Status | Trigger | `error` text |
+|---|---|---|
+| 202 | Run accepted (`started: true`) or already running (`started: false`) | — |
+| 404 | Unknown job | `"Job <name> not registered"` |
+| 503 | Scheduler module not running | `"Scheduler is not enabled or not initialized"` |
+
+```bash
+curl -X POST -H "X-Admin-Token: $TOKEN" \
+    http://localhost:4000/api/admin/system/scheduler/job/account-history:snapshot/run
+```
 
 ## Further Reading
 

--- a/docs/system/system-scheduler-operations.md
+++ b/docs/system/system-scheduler-operations.md
@@ -51,13 +51,17 @@ curl -X PATCH \
 
 `GET /api/admin/system/scheduler/status` returns all jobs with enabled state and last-execution metadata. See [system-api-scheduler.md](./system-api-scheduler.md) for the full endpoint reference.
 
+### Running a Job Now
+
+`POST /api/admin/system/scheduler/job/{jobName}/run` runs a job once immediately, outside its schedule — the way to exercise a low-frequency job before its next tick (e.g. the 4-hourly `account-history:snapshot` for a newly tracked account) without waiting or rescheduling. It ignores the enabled flag and preserves single-flight (a job already running reports `started: false` rather than stacking a second run). The dashboard exposes this as a per-job "Run now" button. Full contract in [system-api-scheduler.md](./system-api-scheduler.md#post-schedulerjobjobnamerun).
+
 ## Cron Expressions
 
 Standard 5-field cron (`minute hour day-of-month month day-of-week`). The backend rejects expressions that don't have exactly 5 space-separated fields with a 400 error — there is no degraded mode for malformed schedules.
 
 ## Troubleshooting
 
-Most stalls reduce to four checks: is the global flag on (`echo $ENABLE_SCHEDULER`), is the specific job enabled in `/system`, did the last run fail (red badge → tail backend logs for the job name), and is `last run` ancient (job never fired — wait one tick or trigger via API).
+Most stalls reduce to four checks: is the global flag on (`echo $ENABLE_SCHEDULER`), is the specific job enabled in `/system`, did the last run fail (red badge → tail backend logs for the job name), and is `last run` ancient (job never fired — wait one tick, or force it with the "Run now" button / the run endpoint above).
 
 | Symptom | Likely cause |
 |---|---|

--- a/packages/types/src/account-history/IAccountHistoryService.ts
+++ b/packages/types/src/account-history/IAccountHistoryService.ts
@@ -466,6 +466,30 @@ export interface IAccountHistoryService {
     getTransactions(query: IAccountTransactionQuery): Promise<IAccountTransactionPage>;
 
     /**
+     * Read specific stored transactions for one account by transaction hash,
+     * newest first. Unlike {@link getTransactions}, this is keyed by an explicit
+     * `txIds` set rather than a pagination window, so a consumer can fetch rows it
+     * knows it needs but that fall outside a bounded window read.
+     *
+     * Why it exists: the valuation engine pairs an internal transfer's two legs
+     * (an out on the source wallet, an in on the destination) by `txId`. Each
+     * owned wallet's ledger is read newest-first under a per-wallet row cap, so a
+     * high-volume wallet can push one leg of a pair beyond its window while the
+     * other leg stays inside another wallet's window. That split silently drops
+     * the transfer's cost basis. This method lets the engine refetch the missing
+     * legs by hash and complete the pair, keeping the bulk read bounded.
+     *
+     * Applies the same outbound-TRC20 dedupe as {@link getTransactions} so a
+     * token transfer's native twin is never returned twice. Authorization is the
+     * caller's responsibility — the service trusts the address it is given.
+     *
+     * @param address - Base58 address whose rows to read.
+     * @param txIds - Transaction hashes to fetch; the service clamps the count.
+     * @returns The matching source-independent transactions, newest first.
+     */
+    getTransactionsByTxIds(address: string, txIds: string[]): Promise<IBlockTransaction[]>;
+
+    /**
      * Build the batched activity/behaviour summary for one account — the calendar
      * heatmap buckets, the "wallet story" stats, the TRON resource totals, the
      * per-month inflow/outflow, and the top counterparties — in a single call so

--- a/src/backend/modules/account-history/README.md
+++ b/src/backend/modules/account-history/README.md
@@ -61,6 +61,7 @@ Each endpoint has its own fingerprint cursor; an account is marked `complete` on
 | `getStats()` | Settings + per-account progress + rollups (admin page and live payload) |
 | `getProgressFor(addresses)` | Progress for a specific address set (tracked subset only) — backs ownership-scoped surfaces like a user's profile |
 | `getTransactions({ address, limit?, offset? })` | Paged history read returning `IBlockTransaction[]` |
+| `getTransactionsByTxIds(address, txIds)` | Read specific rows by hash (clamped, deduped) — lets valuation refetch an internal-transfer leg that fell outside a per-wallet window |
 | `getWalletSummary(address)` | Batched `IWalletActivitySummary` — calendar heatmap, "wallet story" stats, TRON resource totals, monthly inflow/outflow, top counterparties — from the stored ledger in one call (trusts the address; caller authorizes) |
 | `getLatestSnapshot(address)` | Latest `IAccountBalanceSnapshot` (liquid/staked/unstaking TRX, energy/bandwidth, per-token balances) — the valuation anchor and current-holdings source |
 | `getSnapshotSeries(address, fromDay, toDay)` | Scalar snapshot series over a UTC day range (token balances omitted) for balance-over-time calibration |
@@ -119,7 +120,7 @@ The poll never flips an account to `failed` — that would re-admit it to the ba
 
 **ClickHouse `account_transactions`** — `ReplacingMergeTree(ingested_at)`, `PARTITION BY toYYYYMM(timestamp)`, `ORDER BY (account, timestamp, tx_id, source, to_address)`. Columns flatten `IBlockTransaction` plus `account`, `source`, the TRC20 `token_amount`/`token_symbol`/`token_decimals`, and `ingested_at`. No TTL — account history is the product.
 
-**Mongo control collections** — `tracked` (the set, unique `address`), `progress` (resumable cursor per address, unique `address`), `settings` (singleton, keyed `settings`).
+**Mongo control collections** — `tracked` (the set, unique `address`), `progress` (resumable cursor per address, unique `address`), `settings` (singleton, keyed `settings`). The three scheduler ticks (ingest, forward-sync, snapshot) each select their slice with a single indexed query on `progress` — filter (unpaused + dueness) + sort + `limit(accountsPerTick)` — rather than loading the whole tracked+progress set and joining in memory. This needs `paused` denormalized onto `progress` (authoritative copy stays on `tracked`, written by `setAccountPaused`, seeded `false` on insert, backfilled by migration `003`); the selectors read it with `{$ne: true}` so a pre-migration doc reads as unpaused. Composite indexes back the three selectors, ordered by the ESR rule (Equality → Sort → Range) so each sort is index-served rather than blocking: `{lastRunAt, paused, status}` (ingest), `{status, lastForwardRunAt, paused}` (forward sync), `{lastSnapshotDay, paused}` (snapshot), all created in `ensureIndexes`.
 
 ## Related
 

--- a/src/backend/modules/account-history/__tests__/account-history-snapshots.test.ts
+++ b/src/backend/modules/account-history/__tests__/account-history-snapshots.test.ts
@@ -125,6 +125,7 @@ describe('AccountHistoryService balance snapshots', () => {
         const clickhouse = new FakeClickhouse();
         const { service, database } = buildService(clickhouse);
         await database.getCollection(TRACKED_COLLECTION).insertOne({ address: ADDRESS, paused: false, addedAt: new Date(), updatedAt: new Date() });
+        await database.getCollection(PROGRESS_COLLECTION).insertOne({ address: ADDRESS, status: 'queued', rowsIngested: 0, paused: false });
 
         await service.runSnapshotTick();
 
@@ -150,6 +151,7 @@ describe('AccountHistoryService balance snapshots', () => {
         const clickhouse = new FakeClickhouse();
         const { service, database } = buildService(clickhouse);
         await database.getCollection(TRACKED_COLLECTION).insertOne({ address: ADDRESS, paused: false, addedAt: new Date(), updatedAt: new Date() });
+        await database.getCollection(PROGRESS_COLLECTION).insertOne({ address: ADDRESS, status: 'queued', rowsIngested: 0, paused: false });
         await service.runSnapshotTick();
 
         const snapshot = await service.getLatestSnapshot(ADDRESS);
@@ -169,6 +171,7 @@ describe('AccountHistoryService balance snapshots', () => {
         const clickhouse = new FakeClickhouse();
         const { service, database } = buildService(clickhouse);
         await database.getCollection(TRACKED_COLLECTION).insertOne({ address: ADDRESS, paused: false, addedAt: new Date(), updatedAt: new Date() });
+        await database.getCollection(PROGRESS_COLLECTION).insertOne({ address: ADDRESS, status: 'queued', rowsIngested: 0, paused: false });
         await service.runSnapshotTick();
         expect(await service.getHeldTokenAssets()).toEqual(['TXLAtoken']);
     });

--- a/src/backend/modules/account-history/__tests__/account-history.test.ts
+++ b/src/backend/modules/account-history/__tests__/account-history.test.ts
@@ -202,11 +202,80 @@ describe('AccountHistoryService', () => {
         expect(page).toEqual({ transactions: [], total: 0 });
     });
 
+    it('getTransactionsByTxIds returns [] without ClickHouse and for an empty hash set', async () => {
+        const service = buildService(null);
+        expect(await service.getTransactionsByTxIds(VALID_ADDRESS, ['h1'])).toEqual([]);
+
+        // Even with ClickHouse, an empty (or all-blank) hash set short-circuits
+        // before any query, so no unbounded `IN ()` is built.
+        AccountHistoryService.resetForTests();
+        const clickhouse = { query: vi.fn().mockResolvedValue([]), insert: vi.fn() } as unknown as IClickHouseService;
+        AccountHistoryService.setDependencies({ database: createMockDatabaseService(), clickhouse, provider: null, emitter: undefined, logger: createSilentLogger() });
+        const withCh = AccountHistoryService.getInstance();
+        expect(await withCh.getTransactionsByTxIds(VALID_ADDRESS, ['', ''])).toEqual([]);
+        expect(clickhouse.query).not.toHaveBeenCalled();
+    });
+
+    it('getTransactionsByTxIds queries by hash and maps rows back to transactions', async () => {
+        AccountHistoryService.resetForTests();
+        const row = toAccountTransactionRow(VALID_ADDRESS, makeTx('h1', new Date('2024-01-01T00:00:00.000Z')), 'tx', '2024-01-01 00:00:00.000', '2024-06-01 00:00:00.000');
+        const clickhouse = { query: vi.fn().mockResolvedValue([row]), insert: vi.fn() } as unknown as IClickHouseService;
+        AccountHistoryService.setDependencies({ database: createMockDatabaseService(), clickhouse, provider: null, emitter: undefined, logger: createSilentLogger() });
+        const service = AccountHistoryService.getInstance();
+
+        const txs = await service.getTransactionsByTxIds(VALID_ADDRESS, ['h1', 'h1']);
+
+        expect(txs).toHaveLength(1);
+        expect(txs[0].txId).toBe('h1');
+        // The hash set is deduped and passed as an Array param alongside the address.
+        expect(clickhouse.query).toHaveBeenCalledWith(
+            expect.stringContaining('tx_id IN ({txIds:Array(String)})'),
+            expect.objectContaining({ address: VALID_ADDRESS, txIds: ['h1'] })
+        );
+    });
+
     it('runIngestionTick is a no-op without ClickHouse and never calls the provider', async () => {
         const provider: IAccountHistoryProvider = { id: 'test', fetchPage: vi.fn(), fetchAccountSnapshot: vi.fn() };
         const service = buildService(provider);
         await service.runIngestionTick();
         expect(provider.fetchPage).not.toHaveBeenCalled();
+    });
+
+    it('runIngestionTick selects only unpaused, not-complete accounts', async () => {
+        // The backfill selector pushes its predicate into one query: a queued
+        // account advances; a complete one and a paused one are both skipped.
+        AccountHistoryService.resetForTests();
+        const queued = VALID_ADDRESS;
+        const complete = 'TLa2f6VPqDgRE67v7c1pj7iGwsizZ1jGfX';
+        const paused = 'TKzxdSv2FZKQrEqkKVgp5DcwEXBEKMg2Ax';
+        const now = new Date('2024-01-01T00:00:00.000Z');
+        const database = createMockDatabaseService();
+        database.getCollectionData(TRACKED_COLLECTION).push(
+            { address: queued, paused: false, addedAt: now, updatedAt: now },
+            { address: complete, paused: false, addedAt: now, updatedAt: now },
+            { address: paused, paused: true, addedAt: now, updatedAt: now }
+        );
+        database.getCollectionData(PROGRESS_COLLECTION).push(
+            { address: queued, status: 'queued', rowsIngested: 0, paused: false },
+            { address: complete, status: 'complete', paused: false, nativeComplete: true, trc20Complete: true, rowsIngested: 9 },
+            { address: paused, status: 'paused', paused: true, rowsIngested: 0 }
+        );
+
+        const clickhouse = { query: vi.fn().mockResolvedValue([]), insert: vi.fn() } as unknown as IClickHouseService;
+        // Empty pages so the selected account's walk finishes immediately.
+        const provider: IAccountHistoryProvider = {
+            id: 'test',
+            fetchAccountSnapshot: vi.fn(),
+            fetchPage: vi.fn(async () => ({ transactions: [], nextFingerprint: undefined }))
+        };
+        AccountHistoryService.setDependencies({ database, clickhouse, provider, emitter: undefined, logger: createSilentLogger() });
+        const service = AccountHistoryService.getInstance();
+
+        await service.runIngestionTick();
+
+        expect(provider.fetchPage).toHaveBeenCalledWith(queued, expect.anything());
+        expect(provider.fetchPage).not.toHaveBeenCalledWith(complete, expect.anything());
+        expect(provider.fetchPage).not.toHaveBeenCalledWith(paused, expect.anything());
     });
 
     it('getProgressFor returns progress only for tracked addresses, ignoring untracked and malformed', async () => {
@@ -396,6 +465,29 @@ describe('AccountHistoryService', () => {
         const clickhouse = { query: vi.fn().mockResolvedValue([]), insert: vi.fn() } as unknown as IClickHouseService;
         const provider: IAccountHistoryProvider = { id: 'test', fetchPage: vi.fn(), fetchAccountSnapshot: vi.fn() };
 
+        AccountHistoryService.setDependencies({ database, clickhouse, provider, emitter: undefined, logger: createSilentLogger() });
+        const service = AccountHistoryService.getInstance();
+
+        await service.runForwardSyncTick();
+        expect(provider.fetchPage).not.toHaveBeenCalled();
+    });
+
+    it('runForwardSyncTick skips a paused completed account via the denormalized brake', async () => {
+        // A paused account keeps status `complete` (setProgressStatus is a no-op on
+        // completed accounts), so the forward selector must exclude it on the
+        // denormalized `paused` flag, not on status. Without that flag this account
+        // would be wrongly refreshed.
+        AccountHistoryService.resetForTests();
+        const database = createMockDatabaseService();
+        const now = new Date('2024-01-01T00:00:00.000Z');
+        database.getCollectionData(TRACKED_COLLECTION).push({ address: VALID_ADDRESS, paused: true, addedAt: now, updatedAt: now });
+        database.getCollectionData(PROGRESS_COLLECTION).push({
+            address: VALID_ADDRESS, status: 'complete', paused: true,
+            nativeComplete: true, trc20Complete: true, newestTimestampSeen: now, rowsIngested: 10
+        });
+
+        const clickhouse = { query: vi.fn().mockResolvedValue([]), insert: vi.fn() } as unknown as IClickHouseService;
+        const provider: IAccountHistoryProvider = { id: 'test', fetchPage: vi.fn(), fetchAccountSnapshot: vi.fn() };
         AccountHistoryService.setDependencies({ database, clickhouse, provider, emitter: undefined, logger: createSilentLogger() });
         const service = AccountHistoryService.getInstance();
 

--- a/src/backend/modules/account-history/__tests__/account-history.test.ts
+++ b/src/backend/modules/account-history/__tests__/account-history.test.ts
@@ -473,9 +473,9 @@ describe('AccountHistoryService', () => {
     });
 
     it('runForwardSyncTick skips a paused completed account via the denormalized brake', async () => {
-        // A paused account keeps status `complete` (setProgressStatus is a no-op on
-        // completed accounts), so the forward selector must exclude it on the
-        // denormalized `paused` flag, not on status. Without that flag this account
+        // A paused account keeps status `complete` (setAccountPaused leaves status
+        // untouched on completed accounts), so the forward selector must exclude it on
+        // the denormalized `paused` flag, not on status. Without that flag this account
         // would be wrongly refreshed.
         AccountHistoryService.resetForTests();
         const database = createMockDatabaseService();

--- a/src/backend/modules/account-history/database/index.ts
+++ b/src/backend/modules/account-history/database/index.ts
@@ -65,6 +65,17 @@ export interface IAccountProgressDoc {
     address: string;
     /** Lifecycle state of the backfill; `complete` only once BOTH endpoints exhaust. */
     status: 'queued' | 'running' | 'paused' | 'complete' | 'failed';
+    /**
+     * Denormalized copy of the tracked-account `paused` brake, kept here so the
+     * ingest, forward-sync, and snapshot tick selectors push their whole
+     * predicate (unpaused + dueness) into one indexed query on this collection
+     * instead of loading the entire tracked + progress sets and joining in
+     * memory. Authoritative value still lives on the tracked doc; this mirror is
+     * written by `setAccountPaused` and seeded `false` on insert. Absent on
+     * pre-migration documents — selectors use `{$ne: true}` so a missing value
+     * reads as unpaused until migration 003 backfills it.
+     */
+    paused?: boolean;
     /** Opaque fingerprint for the next general `/transactions` page; absent before first run or when that endpoint is exhausted. */
     cursorFingerprint?: string;
     /** Opaque fingerprint for the next `/transactions/trc20` page; absent before first run or when that endpoint is exhausted. */

--- a/src/backend/modules/account-history/migrations/003_denormalize_paused_to_progress.ts
+++ b/src/backend/modules/account-history/migrations/003_denormalize_paused_to_progress.ts
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview Backfill the denormalized `paused` brake onto progress docs.
+ *
+ * Why this migration exists: the ingest, forward-sync, and snapshot scheduler
+ * ticks used to load the entire tracked set *and* the entire progress set every
+ * tick, then join, filter, sort, and slice in memory — the predicate spans two
+ * collections (`paused` on tracked, dueness fields on progress), so a single
+ * indexed query was impossible. The selectors now push their whole predicate
+ * into one indexed query on the progress collection, which requires `paused` to
+ * live there too. New and re-paused accounts get the field at write time; this
+ * migration backfills the documents that predate the change so the selectors do
+ * not read a stale `unpaused` for an account the operator had paused.
+ *
+ * Idempotent: re-running sets the same values. The tick-selector indexes are
+ * created by the module's `ensureIndexes()` on every boot, so this migration
+ * touches data only.
+ */
+
+import type { IMigration, IMigrationContext } from '@/types';
+import { TRACKED_COLLECTION, PROGRESS_COLLECTION } from '../database/index.js';
+import type { ITrackedAccountDoc, IAccountProgressDoc } from '../database/index.js';
+
+/**
+ * Copy each tracked account's `paused` value onto its progress document, then
+ * default every still-unset progress doc to `false`.
+ */
+export const migration: IMigration = {
+    id: '003_denormalize_paused_to_progress',
+    description: 'Backfill the denormalized paused flag onto account-history progress docs so the ingest/forward-sync/snapshot tick selectors can filter unpaused accounts in a single indexed query.',
+    dependencies: [],
+
+    /**
+     * Apply the backfill. Tracked-paused addresses are set first, then any
+     * remaining progress doc missing the field is defaulted to unpaused.
+     *
+     * @param context - Migration context; uses `database` only (MongoDB target).
+     */
+    async up(context: IMigrationContext): Promise<void> {
+        const tracked = context.database.getCollection<ITrackedAccountDoc>(TRACKED_COLLECTION);
+        const progress = context.database.getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION);
+
+        // Step 1: mirror paused=true for accounts the operator has paused.
+        const pausedAddresses = (await tracked.find({ paused: true }).toArray()).map((doc) => doc.address);
+        if (pausedAddresses.length > 0) {
+            const result = await progress.updateMany(
+                { address: { $in: pausedAddresses } },
+                { $set: { paused: true } }
+            );
+            console.log(`[Migration] Set paused=true on ${result.modifiedCount} progress docs`);
+        }
+
+        // Step 2: default every remaining progress doc (field absent) to unpaused.
+        const defaulted = await progress.updateMany(
+            { paused: { $exists: false } },
+            { $set: { paused: false } }
+        );
+        console.log(`[Migration] Defaulted paused=false on ${defaulted.modifiedCount} progress docs`);
+    }
+};

--- a/src/backend/modules/account-history/services/account-history.service.ts
+++ b/src/backend/modules/account-history/services/account-history.service.ts
@@ -297,11 +297,19 @@ export class AccountHistoryService implements IAccountHistoryService {
         if (!doc) {
             throw new Error(`account ${address} is not tracked`);
         }
-        await this.setProgressStatus(address, paused ? 'paused' : 'queued');
         // Mirror the brake onto progress so the tick selectors filter on it directly.
-        // Written even when the account is `complete` (where setProgressStatus is a
-        // no-op), so a paused completed account is excluded from forward sync.
-        await this.patchProgress(address, { paused });
+        // `paused` is written unconditionally — even when the account is `complete` —
+        // so a paused completed account is excluded from forward sync. `status` is
+        // left untouched when `complete`: a completed backfill is never reopened (a
+        // `queued` overwrite would re-walk the whole history and double-count
+        // `rowsIngested`). Consolidated into one ensureProgress + one patchProgress to
+        // drop the redundant status roundtrip.
+        const progress = await this.ensureProgress(address);
+        const update: Partial<IAccountProgressDoc> = { paused };
+        if (progress.status !== 'complete') {
+            update.status = paused ? 'paused' : 'queued';
+        }
+        await this.patchProgress(address, update);
         const tracked = AccountHistoryService.toTrackedAccount(doc);
         return tracked;
     }
@@ -1467,27 +1475,6 @@ export class AccountHistoryService implements IAccountHistoryService {
             update.$unset = unset;
         }
         await this.database.getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION).updateOne({ address }, update, { upsert: true });
-    }
-
-    /**
-     * Force a progress status, used when pausing/resuming an account. A
-     * `complete` backfill is never reopened: overwriting it to `queued` on
-     * resume would re-include the account in the next tick (which filters on
-     * `status !== 'complete'`) and, with the cursor cleared at completion,
-     * trigger a full re-walk that re-fetches the whole history and double-counts
-     * `rowsIngested`. The admin badge reads `account.paused` for the paused
-     * label, so a paused completed account still displays as paused without
-     * losing its terminal status.
-     *
-     * @param address - Base58 address.
-     * @param status - The status to set.
-     */
-    private async setProgressStatus(address: string, status: IAccountProgressDoc['status']): Promise<void> {
-        const progress = await this.ensureProgress(address);
-        if (progress.status === 'complete') {
-            return;
-        }
-        await this.patchProgress(address, { status });
     }
 
     /**

--- a/src/backend/modules/account-history/services/account-history.service.ts
+++ b/src/backend/modules/account-history/services/account-history.service.ts
@@ -90,6 +90,29 @@ const TRON_ADDRESS_PATTERN = /^T[1-9A-HJ-NP-Za-km-z]{33}$/;
 /** WebSocket event name for live ingestion stats; must have a case in WebSocketService.emit(). */
 const STATS_EVENT = 'account-history:stats';
 
+/** Upper bound on a single by-`txId` read, so a caller cannot build an unbounded `IN (...)` list. */
+const MAX_TXID_READ = 2_000;
+
+/**
+ * The `account_transactions` columns every source-independent read projects.
+ * Shared by {@link AccountHistoryService.getTransactions} and
+ * {@link AccountHistoryService.getTransactionsByTxIds} so the projection stays in
+ * lockstep — a column added to one read is added to both.
+ */
+const TRANSACTION_SELECT_COLUMNS = `account, tx_id, source, block_number, timestamp, type, status, from_address, to_address,
+            amount_sun, fee_sun, energy_consumed, energy_fee_sun, bandwidth_consumed, bandwidth_fee_sun,
+            contract_address, contract_method, token_amount, token_symbol, token_decimals, memo`;
+
+/**
+ * ClickHouse predicate suppressing the native `'tx'` twin of an outbound TRC20
+ * transfer when its richer decoded `'trc20'` row exists for the same `tx_id`.
+ * Parameterized on `{address:String}`; shared by every read that must not
+ * double-count outbound token transfers.
+ */
+const OUTBOUND_TRC20_DEDUPE_FILTER = `NOT (source = 'tx' AND tx_id IN (
+                 SELECT tx_id FROM ${TRANSACTIONS_TABLE} WHERE account = {address:String} AND source = 'trc20'
+             ))`;
+
 /**
  * Mutable per-tick state threaded through the two endpoint walks for one account,
  * so both `'tx'` and `'trc20'` advance into a single combined progress record
@@ -199,6 +222,18 @@ export class AccountHistoryService implements IAccountHistoryService {
         await this.database.createIndex(TRACKED_COLLECTION, { address: 1 }, { unique: true });
         await this.database.createIndex(PROGRESS_COLLECTION, { address: 1 }, { unique: true });
         await this.database.createIndex(SETTINGS_COLLECTION, { key: 1 }, { unique: true });
+        // Tick-selector indexes: each scheduler tick pushes its (unpaused + dueness)
+        // predicate and sort into one query on PROGRESS, so coverage rotation no
+        // longer loads the whole tracked + progress set. Composite order follows the
+        // ESR rule (Equality → Sort → Range) so the sort is served by an index walk,
+        // never a blocking in-memory sort: `paused` is a `$ne` range and so trails the
+        // sort key, while `status` (an equality for forward sync) leads it.
+        // Ingest: sort lastRunAt; ranges paused ($ne) + status ($nin).
+        await this.database.createIndex(PROGRESS_COLLECTION, { lastRunAt: 1, paused: 1, status: 1 });
+        // Forward sync: equality status='complete'; sort lastForwardRunAt; range paused.
+        await this.database.createIndex(PROGRESS_COLLECTION, { status: 1, lastForwardRunAt: 1, paused: 1 });
+        // Snapshot: sort lastSnapshotDay (also the dueness range); range paused.
+        await this.database.createIndex(PROGRESS_COLLECTION, { lastSnapshotDay: 1, paused: 1 });
     }
 
     /**
@@ -263,6 +298,10 @@ export class AccountHistoryService implements IAccountHistoryService {
             throw new Error(`account ${address} is not tracked`);
         }
         await this.setProgressStatus(address, paused ? 'paused' : 'queued');
+        // Mirror the brake onto progress so the tick selectors filter on it directly.
+        // Written even when the account is `complete` (where setProgressStatus is a
+        // no-op), so a paused completed account is excluded from forward sync.
+        await this.patchProgress(address, { paused });
         const tracked = AccountHistoryService.toTrackedAccount(doc);
         return tracked;
     }
@@ -419,20 +458,11 @@ export class AccountHistoryService implements IAccountHistoryService {
 
         // An outbound TRC20 transfer lands as both a native call row ('tx') and a
         // decoded transfer row ('trc20') with the same tx_id; the trc20 row is the
-        // richer view, so suppress the native twin on read. The filter drops only a
-        // 'tx' row whose tx_id also has a 'trc20' row — native-only transactions and
-        // every (batch-distinct) trc20 row are preserved.
-        const dedupeFilter =
-            `NOT (source = 'tx' AND tx_id IN (
-                 SELECT tx_id FROM ${TRANSACTIONS_TABLE} WHERE account = {address:String} AND source = 'trc20'
-             ))`;
-
+        // richer view, so suppress the native twin on read (OUTBOUND_TRC20_DEDUPE_FILTER).
         const rows = await this.clickhouse.query<IAccountTransactionRow>(
-            `SELECT account, tx_id, source, block_number, timestamp, type, status, from_address, to_address,
-                    amount_sun, fee_sun, energy_consumed, energy_fee_sun, bandwidth_consumed, bandwidth_fee_sun,
-                    contract_address, contract_method, token_amount, token_symbol, token_decimals, memo
+            `SELECT ${TRANSACTION_SELECT_COLUMNS}
              FROM ${TRANSACTIONS_TABLE} FINAL
-             WHERE account = {address:String} AND ${dedupeFilter}
+             WHERE account = {address:String} AND ${OUTBOUND_TRC20_DEDUPE_FILTER}
              ORDER BY timestamp DESC
              LIMIT {limit:UInt32} OFFSET {offset:UInt32}`,
             { address, limit, offset }
@@ -440,7 +470,7 @@ export class AccountHistoryService implements IAccountHistoryService {
 
         const countRows = await this.clickhouse.query<{ total: string | number }>(
             `SELECT count() AS total FROM ${TRANSACTIONS_TABLE} FINAL
-             WHERE account = {address:String} AND ${dedupeFilter}`,
+             WHERE account = {address:String} AND ${OUTBOUND_TRC20_DEDUPE_FILTER}`,
             { address }
         );
 
@@ -449,6 +479,41 @@ export class AccountHistoryService implements IAccountHistoryService {
             total: Number(countRows[0]?.total ?? 0)
         };
         return page;
+    }
+
+    /**
+     * Read specific stored transactions for one account by transaction hash.
+     *
+     * Why it exists: the valuation engine refetches the missing leg of an
+     * internal transfer whose two rows straddle a per-wallet window boundary (see
+     * {@link IAccountHistoryService.getTransactionsByTxIds}). The read is keyed by
+     * an explicit hash set, clamped to {@link MAX_TXID_READ} so a caller cannot
+     * build an unbounded `IN (...)` list, and carries the same outbound-TRC20
+     * dedupe as {@link getTransactions}. Returns an empty array when ClickHouse is
+     * not configured or no hashes are requested.
+     *
+     * @param address - Base58 address whose rows to read.
+     * @param txIds - Transaction hashes to fetch.
+     * @returns The matching transactions, newest first.
+     */
+    public async getTransactionsByTxIds(address: string, txIds: string[]): Promise<IBlockTransaction[]> {
+        const normalized = String(address ?? '').trim();
+        if (!TRON_ADDRESS_PATTERN.test(normalized)) {
+            throw new Error('address must be a base58 TRON address (T...)');
+        }
+        const unique = Array.from(new Set((txIds ?? []).filter((id) => typeof id === 'string' && id.length > 0))).slice(0, MAX_TXID_READ);
+        if (!this.clickhouse || unique.length === 0) {
+            return [];
+        }
+
+        const rows = await this.clickhouse.query<IAccountTransactionRow>(
+            `SELECT ${TRANSACTION_SELECT_COLUMNS}
+             FROM ${TRANSACTIONS_TABLE} FINAL
+             WHERE account = {address:String} AND tx_id IN ({txIds:Array(String)}) AND ${OUTBOUND_TRC20_DEDUPE_FILTER}
+             ORDER BY timestamp DESC`,
+            { address: normalized, txIds: unique }
+        );
+        return rows.map(AccountHistoryService.rowToBlockTransaction);
     }
 
     /**
@@ -783,32 +848,18 @@ export class AccountHistoryService implements IAccountHistoryService {
      * @returns Base58 addresses to ingest this tick.
      */
     private async selectAccountsForTick(accountsPerTick: number): Promise<string[]> {
-        const tracked = await this.database
-            .getCollection<ITrackedAccountDoc>(TRACKED_COLLECTION)
-            .find({ paused: { $ne: true } })
-            .toArray();
-        if (tracked.length === 0) {
-            return [];
-        }
-
-        const progressDocs = await this.database
+        // One indexed query on PROGRESS does the whole selection: unpaused, not yet
+        // complete, least-recently-advanced first, capped at the per-tick count.
+        // `status: paused` excludes a paused non-complete account; `paused: {$ne:true}`
+        // also excludes a paused *complete*-status account and tolerates the missing
+        // denormalized field on pre-migration docs (reads as unpaused).
+        const docs = await this.database
             .getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION)
-            .find({ address: { $in: tracked.map((t) => t.address) } })
+            .find({ paused: { $ne: true }, status: { $nin: ['complete', 'paused'] } })
+            .sort({ lastRunAt: 1 })
+            .limit(accountsPerTick)
             .toArray();
-        const progressByAddress = new Map<string, IAccountProgressDoc>();
-        for (const doc of progressDocs) {
-            progressByAddress.set(doc.address, doc);
-        }
-
-        const eligible = tracked.filter((t) => progressByAddress.get(t.address)?.status !== 'complete');
-        eligible.sort((a, b) => {
-            const aRun = progressByAddress.get(a.address)?.lastRunAt?.getTime() ?? 0;
-            const bRun = progressByAddress.get(b.address)?.lastRunAt?.getTime() ?? 0;
-            return aRun - bRun;
-        });
-
-        const selected = eligible.slice(0, accountsPerTick).map((t) => t.address);
-        return selected;
+        return docs.map((doc) => doc.address);
     }
 
     /**
@@ -980,36 +1031,21 @@ export class AccountHistoryService implements IAccountHistoryService {
      * @returns Base58 addresses to forward-sync this tick.
      */
     private async selectCompletedAccountsForForward(accountsPerTick: number): Promise<string[]> {
-        const tracked = await this.database
-            .getCollection<ITrackedAccountDoc>(TRACKED_COLLECTION)
-            .find({ paused: { $ne: true } })
-            .toArray();
-        if (tracked.length === 0) {
-            return [];
-        }
-
-        const progressDocs = await this.database
+        // The inverse of selectAccountsForTick: unpaused and `complete`, pushed into
+        // one indexed query on PROGRESS. Ordered by the forward-specific timestamp,
+        // not `lastRunAt`: for a completed account `lastRunAt` was frozen at backfill
+        // completion, so it cannot rotate forward freshness fairly. A
+        // never-forward-synced account (`lastForwardRunAt` absent) sorts first, so it
+        // is refreshed soonest. `paused: {$ne:true}` excludes a paused completed
+        // account (whose status stays `complete`) and tolerates the missing field on
+        // pre-migration docs.
+        const docs = await this.database
             .getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION)
-            .find({ address: { $in: tracked.map((t) => t.address) } })
+            .find({ paused: { $ne: true }, status: 'complete' })
+            .sort({ lastForwardRunAt: 1 })
+            .limit(accountsPerTick)
             .toArray();
-        const progressByAddress = new Map<string, IAccountProgressDoc>();
-        for (const doc of progressDocs) {
-            progressByAddress.set(doc.address, doc);
-        }
-
-        // Order by the forward-specific timestamp, not `lastRunAt`: for a completed
-        // account `lastRunAt` was frozen at backfill completion, so it cannot rotate
-        // forward freshness fairly. A never-forward-synced account (no
-        // `lastForwardRunAt`) sorts first, so it is refreshed soonest.
-        const eligible = tracked.filter((t) => progressByAddress.get(t.address)?.status === 'complete');
-        eligible.sort((a, b) => {
-            const aRun = progressByAddress.get(a.address)?.lastForwardRunAt?.getTime() ?? 0;
-            const bRun = progressByAddress.get(b.address)?.lastForwardRunAt?.getTime() ?? 0;
-            return aRun - bRun;
-        });
-
-        const selected = eligible.slice(0, accountsPerTick).map((t) => t.address);
-        return selected;
+        return docs.map((doc) => doc.address);
     }
 
     /**
@@ -1364,28 +1400,18 @@ export class AccountHistoryService implements IAccountHistoryService {
             return;
         }
         const today = new Date().toISOString().slice(0, 10);
-        const tracked = await this.database
-            .getCollection<ITrackedAccountDoc>(TRACKED_COLLECTION)
-            .find({ paused: { $ne: true } })
-            .toArray();
-        const progressDocs = await this.database
+        // One indexed query on PROGRESS: unpaused, not yet snapshotted today, oldest
+        // snapshot first so the tick rotates fairly across UTC days instead of
+        // starving accounts beyond the per-day ceiling. `lastSnapshotDay: {$ne: today}`
+        // matches both an older day and a missing field (never snapshotted), which
+        // also sorts first under ascending order; `paused: {$ne:true}` tolerates the
+        // missing denormalized field on pre-migration docs.
+        const due = await this.database
             .getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION)
-            .find({ address: { $in: tracked.map((t) => t.address) } })
+            .find({ paused: { $ne: true }, lastSnapshotDay: { $ne: today } })
+            .sort({ lastSnapshotDay: 1 })
+            .limit(settings.accountsPerTick)
             .toArray();
-        const lastSnapshotByAddress = new Map(progressDocs.map((doc) => [doc.address, doc.lastSnapshotDay]));
-
-        const due = tracked
-            .filter((account) => lastSnapshotByAddress.get(account.address) !== today)
-            // Oldest snapshot first (never-snapshotted, mapped to '', sorts first) so the
-            // tick rotates fairly across UTC days instead of re-taking the first accounts
-            // in natural collection order and starving those beyond the per-day ceiling —
-            // mirrors the ingest/forward-sync selectors above.
-            .sort((a, b) => {
-                const aDay = lastSnapshotByAddress.get(a.address) ?? '';
-                const bDay = lastSnapshotByAddress.get(b.address) ?? '';
-                return aDay < bDay ? -1 : aDay > bDay ? 1 : 0;
-            })
-            .slice(0, settings.accountsPerTick);
 
         for (const account of due) {
             try {
@@ -1410,7 +1436,7 @@ export class AccountHistoryService implements IAccountHistoryService {
         const collection = this.database.getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION);
         const result = await collection.findOneAndUpdate(
             { address },
-            { $setOnInsert: { address, status: 'queued', rowsIngested: 0 } },
+            { $setOnInsert: { address, status: 'queued', rowsIngested: 0, paused: false } },
             { upsert: true, returnDocument: 'after' }
         );
         const doc = (result && 'value' in result ? result.value : result) as IAccountProgressDoc;

--- a/src/backend/modules/scheduler/__tests__/scheduler.service.test.ts
+++ b/src/backend/modules/scheduler/__tests__/scheduler.service.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @fileoverview Unit tests for SchedulerService.runNow and the shared executeJob
+ * path it exercises.
+ *
+ * Why these exist: runNow is the on-demand trigger behind the dashboard "Run now"
+ * button, and it shares one execution path with the cron tick (executeJob). The
+ * contract that matters operationally is single-flight (a manual run never stacks
+ * a second concurrent execution on top of an in-flight run) and never-throw (a
+ * failing handler is recorded, not propagated, and always releases the running
+ * lock so the job is not wedged into a permanently-skipped state). These tests pin
+ * exactly that, using the shared in-memory database mock with a spied execution
+ * model so no live MongoDB is required.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+import { SchedulerService } from '../services/scheduler.service.js';
+
+/**
+ * Drain pending micro/macro tasks so a fire-and-forget executeJob() reaches its
+ * `finally` (lock release) before assertions run.
+ *
+ * @returns A promise that resolves after several event-loop turns.
+ */
+async function flush(): Promise<void> {
+    for (let i = 0; i < 4; i += 1) {
+        await new Promise((resolve) => setImmediate(resolve));
+    }
+}
+
+describe('SchedulerService.runNow', () => {
+    let mockDb: ReturnType<typeof createMockDatabaseService>;
+
+    /**
+     * Fresh singleton + a spied execution model before each test. The model's
+     * create() returns a doc whose updateOne() is a no-op, matching what executeJob
+     * needs to record start/finish without a real collection.
+     */
+    beforeEach(() => {
+        SchedulerService.resetInstance();
+        mockDb = createMockDatabaseService();
+        vi.spyOn(mockDb, 'getModel').mockReturnValue({
+            create: vi.fn(async (doc: unknown) => ({ ...(doc as object), updateOne: vi.fn(async () => {}) }))
+        } as never);
+        SchedulerService.setDependencies(mockDb);
+    });
+
+    afterEach(() => {
+        SchedulerService.resetInstance();
+        mockDb.clear();
+        vi.restoreAllMocks();
+    });
+
+    it('starts a registered job and invokes its handler', async () => {
+        const handler = vi.fn(async () => {});
+        const scheduler = SchedulerService.getInstance();
+        scheduler.register('test:job', '* * * * *', handler);
+
+        const result = await scheduler.runNow('test:job');
+        await flush();
+
+        expect(result).toEqual({ started: true });
+        expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws for an unregistered job', async () => {
+        const scheduler = SchedulerService.getInstance();
+        await expect(scheduler.runNow('does:not-exist')).rejects.toThrow('not registered');
+    });
+
+    it('reports started:false when the job is already running (single-flight)', async () => {
+        let release!: () => void;
+        const gate = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+        const handler = vi.fn(async () => {
+            await gate;
+        });
+        const scheduler = SchedulerService.getInstance();
+        scheduler.register('test:slow', '* * * * *', handler);
+
+        // First run parks inside the handler, holding the running lock.
+        const first = await scheduler.runNow('test:slow');
+        // Second run, while the first is still in flight, must not stack.
+        const second = await scheduler.runNow('test:slow');
+
+        expect(first).toEqual({ started: true });
+        expect(second).toEqual({ started: false });
+        expect(handler).toHaveBeenCalledTimes(1);
+
+        release();
+        await flush();
+    });
+
+    it('does not reject and releases the lock when the handler throws', async () => {
+        const handler = vi.fn(async () => {
+            throw new Error('boom');
+        });
+        const scheduler = SchedulerService.getInstance();
+        scheduler.register('test:flaky', '* * * * *', handler);
+
+        // never-throw: the rejection is recorded inside executeJob, not propagated.
+        await expect(scheduler.runNow('test:flaky')).resolves.toEqual({ started: true });
+        await flush();
+
+        // Lock released despite the failure: a second run is accepted and re-invokes.
+        const again = await scheduler.runNow('test:flaky');
+        await flush();
+        expect(again).toEqual({ started: true });
+        expect(handler).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/backend/modules/scheduler/api/scheduler.controller.ts
+++ b/src/backend/modules/scheduler/api/scheduler.controller.ts
@@ -230,4 +230,57 @@ export class SchedulerController {
             });
         }
     };
+
+    /**
+     * POST /job/:jobName/run - Trigger a job immediately, outside its schedule.
+     *
+     * Lets an operator force a run from the dashboard without waiting for the next
+     * cron tick — the path that lets a never-yet-fired low-frequency job (e.g. the
+     * 4-hourly account-history snapshot) be exercised on demand. The job's enabled
+     * state is irrelevant: a manual run executes the handler once and touches
+     * neither the cron task nor persisted config.
+     *
+     * Responds `202` with `started`, which is `false` (not an error) when the job
+     * was already running — single-flight is preserved server-side. The execution
+     * is fire-and-forget; outcome lands in the executions audit log and surfaces on
+     * the next status poll.
+     *
+     * @param req.params.jobName - Registered job identifier to run.
+     */
+    runJob = async (req: Request, res: Response): Promise<void> => {
+        const { jobName } = req.params;
+
+        let scheduler: SchedulerService;
+        try {
+            scheduler = SchedulerService.getInstance();
+        } catch {
+            res.status(503).json({
+                success: false,
+                error: 'Scheduler is not enabled or not initialized'
+            });
+            return;
+        }
+
+        try {
+            const { started } = await scheduler.runNow(jobName);
+
+            this.logger.info({ jobName, started }, 'Scheduler job manual run requested');
+
+            res.status(202).json({
+                success: true,
+                started,
+                message: started
+                    ? `Scheduler job ${jobName} run started`
+                    : `Scheduler job ${jobName} is already running`
+            });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Unknown error';
+            const notRegistered = message.includes('not registered');
+            this.logger.error({ error, jobName }, 'Failed to run scheduler job');
+            res.status(notRegistered ? 404 : 500).json({
+                success: false,
+                error: message
+            });
+        }
+    };
 }

--- a/src/backend/modules/scheduler/api/scheduler.routes.ts
+++ b/src/backend/modules/scheduler/api/scheduler.routes.ts
@@ -36,5 +36,8 @@ export function createSchedulerRouter(controller: SchedulerController): Router {
     // PATCH /job/:jobName - Update job configuration
     router.patch('/job/:jobName', controller.updateJob);
 
+    // POST /job/:jobName/run - Trigger a job immediately, outside its schedule
+    router.post('/job/:jobName/run', controller.runJob);
+
     return router;
 }

--- a/src/backend/modules/scheduler/services/scheduler.service.ts
+++ b/src/backend/modules/scheduler/services/scheduler.service.ts
@@ -335,13 +335,24 @@ export class SchedulerService {
             const errorMessage = error instanceof Error ? error.message : String(error);
 
             // The row may not exist if creation itself threw; only update what we have.
+            // Guard this write in its own try-catch: a failing handler often coincides
+            // with a struggling database, so the update can itself reject. Letting it
+            // escape would break the never-rejects contract and surface as an unhandled
+            // rejection in the fire-and-forget callers (scheduleJob, runNow).
             if (execution) {
-                await execution.updateOne({
-                    completedAt: new Date(),
-                    duration,
-                    status: 'failed',
-                    error: errorMessage
-                });
+                try {
+                    await execution.updateOne({
+                        completedAt: new Date(),
+                        duration,
+                        status: 'failed',
+                        error: errorMessage
+                    });
+                } catch (updateError) {
+                    logger.error(
+                        { job: job.name, error: updateError },
+                        `Failed to persist failure status for job: ${job.name}`
+                    );
+                }
             }
 
             logger.error(

--- a/src/backend/modules/scheduler/services/scheduler.service.ts
+++ b/src/backend/modules/scheduler/services/scheduler.service.ts
@@ -249,24 +249,61 @@ export class SchedulerService {
     /**
      * Schedule a single job with node-cron.
      *
-     * Wraps the handler with execution tracking and overlap protection.
+     * The cron tick delegates to {@link executeJob} so a scheduled run and a
+     * manual {@link runNow} share one execution path — identical overlap
+     * protection, audit record, and never-throw contract. The callback is sync and
+     * fire-and-forget (`void`) because executeJob owns all error handling, so an
+     * unhandled rejection can never escape the node-cron callback.
      *
      * @param job - Job to schedule
      */
     private scheduleJob(job: RegisteredJob): void {
-        const task = cron.schedule(job.currentSchedule, async () => {
-            if (this.runningJobs.has(job.name)) {
-                logger.warn(
-                    { jobName: job.name },
-                    `Scheduled Job Skipped: ${job.name} - previous execution still running`
-                );
-                return;
-            }
+        const task = cron.schedule(job.currentSchedule, () => {
+            void this.executeJob(job);
+        });
 
-            this.runningJobs.add(job.name);
+        job.task = task;
+    }
 
+    /**
+     * Execute one job's handler exactly once, with single-flight overlap
+     * protection and full execution tracking.
+     *
+     * Why extracted from the cron callback: the manual {@link runNow} trigger must
+     * behave identically to a scheduled tick — same guard against a second
+     * concurrent run, same `scheduler_executions` audit row, same contract of never
+     * rejecting — so the logic lives here rather than inline where only cron could
+     * reach it.
+     *
+     * Never rejects: a handler failure is captured to the execution record and
+     * logged, so both callers (cron and runNow) can fire-and-forget safely. The
+     * running-set membership is released in `finally` and the execution row is
+     * created *inside* the try, so even a failure while writing that row cannot
+     * wedge the job into a permanently "running" state that would silently skip
+     * every future tick and every future manual run.
+     *
+     * @param job - The registered job to execute.
+     */
+    private async executeJob(job: RegisteredJob): Promise<void> {
+        if (this.runningJobs.has(job.name)) {
+            logger.warn(
+                { jobName: job.name },
+                `Scheduled Job Skipped: ${job.name} - previous execution still running`
+            );
+            return;
+        }
+
+        this.runningJobs.add(job.name);
+        const started = Date.now();
+        logger.debug({ job: job.name }, `Scheduled Job Start: ${job.name}`);
+
+        // Held as a nullable outer binding so the catch can tell whether the row was
+        // ever created (creation itself may throw); the success path uses the
+        // non-null `created` const directly.
+        let execution: SchedulerExecutionDoc | null = null;
+        try {
             const executionModel = this.database.getModel<SchedulerExecutionDoc>(this.EXECUTION_COLLECTION);
-            const execution = await executionModel.create({
+            const created = await executionModel.create({
                 jobName: job.name,
                 startedAt: new Date(),
                 status: 'running',
@@ -274,54 +311,88 @@ export class SchedulerService {
                 duration: null,
                 error: null
             });
+            execution = created;
 
-            const started = Date.now();
-            logger.debug({ job: job.name }, `Scheduled Job Start: ${job.name}`);
+            await job.handler();
+            const duration = Date.now() - started;
 
-            try {
-                await job.handler();
-                const duration = Date.now() - started;
+            await created.updateOne({
+                completedAt: new Date(),
+                duration,
+                status: 'success'
+            });
 
-                await execution.updateOne({
-                    completedAt: new Date(),
-                    duration,
+            logger.info(
+                {
+                    job: job.name,
+                    durationMs: duration,
                     status: 'success'
-                });
+                },
+                `Scheduled Job Complete: ${job.name}`
+            );
+        } catch (error) {
+            const duration = Date.now() - started;
+            const errorMessage = error instanceof Error ? error.message : String(error);
 
-                logger.info(
-                    {
-                        job: job.name,
-                        durationMs: duration,
-                        status: 'success'
-                    },
-                    `Scheduled Job Complete: ${job.name}`
-                );
-            } catch (error) {
-                const duration = Date.now() - started;
-                const errorMessage = error instanceof Error ? error.message : String(error);
-
+            // The row may not exist if creation itself threw; only update what we have.
+            if (execution) {
                 await execution.updateOne({
                     completedAt: new Date(),
                     duration,
                     status: 'failed',
                     error: errorMessage
                 });
-
-                logger.error(
-                    {
-                        job: job.name,
-                        durationMs: duration,
-                        status: 'failed',
-                        error: errorMessage
-                    },
-                    `Scheduled Job Failed: ${job.name}`
-                );
-            } finally {
-                this.runningJobs.delete(job.name);
             }
-        });
 
-        job.task = task;
+            logger.error(
+                {
+                    job: job.name,
+                    durationMs: duration,
+                    status: 'failed',
+                    error: errorMessage
+                },
+                `Scheduled Job Failed: ${job.name}`
+            );
+        } finally {
+            this.runningJobs.delete(job.name);
+        }
+    }
+
+    /**
+     * Trigger a registered job's handler immediately, outside its cron schedule.
+     *
+     * Why: operators need to force a run without waiting for the next tick — to
+     * pick up a newly added work item, recover after a failed run, or exercise a
+     * low-frequency job (e.g. a 4-hourly balance snapshot) that has not yet reached
+     * its first scheduled boundary. The job's enabled flag is intentionally ignored
+     * because a manual run is an explicit operator action that neither touches the
+     * cron task nor mutates persisted config: a disabled job can be run once without
+     * re-enabling it.
+     *
+     * Single-flight is preserved. If the job is already running (scheduled or
+     * manual) this is a no-op reporting `started: false`, never a second concurrent
+     * execution. The run is fire-and-forget — {@link executeJob} records the
+     * outcome to the executions collection — so this resolves as soon as the run is
+     * accepted and the HTTP caller is not held open for a long-running job.
+     *
+     * @param name - Registered job identifier to run.
+     * @returns `{ started: true }` when a run was kicked off, `{ started: false }`
+     *   when one was already in flight.
+     * @throws Error if the job name is not registered.
+     */
+    async runNow(name: string): Promise<{ started: boolean }> {
+        const job = this.jobs.get(name);
+        if (!job) {
+            throw new Error(`Job ${name} not registered`);
+        }
+        if (this.runningJobs.has(name)) {
+            return { started: false };
+        }
+        // Fire-and-forget: executeJob re-checks the running set synchronously before
+        // its first await, so there is no window for a stacked run between here and
+        // there. We do not await it — the HTTP layer returns 202 immediately.
+        void this.executeJob(job);
+        return { started: true };
     }
 
     /**

--- a/src/backend/modules/valuation/README.md
+++ b/src/backend/modules/valuation/README.md
@@ -21,6 +21,8 @@ Cost-basis PnL is inherently **per user**, not per wallet: moving a token betwee
 
 The engine keeps lots in **per-wallet (segregated) sub-books** and treats an *internal* transfer as a **basis migration**: the source wallet's consumed lots move, basis intact, into the receiving wallet's sub-book (matched by `txId`). A sale therefore draws on the *selling* wallet's own basis, never a global pool, so per-user figures are exactly the **sum** of the per-wallet figures — coherent and additive. The service walks the **full owned set's** ledgers even for a single-wallet zoom (basis can only migrate in if the source ledger is read); holdings come only from the report-scope snapshots. Single-address explorers cannot do this — they book a phantom gain on the receiving side of every internal transfer.
 
+Each wallet's ledger read is bounded (`MAX_LEDGER_ROWS`, newest-first), so a high-volume wallet can push one leg of a migration past its window while the other leg stays inside another wallet's. The service detects that split — a `txId|asset` whose in and out quantities, summed across the owned set, disagree — and refetches the missing legs by hash via `getTransactionsByTxIds`, rebuilding the pair so basis is never silently dropped. A transfer whose *both* legs are beyond their windows stays invisible, which is the pre-existing deep-history approximation below, not a split.
+
 ## Source Map
 
 | Path | Responsibility |

--- a/src/backend/modules/valuation/__tests__/valuation.service.test.ts
+++ b/src/backend/modules/valuation/__tests__/valuation.service.test.ts
@@ -53,16 +53,26 @@ function trxTx(from: string, to: string, trx: number, day: string): IBlockTransa
 /**
  * Build a fake account-history service from per-address ledgers and snapshots.
  *
- * @param ledgers - Address → its transactions.
+ * @param ledgers - Address → the transactions a windowed `getTransactions` returns.
  * @param balances - Address → liquid TRX (human units) in its latest snapshot.
+ * @param fullLedgers - Address → the complete row set a by-`txId` refetch can reach;
+ *   defaults to `ledgers`. Diverging it from `ledgers` simulates a row that fell
+ *   outside the per-wallet read window but is still fetchable by hash.
  * @returns A partial IAccountHistoryService sufficient for the valuation reads.
  */
-function fakeAccountHistory(ledgers: Record<string, IBlockTransaction[]>, balances: Record<string, number>) {
+function fakeAccountHistory(
+    ledgers: Record<string, IBlockTransaction[]>,
+    balances: Record<string, number>,
+    fullLedgers: Record<string, IBlockTransaction[]> = ledgers
+) {
     return {
         getTransactions: vi.fn(async ({ address }: { address: string }) => ({
             transactions: ledgers[address] ?? [],
             total: (ledgers[address] ?? []).length
         })),
+        getTransactionsByTxIds: vi.fn(async (address: string, txIds: string[]) =>
+            (fullLedgers[address] ?? []).filter((tx) => txIds.includes(tx.txId))
+        ),
         getLatestSnapshot: vi.fn(async (address: string) =>
             balances[address] === undefined
                 ? null
@@ -186,6 +196,41 @@ describe('ValuationService.getPortfolio', () => {
         expect(trx?.costBasisUsd).toBeCloseTo(6, 6); // 60 * $0.10, migrated from A
         expect(summary.unrealizedPnlUsd).toBeCloseTo(0, 6); // value 6 - basis 6, not 6 - 0
         expect(summary.realizedPnlUsd).toBeCloseTo(0, 6);
+    });
+
+    it('repairs an internal transfer whose receiving leg fell outside the read window', async () => {
+        // A buys 100 @ $0.10, sends 60 to B internally (01-02), then B sells 60
+        // externally (01-03) @ $0.20. B's windowed ledger has only the sale — the
+        // internal-in row was pushed past B's window. Without repair the sale
+        // realizes against ZERO basis ($12 phantom gain); the by-txId refetch
+        // restores B's $6 migrated basis so realized is the true $6.
+        const internalTx = trxTx(WALLET_A, WALLET_B, 60, '2024-01-02');
+        const accountHistory = fakeAccountHistory(
+            {
+                [WALLET_A]: [trxTx(EXTERNAL, WALLET_A, 100, '2024-01-01'), internalTx],
+                // B's window: only the external sale; the internal-in is missing.
+                [WALLET_B]: [trxTx(WALLET_B, EXTERNAL, 60, '2024-01-03')]
+            },
+            { [WALLET_A]: 40, [WALLET_B]: 0 },
+            {
+                // Full reach for the by-txId refetch: B's internal-in row is fetchable.
+                [WALLET_A]: [internalTx],
+                [WALLET_B]: [internalTx]
+            }
+        );
+        const service = buildService(
+            accountHistory,
+            fakePriceHistory({ 'TRX|2024-01-01': 0.1, 'TRX|2024-01-03': 0.2 }, 0.2)
+        );
+
+        const summary = await service.getPortfolio({
+            addresses: [WALLET_A, WALLET_B],
+            ownedAddresses: [WALLET_A, WALLET_B],
+            scope: 'user'
+        });
+
+        expect(accountHistory.getTransactionsByTxIds).toHaveBeenCalled();
+        expect(summary.realizedPnlUsd).toBeCloseTo(6, 6); // proceeds 12 - migrated basis 6, not 12 - 0
     });
 
     it('returns a zeroed summary when the data services are unavailable', async () => {

--- a/src/backend/modules/valuation/services/valuation.service.ts
+++ b/src/backend/modules/valuation/services/valuation.service.ts
@@ -141,6 +141,90 @@ export class ValuationService implements IValuationService {
     }
 
     /**
+     * Repair internal-transfer pairs the bounded per-wallet ledger read split.
+     *
+     * Why: the engine pairs an internal transfer's two legs (an `out` on the
+     * source wallet, an `in` on the destination) by `txId|asset` and migrates
+     * basis between sub-books. {@link readLedger} caps each wallet at
+     * {@link MAX_LEDGER_ROWS} newest-first *independently*, so a high-volume wallet
+     * can push one leg beyond its window while the other leg stays inside another
+     * wallet's window. The engine then sees a half-pair and the transfer's basis
+     * silently vanishes. Both legs share one on-chain `txId`, so the split is
+     * detectable: for an intact internal transfer the `in` and `out` quantities
+     * summed across the owned set are equal, so any `txId|asset` whose sums differ
+     * has a leg outside a window. Refetch every owned wallet's rows for those
+     * hashes (each `txId`'s full row set is then in hand), drop the partial moves,
+     * and rebuild them from the authoritative refetch. A transfer whose *both*
+     * legs are beyond their windows stays invisible — the pre-existing
+     * deep-history approximation, not this split.
+     *
+     * Mutates `moves` in place. The refetch is bounded by the count of
+     * cross-window internal transfers, so the per-wallet read bound is preserved.
+     *
+     * @param accountHistory - The account-history service for the by-`txId` read.
+     * @param moves - The assembled moves, mutated in place when a refetch occurs.
+     * @param ownedAddresses - The user's full owned set; every leg lives on one of these.
+     * @param ownedSet - The owned set as a set, for internal classification on rebuild.
+     * @param tokenMeta - Token-metadata map, populated as refetched rows normalize.
+     */
+    private async reconcileSplitMigrations(
+        accountHistory: IAccountHistoryService,
+        moves: ILedgerMove[],
+        ownedAddresses: string[],
+        ownedSet: Set<string>,
+        tokenMeta: Map<string, ITokenMeta>
+    ): Promise<void> {
+        // Sum in vs out per txId|asset over internal moves; an imbalance means a leg
+        // fell outside a window. Keep the txId so we can refetch it.
+        const balances = new Map<string, { txId: string; inQty: number; outQty: number }>();
+        for (const move of moves) {
+            if (!move.internal) {
+                continue;
+            }
+            const key = `${move.txId}|${move.asset}`;
+            const entry = balances.get(key) ?? { txId: move.txId, inQty: 0, outQty: 0 };
+            if (move.direction === 'in') {
+                entry.inQty += move.quantity;
+            } else {
+                entry.outQty += move.quantity;
+            }
+            balances.set(key, entry);
+        }
+
+        const txIdsToRefetch = new Set<string>();
+        for (const { txId, inQty, outQty } of balances.values()) {
+            // Intact pairs are bit-identical (both legs decode the same on-chain
+            // amount), so a tiny tolerance only absorbs token-decimal float noise.
+            const tolerance = 1e-9 * Math.max(1, inQty, outQty);
+            if (Math.abs(inQty - outQty) > tolerance) {
+                txIdsToRefetch.add(txId);
+            }
+        }
+        if (txIdsToRefetch.size === 0) {
+            return;
+        }
+
+        const txIds = Array.from(txIdsToRefetch);
+        const refetched = await Promise.all(
+            ownedAddresses.map((address) => accountHistory.getTransactionsByTxIds(address, txIds))
+        );
+
+        // Drop the partial moves for these hashes, then rebuild from the complete
+        // refetch (every owned wallet's rows for each hash are now present).
+        const rebuilt = moves.filter((move) => !txIdsToRefetch.has(move.txId));
+        ownedAddresses.forEach((address, index) => {
+            for (const tx of refetched[index]) {
+                const move = ValuationService.toMove(tx, address, ownedSet, tokenMeta);
+                if (move) {
+                    rebuilt.push(move);
+                }
+            }
+        });
+        moves.length = 0;
+        moves.push(...rebuilt);
+    }
+
+    /**
      * Normalize one transaction into a value move from a scope address's
      * viewpoint, learning token metadata as a side effect. Returns null for rows
      * that move no tracked asset (staking, plain contract calls).
@@ -232,6 +316,13 @@ export class ValuationService implements IValuationService {
                 }
             }
         });
+
+        // Repair internal-transfer pairs the per-wallet read window split in half.
+        // readLedger caps each wallet at MAX_LEDGER_ROWS newest-first independently,
+        // so a high-volume wallet can push one leg of a migration beyond its window
+        // while the other leg stays inside another wallet's — silently dropping the
+        // transfer's basis. Refetch the missing legs by txId and rebuild them.
+        await this.reconcileSplitMigrations(accountHistory, moves, query.ownedAddresses, ownedSet, tokenMeta);
 
         // Current holdings come only from the report-scope snapshots (read in parallel).
         const snapshots = (

--- a/src/backend/modules/valuation/services/valuation.service.ts
+++ b/src/backend/modules/valuation/services/valuation.service.ts
@@ -205,9 +205,22 @@ export class ValuationService implements IValuationService {
         }
 
         const txIds = Array.from(txIdsToRefetch);
-        const refetched = await Promise.all(
-            ownedAddresses.map((address) => accountHistory.getTransactionsByTxIds(address, txIds))
-        );
+        // getTransactionsByTxIds clamps each read to its own by-hash maximum to
+        // bound the SQL IN-list, so a portfolio with more imbalanced hashes than
+        // that clamp would have the overflow silently dropped from the refetch —
+        // yet the rebuild below removes the partial moves for *every* requested
+        // hash, so those overflow transfers would lose their moves entirely,
+        // understating basis/PnL. Read the hashes in batches no larger than the
+        // clamp and accumulate, so every requested hash is refetched and rebuilt.
+        const TXID_READ_CHUNK = 2_000;
+        const refetched: IBlockTransaction[][] = ownedAddresses.map(() => []);
+        for (let start = 0; start < txIds.length; start += TXID_READ_CHUNK) {
+            const chunk = txIds.slice(start, start + TXID_READ_CHUNK);
+            const chunkRows = await Promise.all(
+                ownedAddresses.map((address) => accountHistory.getTransactionsByTxIds(address, chunk))
+            );
+            chunkRows.forEach((rows, index) => refetched[index].push(...rows));
+        }
 
         // Drop the partial moves for these hashes, then rebuild from the complete
         // refetch (every owned wallet's rows for each hash are now present).

--- a/src/backend/tests/vitest/mocks/mongoose.ts
+++ b/src/backend/tests/vitest/mocks/mongoose.ts
@@ -57,7 +57,7 @@ const mockCollectionInstances = new Map<string, any>();
 /**
  * Shared filter matching logic for all mock operations.
  *
- * Supports MongoDB query operators: $in, $ne, $or, $regex, $exists, $gte, $lte,
+ * Supports MongoDB query operators: $in, $nin, $ne, $or, $regex, $exists, $gte, $lte,
  * RegExp, array contains, ObjectId comparison, and nested field paths.
  * Exported for reuse in custom IDatabaseService mocks.
  *
@@ -120,6 +120,18 @@ export function matchesFilter(doc: any, filter: Filter<any>): boolean {
                 }
                 // Document field is scalar - check if it matches any value in $in array
                 return inValues.includes(docValue);
+            }
+
+            // Handle $nin operator: { field: { $nin: [value1, value2] } } — matches
+            // when the field value is in none of the listed values. A missing field
+            // matches (undefined is in no list), mirroring MongoDB semantics.
+            if ('$nin' in value) {
+                const ninValues = (value as any).$nin;
+                const docValue = getNestedValue(doc, key);
+                if (Array.isArray(docValue)) {
+                    return !docValue.some((dv: any) => ninValues.includes(dv));
+                }
+                return !ninValues.includes(docValue);
             }
 
             // Handle $ne operator: { field: { $ne: value } }

--- a/src/frontend/modules/scheduler/api/client.ts
+++ b/src/frontend/modules/scheduler/api/client.ts
@@ -75,3 +75,37 @@ export async function updateSchedulerJob(
         throw new Error(errorData.message || `Server returned ${response.status}`);
     }
 }
+
+/**
+ * Triggers an immediate, out-of-schedule run of a scheduler job.
+ *
+ * Lets an operator force a job to run now rather than waiting for its next cron
+ * tick — the only way to exercise a low-frequency job (e.g. a 4-hourly snapshot)
+ * that has not yet reached its first boundary. The job's enabled state is
+ * irrelevant; the backend runs the handler once regardless and preserves
+ * single-flight, so `started` is `false` (not an error) when a run was already in
+ * progress.
+ *
+ * Authorization rides the same-origin Better Auth session cookie.
+ *
+ * @param jobName - Name of the job to run now.
+ * @returns Whether a run was started (`false` if one was already in flight).
+ * @throws Error if the API request fails.
+ */
+export async function runSchedulerJob(jobName: string): Promise<{ started: boolean }> {
+    const response = await fetch(
+        `/api/admin/system/scheduler/job/${jobName}/run`,
+        {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' }
+        }
+    );
+
+    if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: 'Unknown error' }));
+        throw new Error(errorData.error || errorData.message || `Server returned ${response.status}`);
+    }
+
+    const data = await response.json();
+    return { started: Boolean(data.started) };
+}

--- a/src/frontend/modules/scheduler/api/index.ts
+++ b/src/frontend/modules/scheduler/api/index.ts
@@ -3,4 +3,4 @@
  * @module modules/scheduler/api
  */
 
-export { getSchedulerStatus, getSchedulerHealth, updateSchedulerJob } from './client';
+export { getSchedulerStatus, getSchedulerHealth, updateSchedulerJob, runSchedulerJob } from './client';

--- a/src/frontend/modules/scheduler/components/SchedulerMonitor/SchedulerMonitor.module.scss
+++ b/src/frontend/modules/scheduler/components/SchedulerMonitor/SchedulerMonitor.module.scss
@@ -110,6 +110,14 @@
     text-align: center;
 }
 
+.th_actions {
+    text-align: center;
+}
+
+.cell_actions {
+    text-align: center;
+}
+
 .expand_btn {
     display: flex;
     align-items: center;

--- a/src/frontend/modules/scheduler/components/SchedulerMonitor/SchedulerMonitor.tsx
+++ b/src/frontend/modules/scheduler/components/SchedulerMonitor/SchedulerMonitor.tsx
@@ -15,14 +15,15 @@
  */
 
 import { useEffect, useState } from 'react';
-import { ChevronDown, ChevronRight, AlertCircle } from 'lucide-react';
+import { ChevronDown, ChevronRight, AlertCircle, Play } from 'lucide-react';
 import { Page, Stack } from '../../../../components/layout';
 import { Badge } from '../../../../components/ui/Badge';
+import { Button } from '../../../../components/ui/Button';
 import { Input } from '../../../../components/ui/Input';
 import { Switch } from '../../../../components/ui/Switch';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../components/ui/Table';
 import { ClientTime } from '../../../../components/ui/ClientTime';
-import { getSchedulerStatus, getSchedulerHealth, updateSchedulerJob } from '../../api';
+import { getSchedulerStatus, getSchedulerHealth, updateSchedulerJob, runSchedulerJob } from '../../api';
 import type { SchedulerJob, SchedulerHealth } from '../../types';
 import styles from './SchedulerMonitor.module.scss';
 
@@ -41,10 +42,11 @@ interface Props {
  * Displays job metadata in a compact row with expandable details section.
  * Provides inline toggle for enable/disable and editable schedule field.
  */
-function JobRow({ job, onToggleEnabled, onScheduleChange, isLoading, loadingJobName, feedback }: {
+function JobRow({ job, onToggleEnabled, onScheduleChange, onRunNow, isLoading, loadingJobName, feedback }: {
     job: SchedulerJob;
     onToggleEnabled: (jobName: string, enabled: boolean) => void;
     onScheduleChange: (jobName: string, schedule: string) => void;
+    onRunNow: (jobName: string) => void;
     isLoading: boolean;
     loadingJobName: string | null;
     feedback: { jobName: string; type: 'success' | 'error'; message: string } | null;
@@ -124,10 +126,27 @@ function JobRow({ job, onToggleEnabled, onScheduleChange, isLoading, loadingJobN
                         aria-label={`${job.enabled ? 'Disable' : 'Enable'} ${job.name}`}
                     />
                 </Td>
+                <Td className={styles.cell_actions}>
+                    {/* Manual run is an out-of-schedule trigger — useful when a
+                        low-frequency job (e.g. a 4-hourly snapshot) has not yet
+                        reached its first boundary. Disabled while any update is in
+                        flight or this job is already running, since the backend
+                        rejects a stacked run anyway. */}
+                    <Button
+                        variant="ghost"
+                        size="xs"
+                        onClick={() => onRunNow(job.name)}
+                        disabled={isLoading || isThisLoading || job.status === 'running'}
+                        aria-label={`Run ${job.name} now`}
+                        title="Run now"
+                    >
+                        <Play size={14} aria-hidden />
+                    </Button>
+                </Td>
             </Tr>
             {expanded && (
                 <Tr isExpanded>
-                    <Td colSpan={6}>
+                    <Td colSpan={7}>
                         <div className={styles.details_content}>
                             {jobFeedback && (
                                 <div className={jobFeedback.type === 'success' ? styles.alert_success : styles.alert_error}>
@@ -276,6 +295,36 @@ export function SchedulerMonitor({ jobFilter, title = 'Scheduled Jobs', hideStat
         await handleUpdateJob(jobName, { enabled });
     };
 
+    /**
+     * Triggers an immediate, out-of-schedule run of a job, then refreshes the
+     * table so the status badge reflects the new execution. Feedback is driven off
+     * the run response (started vs already-running) rather than the status badge,
+     * because a disabled job's badge is masked to "never run" by the status
+     * endpoint and would not reflect a manual run.
+     */
+    const handleRunNow = async (jobName: string) => {
+        setLoadingJobName(jobName);
+        setFeedback(null);
+
+        try {
+            const { started } = await runSchedulerJob(jobName);
+            setFeedback({
+                jobName,
+                type: 'success',
+                message: started ? 'Run started' : 'Job is already running'
+            });
+            await fetchData();
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Failed to run job';
+            setFeedback({ jobName, type: 'error', message });
+        } finally {
+            setLoadingJobName(null);
+            setTimeout(() => {
+                setFeedback(prev => prev?.jobName === jobName ? null : prev);
+            }, 3000);
+        }
+    };
+
     const handleScheduleChange = async (jobName: string, newSchedule: string) => {
         if (!isValidCronExpression(newSchedule)) {
             setFeedback({
@@ -380,6 +429,7 @@ export function SchedulerMonitor({ jobFilter, title = 'Scheduled Jobs', hideStat
                                 <Th width="shrink">Status</Th>
                                 <Th width="shrink" className={styles.th_last_run}>Last Run</Th>
                                 <Th width="shrink" className={styles.th_enabled}>Enabled</Th>
+                                <Th width="shrink" className={styles.th_actions}>Run</Th>
                             </Tr>
                         </Thead>
                         <Tbody>
@@ -389,6 +439,7 @@ export function SchedulerMonitor({ jobFilter, title = 'Scheduled Jobs', hideStat
                                     job={job}
                                     onToggleEnabled={handleToggleEnabled}
                                     onScheduleChange={handleScheduleChange}
+                                    onRunNow={handleRunNow}
                                     isLoading={!!loadingJobName}
                                     loadingJobName={loadingJobName}
                                     feedback={feedback}

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/PortfolioHero.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/PortfolioHero.tsx
@@ -12,7 +12,7 @@
  */
 
 import type { IPortfolioSummary } from '@/types';
-import { Wallet, TrendingUp, TrendingDown } from 'lucide-react';
+import { Wallet, TrendingUp, TrendingDown, Hourglass } from 'lucide-react';
 import { LineChart, DonutChart, type DonutSlice } from '../../../../../features/charts';
 import { Card } from '../../../../../components/ui/Card';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
@@ -62,6 +62,33 @@ function formatQty(value: number): string {
  * @returns The hero section.
  */
 export function PortfolioHero({ summary }: IPortfolioHeroProps) {
+    // No snapshot has been captured yet for this scope. Holdings and net worth are
+    // derived solely from the balance snapshot, so without one every figure would
+    // read $0 / "No holdings" — indistinguishable from a wallet that genuinely
+    // holds nothing. `capturedAt === null` is the unambiguous "snapshot pending"
+    // signal (it arrives as JSON null, never a Date), so we show a friendly
+    // preparing state instead of misleading zeros. Once the first snapshot tick
+    // runs, capturedAt becomes a date and the real hero renders.
+    if (summary.capturedAt === null) {
+        return (
+            <WalletDetailSection
+                icon={<Wallet size={16} aria-hidden style={{ color: 'var(--color-primary)' }} />}
+                title="Portfolio"
+            >
+                <div className={styles.portfolio_pending}>
+                    <span className={styles.portfolio_pending_title}>
+                        <Hourglass size={16} aria-hidden style={{ color: 'var(--color-primary)' }} />
+                        Preparing your portfolio
+                    </span>
+                    <p className="text-muted">
+                        We&rsquo;re capturing your current balances. Net worth and holdings appear
+                        here once the first snapshot completes &mdash; usually within a few hours.
+                    </p>
+                </div>
+            </WalletDetailSection>
+        );
+    }
+
     const pnlPositive = summary.totalPnlUsd >= 0;
     const slices: DonutSlice[] = summary.allocation.map((entry) => ({ label: entry.symbol, value: entry.valueUsd }));
     const series = [

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetail.module.scss
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetail.module.scss
@@ -92,3 +92,22 @@
     align-items: center;
     gap: var(--gap-2xs);
 }
+
+/* Snapshot-pending notice — shown in place of the zeroed hero until the first
+   balance snapshot is captured for the scope. */
+.portfolio_pending {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--gap-xs);
+    padding: var(--padding-md) 0;
+    text-align: center;
+}
+
+.portfolio_pending_title {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    color: var(--color-text);
+    font-weight: var(--font-weight-semibold);
+}


### PR DESCRIPTION
## Scheduler — manual run-now

Adds `POST /admin/system/scheduler/job/:jobName/run` to run a job once outside its schedule — the only way to exercise a low-frequency job (e.g. the 4-hourly `account-history:snapshot` for a newly tracked wallet) before its next tick. Ignores the `enabled` flag, preserves single-flight (a job already running returns `started: false`, not an error), returns `202` fire-and-forget. Wired through the controller, routes, and a per-job "Run now" button in `SchedulerMonitor`.

## Account-history — single-query tick selectors

The ingest, forward-sync, and snapshot ticks used to load the entire tracked + progress sets every tick and join/filter/sort/slice in memory. They now push the whole predicate into one indexed query on `progress`. This requires `paused` denormalized onto `progress` (authoritative copy stays on `tracked`, written by `setAccountPaused`, seeded `false` on insert); migration `003` backfills pre-existing docs, and selectors read `{$ne: true}` so a pre-migration doc reads as unpaused. ESR-ordered composite indexes back the three selectors. Also adds `getTransactionsByTxIds(address, txIds)` for explicit hash-keyed reads.

## Valuation — internal-transfer leg recovery

Each wallet's ledger read is bounded by `MAX_LEDGER_ROWS` (newest-first), so a high-volume wallet can push one leg of an internal transfer past its window while the other leg stays inside another wallet's — silently dropping the transfer's cost basis. The engine now detects that split (a `txId|asset` whose summed in/out quantities disagree across the owned set) and refetches the missing legs by hash via `getTransactionsByTxIds`, rebuilding the pair so basis is preserved.