### PR TITLE
fix(wallet): surface staking/delegation amounts and flatten portfolio card nesting

### DIFF
--- a/src/backend/modules/account-history/__tests__/account-history-value-transfers.test.ts
+++ b/src/backend/modules/account-history/__tests__/account-history-value-transfers.test.ts
@@ -272,3 +272,67 @@ describe('TronGridAccountHistoryProvider.fetchTokenTransferLegs', () => {
         expect(legs).toEqual([]);
     });
 });
+
+describe('TronGridAccountHistoryProvider.fetchAccountSnapshot', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    /**
+     * Stub the shared client's account/resource/reward calls so the snapshot
+     * builder reads canned `getaccount`/`getaccountresource` responses.
+     *
+     * @param account - Raw `getaccount`-shaped response.
+     * @param resource - Raw `getaccountresource`-shaped response.
+     */
+    function stubAccountClient(account: unknown, resource: unknown = {}): void {
+        vi.spyOn(TronGridClient, 'getInstance').mockReturnValue({
+            getAccount: vi.fn(async () => account),
+            getAccountResource: vi.fn(async () => resource),
+            getReward: vi.fn(async () => 0)
+        } as unknown as TronGridClient);
+    }
+
+    it('folds delegated-OUT energy (nested under account_resource) into stakedEnergySun', async () => {
+        // Regression for the account TBCH5NjugqyJwTRKh5fZxoAJ8nsnZtmzz1: this
+        // TRX is still this account's own stake (it counts toward net worth
+        // and TRON Power/votes) even though TronGrid drops it from `frozenV2`
+        // once delegated to another address for that address's own use.
+        stubAccountClient({
+            balance: 24_224_773,
+            frozenV2: [{ amount: 285_000_000 }, { type: 'ENERGY', amount: 4_136_700_000 }],
+            account_resource: { delegated_frozenV2_balance_for_energy: 6_847_300_000 }
+        });
+
+        const sample = await new TronGridAccountHistoryProvider().fetchAccountSnapshot('Taddr');
+
+        expect(sample.stakedEnergySun).toBe(4_136_700_000 + 6_847_300_000);
+        expect(sample.stakedBandwidthSun).toBe(285_000_000);
+    });
+
+    it('folds delegated-OUT bandwidth (top-level on the account response) into stakedBandwidthSun', async () => {
+        stubAccountClient({
+            balance: 0,
+            frozenV2: [{ amount: 100 }],
+            delegated_frozenV2_balance_for_bandwidth: 50
+        });
+
+        const sample = await new TronGridAccountHistoryProvider().fetchAccountSnapshot('Taddr');
+
+        expect(sample.stakedBandwidthSun).toBe(150);
+    });
+
+    it('does not count resource delegated IN from another account', async () => {
+        // `acquired_delegated_frozenV2_balance_for_*` is someone else's stake
+        // used by this account's resources — never this account's own TRX.
+        stubAccountClient({
+            balance: 0,
+            frozenV2: [],
+            account_resource: { acquired_delegated_frozenV2_balance_for_energy: 9_999_999 }
+        });
+
+        const sample = await new TronGridAccountHistoryProvider().fetchAccountSnapshot('Taddr');
+
+        expect(sample.stakedEnergySun).toBe(0);
+    });
+});

--- a/src/backend/modules/account-history/providers/trongrid-account-history.provider.ts
+++ b/src/backend/modules/account-history/providers/trongrid-account-history.provider.ts
@@ -291,6 +291,18 @@ export class TronGridAccountHistoryProvider implements IAccountHistoryProvider {
                 stakedBandwidthSun += amount; // TronGrid omits `type` for bandwidth
             }
         }
