### PR TITLE
feat(frontend): wildcard plugin page routes with per-URL SEO metadata

### DIFF
--- a/docs/plugins/plugins-page-registration-pages.md
+++ b/docs/plugins/plugins-page-registration-pages.md
@@ -25,14 +25,19 @@ export const myFrontendPlugin = definePlugin({
 });
 ```
 
+## Wildcard Routes
+
+A `path` ending in `/*` (e.g. `'/blog/*'`) registers a wildcard page owning every strictly deeper URL — the mechanism behind per-resource plugin pages like `/blog/my-post`. `/blog/*` matches `/blog/my-post` and `/blog/2026/recap` but never `/blog` itself; register the index page's exact path separately. Exact registrations beat wildcards, and the longest wildcard prefix wins among overlaps. Both `serverDataFetcher` and `serverMetadataFetcher` receive the concrete requested URL as `ctx.path`, so the fetcher derives its route parameter by stripping the declared prefix. Per-URL SEO comes from `serverMetadataFetcher` — see [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md#servermetadatafetcher-pattern).
+
 ## IPageConfig Fields
 
 | Field | Purpose |
 |-------|---------|
-| `path` | URL route; must match backend menu `url` exactly |
+| `path` | URL route; must match backend menu `url` exactly. A trailing `/*` registers a wildcard route (see [Wildcard Routes](#wildcard-routes)) |
 | `component` | React component receiving `{ context, initialData }` |
 | `title`, `description`, `keywords`, `ogImage`, `ogType`, `canonical`, `noindex`, `structuredData` | SEO metadata — see [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md) |
 | `serverDataFetcher` | Async hook returning `initialData` for SSR — see [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md) |
+| `serverMetadataFetcher` | Async hook computing per-URL SEO metadata for wildcard pages; `null` return means the resource does not exist (404 + noindex) — see [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md#servermetadatafetcher-pattern) |
 | `requiresAuth` | Authentication required (declarative; enforce in component) |
 | `requiresAdmin` | Admin required (declarative; admin pages auto-enforce — see [plugins-page-registration-admin.md](./plugins-page-registration-admin.md)) |
 

--- a/docs/plugins/plugins-seo-and-ssr.md
+++ b/docs/plugins/plugins-seo-and-ssr.md
@@ -49,8 +49,19 @@ serverDataFetcher?: (ctx: IServerDataContext) => Promise<unknown>;
 |-------|-------------|
 | `apiBaseUrl` | Backend API base URL with `/api` suffix (Docker-internal in containers, localhost otherwise) |
 | `siteUrl` | Public site URL from runtime config |
+| `path` | The concrete URL being rendered (e.g. `/blog/my-post`) — essential for wildcard pages, whose registered path (`/blog/*`) doesn't identify the resource |
 
 The returned data **must be JSON-serializable** because it crosses the React Server Components boundary. Functions, class instances, Maps, Sets, and component references will fail. Stick to plain objects, arrays, strings, numbers, booleans, and `null`.
+
+## serverMetadataFetcher Pattern
+
+Static SEO fields describe a page fixed at registration time. A wildcard page renders a different resource per URL, so its `<head>` must be computed per request. The optional `serverMetadataFetcher` runs during SSR before rendering; its returned fields (same shape as the static SEO fields, `IPluginPageMetadata`) override the static ones field by field.
+
+```typescript
+serverMetadataFetcher?: (ctx: IServerDataContext) => Promise<IPluginPageMetadata | null>;
+```
+
+The return value carries a contract with teeth: return `null` **only** when the backend authoritatively reported the resource absent (HTTP 404) — the catch-all then emits noindex metadata and renders a 404. Throw on transient failures instead; thrown errors are caught and the route falls back to the static fields, so a brief backend outage never serves 404s to crawlers. The catch-all invokes the fetcher once per request (shared between `generateMetadata` and the body via `React.cache()`), so a fetcher and a `serverDataFetcher` hitting the same URL cost one backend call under Next's fetch dedupe.
 
 ## Canonical Example: bazi-fortune
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delphian/tronrelic-types",
-  "version": "4.24.0",
+  "version": "4.25.0",
   "description": "Core type definitions for the TronRelic platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -141,6 +141,8 @@ export type {
     IContentClassification,
     IContentSink,
     IContentSinkInfo,
+    IContentSinkRefusal,
+    IContentDeliveryContext,
     ContentDescriptorFeature,
     ContentSinkKind,
     ContentSinkDisposer,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,6 @@
 export type { Block } from './Block.js';
 export type { IBaseObserver, IBaseBatchObserver, TransactionBatches, IBaseBlockObserver, IBlockData, IBlockchainObserverService, IWebSocketService, IPluginContext, IObserverStats, IPluginWebSocketManager, PluginSubscriptionHandler, PluginUnsubscribeHandler, IPluginWebSocketStats, IAggregatePluginWebSocketStats } from './observer/index.js';
-export type { IPlugin, IPluginManifest, IAdminUIConfig, IApiRouteConfig, HttpMethod, ApiRouteHandler, ApiMiddleware, IMenuItemConfig, IPageConfig, IPluginMetadata, IPluginManagementRequest, IPluginManagementResponse, IPluginInfo, IFrontendPluginContext, IUIComponents, ILayoutComponents, ISubMenuItem, IChartComponents, ISystemComponents, IApiClient, IWebSocketClient, IPluginUserState } from './plugin/index.js';
+export type { IPlugin, IPluginManifest, IAdminUIConfig, IApiRouteConfig, HttpMethod, ApiRouteHandler, ApiMiddleware, IMenuItemConfig, IPageConfig, IServerDataContext, IPluginPageMetadata, IPluginMetadata, IPluginManagementRequest, IPluginManagementResponse, IPluginInfo, IFrontendPluginContext, IUIComponents, ILayoutComponents, ISubMenuItem, IChartComponents, ISystemComponents, IApiClient, IWebSocketClient, IPluginUserState } from './plugin/index.js';
 export { definePlugin } from './plugin/index.js';
 export type { ITransaction, ITransactionPersistencePayload, ITransactionCategoryFlags } from './transaction/index.js';
 export { ProcessedTransaction } from './transaction/index.js';

--- a/packages/types/src/plugin/IPageConfig.ts
+++ b/packages/types/src/plugin/IPageConfig.ts
@@ -22,6 +22,51 @@ export interface IServerDataContext {
      * Use this when building absolute URLs in fetched data.
      */
     siteUrl: string;
