### PR TITLE
fix(wallet): unnest tables from their wrapping card on the profile Wallets tab

### DIFF
--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletCounterparties.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletCounterparties.tsx
@@ -10,8 +10,9 @@
 import { Users } from 'lucide-react';
 import type { IWalletCounterparty } from '@/types';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
-import { AddressDisplay, WalletDetailSection } from './WalletDetailPrimitives';
+import { AddressDisplay } from './WalletDetailPrimitives';
 import { formatCount, formatTrxFromSun } from '../../../lib/walletFormat';
+import styles from './WalletDetail.module.scss';
 
 /**
  * Props for {@link WalletCounterparties}.
@@ -31,7 +32,11 @@ interface IWalletCounterpartiesProps {
  */
 export function WalletCounterparties({ counterparties, labels }: IWalletCounterpartiesProps) {
     return (
-        <WalletDetailSection icon={<Users size={16} aria-hidden />} title="Top counterparties">
+        <>
+            <div className={styles.section_header}>
+                <Users size={16} aria-hidden />
+                <h3 className={styles.section_title}>Top counterparties</h3>
+            </div>
             {counterparties.length === 0 ? (
                 <p className="text-muted">No counterparties recorded yet.</p>
             ) : (
@@ -39,9 +44,9 @@ export function WalletCounterparties({ counterparties, labels }: IWalletCounterp
                     <Thead>
                         <Tr>
                             <Th width="expand">Address</Th>
-                            <Th>Txns</Th>
-                            <Th>TRX sent</Th>
-                            <Th>TRX received</Th>
+                            <Th width="shrink">Txns</Th>
+                            <Th width="shrink">TRX sent</Th>
+                            <Th width="shrink">TRX received</Th>
                         </Tr>
                     </Thead>
                     <Tbody>
@@ -53,14 +58,14 @@ export function WalletCounterparties({ counterparties, labels }: IWalletCounterp
                                         label={labels?.[counterparty.address]}
                                     />
                                 </Td>
-                                <Td>{formatCount(counterparty.txCount)}</Td>
-                                <Td muted>{formatTrxFromSun(counterparty.trxSentSun)}</Td>
-                                <Td muted>{formatTrxFromSun(counterparty.trxReceivedSun)}</Td>
+                                <Td className={styles.counterparty_nowrap}>{formatCount(counterparty.txCount)}</Td>
+                                <Td className={styles.counterparty_nowrap} muted>{formatTrxFromSun(counterparty.trxSentSun)}</Td>
+                                <Td className={styles.counterparty_nowrap} muted>{formatTrxFromSun(counterparty.trxReceivedSun)}</Td>
                             </Tr>
                         ))}
                     </Tbody>
                 </Table>
             )}
-        </WalletDetailSection>
+        </>
     );
 }

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletCounterparties.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletCounterparties.tsx
@@ -10,7 +10,7 @@
 import { Users } from 'lucide-react';
 import type { IWalletCounterparty } from '@/types';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
-import { AddressDisplay } from './WalletDetailPrimitives';
+import { AddressDisplay, SectionHeader } from './WalletDetailPrimitives';
 import { formatCount, formatTrxFromSun } from '../../../lib/walletFormat';
 import styles from './WalletDetail.module.scss';
 
@@ -32,11 +32,8 @@ interface IWalletCounterpartiesProps {
  */
 export function WalletCounterparties({ counterparties, labels }: IWalletCounterpartiesProps) {
     return (
-        <>
-            <div className={styles.section_header}>
-                <Users size={16} aria-hidden />
-                <h3 className={styles.section_title}>Top counterparties</h3>
-            </div>
+        <div>
+            <SectionHeader icon={<Users size={16} aria-hidden />} title="Top counterparties" />
             {counterparties.length === 0 ? (
                 <p className="text-muted">No counterparties recorded yet.</p>
             ) : (
@@ -66,6 +63,6 @@ export function WalletCounterparties({ counterparties, labels }: IWalletCounterp
                     </Tbody>
                 </Table>
             )}
-        </>
+        </div>
     );
 }

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetail.module.scss
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetail.module.scss
@@ -152,9 +152,14 @@
 }
 
 /* Counterparties table's numeric columns pair Th's width="shrink" (column
-   sizing) with this on the Td (Td has no width prop) so values never wrap. */
-.counterparty_nowrap {
-    white-space: nowrap;
+   sizing) with this on the Td (Td has no width prop). On non-mobile container
+   widths keep the "12,345 TRX" values on one line; narrow containers keep
+   wrapping so the shared Table wrapper (overflow: hidden, no horizontal scroll
+   path) can't clip the rightmost amounts. Mirrors .feed_cell in this file. */
+@container wallet-detail (min-width: #{$breakpoint-mobile-lg}) {
+    .counterparty_nowrap {
+        white-space: nowrap;
+    }
 }
 
 /* Directional value colours, shared by the flow legend and the feed amounts. */

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetail.module.scss
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetail.module.scss
@@ -151,6 +151,12 @@
     color: var(--color-text);
 }
 