+        // Delegated-OUT stake: TRX this account froze but delegated to another
+        // address for that address to use. Still owned/staked by this account
+        // (counts toward its own net worth and its own TRON Power/votes), but
+        // TronGrid excludes it from `frozenV2` once delegated out, so it must
+        // be added back separately. Bandwidth's delegated-out amount sits
+        // top-level on the account response; energy's sits nested under
+        // `account_resource` — asymmetric per protobuf `Account`/`AccountResource`.
+        // `acquired_delegated_frozenV2_balance_for_*` (resource delegated IN
+        // from someone else) is intentionally excluded — that stake belongs to
+        // the delegator, not this account.
+        stakedBandwidthSun += account?.delegated_frozenV2_balance_for_bandwidth ?? 0;
+        stakedEnergySun += account?.account_resource?.delegated_frozenV2_balance_for_energy ?? 0;
 
         let unstakingSun = 0;
         for (const pending of account?.unfrozenV2 ?? []) {

--- a/src/backend/modules/blockchain/tron-grid.client.ts
+++ b/src/backend/modules/blockchain/tron-grid.client.ts
@@ -322,6 +322,22 @@ export interface TronGridAccountResponse {
      * objects (TronGrid's wire shape), the raw balance a decimal string.
      */
     trc20?: Array<Record<string, string>>;
+    /**
+     * TRX (sun) this account froze for bandwidth but delegated OUT to another
+     * address to use. Still this account's own stake — it counts toward its
+     * net worth and its own TRON Power/votes — TronGrid just excludes it from
+     * `frozenV2` once delegated out. Mirrors protobuf
+     * `Account.delegated_frozenV2_balance_for_bandwidth`.
+     */
+    delegated_frozenV2_balance_for_bandwidth?: number;
+    /** Nested per protobuf `Account.account_resource`; carries the energy-side delegated-out counterpart. */
+    account_resource?: {
+        /**
+         * TRX (sun) this account froze for energy but delegated OUT to
+         * another address. Same ownership semantics as the bandwidth field above.
+         */
+        delegated_frozenV2_balance_for_energy?: number;
+    };
 }
 
 export class TronGridClient {

--- a/src/frontend/components/ui/Card/Card.module.scss
+++ b/src/frontend/components/ui/Card/Card.module.scss
@@ -40,6 +40,10 @@
 }
 
 /* Padding Variants */
+.card--padding-xs {
+    padding: var(--card-padding-xs);
+}
+
 .card--padding-sm {
     padding: var(--card-padding-sm);
 }
@@ -122,4 +126,19 @@
 /* Modifier to disable background image for specific cards */
 .card--no-bg-image::after {
     display: none;
+}
+
+/* Flat modifier — for a Card nested inside another Card (e.g. a stat tile
+ * inside a titled section). Drops the border and shadow so the pairing
+ * doesn't double up on the boxed treatment; the outer Card already owns
+ * that boundary and this one keeps only its tone background. Declared last
+ * so it overrides the base border/shadow and hover rules above. */
+.card--flat {
+    border: none;
+    box-shadow: none;
+}
+
+.card--flat:hover {
+    border-color: transparent;
+    box-shadow: none;
 }

--- a/src/frontend/components/ui/Card/Card.tsx
+++ b/src/frontend/components/ui/Card/Card.tsx
@@ -13,7 +13,7 @@ interface CardProps extends HTMLAttributes<HTMLDivElement> {
      * Padding size variant
      * @default 'md'
      */
-    padding?: 'sm' | 'md' | 'lg';
+    padding?: 'xs' | 'sm' | 'md' | 'lg';
     /**
      * Enables elevated shadow effect
      * @default false
@@ -24,6 +24,14 @@ interface CardProps extends HTMLAttributes<HTMLDivElement> {
      * @default 'default'
      */
     tone?: 'default' | 'muted' | 'accent';
+    /**
+     * Renders the border and box-shadow. Set false for a Card nested inside
+     * another Card (e.g. a stat tile inside a titled section) so the pairing
+     * doesn't double up on border/radius/shadow — the outer Card already owns
+     * that boundary, and the inner one only needs its tone background.
+     * @default true
+     */
+    bordered?: boolean;
     /**
      * Disables the theme background image watermark for this card
      * @default false
@@ -36,6 +44,7 @@ interface CardProps extends HTMLAttributes<HTMLDivElement> {
  * Ensures type-safe selection of padding variants.
  */
 const paddingClass: Record<NonNullable<CardProps['padding']>, string> = {
+    xs: styles['card--padding-xs'],
     sm: styles['card--padding-sm'],
     md: styles['card--padding-md'],
     lg: styles['card--padding-lg']
@@ -76,13 +85,14 @@ const toneClass: Record<NonNullable<CardProps['tone']>, string> = {
  * @param props - Card component properties
  * @returns A styled div element with surface styling
  */
-export function Card({ className, padding = 'md', elevated = false, tone = 'default', noBackgroundImage = false, ...props }: CardProps) {
+export function Card({ className, padding = 'md', elevated = false, tone = 'default', bordered = true, noBackgroundImage = false, ...props }: CardProps) {
     return (
         <div
             className={cn(
                 toneClass[tone],
                 paddingClass[padding],
                 elevated && styles['card--elevated'],
+                !bordered && styles['card--flat'],
                 noBackgroundImage && styles['card--no-bg-image'],
                 className
             )}

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/PortfolioHero.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/PortfolioHero.tsx
@@ -25,7 +25,6 @@ import { useMemo, useState } from 'react';
 import type { IPortfolioSummary, IPortfolioBalancePoint } from '@/types';
 import { Wallet, TrendingUp, TrendingDown, Hourglass, Coins } from 'lucide-react';
 import { LineChart, DonutChart, type DonutSlice } from '../../../../../features/charts';
-import { Card } from '../../../../../components/ui/Card';
 import { Button } from '../../../../../components/ui/Button';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
 import { Stack } from '../../../../../components/layout';
@@ -277,16 +276,18 @@ export function PortfolioHero({ summary }: IPortfolioHeroProps) {
                     </div>
                 </div>
 
+                <div className="divider" />
+
                 <div className={styles.portfolio_split}>
-                    <Card padding="md" className={styles.portfolio_donut}>
+                    <div className={styles.portfolio_donut}>
                         <DonutChart
                             slices={slices}
                             centerLabel={formatUsd(summary.netWorthUsd)}
                             centerCaption="Net worth"
                             emptyLabel="No priced holdings"
                         />
-                    </Card>
-                    <Card padding="md" className={styles.portfolio_holdings}>
+                    </div>
+                    <div className={styles.portfolio_holdings}>
                         <Table variant="compact">
                             <Thead>
                                 <Tr>
@@ -321,10 +322,12 @@ export function PortfolioHero({ summary }: IPortfolioHeroProps) {
                                 )}
                             </Tbody>
                         </Table>
-                    </Card>
+                    </div>
                 </div>
 
-                <Card padding="md">
+                <div className="divider" />
+
+                <div className={styles.portfolio_chart}>
                     <LineChart
                         series={balanceSeries}
                         title="Net worth over time"
@@ -348,7 +351,7 @@ export function PortfolioHero({ summary }: IPortfolioHeroProps) {
                             Some early history is beyond what data sources can reach, so PnL and cost basis are approximate. Net worth is exact — it comes from live balances.
                         </p>
                     )}
-                </Card>
+                </div>
 
                 {summary.unpricedAssets.length > 0 && (
                     <p className="text-muted">

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetail.module.scss
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetail.module.scss
@@ -31,6 +31,15 @@
     overflow-x: auto;
 }
 
+/* Balance-over-time chart + its caption/warning banner, grouped without a
+   nested Card — the outer WalletDetailSection already provides the one
+   bordered boundary for this panel. */
+.portfolio_chart {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+}
+
 @container wallet-detail (max-width: #{$breakpoint-mobile-md}) {
     .portfolio_split {
         grid-template-columns: 1fr;

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetailPrimitives.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetailPrimitives.tsx
@@ -90,14 +90,17 @@ interface IStatTileProps {
 
 /**
  * One labelled metric tile, composing the global `stat-card__*` utilities inside
- * a muted card so a grid of these reads as a stat strip.
+ * a muted card so a grid of these reads as a stat strip. Always nested inside a
+ * {@link WalletDetailSection} card, so it renders flat (no border/shadow) —
+ * the section already owns the boxed boundary; the tile only needs the muted
+ * tone to read as a distinct metric within the grid.
  *
  * @param props - {@link IStatTileProps}.
- * @returns A stat tile card.
+ * @returns A flat, muted-tone stat tile.
  */
 export function StatTile({ label, value, icon }: IStatTileProps) {
     return (
-        <Card padding="sm" tone="muted">
+        <Card padding="xs" tone="muted" bordered={false}>
             <span className={`stat-card__label ${styles.tile_label}`}>
                 {icon}
                 {label}

--- a/src/frontend/modules/user/lib/decodeTronTransaction.ts
+++ b/src/frontend/modules/user/lib/decodeTronTransaction.ts
@@ -97,15 +97,15 @@ export function decodeTronTransaction(tx: IBlockTransaction, wallet: string): ID
         case 'FreezeBalanceV2Contract':
             return { label: 'Staked TRX', direction, amount: formatSunAmount(tx.amountSun) };
         case 'UnfreezeBalanceV2Contract':
-            return { label: 'Unstaked TRX', direction, amount: '' };
+            return { label: 'Unstaked TRX', direction, amount: formatSunAmount(tx.amountSun) };
         case 'DelegateResourceContract':
             return { label: 'Delegated resources', direction, amount: formatSunAmount(tx.amountSun) };
         case 'UnDelegateResourceContract':
-            return { label: 'Reclaimed resources', direction, amount: '' };
+            return { label: 'Reclaimed resources', direction, amount: formatSunAmount(tx.amountSun) };
         case 'WithdrawExpireUnfreezeContract':
-            return { label: 'Withdrew unstaked TRX', direction, amount: '' };
+            return { label: 'Withdrew unstaked TRX', direction, amount: formatSunAmount(tx.amountSun) };
         case 'WithdrawBalanceContract':
-            return { label: 'Withdraw Balance', direction, amount: formatSunAmount(tx.amountSun) };
+            return { label: 'Claimed rewards', direction, amount: formatSunAmount(tx.amountSun) };
         default: {
             // Humanize an unmapped contract type: strip the trailing "Contract"
             // and space the PascalCase so it still reads, rather than dumping the

--- a/src/frontend/modules/user/lib/decodeTronTransaction.ts
+++ b/src/frontend/modules/user/lib/decodeTronTransaction.ts
@@ -56,6 +56,16 @@ function resolveDirection(tx: IBlockTransaction, wallet: string): TransactionDir
 }
 
 /**
+ * Format a SUN amount for display, or an empty string when the type carries none.
+ *
+ * @param amountSun - The transaction's `amountSun` field, if the contract type populates it.
+ * @returns The formatted TRX amount, or `''` when `amountSun` is absent.
+ */
+function formatSunAmount(amountSun: number | undefined): string {
+    return typeof amountSun === 'number' ? formatTrxFromSun(amountSun) : '';
+}
+
+/**
  * Decode a transaction into feed-ready copy. Branches on TRON's contract type and
  * (for token transfers) the decoded token symbol carried in `contract.parameters`.
  *
@@ -69,10 +79,8 @@ export function decodeTronTransaction(tx: IBlockTransaction, wallet: string): ID
     const token = tx.contract?.parameters;
 
     switch (tx.type) {
-        case 'TransferContract': {
-            const amount = typeof tx.amountSun === 'number' ? formatTrxFromSun(tx.amountSun) : '';
-            return { label: sent ? 'Sent TRX' : 'Received TRX', direction, amount };
-        }
+        case 'TransferContract':
+            return { label: sent ? 'Sent TRX' : 'Received TRX', direction, amount: formatSunAmount(tx.amountSun) };
         case 'TriggerSmartContract': {
             // A decoded token transfer carries a symbol in the open parameters bag
             // (typed `unknown`, so narrow it); otherwise it is a bare contract call
@@ -87,15 +95,17 @@ export function decodeTronTransaction(tx: IBlockTransaction, wallet: string): ID
             return { label: 'Contract call', direction, amount: '' };
         }
         case 'FreezeBalanceV2Contract':
-            return { label: 'Staked TRX', direction, amount: '' };
+            return { label: 'Staked TRX', direction, amount: formatSunAmount(tx.amountSun) };
         case 'UnfreezeBalanceV2Contract':
             return { label: 'Unstaked TRX', direction, amount: '' };
         case 'DelegateResourceContract':
-            return { label: 'Delegated resources', direction, amount: '' };
+            return { label: 'Delegated resources', direction, amount: formatSunAmount(tx.amountSun) };
         case 'UnDelegateResourceContract':
             return { label: 'Reclaimed resources', direction, amount: '' };
         case 'WithdrawExpireUnfreezeContract':
             return { label: 'Withdrew unstaked TRX', direction, amount: '' };
+        case 'WithdrawBalanceContract':
+            return { label: 'Withdraw Balance', direction, amount: formatSunAmount(tx.amountSun) };
         default: {
             // Humanize an unmapped contract type: strip the trailing "Contract"
             // and space the PascalCase so it still reads, rather than dumping the


### PR DESCRIPTION
## Summary

Three related fixes to the profile Wallets tab and its account-history data.

**Transaction amounts.** `decodeTronTransaction` only wired `amountSun` into `TransferContract` and `TriggerSmartContract`, so `FreezeBalanceV2Contract`, `DelegateResourceContract`, and `WithdrawBalanceContract` rows rendered a dash despite the backend already computing real values. Added those cases behind a shared `formatSunAmount` helper. Vote Witness intentionally stays a dash — voting carries no TRX amount.

**Card nesting.** The portfolio hero wrapped the donut, holdings table, and balance chart in their own `<Card padding="md">` *inside* the section's Card, and `StatTile` is itself a Card nested in a section Card — compounding padding/border/radius that cramped the tab on small screens. Added a `bordered` prop (default `true`, backward-compatible) and an `xs` padding step to the core `Card`; the hero subsections now use plain grouping divs with the global `.divider`, and stat tiles render flat and tinted.

**Delegated-out stake.** Account snapshots omitted TRX this account froze but delegated out — still its own stake for net worth and TRON Power. Folded the bandwidth (top-level) and energy (under `account_resource`) fields back into staked totals; `acquired_delegated_*` (delegated in) stays excluded. Covered by three regression tests.