### PR TITLE
feat(providers): providers module + TronScan price-history provider

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -42,6 +42,7 @@ import { IdentityModule } from './modules/identity/index.js';
 import { TrafficModule } from './modules/traffic/index.js';
 import { AccountHistoryModule } from './modules/account-history/index.js';
 import { PriceHistoryModule } from './modules/price-history/index.js';
+import { ProvidersModule } from './modules/providers/index.js';
 import { ValuationModule } from './modules/valuation/index.js';
 import { ToolsModule } from './modules/tools/index.js';
 import { AiToolsModule } from './modules/ai-tools/index.js';
@@ -244,6 +245,7 @@ interface BootstrapContext {
         traffic: TrafficModule;
         accountHistory: AccountHistoryModule;
         priceHistory: PriceHistoryModule;
+        providers: ProvidersModule;
         valuation: ValuationModule;
         tools: ToolsModule;
         notifications: NotificationsModule;
@@ -392,6 +394,7 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     const trafficModule = new TrafficModule();
     const accountHistoryModule = new AccountHistoryModule();
     const priceHistoryModule = new PriceHistoryModule();
+    const providersModule = new ProvidersModule();
     const valuationModule = new ValuationModule();
     const toolsModule = new ToolsModule();
     const notificationsModule = new NotificationsModule();
@@ -414,6 +417,9 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     // Price-history: scheduled local daily USD price series (CoinGecko-backed) into
     // ClickHouse, the data layer portfolio valuation reads from. No-ops ingestion
     // when clickhouse is absent. Inits before the valuation engine that consumes it.
+    // Providers must init before price-history: it wires the ProviderConfigService
+    // and TronScanClient singletons the price-history TronScan provider reads from.
+    await providersModule.init({ database: coreDatabase, app });
     await priceHistoryModule.init({ database: coreDatabase, clickhouse, scheduler: schedulerService, serviceRegistry, app, menuService });
     // Valuation: joins account-history, price-history, and the caller's wallet set
     // into portfolio summaries. Owns no storage; resolves its data services lazily
@@ -471,6 +477,7 @@ async function bootstrapInit(): Promise<BootstrapContext> {
             traffic: trafficModule,
             accountHistory: accountHistoryModule,
             priceHistory: priceHistoryModule,
+            providers: providersModule,
             valuation: valuationModule,
             tools: toolsModule,
             notifications: notificationsModule,
@@ -529,6 +536,7 @@ async function bootstrapRun(ctx: BootstrapContext): Promise<void> {
     // Account-history runs before scheduler (which runs last and starts ticking),
     // so its `account-history:ingest` job is registered before the scheduler activates.
     await modules.accountHistory.run();
+    await modules.providers.run();
     // Price-history runs before scheduler (which runs last and starts ticking), so
     // its backfill/forward-sync jobs are registered before the scheduler activates.
     await modules.priceHistory.run();
@@ -657,6 +665,28 @@ async function registerTemporaryMenuItems(menuService: IMenuService): Promise<vo
             order: item.order,
             parent: MAIN_SYSTEM_CONTAINER_ID,
             enabled: true
+        });
+    }
+
+    // In-page submenu tabs for the consolidated System page (the menu Submenu
+    // Pattern). These live in the dedicated 'system' namespace, not under the
+    // System container, so each node sets requiresAdmin itself. 'Overview' wraps
+    // the existing subsystem consoles; 'Providers' hosts external-provider config
+    // (TronScan). Registered here for now since the page is not yet a module.
+    const systemTabs = [
+        { label: 'Overview', tab: 'overview', icon: 'SlidersHorizontal', order: 0 },
+        { label: 'Providers', tab: 'providers', icon: 'Plug', order: 1 }
+    ];
+    for (const tab of systemTabs) {
+        await menuService.create({
+            namespace: 'system',
+            label: tab.label,
+            url: `/system/system?tab=${tab.tab}`,
+            icon: tab.icon,
+            order: tab.order,
+            parent: null,
+            enabled: true,
+            requiresAdmin: true
         });
     }
 }

--- a/src/backend/modules/price-history/PriceHistoryModule.ts
+++ b/src/backend/modules/price-history/PriceHistoryModule.ts
@@ -26,7 +26,7 @@ import { MAIN_SYSTEM_CONTAINER_ID } from '../menu/index.js';
 import { requireAdmin } from '../../api/middleware/admin-auth.js';
 import { createAdminRateLimiter } from '../../api/middleware/rate-limit.js';
 import { PriceHistoryService } from './services/price-history.service.js';
-import { CoinGeckoPriceHistoryProvider } from './providers/coingecko-price-history.provider.js';
+import { TronScanPriceHistoryProvider } from './providers/tronscan-price-history.provider.js';
 import { PriceHistoryAdminController } from './api/price-history.admin.controller.js';
 import { createPriceHistoryAdminRouter } from './api/price-history.admin.routes.js';
 import { SETTINGS_COLLECTION, PROGRESS_COLLECTION } from './database/index.js';
@@ -75,7 +75,7 @@ export class PriceHistoryModule implements IModule<IPriceHistoryModuleDependenci
         id: 'price-history',
         name: 'Price History',
         version: '1.0.0',
-        description: 'Scheduled local daily USD price series (CoinGecko-backed) for portfolio valuation.'
+        description: 'Scheduled local daily USD price series (TronScan-backed, TRX) for portfolio valuation.'
     };
 
     private scheduler: ISchedulerService | null = null;
@@ -98,7 +98,7 @@ export class PriceHistoryModule implements IModule<IPriceHistoryModuleDependenci
         this.app = deps.app;
         this.menuService = deps.menuService;
 