+
+    /**
+     * The actual URL path being rendered (e.g., '/blog/my-post').
+     *
+     * Essential for wildcard pages, whose registered `path` (e.g. '/blog/*')
+     * does not identify the concrete resource requested — fetchers derive
+     * route parameters by stripping their declared prefix from this value.
+     * Optional so plugins compiled against older core versions (which did not
+     * supply it) still typecheck; current core always populates it.
+     */
+    path?: string;
+}
+
+/**
+ * Dynamic SEO metadata returned by a page's `serverMetadataFetcher`.
+ *
+ * Static `IPageConfig` SEO fields describe a page whose content is fixed at
+ * registration time. A wildcard page renders a different resource per URL, so
+ * its metadata must be computed per request. This shape mirrors the static
+ * fields; values returned here override the corresponding static field.
+ */
+export interface IPluginPageMetadata {
+    /** Page title for <title>, og:title, and twitter:title. */
+    title?: string;
+
+    /** Page description for <meta description>, og:description, and twitter:description. */
+    description?: string;
+
+    /** SEO keywords for <meta name="keywords">. */
+    keywords?: string[];
+
+    /** Open Graph image URL (relative to siteUrl or absolute). */
+    ogImage?: string;
+
+    /** Open Graph type; use 'article' for time-stamped content. */
+    ogType?: 'website' | 'article';
+
+    /** Canonical URL override for search-engine signal consolidation. */
+    canonical?: string;
+
+    /** If true, instructs search engines not to index this page. */
+    noindex?: boolean;
+
+    /** Schema.org JSON-LD injected as a <script type="application/ld+json"> tag. */
+    structuredData?: Record<string, unknown>;
 }
 
 /**
@@ -47,7 +92,17 @@ export interface IPageConfig {
     /** Plugin identifier (set automatically by the registry) */
     pluginId?: string;
 
-    /** URL path (e.g., '/whales', '/my-plugin/settings') */
+    /**
+     * URL path (e.g., '/whales', '/my-plugin/settings').
+     *
+     * A path ending in '/*' registers a wildcard page (e.g. '/blog/*') that
+     * matches any strictly deeper path — '/blog/*' matches '/blog/my-post'
+     * and '/blog/2026/recap' but never '/blog' itself (register '/blog'
+     * separately for the index page). Exact registrations always win over
+     * wildcards; among overlapping wildcards the longest prefix wins.
+     * Wildcard pages should pair `serverDataFetcher`/`serverMetadataFetcher`
+     * with `IServerDataContext.path` to resolve the concrete resource.
+     */
     path: string;
 
     /**
@@ -109,6 +164,24 @@ export interface IPageConfig {
      * ```
      */
     serverDataFetcher?: (ctx: IServerDataContext) => Promise<unknown>;
+
+    /**
+     * Optional async function computing per-request SEO metadata during SSR.
+     *
+     * Static SEO fields cannot describe a wildcard page's concrete resource
+     * (a specific blog post, a specific record), so crawlers would see one
+     * generic title for every URL. When defined, the catch-all route invokes
+     * this before rendering and merges the returned fields over the static
+     * ones for <head> generation.
+     *
+     * Returning `null` is an authoritative "resource not found": the route
+     * emits noindex metadata and renders a 404. Only return `null` when the
+     * backend definitively reported the resource absent (e.g. HTTP 404).
+     * Throw on transient failures instead — thrown errors are caught and the
+     * route falls back to the static fields, so a brief backend outage never
+     * serves 404s to crawlers.
+     */
+    serverMetadataFetcher?: (ctx: IServerDataContext) => Promise<IPluginPageMetadata | null>;
 
     /** Page title for SEO. Used in <title>, og:title, and twitter:title. */
     title?: string;