+/* Counterparties table's numeric columns pair Th's width="shrink" (column
+   sizing) with this on the Td (Td has no width prop) so values never wrap. */
+.counterparty_nowrap {
+    white-space: nowrap;
+}
+
 /* Directional value colours, shared by the flow legend and the feed amounts. */
 .value_in {
     color: var(--color-success);

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetailPrimitives.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletDetailPrimitives.tsx
@@ -18,6 +18,34 @@ import { truncateAddress } from '../../../lib/walletFormat';
 import styles from './WalletDetail.module.scss';
 
 /**
+ * Props for {@link SectionHeader}.
+ */
+interface ISectionHeaderProps {
+    /** Leading icon for the header. */
+    icon: ReactNode;
+    /** Header title. */
+    title: string;
+}
+
+/**
+ * The icon-plus-title row shared by every detail panel header, whether the
+ * panel sits inside a {@link WalletDetailSection} card or renders its own
+ * boxed content (e.g. a Table, which already draws its own border/background)
+ * directly under a flat header.
+ *
+ * @param props - {@link ISectionHeaderProps}.
+ * @returns The icon/title header row.
+ */
+export function SectionHeader({ icon, title }: ISectionHeaderProps) {
+    return (
+        <div className={styles.section_header}>
+            {icon}
+            <h3 className={styles.section_title}>{title}</h3>
+        </div>
+    );
+}
+
+/**
  * Props for {@link WalletDetailSection}.
  */
 interface IWalletDetailSectionProps {
@@ -38,10 +66,7 @@ interface IWalletDetailSectionProps {
 export function WalletDetailSection({ icon, title, children }: IWalletDetailSectionProps) {
     return (
         <Card padding="md">
-            <div className={styles.section_header}>
-                {icon}
-                <h3 className={styles.section_title}>{title}</h3>
-            </div>
+            <SectionHeader icon={icon} title={title} />
             {children}
         </Card>
     );

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletTransactionFeed.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletTransactionFeed.tsx
@@ -21,7 +21,7 @@ import { Badge } from '../../../../../components/ui/Badge';
 import { Skeleton } from '../../../../../components/ui/Skeleton';
 import { Pagination } from '../../../../../components/ui/Pagination';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
-import { AddressDisplay, WalletDetailSection } from './WalletDetailPrimitives';
+import { AddressDisplay } from './WalletDetailPrimitives';
 import { fetchWalletTransactions, type IWalletTransactionPage } from '../../../api/account-history-user.api';
 import { decodeTronTransaction } from '../../../lib/decodeTronTransaction';
 import styles from './WalletDetail.module.scss';
@@ -139,7 +139,11 @@ export function WalletTransactionFeed({ address }: IWalletTransactionFeedProps) 
     let lastDayKey: string | null = null;
 
     return (
-        <WalletDetailSection icon={<ListOrdered size={16} aria-hidden />} title="Transactions">
+        <>
+            <div className={styles.section_header}>
+                <ListOrdered size={16} aria-hidden />
+                <h3 className={styles.section_title}>Transactions</h3>
+            </div>
             {error ? (
                 <div className="alert">{error}</div>
             ) : !page && loading ? (
@@ -199,7 +203,7 @@ export function WalletTransactionFeed({ address }: IWalletTransactionFeedProps) 
                     </div>
                 </>
             )}
-        </WalletDetailSection>
+        </>
     );
 }
 

--- a/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletTransactionFeed.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletDetail/WalletTransactionFeed.tsx
@@ -21,7 +21,7 @@ import { Badge } from '../../../../../components/ui/Badge';
 import { Skeleton } from '../../../../../components/ui/Skeleton';
 import { Pagination } from '../../../../../components/ui/Pagination';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
-import { AddressDisplay } from './WalletDetailPrimitives';
+import { AddressDisplay, SectionHeader } from './WalletDetailPrimitives';
 import { fetchWalletTransactions, type IWalletTransactionPage } from '../../../api/account-history-user.api';
 import { decodeTronTransaction } from '../../../lib/decodeTronTransaction';
 import styles from './WalletDetail.module.scss';
@@ -139,11 +139,8 @@ export function WalletTransactionFeed({ address }: IWalletTransactionFeedProps) 
     let lastDayKey: string | null = null;
 
     return (
-        <>
-            <div className={styles.section_header}>
-                <ListOrdered size={16} aria-hidden />
-                <h3 className={styles.section_title}>Transactions</h3>
-            </div>
+        <div>
+            <SectionHeader icon={<ListOrdered size={16} aria-hidden />} title="Transactions" />
             {error ? (
                 <div className="alert">{error}</div>
             ) : !page && loading ? (
@@ -203,7 +200,7 @@ export function WalletTransactionFeed({ address }: IWalletTransactionFeedProps) 
                     </div>
                 </>
             )}
-        </>
+        </div>
     );
 }
 


### PR DESCRIPTION
## Summary

On the profile Wallets tab, the **Top Counterparties** and **Transactions** panels each wrapped a `<Table>` inside a `WalletDetailSection` (a `<Card padding="md">`). The `Table` component already renders its own bordered, rounded, filled box via `.table_wrapper`, so nesting it in a Card produced a visible card-within-a-card.

This drops the Card wrapper for those two panels, rendering a plain icon+title header (reusing the existing `.section_header`/`.section_title` classes) followed by the table as a first-class element — one box instead of two.

## Changes

- **WalletCounterparties.tsx** — remove `WalletDetailSection` wrapper; additionally mark the numeric columns (`Txns`, `TRX sent`, `TRX received`) `width="shrink"` and add a `nowrap` cell class so the TRX values stop wrapping on wide screens.
- **WalletTransactionFeed.tsx** — remove `WalletDetailSection` wrapper; table + pagination footer now render as siblings under a plain header.
- **WalletDetail.module.scss** — add `.counterparty_nowrap` helper.

`PortfolioHero` was intentionally left unchanged: its Card wraps a table alongside a net-worth stat block, donut chart, and line chart, so the Card grouping is legitimate there.

Frontend type check passes.