-        const provider = new CoinGeckoPriceHistoryProvider(this.logger.child({ provider: 'coingecko' }));
+        const provider = new TronScanPriceHistoryProvider(this.logger.child({ provider: 'tronscan' }));
         PriceHistoryService.setDependencies({
             database: deps.database,
             clickhouse: deps.clickhouse,

--- a/src/backend/modules/price-history/README.md
+++ b/src/backend/modules/price-history/README.md
@@ -16,12 +16,12 @@ Maintains a **local** daily USD price series (TRX + tracked TRC20 tokens) in Cli
 | Types package | `@delphian/tronrelic-types` → `IPriceHistoryService`, `IPricePoint`, `PriceAsset`, `PRICE_ASSET_TRX` |
 | ClickHouse table | `price_history` (ReplacingMergeTree) |
 | Mongo collections | `module_price-history_settings`, `module_price-history_progress` |
-| Provider seam | `IPriceHistoryProvider` (v1 impl: `CoinGeckoPriceHistoryProvider`) |
+| Provider seam | `IPriceHistoryProvider` (active impl: `TronScanPriceHistoryProvider`, TRX-only; `CoinGeckoPriceHistoryProvider` retained for future token coverage) |
 | Bootstrap order | Inits after the scheduler service; before the valuation module that consumes it |
 
 ## Why It Is a Module
 
-Valuation depends on a local price series existing, ingested on a schedule regardless of which optional features are enabled — core, non-toggleable infrastructure. There is no live-fetch fallback by design: a missing day reads as "unpriced", never a synchronous CoinGecko call.
+Valuation depends on a local price series existing, ingested on a schedule regardless of which optional features are enabled — core, non-toggleable infrastructure. There is no live-fetch fallback by design: a missing day reads as "unpriced", never a synchronous provider call.
 
 ## Source Map
 
@@ -30,7 +30,8 @@ Valuation depends on a local price series existing, ingested on a schedule regar
 | `PriceHistoryModule.ts` | Lifecycle; creates the service, registers the two jobs, publishes `'price-history'` |
 | `services/price-history.service.ts` | `PriceHistoryService` singleton — settings, cursors, the two-phase ingestion, ClickHouse reads |
 | `providers/IPriceHistoryProvider.ts` | The source seam (`fetchRange` seed + `fetchDay` deep walk) the service depends on |
-| `providers/coingecko-price-history.provider.ts` | v1 CoinGecko provider; maps `'TRX'`→`tron`, a token→`contract/{address}` |
+| `providers/tronscan-price-history.provider.ts` | **Active** provider; TRX via TronScan `/api/trx/volume` (`close` per day), tokens → empty |
+| `providers/coingecko-price-history.provider.ts` | Retained CoinGecko provider; maps `'TRX'`→`tron`, a token→`contract/{address}` — kept for future token coverage |
 | `lib/price-day.ts` | UTC `YYYY-MM-DD` day arithmetic |
 | `database/index.ts` | Collection/table constants, cursor/settings doc shapes, ClickHouse row shape |
 | `api/price-history.admin.{controller,routes}.ts` | Admin surface (coverage stats, settings, manual backfill/forward) behind `requireAdmin` |
@@ -50,7 +51,9 @@ Valuation depends on a local price series existing, ingested on a schedule regar
 
 ## Ingestion Strategy
 
-CoinGecko's free tier serves a dense recent window cheaply but caps how far back it reaches, so backfill is two-phase. **Seed**: one `market_chart/range` call fills the recent window (`RECENT_WINDOW_DAYS`), flipping `recentSeeded`. **Deep walk**: the backward backfill walks older days one at a time via `/coins/{id}/history` (TRX) or a single-day range (tokens), up to `daysPerTick`, stopping at the first null (listing reached → `backfillComplete`) or the `MAX_BACKFILL_DAYS` floor. Each clean write advances the per-asset cursor, so a failed tick resumes without re-fetching. ReplacingMergeTree keyed `(asset, day)` makes re-fetch idempotent. Pacing dials throttle *down* only, respecting CoinGecko's rate budget (separate from the TronGrid limiter).
+Backfill is two-phase, provider-agnostic at the service layer. **Seed**: one `fetchRange` call fills the recent window (`RECENT_WINDOW_DAYS`), flipping `recentSeeded`. **Deep walk**: the backward backfill walks older days one at a time via `fetchDay`, up to `daysPerTick`, stopping at the first null (listing reached → `backfillComplete`) or the `MAX_BACKFILL_DAYS` floor. Each clean write advances the per-asset cursor, so a failed tick resumes without re-fetching. ReplacingMergeTree keyed `(asset, day)` makes re-fetch idempotent. Pacing dials throttle *down* only.
+
+The active TronScan provider fills the seed window and each forward append in a single `/api/trx/volume` call with no keyless history wall (the wall that stalled the prior CoinGecko deep walk). The service still drives the deep walk one `fetchDay` per day, so a full multi-year TRX backfill spans many ticks — bounded and resumable, just not instant. Token assets resolve to empty (TronScan has no per-token history), leaving tokens "seeded-but-empty" until a token source is added. Provider config (key, source, enable) lives in the [providers module](../providers/README.md), edited from `/system/system` → Providers.
 
 Granularity is one closing price per UTC day — the reproducible standard for cost-basis math, and it joins to the ledger's day buckets directly.
 

--- a/src/backend/modules/price-history/__tests__/tronscan-price-history.provider.test.ts
+++ b/src/backend/modules/price-history/__tests__/tronscan-price-history.provider.test.ts
@@ -3,10 +3,11 @@
  *
  * Locks the contract the price-history service relies on: TRX rows map to one
  * `IPricePoint` per UTC day keyed off the row's end-of-day `time` with `close` as
- * the price; token assets and a disabled provider resolve to empty/null without
- * touching TronScan (so the service degrades them gracefully); and `fetchDay`
- * yields the day's point or null at the listing floor. The TronScan client call is
- * spied so no live HTTP is made.
+ * the price; token assets resolve to empty/null without touching TronScan (so the
+ * service degrades them gracefully); a disabled provider throws so the tick is
+ * treated as retryable rather than wedging cursor state as seeded-but-empty; and
+ * `fetchDay` yields the day's point or null at the listing floor. The TronScan
+ * client call is spied so no live HTTP is made.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -71,14 +72,12 @@ describe('TronScanPriceHistoryProvider', () => {
         expect(spy).not.toHaveBeenCalled();
     });
 
-    it('returns empty when the provider is disabled in config', async () => {
+    it('throws when the provider is disabled in config, leaving cursor state resumable', async () => {
         await mockDb.set(TRONSCAN_CONFIG_KEY, { enabled: false });
         const spy = vi.spyOn(TronScanClient.getInstance(), 'getTrxPriceVolume');
         const provider = new TronScanPriceHistoryProvider(stubLogger as never);
 
-        const points = await provider.fetchRange('TRX', '2024-01-01', '2024-01-02');
-
-        expect(points).toEqual([]);
+        await expect(provider.fetchRange('TRX', '2024-01-01', '2024-01-02')).rejects.toThrow(/disabled/);
         expect(spy).not.toHaveBeenCalled();
     });
 

--- a/src/backend/modules/price-history/__tests__/tronscan-price-history.provider.test.ts
+++ b/src/backend/modules/price-history/__tests__/tronscan-price-history.provider.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview Unit tests for the TronScan price-history provider.
+ *
+ * Locks the contract the price-history service relies on: TRX rows map to one
+ * `IPricePoint` per UTC day keyed off the row's end-of-day `time` with `close` as
+ * the price; token assets and a disabled provider resolve to empty/null without
+ * touching TronScan (so the service degrades them gracefully); and `fetchDay`
+ * yields the day's point or null at the listing floor. The TronScan client call is
+ * spied so no live HTTP is made.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
+import { ProviderConfigService, TronScanClient } from '../../providers/index.js';
+import { TRONSCAN_CONFIG_KEY } from '../../providers/database/index.js';
+import { TronScanPriceHistoryProvider } from '../providers/tronscan-price-history.provider.js';
+
+/** Stub logger matching the ISystemLogService shape the provider touches. */
+const stubLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => stubLogger
+};
+
+// 2024-01-01T23:59:59.999Z and 2024-01-02T23:59:59.999Z — TronScan's end-of-day stamps.
+const DAY1_MS = 1704153599999;
+const DAY2_MS = 1704239999999;
+
+describe('TronScanPriceHistoryProvider', () => {
+    let mockDb: ReturnType<typeof createMockDatabaseService>;
+
+    beforeEach(() => {
+        ProviderConfigService.resetInstance();
+        TronScanClient.resetInstance();
+        mockDb = createMockDatabaseService();
+        ProviderConfigService.setDependencies(mockDb, stubLogger as never);
+        TronScanClient.setDependencies(stubLogger as never);
+    });
+
+    afterEach(() => {
+        ProviderConfigService.resetInstance();
+        TronScanClient.resetInstance();
+        mockDb.clear();
+        vi.restoreAllMocks();
+    });
+
+    it('maps TRX daily closes to one price point per UTC day', async () => {
+        vi.spyOn(TronScanClient.getInstance(), 'getTrxPriceVolume').mockResolvedValue([
+            { time: DAY1_MS, close: '0.108' },
+            { time: DAY2_MS, close: '0.110' }
+        ]);
+        const provider = new TronScanPriceHistoryProvider(stubLogger as never);
+
+        const points = await provider.fetchRange('TRX', '2024-01-01', '2024-01-02');
+
+        expect(points).toEqual([
+            { asset: 'TRX', day: '2024-01-01', priceUsd: 0.108 },
+            { asset: 'TRX', day: '2024-01-02', priceUsd: 0.110 }
+        ]);
+    });
+
+    it('returns empty for a token asset without calling TronScan', async () => {
+        const spy = vi.spyOn(TronScanClient.getInstance(), 'getTrxPriceVolume');
+        const provider = new TronScanPriceHistoryProvider(stubLogger as never);
+
+        const points = await provider.fetchRange('TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t', '2024-01-01', '2024-01-02');
+
+        expect(points).toEqual([]);
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('returns empty when the provider is disabled in config', async () => {
+        await mockDb.set(TRONSCAN_CONFIG_KEY, { enabled: false });
+        const spy = vi.spyOn(TronScanClient.getInstance(), 'getTrxPriceVolume');
+        const provider = new TronScanPriceHistoryProvider(stubLogger as never);
+
+        const points = await provider.fetchRange('TRX', '2024-01-01', '2024-01-02');
+
+        expect(points).toEqual([]);
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('fetchDay returns the day point, or null at the listing floor and for tokens', async () => {
+        vi.spyOn(TronScanClient.getInstance(), 'getTrxPriceVolume')
+            .mockResolvedValueOnce([{ time: DAY1_MS, close: '0.108' }])
+            .mockResolvedValueOnce([]);
+        const provider = new TronScanPriceHistoryProvider(stubLogger as never);
+
+        await expect(provider.fetchDay('TRX', '2024-01-01')).resolves.toEqual({
+            asset: 'TRX',
+            day: '2024-01-01',
+            priceUsd: 0.108
+        });
+        await expect(provider.fetchDay('TRX', '2017-01-01')).resolves.toBeNull();
+        await expect(provider.fetchDay('TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t', '2024-01-01')).resolves.toBeNull();
+    });
+});

--- a/src/backend/modules/price-history/providers/tronscan-price-history.provider.ts
+++ b/src/backend/modules/price-history/providers/tronscan-price-history.provider.ts
@@ -40,15 +40,17 @@ export class TronScanPriceHistoryProvider implements IPriceHistoryProvider {
 
     /**
      * Fetch a daily TRX price range from TronScan, collapsed to one close per UTC
-     * day. Returns empty for any non-TRX asset (TronScan has no token history) and
-     * when the provider is disabled in config. A transport failure propagates so
-     * the calling tick retries rather than flipping an asset to seeded-but-empty on
-     * a transient error.
+     * day. Returns empty only for a non-TRX asset (TronScan has no token history) —
+     * a stable "no prices exist" answer the service degrades to seeded-but-empty. A
+     * disabled provider or a transport failure instead throws, so the calling tick
+     * retries rather than flipping an asset to seeded/backfill-complete on a pause
+     * the operator will reverse (which would otherwise wedge the cursor state and
+     * require manual Mongo repair to resume).
      *
      * @param asset - The asset to price.
      * @param fromDay - Inclusive start UTC `YYYY-MM-DD`.
      * @param toDay - Inclusive end UTC `YYYY-MM-DD`.
-     * @returns Daily points in the range, oldest first; empty for tokens/disabled.
+     * @returns Daily points in the range, oldest first; empty for tokens. Throws when disabled.
      */
     async fetchRange(asset: PriceAsset, fromDay: string, toDay: string): Promise<IPricePoint[]> {
         if (asset !== PRICE_ASSET_TRX) {
@@ -56,7 +58,7 @@ export class TronScanPriceHistoryProvider implements IPriceHistoryProvider {
         }
         const config = await ProviderConfigService.getInstance().getTronScanConfig();
         if (!config.enabled) {
-            return [];
+            throw new Error('TronScan price-history provider is disabled; skipping tick to keep cursor state resumable');
         }
         const startMs = utcDayStartSeconds(fromDay) * MS_PER_SECOND;
         const endMs = utcDayEndSeconds(toDay) * MS_PER_SECOND;
@@ -66,9 +68,10 @@ export class TronScanPriceHistoryProvider implements IPriceHistoryProvider {
 
     /**
      * Fetch a single day's TRX close. Implemented as a one-day range so deep-walk
-     * and forward callers share one mapping path. Returns null for tokens, when
-     * disabled, or when TronScan has no row for the day (the pre-listing floor that
-     * signals the backfill to complete).
+     * and forward callers share one mapping path. Returns null for tokens or when
+     * TronScan has no row for the day (the pre-listing floor that signals the
+     * backfill to complete); a disabled provider throws via the delegated range
+     * call so the deep walk retries rather than booking the pause as listing-reached.
      *
      * Selects the row whose mapped day equals the requested day rather than taking
      * the last point: TronScan's end bound is loose (a one-day range query can
@@ -91,8 +94,13 @@ export class TronScanPriceHistoryProvider implements IPriceHistoryProvider {
     /**
      * Collapse TronScan's daily rows to one `IPricePoint` per UTC day, keyed by the
      * row's end-of-day `time`. Rows are already daily; the map dedupes defensively
-     * and the sort guarantees oldest-first regardless of upstream order. Rows whose
-     * `close` is not a finite number are skipped.
+     * and the sort guarantees oldest-first regardless of upstream order. Rows that
+     * are missing, carry a non-numeric `time`, or whose `close` is not a positive
+     * finite number are skipped — the client casts the upstream shape without
+     * runtime validation, and an unguarded bad `time` would throw via
+     * `toUtcDay`→`toISOString` (or silently book a `1970-01-01` price for `null`),
+     * stalling the backward backfill on that asset since its cursor only advances
+     * on a clean write.
      *
      * @param asset - The asset the points belong to (always TRX here).
      * @param rows - Raw TronScan volume rows.
@@ -104,6 +112,9 @@ export class TronScanPriceHistoryProvider implements IPriceHistoryProvider {
     ): IPricePoint[] {
         const byDay = new Map<string, number>();
         for (const row of rows) {
+            if (!row || typeof row.time !== 'number' || !Number.isFinite(row.time)) {
+                continue;
+            }
             const priceUsd = Number(row.close);
             if (!Number.isFinite(priceUsd) || priceUsd <= 0) {
                 continue;

--- a/src/backend/modules/price-history/providers/tronscan-price-history.provider.ts
+++ b/src/backend/modules/price-history/providers/tronscan-price-history.provider.ts
@@ -1,0 +1,118 @@
+/**
+ * @fileoverview TronScan implementation of the price-history provider seam.
+ *
+ * Why TronScan for TRX: its `/api/trx/volume` endpoint returns clean daily TRX
+ * OHLC over an arbitrary range in a single call, with no keyless 365-day history
+ * wall — the limitation that made the CoinGecko deep-backfill 401 and stall. It
+ * therefore serves the seed, the deep backward walk, and the daily forward append
+ * from one endpoint, mapping each row's `close` to that day's reference price.
+ *
+ * Scope is deliberately TRX-only. TronScan has no per-contract historical token
+ * series, so token assets resolve to empty/null here; the price-history service
+ * degrades those gracefully (seeded-but-empty), leaving token holdings unpriced
+ * until a dedicated token-history source (e.g. on-chain SunSwap) is added. The
+ * `enabled` flag on the provider config pauses TRX ingestion without code changes.
+ */
+
+import type { IPricePoint, PriceAsset, ISystemLogService } from '@/types';
+import { PRICE_ASSET_TRX } from '@/types';
+import { TronScanClient, ProviderConfigService } from '../../providers/index.js';
+import { toUtcDay, utcDayStartSeconds, utcDayEndSeconds } from '../lib/price-day.js';
+import type { IPriceHistoryProvider } from './IPriceHistoryProvider.js';
+
+/** Milliseconds per second, for the seconds→ms conversion TronScan expects. */
+const MS_PER_SECOND = 1000;
+
+/**
+ * Fetches historical TRX prices from TronScan; returns nothing for token assets.
+ */
+export class TronScanPriceHistoryProvider implements IPriceHistoryProvider {
+    public readonly id = 'tronscan';
+
+    private readonly logger: ISystemLogService;
+
+    /**
+     * @param logger - Child logger for provider diagnostics.
+     */
+    constructor(logger: ISystemLogService) {
+        this.logger = logger;
+    }
+
+    /**
+     * Fetch a daily TRX price range from TronScan, collapsed to one close per UTC
+     * day. Returns empty for any non-TRX asset (TronScan has no token history) and
+     * when the provider is disabled in config. A transport failure propagates so
+     * the calling tick retries rather than flipping an asset to seeded-but-empty on
+     * a transient error.
+     *
+     * @param asset - The asset to price.
+     * @param fromDay - Inclusive start UTC `YYYY-MM-DD`.
+     * @param toDay - Inclusive end UTC `YYYY-MM-DD`.
+     * @returns Daily points in the range, oldest first; empty for tokens/disabled.
+     */
+    async fetchRange(asset: PriceAsset, fromDay: string, toDay: string): Promise<IPricePoint[]> {
+        if (asset !== PRICE_ASSET_TRX) {
+            return [];
+        }
+        const config = await ProviderConfigService.getInstance().getTronScanConfig();
+        if (!config.enabled) {
+            return [];
+        }
+        const startMs = utcDayStartSeconds(fromDay) * MS_PER_SECOND;
+        const endMs = utcDayEndSeconds(toDay) * MS_PER_SECOND;
+        const rows = await TronScanClient.getInstance().getTrxPriceVolume(startMs, endMs, config.priceSource);
+        return this.collapseToDaily(asset, rows);
+    }
+
+    /**
+     * Fetch a single day's TRX close. Implemented as a one-day range so deep-walk
+     * and forward callers share one mapping path. Returns null for tokens, when
+     * disabled, or when TronScan has no row for the day (the pre-listing floor that
+     * signals the backfill to complete).
+     *
+     * Selects the row whose mapped day equals the requested day rather than taking
+     * the last point: TronScan's end bound is loose (a one-day range query can
+     * return an adjacent day past the bound — confirmed against the live API), so
+     * picking by day keeps the deep walk from booking an off-by-one day's price or
+     * mistaking an extra trailing row for "the day exists."
+     *
+     * @param asset - The asset to price.
+     * @param day - UTC `YYYY-MM-DD`.
+     * @returns The day's point, or null.
+     */
+    async fetchDay(asset: PriceAsset, day: string): Promise<IPricePoint | null> {
+        if (asset !== PRICE_ASSET_TRX) {
+            return null;
+        }
+        const points = await this.fetchRange(asset, day, day);
+        return points.find((point) => point.day === day) ?? null;
+    }
+
+    /**
+     * Collapse TronScan's daily rows to one `IPricePoint` per UTC day, keyed by the
+     * row's end-of-day `time`. Rows are already daily; the map dedupes defensively
+     * and the sort guarantees oldest-first regardless of upstream order. Rows whose
+     * `close` is not a finite number are skipped.
+     *
+     * @param asset - The asset the points belong to (always TRX here).
+     * @param rows - Raw TronScan volume rows.
+     * @returns One point per UTC day, oldest first.
+     */
+    private collapseToDaily(
+        asset: PriceAsset,
+        rows: Array<{ time: number; close: string }>
+    ): IPricePoint[] {
+        const byDay = new Map<string, number>();
+        for (const row of rows) {
+            const priceUsd = Number(row.close);
+            if (!Number.isFinite(priceUsd) || priceUsd <= 0) {
+                continue;
+            }
+            byDay.set(toUtcDay(new Date(row.time)), priceUsd);
+        }
+        const points = Array.from(byDay.entries())
+            .map(([day, priceUsd]) => ({ asset, day, priceUsd }))
+            .sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0));
+        return points;
+    }
+}

--- a/src/backend/modules/providers/ProvidersModule.ts
+++ b/src/backend/modules/providers/ProvidersModule.ts
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview Providers module: owns runtime configuration and clients for
+ * external data providers, starting with TronScan.
+ *
+ * Why a module: the platform needs an always-on, core home for provider
+ * credentials and transports that the admin Providers tab edits and that core
+ * ingestion (price-history) consumes. It is not runtime-toggleable and provides
+ * shared singletons (the config store and the TronScan client), so it is a module,
+ * not a plugin. `init()` wires the config service and client singletons and builds
+ * the controller; `run()` mounts the admin API. The system page's Providers tab is
+ * registered centrally in bootstrap alongside the other system submenu tabs.
+ */
+
+import type { Express, Router } from 'express';
+import type { IDatabaseService, IModule, IModuleMetadata } from '@/types';
+import { logger } from '../../lib/logger.js';
+import { requireAdmin } from '../../api/middleware/admin-auth.js';
+import { createAdminRateLimiter } from '../../api/middleware/rate-limit.js';
+import { ProviderConfigService } from './services/provider-config.service.js';
+import { TronScanClient } from './clients/tron-scan.client.js';
+import { ProvidersController } from './api/providers.controller.js';
+import { createProvidersRouter } from './api/providers.routes.js';
+
+/** Dependencies the providers module needs at bootstrap. */
+export interface IProvidersModuleDependencies {
+    /** Core KV store the provider config blobs persist to. */
+    database: IDatabaseService;
+    /** Express app the module mounts its admin router onto. */
+    app: Express;
+}
+
+/**
+ * Two-phase module wiring the provider-config service, the TronScan client, and
+ * the admin API.
+ */
+export class ProvidersModule implements IModule<IProvidersModuleDependencies> {
+    readonly metadata: IModuleMetadata = {
+        id: 'providers',
+        name: 'Providers',
+        version: '1.0.0',
+        description: 'Runtime configuration and clients for external data providers (TronScan).'
+    };
+
+    private app!: Express;
+    private controller!: ProvidersController;
+    private readonly logger = logger.child({ module: 'providers' });
+
+    /**
+     * Phase 1: wire the config-service and client singletons and build the
+     * controller. No routes mounted yet.
+     *
+     * @param deps - Injected collaborators.
+     */
+    async init(deps: IProvidersModuleDependencies): Promise<void> {
+        this.app = deps.app;
+
+        ProviderConfigService.setDependencies(deps.database, this.logger.child({ service: 'provider-config' }));
+        TronScanClient.setDependencies(this.logger.child({ client: 'tronscan' }));
+
+        this.controller = new ProvidersController(
+            ProviderConfigService.getInstance(),
+            TronScanClient.getInstance(),
+            this.logger
+        );
+
+        this.logger.info('Providers module initialized');
+    }
+
+    /**
+     * Phase 2: mount the admin router behind the admin rate limiter and auth gate.
+     */
+    async run(): Promise<void> {
+        const router: Router = createProvidersRouter(this.controller);
+        this.app.use(
+            '/api/admin/system/providers',
+            createAdminRateLimiter('providers-admin'),
+            requireAdmin,
+            router
+        );
+        this.logger.info('Providers module running; admin surface mounted at /api/admin/system/providers');
+    }
+}

--- a/src/backend/modules/providers/README.md
+++ b/src/backend/modules/providers/README.md
@@ -1,0 +1,55 @@
+# Providers Module
+
+Owns runtime configuration and HTTP clients for external data providers, kept out of env so an operator edits them live from the admin UI. First provider: **TronScan**, the TRX price source behind the local price-history series.
+
+## Why It Is a Module
+
+Provider credentials and transports are core, always-on infrastructure that core ingestion (price-history) depends on and the admin Providers tab edits. It is not runtime-toggleable and publishes shared singletons (the config store, the TronScan client), so it is a module, not a plugin. Storing the API key in the database — never env — is the whole point: it must be editable at runtime, survive restarts, and never appear in source.
+
+## Agent Quick Surface
+
+| Surface | Value |
+|---------|-------|
+| Module id | `providers` |
+| Module class | `src/backend/modules/providers/ProvidersModule.ts` |
+| Admin page | `/system/system` → **Providers** tab (menu Submenu Pattern; the `system` namespace tabs are registered in bootstrap) |
+| Mounted routes | `/api/admin/system/providers/*` (`createAdminRateLimiter` + `requireAdmin`) |
+| Singletons | `ProviderConfigService` (DB-backed config + masking), `TronScanClient` (transport) |
+| Owned storage | One KV blob per provider via `IDatabaseService.set` — key `provider:tronscan` |
+| Scheduler jobs | none (consumed by price-history's jobs) |
+| Bootstrap order | Inits **before** price-history, which reads the config service and client through the TronScan price provider |
+
+## Source Map
+
+| Path | Responsibility |
+|------|----------------|
+| `ProvidersModule.ts` | Lifecycle; wires the config/client singletons, mounts the admin router |
+| `services/provider-config.service.ts` | `ProviderConfigService` — DB-backed read/write, secret masking (`****` + last 4), masked vs raw views |
+| `clients/tron-scan.client.ts` | `TronScanClient` — `/api/trx/volume` transport + `testConnection()`; reads config per call |
+| `api/providers.controller.ts` | Admin handlers; guards a re-echoed mask and the clear sentinel on save |
+| `api/providers.routes.ts` | Router factory (guards applied at mount) |
+| `database/index.ts` | KV key, config shapes (raw + masked), `CLEAR_SENTINEL`, defaults |
+
+## REST Endpoints (`requireAdmin`)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/admin/system/providers/tronscan` | Masked config (`apiKey` is `****abcd`, plus `apiKeyConfigured`) |
+| PUT | `/api/admin/system/providers/tronscan` | Persist `apiKey?` / `baseUrl?` / `priceSource?` / `enabled?` |
+| POST | `/api/admin/system/providers/tronscan/test` | Live connectivity/credential check — `{ result: { ok, message, latencyMs, … } }` |
+
+The key is never returned in the clear. On save, a value beginning `****` (a re-echoed mask) is ignored, `__clear__` empties the key, and any other string sets it.
+
+## TronScan Config
+
+`provider:tronscan` → `{ apiKey?, baseUrl, priceSource, enabled }`. The key is optional — TronScan works keyless at lower rate limits. `priceSource` is `coinmarketcap | coingecko` (the sources `/api/trx/volume` reports from). `enabled: false` pauses TRX ingestion at the price provider. Defaults: `baseUrl: https://apilist.tronscanapi.com`, `priceSource: coinmarketcap`, `enabled: true`.
+
+## Consuming the Client
+
+The price-history `TronScanPriceHistoryProvider` calls `TronScanClient.getInstance().getTrxPriceVolume(startMs, endMs, source)` for TRX daily OHLC (`close` = the day's price) and resolves token assets to empty — TronScan has no per-token history. See the [Price History Module README](../price-history/README.md).
+
+## Related
+
+- [Price History Module README](../price-history/README.md) — the consumer; the TronScan provider and the two ingestion jobs it backs
+- [system-database.md](../../../../docs/system/system-database.md) — `IDatabaseService` KV store the config persists to
+- [Menu Module README](../menu/README.md) — the Submenu Pattern the `/system/system` tab row uses

--- a/src/backend/modules/providers/api/providers.controller.ts
+++ b/src/backend/modules/providers/api/providers.controller.ts
@@ -71,8 +71,18 @@ export class ProvidersController {
             if (typeof body.baseUrl === 'string' && body.baseUrl.trim()) {
                 // Strip trailing slashes so the client's `${baseUrl}${path}` join
                 // can't produce a double-slash path (e.g. `//api/trx/volume`) from
-                // an operator pasting a URL with a trailing `/`.
-                updates.baseUrl = body.baseUrl.trim().replace(/\/+$/, '');
+                // an operator pasting a URL with a trailing `/`. Done with a linear
+                // scan rather than a `/\/+$/` regex, which CodeQL flags as a
+                // polynomial-ReDoS risk on this user-provided value.
+                let normalizedBaseUrl = body.baseUrl.trim();
+                let sliceEnd = normalizedBaseUrl.length;
+                while (sliceEnd > 0 && normalizedBaseUrl[sliceEnd - 1] === '/') {
+                    sliceEnd -= 1;
+                }
+                normalizedBaseUrl = normalizedBaseUrl.slice(0, sliceEnd);
+                if (normalizedBaseUrl) {
+                    updates.baseUrl = normalizedBaseUrl;
+                }
             }
             if (body.priceSource === 'coinmarketcap' || body.priceSource === 'coingecko') {
                 updates.priceSource = body.priceSource;

--- a/src/backend/modules/providers/api/providers.controller.ts
+++ b/src/backend/modules/providers/api/providers.controller.ts
@@ -1,0 +1,115 @@
+/**
+ * @fileoverview Admin HTTP handlers for external-provider configuration.
+ *
+ * Why these guards matter: the TronScan API key is a secret. GET returns only the
+ * masked view, and the save handler refuses to persist a re-echoed mask (so a
+ * round-trip of the masked value can never overwrite the real key with `****…`),
+ * while honouring an explicit clear sentinel. The test handler exercises a live
+ * TronScan call so an operator can confirm a pasted key works before relying on
+ * it for ingestion.
+ */
+
+import type { Request, Response } from 'express';
+import type { ISystemLogService } from '@/types';
+import { ProviderConfigService } from '../services/provider-config.service.js';
+import { TronScanClient } from '../clients/tron-scan.client.js';
+import { CLEAR_SENTINEL, type ITronScanProviderConfig } from '../database/index.js';
+
+/**
+ * Controller for `/api/admin/system/providers/*`. Stateless beyond its injected
+ * collaborators; one instance is mounted by the module.
+ */
+export class ProvidersController {
+    private readonly configService: ProviderConfigService;
+    private readonly tronScanClient: TronScanClient;
+    private readonly logger: ISystemLogService;
+
+    /**
+     * @param configService - DB-backed provider config (masked reads, guarded writes).
+     * @param tronScanClient - TronScan transport, used by the connectivity test.
+     * @param logger - Child logger for request diagnostics.
+     */
+    constructor(
+        configService: ProviderConfigService,
+        tronScanClient: TronScanClient,
+        logger: ISystemLogService
+    ) {
+        this.configService = configService;
+        this.tronScanClient = tronScanClient;
+        this.logger = logger;
+    }
+
+    /**
+     * GET /tronscan — return the masked TronScan config for the admin form.
+     *
+     * @param _req - Unused.
+     * @param res - JSON `{ success, config }` with the key masked.
+     */
+    getTronScanConfig = async (_req: Request, res: Response): Promise<void> => {
+        try {
+            const config = await this.configService.getMaskedTronScanConfig();
+            res.json({ success: true, config });
+        } catch (error) {
+            this.logger.error({ error }, 'Failed to read TronScan provider config');
+            res.status(500).json({ success: false, error: 'Failed to read provider config' });
+        }
+    };
+
+    /**
+     * PUT /tronscan — persist a partial config update. The `apiKey` field is
+     * sanitised here: a masked echo (`****…`) is ignored, the clear sentinel empties
+     * the key, and any other non-empty string sets a new key.
+     *
+     * @param req - Body with optional `apiKey`, `baseUrl`, `priceSource`, `enabled`.
+     * @param res - JSON `{ success, config }` with the new masked config.
+     */
+    updateTronScanConfig = async (req: Request, res: Response): Promise<void> => {
+        try {
+            const body = (req.body ?? {}) as Record<string, unknown>;
+            const updates: Partial<ITronScanProviderConfig> = {};
+
+            if (typeof body.baseUrl === 'string' && body.baseUrl.trim()) {
+                updates.baseUrl = body.baseUrl.trim();
+            }
+            if (body.priceSource === 'coinmarketcap' || body.priceSource === 'coingecko') {
+                updates.priceSource = body.priceSource;
+            }
+            if (typeof body.enabled === 'boolean') {
+                updates.enabled = body.enabled;
+            }
+            if (typeof body.apiKey === 'string') {
+                const trimmed = body.apiKey.trim();
+                if (trimmed === CLEAR_SENTINEL) {
+                    updates.apiKey = '';
+                } else if (trimmed && !trimmed.startsWith('****')) {
+                    updates.apiKey = trimmed;
+                }
+                // A masked echo or empty string leaves the stored key untouched.
+            }
+
+            const config = await this.configService.saveTronScanConfig(updates);
+            res.json({ success: true, config });
+        } catch (error) {
+            this.logger.error({ error }, 'Failed to update TronScan provider config');
+            res.status(500).json({ success: false, error: 'Failed to update provider config' });
+        }
+    };
+
+    /**
+     * POST /tronscan/test — run a live connectivity/credential check and return the
+     * structured outcome. Never 500s on an upstream failure: a failed test is a
+     * `200` with `result.ok === false` so the form can render the reason inline.
+     *
+     * @param _req - Unused.
+     * @param res - JSON `{ success, result }` where `result` carries ok/message/latency.
+     */
+    testTronScan = async (_req: Request, res: Response): Promise<void> => {
+        try {
+            const result = await this.tronScanClient.testConnection();
+            res.json({ success: result.ok, result });
+        } catch (error) {
+            this.logger.error({ error }, 'TronScan provider test threw unexpectedly');
+            res.status(500).json({ success: false, error: 'Provider test failed' });
+        }
+    };
+}

--- a/src/backend/modules/providers/api/providers.controller.ts
+++ b/src/backend/modules/providers/api/providers.controller.ts
@@ -69,7 +69,10 @@ export class ProvidersController {
             const updates: Partial<ITronScanProviderConfig> = {};
 
             if (typeof body.baseUrl === 'string' && body.baseUrl.trim()) {
-                updates.baseUrl = body.baseUrl.trim();
+                // Strip trailing slashes so the client's `${baseUrl}${path}` join
+                // can't produce a double-slash path (e.g. `//api/trx/volume`) from
+                // an operator pasting a URL with a trailing `/`.
+                updates.baseUrl = body.baseUrl.trim().replace(/\/+$/, '');
             }
             if (body.priceSource === 'coinmarketcap' || body.priceSource === 'coingecko') {
                 updates.priceSource = body.priceSource;

--- a/src/backend/modules/providers/api/providers.routes.ts
+++ b/src/backend/modules/providers/api/providers.routes.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Router for the external-providers admin API.
+ *
+ * Mounts the TronScan config read/write/test endpoints under
+ * `/api/admin/system/providers`. The module applies the admin rate limiter and
+ * `requireAdmin` at mount time, so this factory only wires paths to handlers.
+ */
+
+import { Router } from 'express';
+import type { ProvidersController } from './providers.controller.js';
+
+/**
+ * Build the providers admin router.
+ *
+ * @param controller - Providers controller instance.
+ * @returns Configured Express router.
+ */
+export function createProvidersRouter(controller: ProvidersController): Router {
+    const router = Router();
+
+    // GET /tronscan - masked config for the admin form
+    router.get('/tronscan', controller.getTronScanConfig);
+
+    // PUT /tronscan - persist config changes (key sanitised in the controller)
+    router.put('/tronscan', controller.updateTronScanConfig);
+
+    // POST /tronscan/test - live connectivity/credential check
+    router.post('/tronscan/test', controller.testTronScan);
+
+    return router;
+}

--- a/src/backend/modules/providers/clients/tron-scan.client.ts
+++ b/src/backend/modules/providers/clients/tron-scan.client.ts
@@ -1,0 +1,224 @@
+/**
+ * @fileoverview TronScan HTTP client — the transport for the TronScan explorer
+ * API, sibling to the TronGrid client.
+ *
+ * Why a dedicated client: TronScan is a distinct provider with its own base URL,
+ * its own API-key header, and its own response shapes. Centralizing them here
+ * keeps callers (currently the price-history TronScan provider) free of wire
+ * details and gives the provider a single place to grow more TronScan methods.
+ *
+ * Configuration is read from {@link ProviderConfigService} on every call rather
+ * than captured at construction, so an operator's edit on the admin Providers tab
+ * (key, base URL, source, enable flag) takes effect immediately without a
+ * restart. The key is sensitive and is only ever read here for the outbound
+ * header — it is never returned to a caller.
+ */
+
+import type { ISystemLogService } from '@/types';
+import { httpClient } from '../../../lib/http-client.js';
+import { retry } from '../../../lib/retry.js';
+import { ProviderConfigService } from '../services/provider-config.service.js';
+import type { TronScanPriceSource } from '../database/index.js';
+
+/** Path of the historical TRX price/volume endpoint. */
+const TRX_VOLUME_PATH = '/api/trx/volume';
+
+/** Header TronScan uses for an API key (shared TRON-ecosystem convention). */
+const API_KEY_HEADER = 'TRON-PRO-API-KEY';
+
+/** Per-request timeout; TronScan occasionally stalls and we would rather retry. */
+const REQUEST_TIMEOUT_MS = 12_000;
+
+/** Days of history a connectivity test asks for — small but non-empty. */
+const TEST_RANGE_DAYS = 3;
+
+/**
+ * Row cap requested per call. TronScan caps returned rows when no limit is given,
+ * which would truncate a wide seed window; this comfortably exceeds the widest
+ * range any caller asks for (a 360-day seed) with daily granularity.
+ */
+const DEFAULT_ROW_LIMIT = 4000;
+
+/**
+ * One daily row from `/api/trx/volume`. Prices arrive as decimal strings; `time`
+ * is the end-of-day epoch in milliseconds. Only the fields we consume are typed.
+ */
+export interface ITronScanTrxVolumePoint {
+    /** End-of-day epoch milliseconds for the row. */
+    time: number;
+    /** Daily close price in USD (decimal string). */
+    close: string;
+    /** Daily open price in USD (decimal string). */
+    open?: string;
+    /** Source the row was sampled from. */
+    source?: string;
+}
+
+/** Envelope of the `/api/trx/volume` response. */
+interface ITronScanTrxVolumeResponse {
+    code?: number;
+    total?: number;
+    data?: ITronScanTrxVolumePoint[];
+}
+
+/** Outcome of a connectivity/credential test, surfaced to the admin UI. */
+export interface ITronScanTestResult {
+    /** Whether the test call succeeded and returned at least one priced day. */
+    ok: boolean;
+    /** Human-readable result for the admin UI. */
+    message: string;
+    /** A sample close price from the test window, when available. */
+    sampleClose?: number;
+    /** Round-trip latency of the test call in milliseconds. */
+    latencyMs?: number;
+    /** Whether an API key was sent with the test (vs keyless). */
+    usingKey?: boolean;
+}
+
+/**
+ * Singleton TronScan client. No construction-time config — every call resolves the
+ * current config from {@link ProviderConfigService}.
+ */
+export class TronScanClient {
+    private static instance: TronScanClient | null = null;
+
+    private readonly logger: ISystemLogService;
+
+    /**
+     * @param logger - Child logger for diagnostics.
+     */
+    private constructor(logger: ISystemLogService) {
+        this.logger = logger;
+    }
+
+    /**
+     * Wire the logger on first call; idempotent.
+     *
+     * @param logger - Child logger.
+     */
+    public static setDependencies(logger: ISystemLogService): void {
+        if (!TronScanClient.instance) {
+            TronScanClient.instance = new TronScanClient(logger);
+        }
+    }
+
+    /**
+     * @returns The shared instance.
+     * @throws If {@link setDependencies} has not run.
+     */
+    public static getInstance(): TronScanClient {
+        if (!TronScanClient.instance) {
+            throw new Error('TronScanClient.setDependencies() must be called before getInstance()');
+        }
+        return TronScanClient.instance;
+    }
+
+    /** Reset for tests. */
+    public static resetInstance(): void {
+        TronScanClient.instance = null;
+    }
+
+    /**
+     * Build the outbound headers, attaching the API key only when one is set so a
+     * keyless deployment still works (at TronScan's lower anonymous limits).
+     *
+     * @param apiKey - The configured key, possibly empty.
+     * @returns Headers for the request.
+     */
+    private static buildHeaders(apiKey: string | undefined): Record<string, string> {
+        const headers: Record<string, string> = {};
+        if (apiKey) {
+            headers[API_KEY_HEADER] = apiKey;
+        }
+        return headers;
+    }
+
+    /**
+     * Fetch TRX daily OHLC over an inclusive epoch-millisecond range from
+     * `/api/trx/volume`. Returns the rows as TronScan provides them (one per day,
+     * `close` being the day's reference price) for the caller to map. Retries
+     * transient transport failures; a non-2xx from TronScan propagates so the
+     * caller can treat it as a tick failure rather than silently empty.
+     *
+     * @param startMs - Inclusive start epoch milliseconds.
+     * @param endMs - Inclusive end epoch milliseconds.
+     * @param source - Price source TronScan should report from.
+     * @param limit - Max rows to request (defaults high enough for any seed window).
+     * @returns The daily volume/price rows, oldest first as TronScan returns them.
+     */
+    public async getTrxPriceVolume(
+        startMs: number,
+        endMs: number,
+        source: TronScanPriceSource,
+        limit: number = DEFAULT_ROW_LIMIT
+    ): Promise<ITronScanTrxVolumePoint[]> {
+        const config = await ProviderConfigService.getInstance().getTronScanConfig();
+        const url = `${config.baseUrl}${TRX_VOLUME_PATH}`;
+        const rows = await retry(
+            async () => {
+                const response = await httpClient.get<ITronScanTrxVolumeResponse>(url, {
+                    params: { start_timestamp: startMs, end_timestamp: endMs, source, limit },
+                    headers: TronScanClient.buildHeaders(config.apiKey),
+                    timeout: REQUEST_TIMEOUT_MS
+                });
+                return response.data?.data ?? [];
+            },
+            {
+                retries: 3,
+                delayMs: 1000,
+                factor: 2,
+                onRetry: (attempt, error) =>
+                    this.logger.warn({ attempt, error, startMs, endMs }, 'Retrying TronScan getTrxPriceVolume')
+            }
+        );
+        return rows;
+    }
+
+    /**
+     * Probe the TronScan endpoint for the admin "Test" button. Issues one small
+     * ranged TRX call with the currently-saved config (key included if set),
+     * reports latency and a sample close price on success, and turns any failure
+     * into a friendly message rather than throwing — the UI shows the result
+     * inline. This is also how an operator confirms a newly-pasted key is accepted.
+     *
+     * @returns The structured test outcome.
+     */
+    public async testConnection(): Promise<ITronScanTestResult> {
+        const config = await ProviderConfigService.getInstance().getTronScanConfig();
+        const endMs = Date.now();
+        const startMs = endMs - TEST_RANGE_DAYS * 86_400_000;
+        const startedAt = Date.now();
+        let result: ITronScanTestResult;
+        try {
+            const rows = await this.getTrxPriceVolume(startMs, endMs, config.priceSource);
+            const latencyMs = Date.now() - startedAt;
+            const lastClose = rows.length > 0 ? Number(rows[rows.length - 1].close) : NaN;
+            if (rows.length === 0 || !Number.isFinite(lastClose)) {
+                result = {
+                    ok: false,
+                    message: 'TronScan responded but returned no usable price data.',
+                    latencyMs,
+                    usingKey: !!config.apiKey
+                };
+            } else {
+                result = {
+                    ok: true,
+                    message: `Connected to TronScan (${config.priceSource}) — latest TRX close $${lastClose.toFixed(4)}.`,
+                    sampleClose: lastClose,
+                    latencyMs,
+                    usingKey: !!config.apiKey
+                };
+            }
+        } catch (error) {
+            const status = (error as { response?: { status?: number } })?.response?.status;
+            const detail = status ? ` (HTTP ${status})` : '';
+            this.logger.warn({ error, usingKey: !!config.apiKey }, 'TronScan connectivity test failed');
+            result = {
+                ok: false,
+                message: `TronScan request failed${detail}. ${config.apiKey ? 'Check the API key and base URL.' : 'Check the base URL or add an API key.'}`,
+                usingKey: !!config.apiKey
+            };
+        }
+        return result;
+    }
+}

--- a/src/backend/modules/providers/database/index.ts
+++ b/src/backend/modules/providers/database/index.ts
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Storage constants and config shapes for the providers module.
+ *
+ * Why here: external data providers (starting with TronScan) carry operator-set
+ * configuration — an optional API key, a base URL, a price source — that must
+ * live in the database and be editable at runtime from the admin UI, never in
+ * env. Centralizing the key, the raw shape, the masked shape, and the defaults in
+ * one file keeps the service, controller, and any future provider on the same
+ * contract.
+ */
+
+/**
+ * KV-store key under which the TronScan provider config blob is persisted via
+ * `IDatabaseService.set`. One JSON document, read at request time so edits take
+ * effect without a restart.
+ */
+export const TRONSCAN_CONFIG_KEY = 'provider:tronscan';
+
+/** Sentinel a client may send in `apiKey` to explicitly clear a stored key. */
+export const CLEAR_SENTINEL = '__clear__';
+
+/** Price source the TronScan `/api/trx/volume` endpoint will report from. */
+export type TronScanPriceSource = 'coinmarketcap' | 'coingecko';
+
+/**
+ * Raw TronScan provider config as stored. The `apiKey` is sensitive and never
+ * leaves the backend unmasked.
+ */
+export interface ITronScanProviderConfig {
+    /** Optional API key. TronScan works keyless at lower limits; a key lifts them. */
+    apiKey?: string;
+    /** API base, overridable only for testing/migration. */
+    baseUrl: string;
+    /** Which upstream source TronScan should report TRX prices from. */
+    priceSource: TronScanPriceSource;
+    /** Master switch: when false the price provider pauses TRX ingestion. */
+    enabled: boolean;
+}
+
+/**
+ * Admin-safe projection of {@link ITronScanProviderConfig}: the key is masked to
+ * its last four characters and a boolean states whether one is set, so the UI can
+ * show "configured" without ever receiving the secret.
+ */
+export interface ITronScanProviderConfigMasked {
+    /** Masked key (`****abcd`) or empty when none is set. */
+    apiKey: string;
+    /** True when a non-empty key is stored — drives the UI "configured" state. */
+    apiKeyConfigured: boolean;
+    baseUrl: string;
+    priceSource: TronScanPriceSource;
+    enabled: boolean;
+}
+
+/**
+ * Defaults applied when no config has been saved. Keyless and enabled, pointing
+ * at the public TronScan API with CoinMarketCap as the reported source (the
+ * endpoint's own default).
+ */
+export const DEFAULT_TRONSCAN_CONFIG: ITronScanProviderConfig = {
+    baseUrl: 'https://apilist.tronscanapi.com',
+    priceSource: 'coinmarketcap',
+    enabled: true
+};

--- a/src/backend/modules/providers/index.ts
+++ b/src/backend/modules/providers/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @fileoverview Public surface of the providers module.
+ */
+
+export { ProvidersModule } from './ProvidersModule.js';
+export type { IProvidersModuleDependencies } from './ProvidersModule.js';
+export { ProviderConfigService } from './services/provider-config.service.js';
+export { TronScanClient } from './clients/tron-scan.client.js';
+export type { ITronScanTrxVolumePoint, ITronScanTestResult } from './clients/tron-scan.client.js';
+export type {
+    ITronScanProviderConfig,
+    ITronScanProviderConfigMasked,
+    TronScanPriceSource
+} from './database/index.js';

--- a/src/backend/modules/providers/services/provider-config.service.ts
+++ b/src/backend/modules/providers/services/provider-config.service.ts
@@ -1,0 +1,152 @@
+/**
+ * @fileoverview Database-backed configuration store for external data providers.
+ *
+ * Why a service (not env): a provider's API key and pacing must be editable by an
+ * operator at runtime from the admin UI, survive restarts, and never appear in
+ * source or process env. This singleton owns the read/write of the TronScan
+ * config blob in the KV store, plus the secret-masking projection the admin API
+ * returns so a key is never sent back to the browser in the clear.
+ *
+ * It is the single source of truth both the {@link TronScanClient} (which reads
+ * the raw key per request) and the admin controller (which reads the masked view)
+ * depend on, so the key has exactly one home.
+ */
+
+import type { IDatabaseService, ISystemLogService } from '@/types';
+import {
+    TRONSCAN_CONFIG_KEY,
+    DEFAULT_TRONSCAN_CONFIG,
+    type ITronScanProviderConfig,
+    type ITronScanProviderConfigMasked
+} from '../database/index.js';
+
+/** Number of trailing key characters left visible when masking. */
+const MASK_VISIBLE_CHARS = 4;
+
+/**
+ * Singleton provider-config service. Dependencies are injected once at bootstrap
+ * via {@link setDependencies} before any {@link getInstance} call.
+ */
+export class ProviderConfigService {
+    private static instance: ProviderConfigService | null = null;
+
+    private readonly database: IDatabaseService;
+    private readonly logger: ISystemLogService;
+
+    /**
+     * @param database - Core KV store the config blob persists to.
+     * @param logger - Child logger for diagnostics.
+     */
+    private constructor(database: IDatabaseService, logger: ISystemLogService) {
+        this.database = database;
+        this.logger = logger;
+    }
+
+    /**
+     * Wire dependencies on first call; idempotent so repeated bootstrap paths are
+     * harmless.
+     *
+     * @param database - Core database service.
+     * @param logger - Child logger.
+     */
+    public static setDependencies(database: IDatabaseService, logger: ISystemLogService): void {
+        if (!ProviderConfigService.instance) {
+            ProviderConfigService.instance = new ProviderConfigService(database, logger);
+        }
+    }
+
+    /**
+     * @returns The shared instance.
+     * @throws If {@link setDependencies} has not run.
+     */
+    public static getInstance(): ProviderConfigService {
+        if (!ProviderConfigService.instance) {
+            throw new Error('ProviderConfigService.setDependencies() must be called before getInstance()');
+        }
+        return ProviderConfigService.instance;
+    }
+
+    /** Reset for tests. */
+    public static resetInstance(): void {
+        ProviderConfigService.instance = null;
+    }
+
+    /**
+     * Read the full TronScan config, merged over defaults so callers always get a
+     * complete object even before anything has been saved. Returns the raw key —
+     * for backend use (the client) only, never the admin API.
+     *
+     * @returns The effective TronScan config.
+     */
+    public async getTronScanConfig(): Promise<ITronScanProviderConfig> {
+        const stored = await this.database.get<Partial<ITronScanProviderConfig>>(TRONSCAN_CONFIG_KEY);
+        return { ...DEFAULT_TRONSCAN_CONFIG, ...(stored ?? {}) };
+    }
+
+    /**
+     * The admin-safe view: the key reduced to `****` plus its last four chars and a
+     * boolean flag, so the UI can render "configured" without the secret crossing
+     * the wire.
+     *
+     * @returns The masked TronScan config.
+     */
+    public async getMaskedTronScanConfig(): Promise<ITronScanProviderConfigMasked> {
+        const config = await this.getTronScanConfig();
+        const key = config.apiKey ?? '';
+        return {
+            apiKey: ProviderConfigService.maskKey(key),
+            apiKeyConfigured: key.length > 0,
+            baseUrl: config.baseUrl,
+            priceSource: config.priceSource,
+            enabled: config.enabled
+        };
+    }
+
+    /**
+     * Merge a partial update over the stored config and persist it. The caller
+     * (controller) is responsible for stripping a re-echoed mask and resolving the
+     * clear-sentinel before passing `apiKey` here, so this method trusts the
+     * `apiKey` it receives: a string sets it, `''` clears it, `undefined` leaves it.
+     *
+     * @param updates - Fields to change; omitted fields are preserved.
+     * @returns The new masked config (never the raw key).
+     */
+    public async saveTronScanConfig(
+        updates: Partial<ITronScanProviderConfig>
+    ): Promise<ITronScanProviderConfigMasked> {
+        const current = await this.getTronScanConfig();
+        const merged: ITronScanProviderConfig = {
+            ...current,
+            ...updates
+        };
+        // An empty-string apiKey means "clear"; drop the field so we don't persist
+        // a meaningless empty secret.
+        if (!merged.apiKey) {
+            delete merged.apiKey;
+        }
+        await this.database.set(TRONSCAN_CONFIG_KEY, merged);
+        this.logger.info(
+            { enabled: merged.enabled, priceSource: merged.priceSource, apiKeyConfigured: !!merged.apiKey },
+            'TronScan provider config saved'
+        );
+        return this.getMaskedTronScanConfig();
+    }
+
+    /**
+     * Mask a secret to its last {@link MASK_VISIBLE_CHARS} characters, matching the
+     * platform's established `****abcd` convention, so an operator can recognise
+     * which key is set without it being recoverable.
+     *
+     * @param key - The raw key, possibly empty.
+     * @returns The masked key, or '' when none is set.
+     */
+    private static maskKey(key: string): string {
+        if (!key) {
+            return '';
+        }
+        if (key.length <= MASK_VISIBLE_CHARS) {
+            return '****';
+        }
+        return `****${key.slice(-MASK_VISIBLE_CHARS)}`;
+    }
+}

--- a/src/frontend/app/(core)/system/system/SystemAdminClient.tsx
+++ b/src/frontend/app/(core)/system/system/SystemAdminClient.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+/**
+ * @fileoverview Client shell for /system/system.
+ *
+ * Hosts the in-page tab row (the menu module's Submenu Pattern — a namespaced
+ * menu rendered with `MenuNavClient`, not a hand-rolled control) and the tab
+ * panels. The server entry fetches the `system` namespace tree SSR-first and
+ * passes it in; clicking a tab drives local state via `onItemSelect` rather than
+ * navigating, and `activeUrl` highlights the active tab since the route is
+ * identical across them. "Overview" carries the subsystem consoles; "Providers"
+ * hosts external-provider configuration.
+ */
+
+import { useState, useCallback } from 'react';
+import type { MenuNodeSerialized } from '@/shared';
+import { Page, PageHeader } from '../../../../components/layout';
+import { MenuNavClient } from '../../../../components/layout/MenuNav/MenuNavClient';
+import { OverviewTab } from './components/OverviewTab';
+import { ProvidersTab } from './components/ProvidersTab';
+import styles from './page.module.scss';
+
+/** The page's tab ids; the `?tab=` value carried by each submenu node. */
+type TabId = 'overview' | 'providers';
+
+/** The menu namespace the tab nodes are registered under. */
+const SUBMENU_NAMESPACE = 'system';
+
+/**
+ * Props for the client shell.
+ */
+interface ISystemAdminClientProps {
+    /** SSR-fetched submenu nodes (the tab row), already gated for the admin. */
+    submenuTree: MenuNodeSerialized[];
+    /** Snapshot timestamp of the submenu tree, seeded onto the menu Redux slice. */
+    submenuGeneratedAt: string;
+    /** The `?tab=` value from the request URL; unknown/absent resolves to `overview`. */
+    initialTab?: string;
+}
+
+/**
+ * Resolve a node's `?tab=` value to a known TabId, defaulting to `overview`.
+ *
+ * @param url - The clicked node's url (e.g. `/system/system?tab=providers`).
+ * @returns The matching tab id.
+ */
+function tabFromUrl(url: string | undefined): TabId {
+    const tab = url?.match(/[?&]tab=([^&]+)/)?.[1];
+    return tab === 'providers' ? 'providers' : 'overview';
+}
+
+/**
+ * System admin client shell.
+ *
+ * @param props - SSR submenu tree, its timestamp, and the deep-linked initial tab.
+ * @returns The page.
+ */
+export function SystemAdminClient({ submenuTree, submenuGeneratedAt, initialTab }: ISystemAdminClientProps) {
+    const [activeTab, setActiveTab] = useState<TabId>(initialTab === 'providers' ? 'providers' : 'overview');
+
+    /**
+     * Activate the clicked tab and keep its URL a real deep link.
+     *
+     * `MenuNavClient` suppresses the <Link> navigation when `onItemSelect` is set,
+     * so rewrite the address in place with `history.replaceState` — no server
+     * round-trip — so the `?tab=` URLs become true deep links the server entry can
+     * read SSR-first on next load.
+     *
+     * @param item - The clicked submenu node, carrying its `?tab=` url.
+     */
+    const handleTabSelect = useCallback((item: MenuNodeSerialized) => {
+        const tab = tabFromUrl(item.url);
+        setActiveTab(tab);
+        window.history.replaceState(null, '', `/system/system?tab=${tab}`);
+    }, []);
+
+    return (
+        <Page>
+            <PageHeader
+                title="System"
+                subtitle="Live status across every subsystem, plus runtime configuration for external data providers."
+            />
+
+            <div className={styles.submenu}>
+                <MenuNavClient
+                    namespace={SUBMENU_NAMESPACE}
+                    items={submenuTree}
+                    generatedAt={submenuGeneratedAt}
+                    ariaLabel="System sections"
+                    activeUrl={`/system/system?tab=${activeTab}`}
+                    onItemSelect={handleTabSelect}
+                />
+            </div>
+
+            <div className={styles.content}>
+                {activeTab === 'overview' && <OverviewTab />}
+                {activeTab === 'providers' && <ProvidersTab />}
+            </div>
+        </Page>
+    );
+}

--- a/src/frontend/app/(core)/system/system/components/OverviewTab.tsx
+++ b/src/frontend/app/(core)/system/system/components/OverviewTab.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Stack } from '../../../../../components/layout';
+import { Card } from '../../../../../components/ui/Card';
+import { ConsoleRow } from './ConsoleRow';
+import { OverviewBar } from './OverviewBar';
+import { SystemConfigSection } from './SystemConfigSection';
+import { ServerSection } from './ServerSection';
+import { BlockchainSection } from './BlockchainSection';
+import { WebSocketsSection } from './WebSocketsSection';
+import { MongoSection } from './MongoSection';
+import { ClickHouseSection } from './ClickHouseSection';
+
+/**
+ * Overview tab — the subsystem mission-control console, unchanged from the prior
+ * flat page.
+ *
+ * The OverviewBar polls lightly so admins see live state across all subsystems
+ * even with every console row collapsed; each ConsoleRow defers its own fetch
+ * until expanded, preserving the "no API storm on page load" guarantee. Extracted
+ * into its own tab panel so the System page can host sibling concerns (Providers)
+ * without disturbing this content.
+ *
+ * @returns The overview console.
+ */
+export function OverviewTab() {
+    return (
+        <Stack gap="sm">
+            <OverviewBar />
+            <Card padding="sm" noBackgroundImage>
+                <ConsoleRow id="config" title="Configuration" status="idle">
+                    <SystemConfigSection />
+                </ConsoleRow>
+                <ConsoleRow id="server" title="Server" status="idle">
+                    <ServerSection />
+                </ConsoleRow>
+                <ConsoleRow id="blockchain" title="Blockchain" status="idle">
+                    <BlockchainSection />
+                </ConsoleRow>
+                <ConsoleRow id="websockets" title="WebSockets" status="idle">
+                    <WebSocketsSection />
+                </ConsoleRow>
+                <ConsoleRow id="mongo" title="MongoDB" status="idle">
+                    <MongoSection />
+                </ConsoleRow>
+                <ConsoleRow id="clickhouse" title="ClickHouse" status="idle">
+                    <ClickHouseSection />
+                </ConsoleRow>
+            </Card>
+        </Stack>
+    );
+}

--- a/src/frontend/app/(core)/system/system/components/ProvidersTab.tsx
+++ b/src/frontend/app/(core)/system/system/components/ProvidersTab.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { Stack } from '../../../../../components/layout';
+import { TronScanProviderSection } from './TronScanProviderSection';
+
+/**
+ * Providers tab — runtime configuration for external data providers.
+ *
+ * A thin host so additional provider sections can be added beside TronScan
+ * without touching the page shell. Each section owns its own fetch/save/test
+ * lifecycle.
+ *
+ * @returns The providers configuration panel.
+ */
+export function ProvidersTab() {
+    return (
+        <Stack gap="md">
+            <TronScanProviderSection />
+        </Stack>
+    );
+}

--- a/src/frontend/app/(core)/system/system/components/TronScanProviderSection.tsx
+++ b/src/frontend/app/(core)/system/system/components/TronScanProviderSection.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+/**
+ * @fileoverview TronScan provider configuration section.
+ *
+ * Lets an operator configure the TronScan provider that backs the local TRX price
+ * history (and powers portfolio valuation) entirely from the UI — no env, no
+ * restart. The API key is a secret: it loads masked, the input never pre-fills the
+ * masked value (so a save can't echo `****` back over the real key), and a Test
+ * button runs a live call so the operator can confirm connectivity/credentials.
+ * Brief inline docs explain that a key is optional and where to obtain one.
+ */
+
+import { useEffect, useState, useCallback, type ChangeEvent } from 'react';
+import { Plug, Eye, EyeOff, CheckCircle, AlertCircle, ExternalLink } from 'lucide-react';
+import { Card } from '../../../../../components/ui/Card';
+import { Button } from '../../../../../components/ui/Button';
+import { Input } from '../../../../../components/ui/Input';
+import { Switch } from '../../../../../components/ui/Switch';
+import { Badge } from '../../../../../components/ui/Badge';
+import { Stack } from '../../../../../components/layout';
+import {
+    getTronScanConfig,
+    updateTronScanConfig,
+    testTronScan,
+    CLEAR_SENTINEL,
+    type ITronScanConfigView,
+    type TronScanPriceSource,
+    type ITronScanTestResult
+} from './providers-api';
+import styles from '../page.module.scss';
+
+/** Where an operator obtains a TronScan API key (optional). */
+const TRONSCAN_KEYS_URL = 'https://docs.tronscan.org/api-endpoints/api-keys';
+
+/**
+ * Render and manage the TronScan provider config form.
+ *
+ * @returns The configuration section.
+ */
+export function TronScanProviderSection() {
+    const [loading, setLoading] = useState(true);
+    const [config, setConfig] = useState<ITronScanConfigView | null>(null);
+    const [apiKeyInput, setApiKeyInput] = useState('');
+    const [showKey, setShowKey] = useState(false);
+    const [baseUrl, setBaseUrl] = useState('');
+    const [source, setSource] = useState<TronScanPriceSource>('coinmarketcap');
+    const [enabled, setEnabled] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [testing, setTesting] = useState(false);
+    const [testResult, setTestResult] = useState<ITronScanTestResult | null>(null);
+    const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+    /**
+     * Seed local form state from a freshly-fetched masked config.
+     *
+     * @param next - The masked config to apply.
+     */
+    const applyConfig = useCallback((next: ITronScanConfigView) => {
+        setConfig(next);
+        setBaseUrl(next.baseUrl);
+        setSource(next.priceSource);
+        setEnabled(next.enabled);
+    }, []);
+
+    useEffect(() => {
+        let active = true;
+        getTronScanConfig()
+            .then((cfg) => {
+                if (active) {
+                    applyConfig(cfg);
+                }
+            })
+            .catch(() => {
+                if (active) {
+                    setFeedback({ type: 'error', message: 'Failed to load TronScan config.' });
+                }
+            })
+            .finally(() => {
+                if (active) {
+                    setLoading(false);
+                }
+            });
+        return () => {
+            active = false;
+        };
+    }, [applyConfig]);
+
+    /**
+     * Persist the form. The API key is sent only when the operator typed a new one;
+     * an untouched field leaves the stored key intact.
+     */
+    const handleSave = useCallback(async () => {
+        setSaving(true);
+        setFeedback(null);
+        setTestResult(null);
+        try {
+            const updates: { baseUrl: string; priceSource: TronScanPriceSource; enabled: boolean; apiKey?: string } = {
+                baseUrl: baseUrl.trim(),
+                priceSource: source,
+                enabled
+            };
+            if (apiKeyInput.trim()) {
+                updates.apiKey = apiKeyInput.trim();
+            }
+            const next = await updateTronScanConfig(updates);
+            applyConfig(next);
+            setApiKeyInput('');
+            setShowKey(false);
+            setFeedback({ type: 'success', message: 'TronScan configuration saved.' });
+            setTimeout(() => setFeedback(null), 4000);
+        } catch (err) {
+            setFeedback({ type: 'error', message: err instanceof Error ? err.message : 'Failed to save.' });
+        } finally {
+            setSaving(false);
+        }
+    }, [apiKeyInput, baseUrl, source, enabled, applyConfig]);
+
+    /**
+     * Clear the stored key via the backend sentinel, returning to keyless mode.
+     */
+    const handleClearKey = useCallback(async () => {
+        setSaving(true);
+        setFeedback(null);
+        try {
+            const next = await updateTronScanConfig({ apiKey: CLEAR_SENTINEL });
+            applyConfig(next);
+            setApiKeyInput('');
+            setFeedback({ type: 'success', message: 'API key cleared (now keyless).' });
+            setTimeout(() => setFeedback(null), 4000);
+        } catch (err) {
+            setFeedback({ type: 'error', message: err instanceof Error ? err.message : 'Failed to clear key.' });
+        } finally {
+            setSaving(false);
+        }
+    }, [applyConfig]);
+
+    /**
+     * Run a live connectivity/credential test against the *saved* config.
+     */
+    const handleTest = useCallback(async () => {
+        setTesting(true);
+        setTestResult(null);
+        try {
+            setTestResult(await testTronScan());
+        } catch (err) {
+            setTestResult({ ok: false, message: err instanceof Error ? err.message : 'Test failed.' });
+        } finally {
+            setTesting(false);
+        }
+    }, []);
+
+    if (loading) {
+        return <Card padding="md"><span className="text-muted">Loading TronScan configuration…</span></Card>;
+    }
+
+    return (
+        <Card padding="md">
+            <Stack gap="md">
+                <div className={styles.provider_header}>
+                    <Plug size={16} aria-hidden style={{ color: 'var(--color-primary)' }} />
+                    <h3 className={styles.provider_title}>TronScan</h3>
+                    {config?.apiKeyConfigured ? (
+                        <Badge tone="success">Key configured</Badge>
+                    ) : (
+                        <Badge tone="neutral">Keyless</Badge>
+                    )}
+                    {config && !config.enabled && <Badge tone="warning">Disabled</Badge>}
+                </div>
+
+                <p className="text-muted">
+                    Supplies the local daily <strong>TRX</strong> price history that powers portfolio valuation. An API key is
+                    optional — TronScan works keyless at lower rate limits; add a key to raise them. TRC20 token history is not
+                    sourced here.
+                </p>
+
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="tronscan-enabled">Enabled</label>
+                    <Switch
+                        on={enabled}
+                        onChange={setEnabled}
+                        disabled={saving}
+                        aria-label="Enable TronScan price ingestion"
+                    />
+                    <span className={styles.hint}>When off, TRX price ingestion pauses.</span>
+                </div>
+
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="tronscan-key">API key (optional)</label>
+                    <div className={styles.input_row}>
+                        <Input
+                            id="tronscan-key"
+                            type={showKey ? 'text' : 'password'}
+                            value={apiKeyInput}
+                            onChange={(e: ChangeEvent<HTMLInputElement>) => setApiKeyInput(e.target.value)}
+                            placeholder={config?.apiKeyConfigured ? `Configured (${config.apiKey}) — type to replace` : 'Paste a TronScan API key'}
+                            disabled={saving}
+                            aria-label="TronScan API key"
+                        />
+                        <button
+                            type="button"
+                            onClick={() => setShowKey((v) => !v)}
+                            className={styles.icon_btn}
+                            disabled={saving}
+                            aria-label={showKey ? 'Hide key' : 'Show key'}
+                        >
+                            {showKey ? <EyeOff size={18} /> : <Eye size={18} />}
+                        </button>
+                        {config?.apiKeyConfigured && (
+                            <Button variant="ghost" size="sm" onClick={handleClearKey} disabled={saving}>Clear</Button>
+                        )}
+                    </div>
+                    <span className={styles.hint}>
+                        Get a key from{' '}
+                        <a className={styles.docs_link} href={TRONSCAN_KEYS_URL} target="_blank" rel="noopener noreferrer">
+                            TronScan API keys <ExternalLink size={12} aria-hidden />
+                        </a>
+                        . Leave blank to stay keyless.
+                    </span>
+                </div>
+
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="tronscan-source">Price source</label>
+                    <select
+                        id="tronscan-source"
+                        className={styles.source_select}
+                        value={source}
+                        onChange={(e: ChangeEvent<HTMLSelectElement>) => setSource(e.target.value as TronScanPriceSource)}
+                        disabled={saving}
+                    >
+                        <option value="coinmarketcap">CoinMarketCap</option>
+                        <option value="coingecko">CoinGecko</option>
+                    </select>
+                    <span className={styles.hint}>Which upstream TronScan reports TRX prices from.</span>
+                </div>
+
+                <div className={styles.field}>
+                    <label className={styles.label} htmlFor="tronscan-base">Base URL</label>
+                    <Input
+                        id="tronscan-base"
+                        type="text"
+                        value={baseUrl}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => setBaseUrl(e.target.value)}
+                        placeholder="https://apilist.tronscanapi.com"
+                        disabled={saving}
+                        aria-label="TronScan base URL"
+                    />
+                </div>
+
+                <div className={styles.actions}>
+                    <Button variant="primary" size="md" onClick={handleSave} loading={saving} disabled={saving}>
+                        Save
+                    </Button>
+                    <Button variant="secondary" size="md" onClick={handleTest} loading={testing} disabled={saving || testing}>
+                        Test connection
+                    </Button>
+                    <span className={styles.hint}>Test uses the saved config — save a new key before testing it.</span>
+                </div>
+
+                {testResult && (
+                    <div className={testResult.ok ? styles.feedback_success : styles.feedback_error}>
+                        {testResult.ok ? <CheckCircle size={16} /> : <AlertCircle size={16} />}
+                        <span>
+                            {testResult.message}
+                            {typeof testResult.latencyMs === 'number' && ` (${testResult.latencyMs} ms${testResult.usingKey ? ', with key' : ', keyless'})`}
+                        </span>
+                    </div>
+                )}
+
+                {feedback && (
+                    <div className={feedback.type === 'success' ? styles.feedback_success : styles.feedback_error}>
+                        {feedback.type === 'success' ? <CheckCircle size={16} /> : <AlertCircle size={16} />}
+                        <span>{feedback.message}</span>
+                    </div>
+                )}
+            </Stack>
+        </Card>
+    );
+}

--- a/src/frontend/app/(core)/system/system/components/TronScanProviderSection.tsx
+++ b/src/frontend/app/(core)/system/system/components/TronScanProviderSection.tsx
@@ -87,6 +87,19 @@ export function TronScanProviderSection() {
     }, [applyConfig]);
 
     /**
+     * Auto-dismiss a success message after a short delay. Driving this from an effect
+     * rather than a per-handler timer guarantees the timeout is cleared on unmount and
+     * whenever newer feedback replaces it, so no stale timer fires `setFeedback` after
+     * unmount and back-to-back saves can't clear a fresh message early.
+     */
+    useEffect(() => {
+        const timer = feedback?.type === 'success'
+            ? setTimeout(() => setFeedback(null), 4000)
+            : undefined;
+        return () => clearTimeout(timer);
+    }, [feedback]);
+
+    /**
      * Persist the form. The API key is sent only when the operator typed a new one;
      * an untouched field leaves the stored key intact.
      */
@@ -108,7 +121,6 @@ export function TronScanProviderSection() {
             setApiKeyInput('');
             setShowKey(false);
             setFeedback({ type: 'success', message: 'TronScan configuration saved.' });
-            setTimeout(() => setFeedback(null), 4000);
         } catch (err) {
             setFeedback({ type: 'error', message: err instanceof Error ? err.message : 'Failed to save.' });
         } finally {
@@ -127,7 +139,6 @@ export function TronScanProviderSection() {
             applyConfig(next);
             setApiKeyInput('');
             setFeedback({ type: 'success', message: 'API key cleared (now keyless).' });
-            setTimeout(() => setFeedback(null), 4000);
         } catch (err) {
             setFeedback({ type: 'error', message: err instanceof Error ? err.message : 'Failed to clear key.' });
         } finally {

--- a/src/frontend/app/(core)/system/system/components/providers-api.ts
+++ b/src/frontend/app/(core)/system/system/components/providers-api.ts
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Typed fetch helpers for the external-providers admin API.
+ *
+ * Same-origin admin calls (cookie-authenticated via the /system layout gate), so
+ * these are thin wrappers over `fetch` mirroring SystemConfigSection's pattern —
+ * no client library, no token handling. The TronScan API key is never received in
+ * the clear: GET returns it masked, and saves send the real key only when the
+ * operator types a new one.
+ */
+
+/** Price source the TronScan endpoint reports from. */
+export type TronScanPriceSource = 'coinmarketcap' | 'coingecko';
+
+/** Masked TronScan config as returned by GET — the key is never sent in the clear. */
+export interface ITronScanConfigView {
+    /** Masked key (`****abcd`) or empty when none is set. */
+    apiKey: string;
+    /** Whether a key is stored, for the "configured" UI state. */
+    apiKeyConfigured: boolean;
+    baseUrl: string;
+    priceSource: TronScanPriceSource;
+    enabled: boolean;
+}
+
+/** Fields an operator can change. `apiKey` omitted = leave as-is. */
+export interface ITronScanConfigUpdate {
+    apiKey?: string;
+    baseUrl?: string;
+    priceSource?: TronScanPriceSource;
+    enabled?: boolean;
+}
+
+/** Structured result of a connectivity/credential test. */
+export interface ITronScanTestResult {
+    ok: boolean;
+    message: string;
+    sampleClose?: number;
+    latencyMs?: number;
+    usingKey?: boolean;
+}
+
+/** Sentinel a save sends to explicitly clear a stored key. */
+export const CLEAR_SENTINEL = '__clear__';
+
+const BASE = '/api/admin/system/providers/tronscan';
+
+/**
+ * Read the masked TronScan provider config.
+ *
+ * @returns The masked config for the admin form.
+ * @throws Error if the request fails.
+ */
+export async function getTronScanConfig(): Promise<ITronScanConfigView> {
+    const response = await fetch(BASE);
+    if (!response.ok) {
+        throw new Error(`Failed to load provider config: ${response.status}`);
+    }
+    const data = await response.json();
+    return data.config as ITronScanConfigView;
+}
+
+/**
+ * Persist a partial config change and return the new masked config.
+ *
+ * @param updates - Fields to change.
+ * @returns The updated masked config.
+ * @throws Error if the request fails.
+ */
+export async function updateTronScanConfig(updates: ITronScanConfigUpdate): Promise<ITronScanConfigView> {
+    const response = await fetch(BASE, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates)
+    });
+    if (!response.ok) {
+        const err = await response.json().catch(() => ({ error: 'Unknown error' }));
+        throw new Error(err.error || `Server returned ${response.status}`);
+    }
+    const data = await response.json();
+    return data.config as ITronScanConfigView;
+}
+
+/**
+ * Run a live connectivity/credential test against TronScan with the saved config.
+ *
+ * @returns The structured test result (a failed test resolves, it does not throw).
+ * @throws Error only on an unexpected transport/server error.
+ */
+export async function testTronScan(): Promise<ITronScanTestResult> {
+    const response = await fetch(`${BASE}/test`, { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+    const data = await response.json().catch(() => null);
+    if (!data || !data.result) {
+        throw new Error(`Provider test failed: ${response.status}`);
+    }
+    return data.result as ITronScanTestResult;
+}

--- a/src/frontend/app/(core)/system/system/page.module.scss
+++ b/src/frontend/app/(core)/system/system/page.module.scss
@@ -1,0 +1,99 @@
+/* Styles for the consolidated System admin page (submenu tab row + panels). */
+
+.submenu {
+    margin-bottom: var(--gap-md);
+}
+
+.content {
+    display: block;
+}
+
+/* TronScan provider section */
+.provider_header {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+}
+
+.provider_title {
+    margin: 0;
+    font-size: var(--font-size-heading-sm);
+    font-weight: var(--font-weight-semibold);
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+}
+
+.label {
+    font-size: var(--font-size-body-sm);
+    font-weight: var(--font-weight-medium);
+}
+
+.hint {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-caption);
+}
+
+.input_row {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+}
+
+.icon_btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--padding-2xs);
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-sm);
+    color: var(--color-text-muted);
+    cursor: pointer;
+}
+
+.icon_btn:hover {
+    color: var(--color-text);
+}
+
+.source_select {
+    padding: var(--input-padding-sm);
+    background: var(--color-surface);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    color: var(--color-text);
+    font-size: var(--font-size-body-sm);
+}
+
+.docs_link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-2xs);
+    color: var(--color-primary);
+}
+
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--gap-sm);
+}
+
+.feedback_success {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    color: var(--color-success);
+    font-size: var(--font-size-body-sm);
+}
+
+.feedback_error {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    color: var(--color-danger);
+    font-size: var(--font-size-body-sm);
+}

--- a/src/frontend/app/(core)/system/system/page.tsx
+++ b/src/frontend/app/(core)/system/system/page.tsx
@@ -1,52 +1,65 @@
-'use client';
+/**
+ * @fileoverview /system/system server entry.
+ *
+ * The consolidated System page now carries an in-page tab row (the menu module's
+ * Submenu Pattern) so it can host distinct concerns — the subsystem consoles
+ * under "Overview" and external-provider config under "Providers" — without a
+ * hand-rolled control. This server component fetches the `system` namespace tree
+ * SSR-first (forwarding the admin's cookie so per-node `requiresAdmin` resolves)
+ * and reads `?tab=` to seed the active panel, mirroring /system/account-history.
+ * Admin-gated by the /system layout.
+ */
 
-import { Page, Stack } from '../../../../components/layout';
-import { Card } from '../../../../components/ui/Card';
-import { ConsoleRow } from './components/ConsoleRow';
-import { OverviewBar } from './components/OverviewBar';
-import { SystemConfigSection } from './components/SystemConfigSection';
-import { ServerSection } from './components/ServerSection';
-import { BlockchainSection } from './components/BlockchainSection';
-import { WebSocketsSection } from './components/WebSocketsSection';
-import { MongoSection } from './components/MongoSection';
-import { ClickHouseSection } from './components/ClickHouseSection';
+import { cookies } from 'next/headers';
+import type { MenuNodeSerialized } from '@/shared';
+import { getServerSideApiUrl } from '../../../../lib/api-url';
+import { SystemAdminClient } from './SystemAdminClient';
+
+/** Namespace holding the page's tab nodes; registered in bootstrap. */
+const SUBMENU_NAMESPACE = 'system';
 
 /**
- * Consolidated System admin page — mission-control redesign.
+ * Fetch the submenu namespace tree, forwarding cookies so the admin gating
+ * resolves. Degrades to an empty tree on any failure — the page still renders,
+ * just without the tab row until a live `menu:update` refetch repopulates it.
  *
- * The OverviewBar at the top runs its own light polling so admins see
- * live state across all five subsystems even with every console row
- * collapsed. Below the bar, ConsoleRow sections collapse to a single
- * thin line apiece (status dot + caps title + monospace summary) and
- * defer their own data fetching until expanded — preserving the
- * "no API storm on page load" guarantee from the previous design.
+ * @returns The namespace root nodes and the tree snapshot timestamp.
  */
-export default function SystemAdminPage() {
-    return (
-        <Page>
-            <Stack gap="sm">
-                <OverviewBar />
-                <Card padding="sm" noBackgroundImage>
-                    <ConsoleRow id="config" title="Configuration" status="idle">
-                        <SystemConfigSection />
-                    </ConsoleRow>
-                    <ConsoleRow id="server" title="Server" status="idle">
-                        <ServerSection />
-                    </ConsoleRow>
-                    <ConsoleRow id="blockchain" title="Blockchain" status="idle">
-                        <BlockchainSection />
-                    </ConsoleRow>
-                    <ConsoleRow id="websockets" title="WebSockets" status="idle">
-                        <WebSocketsSection />
-                    </ConsoleRow>
-                    <ConsoleRow id="mongo" title="MongoDB" status="idle">
-                        <MongoSection />
-                    </ConsoleRow>
-                    <ConsoleRow id="clickhouse" title="ClickHouse" status="idle">
-                        <ClickHouseSection />
-                    </ConsoleRow>
-                </Card>
-            </Stack>
-        </Page>
-    );
+async function fetchSubmenu(): Promise<{ roots: MenuNodeSerialized[]; generatedAt: string }> {
+    const fallback = { roots: [] as MenuNodeSerialized[], generatedAt: new Date().toISOString() };
+    try {
+        const cookieHeader = (await cookies()).toString();
+        const response = await fetch(`${getServerSideApiUrl()}/api/menu?namespace=${SUBMENU_NAMESPACE}`, {
+            cache: 'no-store',
+            headers: cookieHeader ? { Cookie: cookieHeader } : undefined
+        });
+        if (!response.ok) {
+            return fallback;
+        }
+        const data = await response.json() as { tree?: { roots?: MenuNodeSerialized[]; generatedAt?: string } };
+        return {
+            roots: data.tree?.roots ?? [],
+            generatedAt: data.tree?.generatedAt ?? fallback.generatedAt
+        };
+    } catch {
+        return fallback;
+    }
+}
+
+/**
+ * System admin page (server entry).
+ *
+ * @param props - Next.js route props.
+ * @param props.searchParams - The `?tab=` deep link (a Promise in Next.js 15+),
+ *   read SSR-first to seed the initially active panel.
+ * @returns The client shell seeded with the SSR-fetched submenu tree.
+ */
+export default async function SystemAdminPage({
+    searchParams
+}: {
+    searchParams: Promise<{ tab?: string }>;
+}) {
+    const { roots, generatedAt } = await fetchSubmenu();
+    const { tab } = await searchParams;
+    return <SystemAdminClient submenuTree={roots} submenuGeneratedAt={generatedAt} initialTab={tab} />;
 }


### PR DESCRIPTION
Introduces a core `providers` module owning external-provider configuration, switches price-history to a TronScan-backed provider, and refactors the System admin page into tabs.

## Providers module
A new non-toggleable module that owns external-provider config: a `ProviderConfigService` and a `TronScanClient` singleton, an admin API, and a `/system/system` → Providers surface for editing key/source/enable. It inits before price-history so those singletons exist when the price provider reads them.

## Price-history provider switch
The active `IPriceHistoryProvider` moves from CoinGecko to `TronScanPriceHistoryProvider` (TRX-only) — it fills the seed window and each forward append from a single `/api/trx/volume` call with no keyless history wall. The CoinGecko provider is retained behind the seam for future token coverage. Token assets resolve seeded-but-empty until a token source exists.

## System page refactor
The System admin page splits into Overview and Providers tabs via the menu Submenu Pattern: a dedicated `system` menu namespace with per-node `requiresAdmin`, fetched SSR-first and rendered with the submenu nav.