--- a/packages/types/src/plugin/IPageConfig.ts
+++ b/packages/types/src/plugin/IPageConfig.ts
@@ -142,9 +142,11 @@ export interface IPageConfig {
      * rendering of plugin pages — the data appears in the initial HTML so crawlers
      * see it without executing JavaScript, and users see no loading flash.
      *
-     * The function receives an IServerDataContext containing the backend API URL
-     * and the public site URL, so plugins can fetch from their own backend without
-     * importing frontend internals or hardcoding environment variables.
+     * The function receives an IServerDataContext containing the backend API URL,
+     * the public site URL, and the concrete requested path (`ctx.path` — essential
+     * for wildcard pages to resolve which resource to fetch), so plugins can fetch
+     * from their own backend without importing frontend internals or hardcoding
+     * environment variables.
      *
      * The returned data must be JSON-serializable because it crosses the React
      * Server Components boundary. Functions, class instances, Maps, Sets, and

--- a/packages/types/src/plugin/index.ts
+++ b/packages/types/src/plugin/index.ts
@@ -8,7 +8,7 @@ export type { IPlugin } from './IPlugin.js';
 export type { IPluginManifest } from './IPluginManifest.js';
 export type { IAdminUIConfig } from './IAdminUIConfig.js';
 export type { IMenuItemConfig } from './IMenuItemConfig.js';
-export type { IPageConfig, IServerDataContext } from './IPageConfig.js';
+export type { IPageConfig, IServerDataContext, IPluginPageMetadata } from './IPageConfig.js';
 export type { IApiRouteConfig, HttpMethod, ApiRouteHandler, ApiMiddleware } from './IApiRouteConfig.js';
 export type {
     IPluginMetadata,

--- a/src/backend/modules/pages/database/IPageSettingsDocument.ts
+++ b/src/backend/modules/pages/database/IPageSettingsDocument.ts
@@ -29,5 +29,6 @@ export const DEFAULT_PAGE_SETTINGS: Omit<IPageSettingsDocument, '_id' | 'updated
         '^/accounts$',
         '^/transactions$',
         '^/whales$',
+        '^/blog(/.*)?$',
     ],
 };

--- a/src/backend/modules/pages/migrations/006_add_blog_route_to_blacklist.ts
+++ b/src/backend/modules/pages/migrations/006_add_blog_route_to_blacklist.ts
@@ -1,0 +1,34 @@
+import type { IMigration, IMigrationContext } from '@/types';
+
+/**
+ * Add the `/blog` route family to the custom-page slug blacklist.
+ *
+ * **Why this migration exists**
+ *
+ * The catch-all route resolves custom CMS pages *before* plugin pages, so an
+ * admin creating a CMS page at `/blog` (or any `/blog/...` slug) would
+ * silently shadow the trp-blog plugin's list page and every post URL. The
+ * default settings gained `^/blog(/.*)?$` for fresh installs; this migration
+ * back-fills the same pattern into existing `page_settings` documents.
+ * `$addToSet` keeps the operation idempotent — re-running it never duplicates
+ * the pattern.
+ */
+export const migration: IMigration = {
+    id: '006_add_blog_route_to_blacklist',
+    description: 'Blacklist /blog and /blog/* custom-page slugs (routes owned by the trp-blog plugin)',
+    dependencies: [],
+
+    async up(context: IMigrationContext): Promise<void> {
+        const pageSettings = context.database.getCollection('page_settings');
+
+        const result = await pageSettings.updateMany({}, {
+            $addToSet: {
+                blacklistedRoutes: '^/blog(/.*)?$'
+            }
+        });
+
+        console.log(
+            `[Migration] Added /blog blacklist pattern to ${result.modifiedCount} page_settings document(s)`
+        );
+    }
+};

