### PR TITLE
feat(account-history): add admin history reset and address-label enrichment

### DIFF
--- a/packages/types/src/account-history/IAccountHistoryService.ts
+++ b/packages/types/src/account-history/IAccountHistoryService.ts
@@ -486,6 +486,18 @@ export interface IAccountHistoryService {
     removeTrackedAccount(address: string): Promise<void>;
 
     /**
+     * Delete all stored history for a tracked account and requeue it for a fresh
+     * backfill. Purges the account's ClickHouse rows (transactions, value legs,
+     * balance snapshots, token balances) and replaces its progress record with a
+     * zeroed `queued` one, so the next ingestion tick re-walks the full history
+     * from scratch. The tracked-account record (label, pause state) is kept.
+     * Irreversible — the operator's remedy for a corrupted or partial backfill.
+     *
+     * @param address - Base58 address whose history to reset; must be tracked.
+     */
+    resetAccountHistory(address: string): Promise<void>;
+
+    /**
      * Pause or resume a single account's backfill without removing it. A paused
      * account keeps its cursor so it resumes exactly where it left off.
      *

--- a/src/backend/modules/account-history/README.md
+++ b/src/backend/modules/account-history/README.md
@@ -63,6 +63,7 @@ Each of the first three sources has its own cursor; an account is marked `comple
 |--------|---------|
 | `addTrackedAccount({ address, label? })` | Begin tracking (idempotent on address) |
 | `removeTrackedAccount(address)` | Stop tracking; retains stored history |
+| `resetAccountHistory(address)` | Purge all stored ClickHouse rows for one tracked account (transactions, value legs, snapshots) and requeue a fresh backfill; keeps the tracked record. Refused mid-tick |
 | `setAccountPaused(address, paused)` | Pause/resume one account, preserving its cursor |
 | `listTrackedAccounts()` | The tracked set, oldest first |
 | `getSettings()` / `updateSettings(patch)` | Read / merge pacing (`ingestionEnabled`, `pagesPerTick`, `accountsPerTick`) |
@@ -92,6 +93,7 @@ Consume from a plugin via `context.services.watch('account-history', ...)`; from
 | GET/POST | `/api/admin/system/account-history/accounts` | List / add tracked accounts |
 | GET | `/api/admin/system/account-history/accounts/:address/transactions` | Paged history |
 | PATCH | `/api/admin/system/account-history/accounts/:address/paused` | Pause/resume |
+| POST | `/api/admin/system/account-history/accounts/:address/reset` | Delete all stored history and requeue a fresh backfill |
 | DELETE | `/api/admin/system/account-history/accounts/:address` | Stop tracking |
 
 ## User Endpoints (`requireLogin`)

--- a/src/backend/modules/account-history/api/account-history-user.controller.ts
+++ b/src/backend/modules/account-history/api/account-history-user.controller.ts
@@ -19,6 +19,24 @@ import type {
 } from '@/types';
 
 /**
+ * Minimal structural view of the optional `'address-labels'` registry service
+ * (published by the trp-address-labels plugin). Core cannot depend on a
+ * plugin's types package — that would invert the dependency direction — so the
+ * controller declares only the one method it consumes and duck-types against
+ * whatever implementation the registry currently holds.
+ */
+interface IAddressLabelResolver {
+    /**
+     * Batch-resolve human-friendly labels for many addresses; unlabeled
+     * addresses are omitted from the returned map.
+     *
+     * @param addresses - TRON base58 addresses to resolve.
+     * @returns Map of address → resolved label record.
+     */
+    resolveMany(addresses: string[]): Promise<Map<string, { label: string }>>;
+}
+
+/**
  * Login-gated controller exposing a user's own wallet backfill progress.
  */
 export class AccountHistoryUserController {
@@ -100,7 +118,10 @@ export class AccountHistoryUserController {
             }
 
             const summary = await this.service.getWalletSummary(address);
-            res.json({ summary });
+            const labels = await this.resolveLabels(
+                summary.counterparties.map((counterparty) => counterparty.address)
+            );
+            res.json({ summary, labels });
         } catch (error) {
             this.logger.error({ error }, 'Failed to read wallet summary');
             res.status(500).json({
@@ -138,7 +159,10 @@ export class AccountHistoryUserController {
             const limit = Number.isNaN(rawLimit) ? undefined : rawLimit;
             const offset = Number.isNaN(rawOffset) ? undefined : rawOffset;
             const page = await this.service.getTransactions({ address, limit, offset });
-            res.json(page);
+            const labels = await this.resolveLabels(
+                page.transactions.flatMap((tx) => [tx.from?.address ?? '', tx.to?.address ?? ''])
+            );
+            res.json({ ...page, labels });
         } catch (error) {
             this.logger.error({ error }, 'Failed to read wallet transactions');
             res.status(500).json({
@@ -147,6 +171,35 @@ export class AccountHistoryUserController {
             });
         }
     };
+
+    /**
+     * Resolve human-friendly labels for a set of addresses through the optional
+     * `'address-labels'` registry service. The wallet detail surfaces render
+     * counterparty addresses; labeling known entities (exchanges, pools) makes
+     * the feed legible. Resolution is best-effort by design — the plugin may be
+     * disabled, so any failure degrades to an empty map and the UI falls back
+     * to truncated addresses rather than the request failing.
+     *
+     * @param addresses - Candidate base58 addresses (blanks and duplicates tolerated).
+     * @returns Plain address → label record, empty when unavailable.
+     */
+    private async resolveLabels(addresses: string[]): Promise<Record<string, string>> {
+        let labels: Record<string, string> = {};
+        try {
+            const resolver = this.serviceRegistry.get<IAddressLabelResolver>('address-labels');
+            const unique = [...new Set(addresses.filter((address) => address.length > 0))];
+            if (resolver && unique.length > 0) {
+                const resolved = await resolver.resolveMany(unique);
+                labels = Object.fromEntries(
+                    [...resolved.entries()].map(([address, entry]) => [address, entry.label])
+                );
+            }
+        } catch (error) {
+            this.logger.warn({ error }, 'Address label resolution failed; returning unlabeled addresses');
+            labels = {};
+        }
+        return labels;
+    }
 
     /**
      * Confirm the caller verified the given wallet. Resolves the identity

--- a/src/backend/modules/account-history/api/account-history.controller.ts
+++ b/src/backend/modules/account-history/api/account-history.controller.ts
@@ -62,6 +62,20 @@ export class AccountHistoryController {
     };
 
     /**
+     * POST /accounts/:address/reset — delete all stored history for a tracked
+     * account and requeue it for a fresh backfill. Irreversible; the tracked
+     * record itself is kept.
+     */
+    resetAccountHistory = async (req: Request, res: Response): Promise<void> => {
+        try {
+            await this.service.resetAccountHistory(req.params.address);
+            res.status(204).end();
+        } catch (error) {
+            this.fail(res, 400, 'Failed to reset account history', error);
+        }
+    };
+
+    /**
      * PATCH /accounts/:address/paused — pause or resume one account. Body: `{ paused }`.
      */
     setAccountPaused = async (req: Request, res: Response): Promise<void> => {

--- a/src/backend/modules/account-history/api/account-history.routes.ts
+++ b/src/backend/modules/account-history/api/account-history.routes.ts
@@ -29,6 +29,7 @@ export function createAccountHistoryRouter(controller: AccountHistoryController)
     router.post('/accounts', controller.addTrackedAccount);
     router.get('/accounts/:address/transactions', controller.getTransactions);
     router.patch('/accounts/:address/paused', controller.setAccountPaused);
+    router.post('/accounts/:address/reset', controller.resetAccountHistory);
     router.delete('/accounts/:address', controller.removeTrackedAccount);
 
     return router;

--- a/src/backend/modules/account-history/services/account-history.service.ts
+++ b/src/backend/modules/account-history/services/account-history.service.ts
@@ -312,6 +312,64 @@ export class AccountHistoryService implements IAccountHistoryService {
     }
 
     /**
+     * Delete all stored history for a tracked account and requeue it for a fresh
+     * backfill. Purges the account's rows from every ClickHouse table the module
+     * owns, then replaces the progress record with a zeroed `queued` one so the
+     * next ingestion tick starts the walk from scratch. The tracked-account
+     * record (label, pause brake) is kept.
+     *
+     * ClickHouse rows are deleted before the progress reset: if a table purge
+     * fails mid-way the cursors are untouched, the operator retries, and the
+     * remaining deletes re-run idempotently. Refused while a tick is running —
+     * a concurrent walk would re-persist its in-memory cursors after the reset
+     * and resume mid-history against an emptied table.
+     *
+     * The interpolated address is safe: it has passed {@link TRON_ADDRESS_PATTERN}
+     * (base58 charset only — no quotes or escapes), and `IClickHouseService.exec`
+     * carries no parameter binding for the lightweight DELETE statement.
+     *
+     * @param address - Base58 address whose history to reset; must be tracked.
+     */
+    public async resetAccountHistory(address: string): Promise<void> {
+        const normalized = String(address ?? '').trim();
+        if (!TRON_ADDRESS_PATTERN.test(normalized)) {
+            throw new Error('address must be a base58 TRON address (T...)');
+        }
+        const tracked = await this.database
+            .getCollection<ITrackedAccountDoc>(TRACKED_COLLECTION)
+            .findOne({ address: normalized });
+        if (!tracked) {
+            throw new Error(`account ${normalized} is not tracked`);
+        }
+        if (this.ticking || this.forwardTicking) {
+            throw new Error('an ingestion tick is currently running — retry once it finishes');
+        }
+
+        if (this.clickhouse) {
+            const tables = [TRANSACTIONS_TABLE, VALUE_TRANSFERS_TABLE, BALANCE_SNAPSHOTS_TABLE, TOKEN_BALANCES_TABLE];
+            for (const table of tables) {
+                await this.clickhouse.exec(`DELETE FROM ${table} WHERE account = '${normalized}'`);
+            }
+        }
+
+        // Replace (not patch) so every cursor, watermark, completion flag, and
+        // snapshot marker is dropped in one write; only the pause brake carries over.
+        await this.database.getCollection<IAccountProgressDoc>(PROGRESS_COLLECTION).replaceOne(
+            { address: normalized },
+            {
+                address: normalized,
+                status: tracked.paused ? 'paused' : 'queued',
+                rowsIngested: 0,
+                paused: Boolean(tracked.paused)
+            },
+            { upsert: true }
+        );
+
+        this.logger.info({ address: normalized }, 'Account-history reset — stored history purged and backfill requeued');
+        await this.broadcastStats();
+    }
+
+    /**
      * Pause or resume one account without removing it; the cursor is preserved so
      * a resumed account continues from where it stopped.
      *

--- a/src/frontend/app/(core)/system/account-history/AccountsTab.tsx
+++ b/src/frontend/app/(core)/system/account-history/AccountsTab.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useState, useCallback } from 'react';
-import { Plus, Play, Trash2, Pause, PlayCircle, RefreshCw } from 'lucide-react';
+import { Plus, Play, Trash2, Pause, PlayCircle, RefreshCw, RotateCcw } from 'lucide-react';
 import { Stack } from '../../../../components/layout';
 import { Button } from '../../../../components/ui/Button';
 import { Badge } from '../../../../components/ui/Badge';
@@ -23,6 +23,7 @@ import { useToast } from '../../../../components/ui/ToastProvider';
 import {
     addTrackedAccount,
     removeTrackedAccount,
+    resetAccountHistory,
     setAccountPaused,
     runIngestion,
     runForwardSync,
@@ -82,6 +83,31 @@ export function AccountsTab({ stats, onChanged }: { stats: IAccountHistoryStatsV
             onChanged();
         } catch (err) {
             push({ tone: 'danger', title: 'Failed to remove account', description: err instanceof Error ? err.message : String(err) });
+        }
+    }, [onChanged, push]);
+
+    /**
+     * Purge all stored history for one account and requeue its backfill, after
+     * an explicit confirmation — the delete is irreversible and the re-ingest
+     * costs real TronGrid budget, so a stray click must not trigger it.
+     *
+     * @param addr - Base58 address whose history to reset.
+     */
+    const reset = useCallback(async (addr: string) => {
+        const confirmed = window.confirm(
+            `Delete ALL stored history for ${addr} and re-ingest from scratch?\n\n` +
+            'This removes the account\'s transactions, value ledger, and balance snapshots, ' +
+            'then requeues the backfill to start fresh. This cannot be undone.'
+        );
+        if (!confirmed) {
+            return;
+        }
+        try {
+            await resetAccountHistory(addr);
+            push({ tone: 'success', title: 'Account history reset', description: 'Stored history purged — backfill requeued from scratch.' });
+            onChanged();
+        } catch (err) {
+            push({ tone: 'danger', title: 'Failed to reset account history', description: err instanceof Error ? err.message : String(err) });
         }
     }, [onChanged, push]);
 
@@ -209,6 +235,14 @@ export function AccountsTab({ stats, onChanged }: { stats: IAccountHistoryStatsV
                                                 >
                                                     {account.paused ? <PlayCircle size={14} /> : <Pause size={14} />}
                                                     {account.paused ? 'Resume' : 'Pause'}
+                                                </Button>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="xs"
+                                                    onClick={() => { void reset(account.address); }}
+                                                    aria-label="Reset account history"
+                                                >
+                                                    <RotateCcw size={14} /> Reset
                                                 </Button>
                                                 <Button
                                                     variant="ghost"

--- a/src/frontend/modules/account-history/api/client.ts
+++ b/src/frontend/modules/account-history/api/client.ts
@@ -157,6 +157,19 @@ export async function removeTrackedAccount(address: string): Promise<void> {
 }
 
 /**
+ * Delete all stored history for a tracked account and requeue it for a fresh
+ * backfill. Irreversible — the automated backfill re-walks the account's full
+ * history from scratch on subsequent ingestion ticks. The tracked record
+ * (label, pause state) is kept.
+ *
+ * @param address - Base58 address whose history to reset.
+ * @returns Resolves when the reset completes.
+ */
+export async function resetAccountHistory(address: string): Promise<void> {
+    await parse(await fetch(`${BASE}/accounts/${encodeURIComponent(address)}/reset`, { method: 'POST' }), 'reset account history');
+}
+
+/**
  * Pause or resume one account's backfill.
  *
  * @param address - Base58 address.

--- a/src/frontend/modules/user/api/account-history-user.api.ts
+++ b/src/frontend/modules/user/api/account-history-user.api.ts
@@ -14,17 +14,44 @@ import type { IAccountTransactionPage, IWalletActivitySummary } from '@/types';
 import { parseJsonResponse } from './http';
 
 /**
+ * Address → human-friendly label map the backend resolves through the
+ * optional address-labels service. May be empty (or missing on older
+ * backends) — callers always fall back to the truncated raw address.
+ */
+export type IAddressLabelMap = Record<string, string>;
+
+/**
+ * The activity summary plus the labels resolved for its counterparty
+ * addresses, so the UI can show entity names instead of raw base58.
+ */
+export interface IWalletSummaryResult {
+    /** The wallet's activity summary. */
+    summary: IWalletActivitySummary;
+    /** Labels for the summary's counterparty addresses (misses omitted). */
+    labels: IAddressLabelMap;
+}
+
+/**
+ * A transaction page plus labels for the from/to addresses it contains.
+ */
+export type IWalletTransactionPage = IAccountTransactionPage & {
+    /** Labels for addresses appearing in the page (misses omitted). */
+    labels?: IAddressLabelMap;
+};
+
+/**
  * Fetch the batched activity summary (heatmap, stats, resources, flow,
- * counterparties) for one wallet the caller owns.
+ * counterparties) for one wallet the caller owns, plus resolved address
+ * labels for its counterparties.
  *
  * @param address - The base58 wallet whose summary to load.
- * @returns The wallet's activity summary.
+ * @returns The wallet's activity summary and counterparty labels.
  */
-export async function fetchWalletSummary(address: string): Promise<IWalletActivitySummary> {
-    const body = await parseJsonResponse<{ summary: IWalletActivitySummary }>(
+export async function fetchWalletSummary(address: string): Promise<IWalletSummaryResult> {
+    const body = await parseJsonResponse<{ summary: IWalletActivitySummary; labels?: IAddressLabelMap }>(
         await fetch(`/api/account-history/me/wallets/${encodeURIComponent(address)}/summary`, { cache: 'no-store' })
     );
-    return body.summary;
+    return { summary: body.summary, labels: body.labels ?? {} };
 }
 
 /**
@@ -33,15 +60,15 @@ export async function fetchWalletSummary(address: string): Promise<IWalletActivi
  * @param address - The base58 wallet whose history to read.
  * @param limit - Page size (the backend clamps to a sane maximum).
  * @param offset - Row offset for pagination.
- * @returns A page of transactions and the total row count.
+ * @returns A page of transactions, the total row count, and address labels.
  */
 export async function fetchWalletTransactions(
     address: string,
     limit: number,
     offset: number
-): Promise<IAccountTransactionPage> {
+): Promise<IWalletTransactionPage> {
     const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
-    const body = await parseJsonResponse<IAccountTransactionPage>(
+    const body = await parseJsonResponse<IWalletTransactionPage>(
         await fetch(`/api/account-history/me/wallets/${encodeURIComponent(address)}/transactions?${params.toString()}`, {
             cache: 'no-store'
         })

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/PortfolioHero.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/PortfolioHero.tsx
@@ -115,6 +115,21 @@ function formatTooltipDay(date: Date): string {
 }
 
 /**
+ * Resolve a human-friendly display name for an asset id (a TRC20 contract
+ * address): prefer the symbol the holdings table already carries for the same
+ * asset, falling back to the truncated contract address so an unknown token
+ * still reads as an address rather than an opaque blob.
+ *
+ * @param summary - The portfolio summary whose holdings carry symbols.
+ * @param asset - The asset id (contract address) to name.
+ * @returns The holding's symbol, or the truncated address.
+ */
+function assetDisplayName(summary: IPortfolioSummary, asset: string): string {
+    const symbol = summary.holdings.find((holding) => holding.asset === asset)?.symbol;
+    return symbol ?? truncateAddress(asset);
+}
+
+/**
  * Props for {@link PortfolioHero}.
  */
 interface IPortfolioHeroProps {
@@ -338,7 +353,7 @@ export function PortfolioHero({ summary }: IPortfolioHeroProps) {
                 {summary.unpricedAssets.length > 0 && (
                     <p className="text-muted">
                         {summary.unpricedAssets.length} held asset{summary.unpricedAssets.length === 1 ? '' : 's'} with no local price, excluded from USD totals
-                        {summary.unpricedAssets.length <= 3 ? ` (${summary.unpricedAssets.map(truncateAddress).join(', ')})` : ''}.
+                        {summary.unpricedAssets.length <= 3 ? ` (${summary.unpricedAssets.map((asset) => assetDisplayName(summary, asset)).join(', ')})` : ''}.
                     </p>
                 )}
             </Stack>

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletCounterparties.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletCounterparties.tsx
@@ -10,10 +10,8 @@
 import { Users } from 'lucide-react';
 import type { IWalletCounterparty } from '@/types';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
-import { Tooltip } from '../../../../../components/ui/Tooltip';
-import { WalletDetailSection } from './WalletDetailPrimitives';
-import { formatCount, formatTrxFromSun, truncateAddress } from '../../../lib/walletFormat';
-import styles from './WalletDetail.module.scss';
+import { AddressDisplay, WalletDetailSection } from './WalletDetailPrimitives';
+import { formatCount, formatTrxFromSun } from '../../../lib/walletFormat';
 
 /**
  * Props for {@link WalletCounterparties}.
@@ -21,6 +19,8 @@ import styles from './WalletDetail.module.scss';
 interface IWalletCounterpartiesProps {
     /** Top counterparties for the wallet, most-frequent first. */
     counterparties: IWalletCounterparty[];
+    /** Address → human-friendly label map resolved by the backend (misses omitted). */
+    labels?: Record<string, string>;
 }
 
 /**
@@ -29,7 +29,7 @@ interface IWalletCounterpartiesProps {
  * @param props - {@link IWalletCounterpartiesProps}.
  * @returns The counterparties section.
  */
-export function WalletCounterparties({ counterparties }: IWalletCounterpartiesProps) {
+export function WalletCounterparties({ counterparties, labels }: IWalletCounterpartiesProps) {
     return (
         <WalletDetailSection icon={<Users size={16} aria-hidden />} title="Top counterparties">
             {counterparties.length === 0 ? (
@@ -48,9 +48,10 @@ export function WalletCounterparties({ counterparties }: IWalletCounterpartiesPr
                         {counterparties.map((counterparty) => (
                             <Tr key={counterparty.address}>
                                 <Td>
-                                    <Tooltip content={counterparty.address}>
-                                        <span className={styles.address}>{truncateAddress(counterparty.address)}</span>
-                                    </Tooltip>
+                                    <AddressDisplay
+                                        address={counterparty.address}
+                                        label={labels?.[counterparty.address]}
+                                    />
                                 </Td>
                                 <Td>{formatCount(counterparty.txCount)}</Td>
                                 <Td muted>{formatTrxFromSun(counterparty.trxSentSun)}</Td>

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetail.module.scss
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetail.module.scss
@@ -158,6 +158,23 @@
     font-size: var(--font-size-body-sm);
 }
 
+/* Resolved address label — a human name (exchange, pool), so regular type
+   rather than the monospace address treatment. */
+.address_label {
+    font-size: var(--font-size-body-sm);
+    font-weight: var(--font-weight-medium);
+}
+
+/* Feed data columns (amount / counterparty / when / status). On non-mobile
+   container widths keep them on one line so the expanding Action column
+   absorbs the slack and rows stay one line tall; narrow containers keep
+   wrapping to avoid forcing horizontal scroll. */
+@container wallet-detail (min-width: #{$breakpoint-mobile-lg}) {
+    .feed_cell {
+        white-space: nowrap;
+    }
+}
+
 .feed_footer {
     display: flex;
     align-items: center;

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetailPanel.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetailPanel.tsx
@@ -19,7 +19,7 @@ import type { IAccountIngestionProgress, IWalletActivitySummary } from '@/types'
 import { Stack } from '../../../../../components/layout';
 import { Skeleton } from '../../../../../components/ui/Skeleton';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
-import { fetchWalletSummary } from '../../../api/account-history-user.api';
+import { fetchWalletSummary, type IAddressLabelMap } from '../../../api/account-history-user.api';
 import { describeHistoryStatus } from '../../../lib/walletHistoryStatus';
 import { formatCount } from '../../../lib/walletFormat';
 import { WalletActivityStats } from './WalletActivityStats';
@@ -118,6 +118,7 @@ function WalletSyncNotice({ progress }: { progress?: IAccountIngestionProgress }
 export function WalletDetailPanel({ address, progress }: IWalletDetailPanelProps) {
     const [tab, setTab] = useState<DetailTab>('overview');
     const [summary, setSummary] = useState<IWalletActivitySummary | null>(null);
+    const [summaryLabels, setSummaryLabels] = useState<IAddressLabelMap>({});
     const [summaryLoading, setSummaryLoading] = useState(false);
     const [summaryError, setSummaryError] = useState<string | null>(null);
 
@@ -132,6 +133,7 @@ export function WalletDetailPanel({ address, progress }: IWalletDetailPanelProps
         setPrevAddress(address);
         setTab('overview');
         setSummary(null);
+        setSummaryLabels({});
         setSummaryError(null);
     }
 
@@ -149,7 +151,8 @@ export function WalletDetailPanel({ address, progress }: IWalletDetailPanelProps
         fetchWalletSummary(address)
             .then((result) => {
                 if (active) {
-                    setSummary(result);
+                    setSummary(result.summary);
+                    setSummaryLabels(result.labels);
                 }
             })
             .catch((cause: unknown) => {
@@ -207,7 +210,7 @@ export function WalletDetailPanel({ address, progress }: IWalletDetailPanelProps
                             <WalletActivityCalendar calendar={summary.calendar} />
                             <WalletResourcePanel resources={summary.resources} />
                             <WalletFlowChart flow={summary.flow} />
-                            <WalletCounterparties counterparties={summary.counterparties} />
+                            <WalletCounterparties counterparties={summary.counterparties} labels={summaryLabels} />
                         </>
                     )
                 )}

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetailPrimitives.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetailPrimitives.tsx
@@ -13,6 +13,8 @@
 
 import type { ReactNode } from 'react';
 import { Card } from '../../../../../components/ui/Card';
+import { Tooltip } from '../../../../../components/ui/Tooltip';
+import { truncateAddress } from '../../../lib/walletFormat';
 import styles from './WalletDetail.module.scss';
 
 /**
@@ -42,6 +44,35 @@ export function WalletDetailSection({ icon, title, children }: IWalletDetailSect
             </div>
             {children}
         </Card>
+    );
+}
+
+/**
+ * Props for {@link AddressDisplay}.
+ */
+interface IAddressDisplayProps {
+    /** The full base58 address. */
+    address: string;
+    /** Human-friendly label resolved by the address-labels service, if any. */
+    label?: string;
+}
+
+/**
+ * Render a TRON address label-first: when the backend resolved a human-friendly
+ * name (an exchange, a pool) show that name, otherwise the truncated monospace
+ * address. The full address always lives in the tooltip so labeling never
+ * hides the underlying identity users may need to verify.
+ *
+ * @param props - {@link IAddressDisplayProps}.
+ * @returns The labeled or truncated address with a full-address tooltip.
+ */
+export function AddressDisplay({ address, label }: IAddressDisplayProps) {
+    return (
+        <Tooltip content={address}>
+            {label
+                ? <span className={styles.address_label}>{label}</span>
+                : <span className={styles.address}>{truncateAddress(address)}</span>}
+        </Tooltip>
     );
 }
 

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletTransactionFeed.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletTransactionFeed.tsx
@@ -15,17 +15,15 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { ListOrdered } from 'lucide-react';
-import type { IAccountTransactionPage, IBlockTransaction } from '@/types';
+import type { IBlockTransaction } from '@/types';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
 import { Badge } from '../../../../../components/ui/Badge';
 import { Skeleton } from '../../../../../components/ui/Skeleton';
-import { Tooltip } from '../../../../../components/ui/Tooltip';
 import { Pagination } from '../../../../../components/ui/Pagination';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
-import { WalletDetailSection } from './WalletDetailPrimitives';
-import { fetchWalletTransactions } from '../../../api/account-history-user.api';
+import { AddressDisplay, WalletDetailSection } from './WalletDetailPrimitives';
+import { fetchWalletTransactions, type IWalletTransactionPage } from '../../../api/account-history-user.api';
 import { decodeTronTransaction } from '../../../lib/decodeTronTransaction';
-import { truncateAddress } from '../../../lib/walletFormat';
 import styles from './WalletDetail.module.scss';
 
 /** Rows per page in the feed. */
@@ -83,7 +81,7 @@ function counterpartyOf(tx: IBlockTransaction, wallet: string, direction: string
  * @returns The transaction feed section.
  */
 export function WalletTransactionFeed({ address }: IWalletTransactionFeedProps) {
-    const [page, setPage] = useState<IAccountTransactionPage | null>(null);
+    const [page, setPage] = useState<IWalletTransactionPage | null>(null);
     const [offset, setOffset] = useState(0);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -131,6 +129,7 @@ export function WalletTransactionFeed({ address }: IWalletTransactionFeedProps) 
 
     const total = page?.total ?? 0;
     const transactions = page?.transactions ?? [];
+    const labels = page?.labels ?? {};
     const rangeStart = total === 0 ? 0 : offset + 1;
     const rangeEnd = Math.min(offset + PAGE_SIZE, total);
     const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
@@ -179,6 +178,7 @@ export function WalletTransactionFeed({ address }: IWalletTransactionFeedProps) 
                                         amount={decoded.amount || '—'}
                                         amountClass={amountClass}
                                         counterparty={counterparty}
+                                        counterpartyLabel={counterparty ? labels[counterparty] : undefined}
                                         timestamp={tx.timestamp}
                                         status={tx.status}
                                     />
@@ -217,6 +217,8 @@ interface ITransactionRowsProps {
     amountClass?: string;
     /** Counterparty base58 address, or empty. */
     counterparty: string;
+    /** Human-friendly label for the counterparty, when the label service knows it. */
+    counterpartyLabel?: string;
     /** Row timestamp. */
     timestamp: IBlockTransaction['timestamp'];
     /** Transaction status. */
@@ -231,7 +233,7 @@ interface ITransactionRowsProps {
  * @param props - {@link ITransactionRowsProps}.
  * @returns The (optional header +) transaction row.
  */
-function TransactionRows({ dayHeader, label, amount, amountClass, counterparty, timestamp, status }: ITransactionRowsProps) {
+function TransactionRows({ dayHeader, label, amount, amountClass, counterparty, counterpartyLabel, timestamp, status }: ITransactionRowsProps) {
     return (
         <>
             {dayHeader && (
@@ -243,16 +245,14 @@ function TransactionRows({ dayHeader, label, amount, amountClass, counterparty, 
             )}
             <Tr>
                 <Td>{label}</Td>
-                <Td className={amountClass}>{amount}</Td>
-                <Td>
+                <Td className={amountClass ? `${amountClass} ${styles.feed_cell}` : styles.feed_cell}>{amount}</Td>
+                <Td className={styles.feed_cell}>
                     {counterparty ? (
-                        <Tooltip content={counterparty}>
-                            <span className={styles.address}>{truncateAddress(counterparty)}</span>
-                        </Tooltip>
+                        <AddressDisplay address={counterparty} label={counterpartyLabel} />
                     ) : '—'}
                 </Td>
-                <Td muted><ClientTime date={timestamp} format="datetime" /></Td>
-                <Td>
+                <Td muted className={styles.feed_cell}><ClientTime date={timestamp} format="datetime" /></Td>
+                <Td className={styles.feed_cell}>
                     <Badge tone={status === 'SUCCESS' ? 'success' : 'danger'}>{status}</Badge>
                 </Td>
             </Tr>


### PR DESCRIPTION
## Summary

Two related account-history changes:

**Admin history reset.** Adds `resetAccountHistory` to `IAccountHistoryService`, a controller action, and a `POST /accounts/:address/reset` admin route. It purges an account's ClickHouse rows (transactions, value legs, balance snapshots, token balances) and replaces its progress record with a zeroed `queued` one, so the next ingestion tick re-walks the full history from scratch. The tracked-account record (label, pause state) is kept. Irreversible — the operator's remedy for a corrupted or partial backfill.

**Address-label enrichment.** Wallet summary and transaction responses now carry best-effort address labels resolved through the optional `'address-labels'` registry service (published by trp-address-labels). Core duck-types the resolver rather than depending on the plugin's types package. Resolution is best-effort: a disabled plugin or any failure degrades to unlabeled addresses. The wallet detail counterparty list and transaction feed render the labels, falling back to truncated addresses.