### PR TITLE
fix(block-ticker): remove border rules, use gap token for top margin

### DIFF
--- a/src/frontend/components/layout/BlockTicker/BlockTicker.module.scss
+++ b/src/frontend/components/layout/BlockTicker/BlockTicker.module.scss
@@ -20,9 +20,7 @@
  * its nowrap metrics internally on viewports too narrow to show them all.
  */
 .ticker {
-    border-top: var(--border-width-thin) solid var(--color-border);
-    border-bottom: var(--border-width-thin) solid var(--color-border);
-    margin-top: var(--spacing-4);
+    margin-top: var(--gap-sm);
     max-width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- Removes the top/bottom border rules on `.ticker` in BlockTicker
- Replaces the hardcoded `--spacing-4` top margin with the semantic `--gap-sm` token