--- a/src/frontend/app/[...slug]/page.tsx
+++ b/src/frontend/app/[...slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
+import type { IPluginPageMetadata } from '@/types';
 import { cache } from 'react';
 import { Page } from '../../components/layout';
 import { PluginPageWithZones } from '../../components/PluginPageWithZones';
@@ -138,6 +139,49 @@ const resolveSlug = cache(async (slug: string): Promise<ISlugResolution> => {
 });
 
 /**
+ * Outcome of running a plugin page's optional serverMetadataFetcher.
+ *
+ * 'none' — the page declares no fetcher; static IPageConfig fields apply.
+ * 'error' — the fetcher threw (transient backend failure); static fields
+ * apply so a brief outage never serves 404s or blank metadata to crawlers.
+ * null — the fetcher authoritatively reported the resource absent; the route
+ * emits noindex metadata and the body renders a 404.
+ */
+type IMetadataFetchOutcome = IPluginPageMetadata | null | 'none' | 'error';
+
+/**
+ * Run the resolved plugin page's serverMetadataFetcher exactly once per request.
+ *
+ * Wildcard plugin pages (e.g. '/blog/*') compute their SEO metadata per URL,
+ * and both generateMetadata() and the page body need the outcome — the head
+ * for <title>/OG tags, the body to 404 when the fetcher says the resource
+ * doesn't exist. React.cache() shares the single invocation between them,
+ * mirroring how resolveSlug() is shared.
+ *
+ * @param slug - The requested URL path, passed to the fetcher as ctx.path
+ * @returns The fetched metadata, null (authoritative not-found), 'none'
+ *   (no fetcher declared), or 'error' (fetcher threw; use static fields)
+ */
+const runServerMetadataFetcher = cache(async (slug: string): Promise<IMetadataFetchOutcome> => {
+    const resolution = await resolveSlug(slug);
+    let outcome: IMetadataFetchOutcome = 'none';
+    if (resolution.type === 'plugin' && resolution.config.serverMetadataFetcher) {
+        try {
+            const { siteUrl } = await getServerConfig();
+            outcome = await resolution.config.serverMetadataFetcher({
+                apiBaseUrl: getServerSideApiUrlWithPath(),
+                siteUrl,
+                path: slug
+            });
+        } catch (error) {
+            console.error(`[catch-all] serverMetadataFetcher failed for ${slug}:`, error);
+            outcome = 'error';
+        }
+    }
+    return outcome;
+});
+
+/**
  * Generate metadata for the page.
  *
  * Uses resolveSlug() to determine which system owns the URL, then builds
@@ -194,38 +238,63 @@ export async function generateMetadata({ params }: { params: Promise<IPageParams
         const { siteUrl } = await getServerConfig();
         let metadata: Metadata;
 
+        // Dynamic metadata for wildcard pages: a serverMetadataFetcher
+        // computes per-URL SEO fields (a specific blog post's title, not the
+        // page config's generic one). An authoritative not-found emits
+        // noindex here and 404s in the body below; a thrown fetcher error
+        // ('error') falls back to the static fields so a transient backend
+        // outage never blanks metadata or serves 404s to crawlers.
+        const fetched = await runServerMetadataFetcher(slug);
+        if (fetched === null) {
+            return { robots: { index: false, follow: false } };
+        }
+        const dynamic: IPluginPageMetadata = fetched === 'none' || fetched === 'error' ? {} : fetched;
+
+        // Effective SEO fields: dynamic values win over static declarations,
+        // field by field, so a fetcher may override only the title while the
+        // static ogImage still applies.
+        const seo = {
+            title: dynamic.title ?? pluginPage.title,
+            description: dynamic.description ?? pluginPage.description,
+            keywords: dynamic.keywords ?? pluginPage.keywords,
+            ogImage: dynamic.ogImage ?? pluginPage.ogImage,
+            ogType: dynamic.ogType ?? pluginPage.ogType,
+            canonical: dynamic.canonical ?? pluginPage.canonical,
+            noindex: dynamic.noindex ?? pluginPage.noindex
+        };
+
         // When both title and description are present, emit the full SEO
         // bundle via the shared buildMetadata helper (canonical, openGraph,
         // twitter card, keywords). For pages that declare only a subset of
         // fields, fall through to a fields-only path that emits whatever
         // was actually declared. Either way, noindex is honored below
         // independently of which other fields are present.
-        if (pluginPage.title && pluginPage.description) {
+        if (seo.title && seo.description) {
             metadata = buildMetadata({
                 siteUrl,
-                title: pluginPage.title,
-                description: pluginPage.description,
+                title: seo.title,
+                description: seo.description,
                 path: slug,
-                image: pluginPage.ogImage,
-                type: pluginPage.ogType,
-                keywords: pluginPage.keywords,
-                canonical: pluginPage.canonical
+                image: seo.ogImage,
+                type: seo.ogType,
+                keywords: seo.keywords,
+                canonical: seo.canonical
             });
         } else {
             metadata = {};
-            if (pluginPage.title) {
-                metadata.title = pluginPage.title;
+            if (seo.title) {
+                metadata.title = seo.title;
             }
-            if (pluginPage.description) {
-                metadata.description = pluginPage.description;
+            if (seo.description) {
+                metadata.description = seo.description;
             }
-            if (pluginPage.keywords) {
-                metadata.keywords = pluginPage.keywords;
+            if (seo.keywords) {
+                metadata.keywords = seo.keywords;
             }
             // Resolve relative canonical paths against siteUrl so the rendered
             // <link rel="canonical"> and og:url are always absolute.
-            const canonicalUrl = pluginPage.canonical
-                ? absoluteUrl(siteUrl, pluginPage.canonical)
+            const canonicalUrl = seo.canonical
+                ? absoluteUrl(siteUrl, seo.canonical)
                 : undefined;
             if (canonicalUrl) {
                 metadata.alternates = { canonical: canonicalUrl };
@@ -233,19 +302,19 @@ export async function generateMetadata({ params }: { params: Promise<IPageParams
             // Build openGraph only when at least one OG-relevant field is
             // present, so we don't synthesize an empty default OG block for
             // pages that explicitly opted out by omitting all SEO fields.
-            if (pluginPage.title || pluginPage.description || pluginPage.ogImage || pluginPage.ogType) {
+            if (seo.title || seo.description || seo.ogImage || seo.ogType) {
                 metadata.openGraph = {
-                    type: pluginPage.ogType ?? 'website',
-                    ...(pluginPage.title ? { title: pluginPage.title } : {}),
-                    ...(pluginPage.description ? { description: pluginPage.description } : {}),
+                    type: seo.ogType ?? 'website',
+                    ...(seo.title ? { title: seo.title } : {}),
+                    ...(seo.description ? { description: seo.description } : {}),
                     ...(canonicalUrl ? { url: canonicalUrl } : {}),
-                    ...(pluginPage.ogImage
+                    ...(seo.ogImage
                         ? {
                             images: [{
-                                url: pluginPage.ogImage,
+                                url: seo.ogImage,
                                 width: 1200,
                                 height: 630,
-                                alt: pluginPage.title ?? 'TronRelic'
+                                alt: seo.title ?? 'TronRelic'
                             }]
                         }
                         : {})
@@ -256,7 +325,7 @@ export async function generateMetadata({ params }: { params: Promise<IPageParams
         // noindex applies independently of which other fields are present —
         // admin pages frequently set noindex without bothering to populate
         // crawler-friendly title/description copy.
-        if (pluginPage.noindex) {
+        if (seo.noindex) {
             metadata.robots = { index: false, follow: false };
         }
 
@@ -363,7 +432,24 @@ export default async function UnifiedPage({ params }: { params: Promise<IPagePar
     }
 
     const pluginPage = resolution.config;
-    const pluginStructuredData = pluginPage.structuredData ?? null;
+
+    // Honor the serverMetadataFetcher's not-found verdict in the body too:
+    // generateMetadata already emitted noindex for this case, and rendering
+    // the component anyway would show a broken page at a URL crawlers were
+    // just told not to index. A fetcher error ('error') renders normally —
+    // the component's own data fetch decides what to show.
+    const fetchedMetadata = await runServerMetadataFetcher(slug);
+    if (fetchedMetadata === null) {
+        notFound();
+    }
+
+    // Dynamic structured data (per-URL, e.g. a BlogPosting for one post)
+    // beats the static page-config declaration when both exist.
+    const dynamicStructuredData =
+        fetchedMetadata !== 'none' && fetchedMetadata !== 'error'
+            ? fetchedMetadata.structuredData ?? null
+            : null;
+    const pluginStructuredData = dynamicStructuredData ?? pluginPage.structuredData ?? null;
 
     // If the plugin declares a serverDataFetcher, run it server-side and pass
     // the result to the plugin component as `initialData`. This is the SSR +
@@ -387,7 +473,8 @@ export default async function UnifiedPage({ params }: { params: Promise<IPagePar
             const { siteUrl } = await getServerConfig();
             const raw = await pluginPage.serverDataFetcher({
                 apiBaseUrl: getServerSideApiUrlWithPath(),
-                siteUrl
+                siteUrl,
+                path: slug
             });
             initialData = raw === undefined ? undefined : JSON.parse(JSON.stringify(raw));
         } catch (error) {

--- a/src/frontend/lib/__tests__/pluginPagePathMatch.test.ts
+++ b/src/frontend/lib/__tests__/pluginPagePathMatch.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Wildcard plugin-page path matching tests.
+ *
+ * Locks in the resolution semantics both registries depend on for hydration
+ * safety: exact registrations beat wildcards, wildcards match only strictly
+ * deeper paths, prefix boundaries are respected ('/blogx' never matches
+ * '/blog/*'), and the longest wildcard prefix wins among overlaps.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+    isWildcardPath,
+    wildcardPrefix,
+    matchPluginPagePath,
+    sortWildcardEntries,
+    type IWildcardPageEntry
+} from '../pluginPagePathMatch';
+
+describe('isWildcardPath', () => {
+    it('accepts a path ending in /*', () => {
+        expect(isWildcardPath('/blog/*')).toBe(true);
+        expect(isWildcardPath('/a/b/*')).toBe(true);
+    });
+
+    it('rejects exact paths and degenerate wildcards', () => {
+        expect(isWildcardPath('/blog')).toBe(false);
+        expect(isWildcardPath('/blog/')).toBe(false);
+        expect(isWildcardPath('/*')).toBe(false);
+        expect(isWildcardPath('')).toBe(false);
+    });
+});
+
+describe('wildcardPrefix', () => {
+    it('strips the trailing /*', () => {
+        expect(wildcardPrefix('/blog/*')).toBe('/blog');
+        expect(wildcardPrefix('/a/b/*')).toBe('/a/b');
+    });
+});
+
+describe('matchPluginPagePath', () => {
+    const exact = new Map<string, string>([['/blog', 'list-page']]);
+    const wildcards: Array<IWildcardPageEntry<string>> = sortWildcardEntries([
+        { prefix: '/blog', value: 'post-page' },
+        { prefix: '/blog/archive', value: 'archive-page' }
+    ]);
+
+    it('resolves an exact registration', () => {
+        expect(matchPluginPagePath(exact, wildcards, '/blog')).toBe('list-page');
+    });
+
+    it('exact registration beats a wildcard covering the same path', () => {
+        const exactOverlap = new Map<string, string>([['/blog/pinned', 'pinned-page']]);
+        expect(matchPluginPagePath(exactOverlap, wildcards, '/blog/pinned')).toBe('pinned-page');
+    });
+
+    it('wildcard matches strictly deeper paths', () => {
+        expect(matchPluginPagePath(new Map(), wildcards, '/blog/my-post')).toBe('post-page');
+        expect(matchPluginPagePath(new Map(), wildcards, '/blog/2026/recap')).toBe('post-page');
+    });
+
+    it('wildcard does not match its own prefix', () => {
+        expect(matchPluginPagePath(new Map(), wildcards, '/blog')).toBeNull();
+    });
+
+    it('wildcard does not match the prefix with a trailing slash only', () => {
+        expect(matchPluginPagePath(new Map(), wildcards, '/blog/')).toBeNull();
+    });
+
+    it('respects prefix boundaries — /blogx never matches /blog/*', () => {
+        expect(matchPluginPagePath(new Map(), wildcards, '/blogx')).toBeNull();
+        expect(matchPluginPagePath(new Map(), wildcards, '/blogx/post')).toBeNull();
+    });
+
+    it('longest wildcard prefix wins among overlaps', () => {
+        expect(matchPluginPagePath(new Map(), wildcards, '/blog/archive/2025')).toBe('archive-page');
+        expect(matchPluginPagePath(new Map(), wildcards, '/blog/other')).toBe('post-page');
+    });
+
+    it('returns null when nothing matches', () => {
+        expect(matchPluginPagePath(exact, wildcards, '/markets')).toBeNull();
+    });
+});
+
+describe('sortWildcardEntries', () => {
+    it('orders by prefix length descending without mutating the input', () => {
+        const input: Array<IWildcardPageEntry<number>> = [
+            { prefix: '/a', value: 1 },
+            { prefix: '/a/b/c', value: 3 },
+            { prefix: '/a/b', value: 2 }
+        ];
+        const sorted = sortWildcardEntries(input);
+        expect(sorted.map(e => e.value)).toEqual([3, 2, 1]);
+        expect(input.map(e => e.value)).toEqual([1, 3, 2]);
+    });
+});

--- a/src/frontend/lib/pluginPagePathMatch.ts
+++ b/src/frontend/lib/pluginPagePathMatch.ts
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview Shared plugin-page path matching for wildcard routes.
+ *
+ * Plugin pages historically resolved by exact path string. Wildcard pages
+ * (a registered path ending in '/*', e.g. '/blog/*') let one page config own
+ * every strictly deeper path — the mechanism behind per-resource plugin URLs
+ * like '/blog/my-post'.
+ *
+ * This module is deliberately pure and free of 'server-only' so BOTH the
+ * server registry (serverPluginRegistry.ts) and the client registry
+ * (pluginRegistry.ts) run the identical matching algorithm. If the two sides
+ * ever diverged, the server could resolve a slug to one plugin page while the
+ * client resolved it to another, producing React hydration mismatches.
+ *
+ * Matching rules:
+ * - An exact registration always beats a wildcard.
+ * - A wildcard '/prefix/*' matches paths strictly deeper than '/prefix'
+ *   ('/prefix/a', '/prefix/a/b') and never '/prefix' itself — the index page
+ *   registers its exact path separately, keeping semantics unambiguous.
+ * - Among overlapping wildcards, the longest prefix wins.
+ */
+
+/**
+ * A wildcard page entry prepared for prefix matching.
+ *
+ * Callers pre-strip the '/*' suffix once at registration time so per-request
+ * matching does no string surgery beyond a startsWith check.
+ */
+export interface IWildcardPageEntry<T> {
+    /** The wildcard's prefix with the trailing '/*' removed (e.g. '/blog'). */
+    prefix: string;
+
+    /** The resolved value (page config or registry record) for this wildcard. */
+    value: T;
+}
+
+/**
+ * Reports whether a registered page path uses the wildcard convention.
+ *
+ * Registries use this at index-build time to divert wildcard entries into the
+ * prefix list instead of the exact-path map.
+ *
+ * @param path - The page path as declared in the plugin's IPageConfig
+ * @returns True when the path ends with '/*' and has a non-empty prefix
+ */
+export function isWildcardPath(path: string): boolean {
+    return path.length > 2 && path.endsWith('/*');
+}
+
+/**
+ * Extracts the matchable prefix from a wildcard page path.
+ *
+ * Callers store this once per wildcard so request-time matching avoids
+ * repeated slicing.
+ *
+ * @param path - A wildcard page path (e.g. '/blog/*'); caller must have
+ *   verified it with isWildcardPath first
+ * @returns The prefix without the trailing '/*' (e.g. '/blog')
+ */
+export function wildcardPrefix(path: string): string {
+    return path.slice(0, -2);
+}
+
+/**
+ * Resolves a requested slug against exact and wildcard page registrations.
+ *
+ * Exact matches take absolute precedence so a plugin owning '/blog' exactly
+ * is never shadowed by another plugin's '/blog/*'. Wildcards match only
+ * strictly deeper paths, and the boundary check requires a '/' after the
+ * prefix so '/blogx' can never match '/blog/*'.
+ *
+ * @param exactMap - Exact-path registrations keyed by their literal path
+ * @param wildcardEntries - Wildcard registrations, pre-sorted by prefix
+ *   length descending so the first hit is the longest (most specific) prefix
+ * @param slug - The requested URL path to resolve (e.g. '/blog/my-post')
+ * @returns The matched value, or null when no registration covers the slug
+ */
+export function matchPluginPagePath<T>(
+    exactMap: Map<string, T>,
+    wildcardEntries: ReadonlyArray<IWildcardPageEntry<T>>,
+    slug: string
+): T | null {
+    let result: T | null = exactMap.get(slug) ?? null;
+    if (result === null) {
+        for (const entry of wildcardEntries) {
+            if (slug.startsWith(entry.prefix + '/') && slug.length > entry.prefix.length + 1) {
+                result = entry.value;
+                break;
+            }
+        }
+    }
+    return result;
+}
+
+/**
+ * Sorts wildcard entries so the longest (most specific) prefix matches first.
+ *
+ * Registries call this once after collecting wildcard registrations; sorting
+ * at build time keeps matchPluginPagePath a simple first-hit scan.
+ *
+ * @param entries - Wildcard entries in registration order
+ * @returns A new array sorted by prefix length descending
+ */
+export function sortWildcardEntries<T>(
+    entries: ReadonlyArray<IWildcardPageEntry<T>>
+): Array<IWildcardPageEntry<T>> {
+    return [...entries].sort((a, b) => b.prefix.length - a.prefix.length);
+}

--- a/src/frontend/lib/pluginRegistry.ts
+++ b/src/frontend/lib/pluginRegistry.ts
@@ -1,5 +1,12 @@
 import type { IMenuItemConfig, IPageConfig, IPlugin } from '@/types';
 import { frontendPlugins } from '../components/plugins/plugins.generated';
+import {
+    isWildcardPath,
+    wildcardPrefix,
+    matchPluginPagePath,
+    sortWildcardEntries,
+    type IWildcardPageEntry
+} from './pluginPagePathMatch';
 
 /**
  * Plugin menu and page registry for dynamic navigation.
@@ -276,15 +283,32 @@ class PluginRegistry {
     /**
      * Get a specific page by path.
      *
-     * Looks up a page configuration by its URL path. This is useful for
-     * dynamic route handlers that need to render the appropriate component
-     * based on the current route.
+     * Looks up a page configuration by its URL path, honoring the wildcard
+     * convention: exact registrations win, then the longest matching '/*'
+     * wildcard prefix. Runs the same shared matcher as the server registry
+     * (serverPluginRegistry.ts) so SSR and client hydration always resolve a
+     * URL to the same page config — a divergence here would hydration-crash
+     * every wildcard route.
      *
-     * @param path - The URL path to lookup (e.g., '/whales', '/my-plugin/settings')
+     * Registration already enforces first-wins on duplicate literal paths, so
+     * the match inputs built here contain no collisions. Page counts are small
+     * (tens), so rebuilding the inputs per lookup is cheaper than keeping a
+     * derived index coherent through registerPlugin/clear.
+     *
+     * @param path - The URL path to lookup (e.g., '/whales', '/blog/my-post')
      * @returns The page configuration if found, undefined otherwise
      */
     getPageByPath(path: string): IPageConfig | undefined {
-        return this.state.pages.find(page => page.path === path);
+        const exactMap = new Map<string, IPageConfig>();
+        const wildcards: Array<IWildcardPageEntry<IPageConfig>> = [];
+        for (const page of this.state.pages) {
+            if (isWildcardPath(page.path)) {
+                wildcards.push({ prefix: wildcardPrefix(page.path), value: page });
+            } else {
+                exactMap.set(page.path, page);
+            }
+        }
+        return matchPluginPagePath(exactMap, sortWildcardEntries(wildcards), path) ?? undefined;
     }
 
     /**

--- a/src/frontend/lib/serverPluginRegistry.ts
+++ b/src/frontend/lib/serverPluginRegistry.ts
@@ -32,6 +32,13 @@ import { cache } from 'react';
 import type { IPageConfig } from '@/types';
 import { frontendPlugins } from '../components/plugins/plugins.generated';
 import { getServerSideApiUrlWithPath } from './api-url';
+import {
+    isWildcardPath,
+    wildcardPrefix,
+    matchPluginPagePath,
+    sortWildcardEntries,
+    type IWildcardPageEntry
+} from './pluginPagePathMatch';
 
 /**
  * A page resolved from a plugin's frontend module, with the owning pluginId
@@ -43,27 +50,39 @@ interface IResolvedPluginPage {
 }
 
 /**
+ * The process-lifetime page index: exact paths keyed literally, plus wildcard
+ * registrations ('/*' suffix) pre-stripped and sorted longest-prefix-first so
+ * request-time matching is a first-hit scan.
+ */
+interface IPluginPageIndex {
+    exact: Map<string, IResolvedPluginPage>;
+    wildcards: Array<IWildcardPageEntry<IResolvedPluginPage>>;
+}
+
+/**
  * Process-lifetime cache of every plugin page declared by every plugin,
  * regardless of enabled state. Built lazily on first call to
  * getEnabledPluginPageConfig.
  */
-let permanentMap: Map<string, IResolvedPluginPage> | null = null;
+let permanentIndex: IPluginPageIndex | null = null;
 
 /**
  * Walks the synchronously-imported plugin list and indexes every plugin's
- * pages and adminPages by URL path.
+ * pages and adminPages by URL path, separating exact paths from wildcard
+ * ('/*' suffix) registrations.
  *
  * Collision policy: first-wins. The first plugin to register a given path
  * keeps it; later plugins are warned and skipped. This matches the
- * client-side `pluginRegistry.getPageByPath` semantics (which uses
- * `Array.find` and returns the first match), so the server and client
+ * client-side `pluginRegistry.getPageByPath` semantics (both sides run the
+ * shared matcher in pluginPagePathMatch.ts), so the server and client
  * always resolve the same plugin for any given path — preventing React
  * hydration mismatches when two plugins accidentally collide.
  *
- * @returns A path-to-resolved-page map covering every plugin's pages
+ * @returns The exact-map + sorted-wildcard index covering every plugin's pages
  */
-function buildPermanentMap(): Map<string, IResolvedPluginPage> {
+function buildPermanentIndex(): IPluginPageIndex {
     const map = new Map<string, IResolvedPluginPage>();
+    const wildcards: Array<IWildcardPageEntry<IResolvedPluginPage>> = [];
     for (const plugin of frontendPlugins) {
         // Defense in depth — the generated registry already filters malformed
         // modules, but a plugin whose pages array contains entries with
@@ -88,6 +107,23 @@ function buildPermanentMap(): Map<string, IResolvedPluginPage> {
                     );
                     continue;
                 }
+                const resolved: IResolvedPluginPage = {
+                    pluginId,
+                    config: { ...page, pluginId }
+                };
+                if (isWildcardPath(page.path)) {
+                    const prefix = wildcardPrefix(page.path);
+                    const existingWildcard = wildcards.find(entry => entry.prefix === prefix);
+                    if (existingWildcard) {
+                        console.warn(
+                            `[serverPluginRegistry] Duplicate wildcard page path '${page.path}' detected. ` +
+                                `Plugin '${pluginId}' will be ignored; '${existingWildcard.value.pluginId}' keeps the route.`
+                        );
+                        continue;
+                    }
+                    wildcards.push({ prefix, value: resolved });
+                    continue;
+                }
                 const existing = map.get(page.path);
                 if (existing) {
                     console.warn(
@@ -96,10 +132,7 @@ function buildPermanentMap(): Map<string, IResolvedPluginPage> {
                     );
                     continue;
                 }
-                map.set(page.path, {
-                    pluginId,
-                    config: { ...page, pluginId }
-                });
+                map.set(page.path, resolved);
             }
         } catch (error) {
             const pluginId = plugin?.manifest?.id ?? '<unknown>';
@@ -109,20 +142,20 @@ function buildPermanentMap(): Map<string, IResolvedPluginPage> {
             );
         }
     }
-    return map;
+    return { exact: map, wildcards: sortWildcardEntries(wildcards) };
 }
 
 /**
- * Returns the permanent path-to-page-config map, building it on first call.
- * Subsequent calls return the cached map immediately.
+ * Returns the permanent page index, building it on first call.
+ * Subsequent calls return the cached index immediately.
  *
- * @returns The permanent path-to-resolved-page map
+ * @returns The permanent exact-map + wildcard page index
  */
-function getPermanentMap(): Map<string, IResolvedPluginPage> {
-    if (!permanentMap) {
-        permanentMap = buildPermanentMap();
+function getPermanentIndex(): IPluginPageIndex {
+    if (!permanentIndex) {
+        permanentIndex = buildPermanentIndex();
     }
-    return permanentMap;
+    return permanentIndex;
 }
 
 /**
@@ -167,20 +200,24 @@ const fetchEnabledPluginIds = cache(async (): Promise<Set<string>> => {
  * Look up a plugin page config by URL path, returning it only if the owning
  * plugin is currently enabled.
  *
+ * Resolution honors the wildcard convention via the shared matcher: an exact
+ * registration wins, then the longest matching '/*' wildcard prefix. The
+ * client registry runs the same matcher so SSR and hydration agree.
+ *
  * Used by the catch-all route's generateMetadata to populate <head> and by the
  * default page render to await serverDataFetcher and render the plugin component.
  * Returns null when the path is not registered by any plugin OR when the
  * registering plugin is currently disabled — both cases collapse to a 404 in
  * the catch-all route.
  *
- * @param slug - URL path to look up (e.g., '/tools/bazi-fortune')
+ * @param slug - URL path to look up (e.g., '/tools/bazi-fortune', '/blog/my-post')
  * @returns The page config with pluginId attached, or null if not found / disabled
  */
 export async function getEnabledPluginPageConfig(
     slug: string
 ): Promise<IPageConfig | null> {
-    const map = getPermanentMap();
-    const resolved = map.get(slug);
+    const index = getPermanentIndex();
+    const resolved = matchPluginPagePath(index.exact, index.wildcards, slug);
     if (!resolved) {
         return null;
     }


### PR DESCRIPTION
## Summary

Plugin pages resolve by exact path string only, which makes per-resource plugin URLs (e.g. `/blog/my-post`) impossible. This PR adds a general wildcard-routing capability any plugin can use (forum permalinks, market detail pages, the upcoming trp-blog plugin).

- **Wildcard convention**: an `IPageConfig.path` ending `/*` (e.g. `'/blog/*'`) matches strictly deeper paths. Exact registrations always beat wildcards; the longest wildcard prefix wins among overlaps. `/blog/*` never matches `/blog` itself.
- **Shared matcher** (`src/frontend/lib/pluginPagePathMatch.ts`) used by both `serverPluginRegistry` and the client `pluginRegistry`, so SSR and hydration always resolve a URL to the same page config.
- **`IServerDataContext.path`**: fetchers receive the concrete requested URL and derive route params by stripping their declared prefix.
- **`IPageConfig.serverMetadataFetcher`**: per-URL SEO metadata (`IPluginPageMetadata`) merged over the static fields, run once per request via `React.cache()`. Returning `null` is an authoritative not-found → noindex + 404; a thrown error falls back to static fields so transient backend outages never serve 404s to crawlers.
- **Types root export fix**: `IServerDataContext` was exported from `plugin/index.ts` but missing from the package root; now re-exported alongside `IPluginPageMetadata`. `@delphian/tronrelic-types` bumped 4.24.0 → 4.25.0.
- **Pages blacklist**: `^/blog(/.*)?$` added to defaults plus migration `006_add_blog_route_to_blacklist`, since CMS pages resolve before plugin pages and would shadow the blog routes.
- **Docs**: wildcard + `serverMetadataFetcher` contract added to `plugins-page-registration-pages.md` and `plugins-seo-and-ssr.md`.

## Verification

- `typecheck:frontend` and `typecheck:backend` clean
- Full Vitest suite green (85 files, 1350 tests) including 12 new matcher tests (exact-beats-wildcard, longest-prefix, `/blogx` boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)