### PR TITLE
feat(traffic): scanner classification and Cloudflare signal capture

### DIFF
--- a/src/backend/modules/traffic/README.md
+++ b/src/backend/modules/traffic/README.md
@@ -11,7 +11,7 @@ Owns cookieless behavioral analytics: the ClickHouse `traffic_events` pipeline, 
 | Admin page | `/system/traffic` (menu item `Traffic`, order 26, registered in `run()`) |
 | Mounted routes | `/api/admin/users/traffic/*`, `/api/admin/users/analytics/*`, `/api/user/bootstrap`, `/api/user/track` |
 | Scheduled job | `gsc:fetch` (daily, `0 3 * * *`) |
-| ClickHouse table | `traffic_events` (migrations 010, 012, 013) |
+| ClickHouse table | `traffic_events` (migrations 010, 012, 013, 014) |
 | Event types | `bootstrap` (cookieless first touch, incl. bots) · `page` (interactive navigation) |
 | Mongo collections | `module_user_gsc_queries` (GSC keyword cache — physical name preserved) · `module_user_gsc_daily_totals` (date-only GSC daily totals) |
 | Analytics key | cookieless `tronrelic_tid` (`candidate_uid`), independent of identity |
@@ -30,13 +30,14 @@ Physical storage names are unchanged from when this code lived under the user mo
 | `TrafficModule.ts` | Two-phase lifecycle; constructs services, mounts the admin router, registers `gsc:fetch` |
 | `services/traffic.service.ts` | ClickHouse `traffic_events` writes + admin aggregate reads; `buildTrafficEvent`, `ITrafficEvent` |
 | `services/gsc.service.ts` | Google Search Console keyword fetch/store (`module_user_gsc_queries`) plus date-only daily totals (`module_user_gsc_daily_totals`) — GSC drops anonymized queries from keyword rows, so chart totals come from the date-only fetch |
-| `services/bot-classifier.ts` | User-Agent → `BotClass` (powers `traffic_events.bot_class`) |
+| `services/bot-classifier.ts` | Request → `BotClass` (powers `traffic_events.bot_class`). `classifyTrafficRequest` runs scanner heuristics first — probe paths (`/.env`, encoded traversal) and spoofed search-engine `Referer` with no `Sec-Fetch-Site` — then falls through to the UA-only `classifyUserAgent`; scanners fake browser UAs, so UA-only classification cannot catch them |
 | `services/geo.service.ts` | IP → country, referrer parsing, device derivation, `getClientIP`; defines `DeviceCategory` / `ScreenSizeCategory` |
 | `api/traffic.{controller,routes}.ts` | `/api/admin/users/traffic/*` raw-traffic reads **and** `/api/admin/users/analytics/*` dashboard aggregates (ClickHouse-backed), including the per-tid / per-user page-activity reads |
 | `api/bootstrap.{controller,routes}.ts` | Public ingestion: `POST /api/user/bootstrap` (first-touch `bootstrap`) and `POST /api/user/track` (navigation `page`) — both tid-keyed, account-attributed when logged in; no identity, no Mongo write |
 | `api/traffic-cookies.ts` | `tronrelic_tid` / `tronrelic_ref` resolve/mint/set helpers |
 | `migrations/010_create_traffic_events_table.ts` | Creates the ClickHouse table (18-month TTL) |
 | `migrations/012_traffic_events_user_referral_columns.ts` | Adds `user_id` + `referral_code` columns |
+| `migrations/014_traffic_events_cloudflare_columns.ts` | Adds `cf_ray` + `cf_ipcountry`; a NULL `cf_ray` on production traffic means the request bypassed Cloudflare (direct-to-origin) |
 
 ## REST Endpoints
 

--- a/src/backend/modules/traffic/__tests__/bot-classifier.test.ts
+++ b/src/backend/modules/traffic/__tests__/bot-classifier.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { classifyUserAgent } from '../services/bot-classifier.js';
+import { classifyUserAgent, classifyTrafficRequest } from '../services/bot-classifier.js';
 
 describe('classifyUserAgent', () => {
     describe('search_engine', () => {
@@ -145,6 +145,102 @@ describe('classifyUserAgent', () => {
             // so a UA containing both `googlebot` and `gptbot` resolves
             // to ai_crawler. This documents the ordering choice.
             expect(classifyUserAgent('GPTBot/1.0 Googlebot/2.1')).toBe('ai_crawler');
+        });
+    });
+});
+
+describe('classifyTrafficRequest', () => {
+    /** Realistic browser UA scanners commonly present. */
+    const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+
+    describe('scanner via probe paths', () => {
+        it.each([
+            ['/.env'],
+            ['/app/.env'],
+            ['/wp-login.php'],
+            ['/wp'],
+            ['/cms/configuration.php'],
+            ['/..%c0%af..%c0%afvar/www/.git/config'],
+            ['/..%ef%bc%8f..%ef%bc%8f.aws/credentials'],
+            ['/%252e%252e/var/www/html/configuration.php'],
+            ['/..%ef%bc%8fetc/apache2/apache2.conf'],
+            ['/.:/WEB-INF/classes/application.properties']
+        ])('classifies probe path %s as scanner despite a browser UA', (path) => {
+            expect(classifyTrafficRequest({
+                userAgent: CHROME_UA,
+                path,
+                referer: null,
+                secFetchSite: null
+            })).toBe('scanner');
+        });
+
+        it('does not flag legitimate app paths', () => {
+            expect(classifyTrafficRequest({
+                userAgent: CHROME_UA,
+                path: '/markets/energy',
+                referer: null,
+                secFetchSite: null
+            })).toBe('human');
+        });
+
+        it('does not flag /wpsomething outside a probe pattern', () => {
+            // '/wp-' and '/wp' as a full segment are probes; but ensure
+            // ordinary content slugs that merely contain "wp" elsewhere pass.
+            expect(classifyTrafficRequest({
+                userAgent: CHROME_UA,
+                path: '/blog/how-to-swap-trx',
+                referer: null,
+                secFetchSite: null
+            })).toBe('human');
+        });
+    });
+
+    describe('scanner via spoofed search referrer', () => {
+        it('flags a google.com referrer with no Sec-Fetch-Site header', () => {
+            expect(classifyTrafficRequest({
+                userAgent: CHROME_UA,
+                path: '/',
+                referer: 'https://www.google.com/',
+                secFetchSite: null
+            })).toBe('scanner');
+        });
+
+        it('accepts a google.com referrer with Sec-Fetch-Site present', () => {
+            expect(classifyTrafficRequest({
+                userAgent: CHROME_UA,
+                path: '/',
+                referer: 'https://www.google.com/',
+                secFetchSite: 'cross-site'
+            })).toBe('human');
+        });
+
+        it('does not flag non-search referrers lacking Sec-Fetch headers', () => {
+            expect(classifyTrafficRequest({
+                userAgent: CHROME_UA,
+                path: '/',
+                referer: 'https://someblog.example.com/post',
+                secFetchSite: null
+            })).toBe('human');
+        });
+    });
+
+    describe('fallthrough to UA classification', () => {
+        it('still classifies honest bots by UA', () => {
+            expect(classifyTrafficRequest({
+                userAgent: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+                path: '/',
+                referer: null,
+                secFetchSite: null
+            })).toBe('search_engine');
+        });
+
+        it('classifies a missing UA on a clean path as bot_other', () => {
+            expect(classifyTrafficRequest({
+                userAgent: null,
+                path: '/',
+                referer: null,
+                secFetchSite: null
+            })).toBe('bot_other');
         });
     });
 });

--- a/src/backend/modules/traffic/__tests__/bot-classifier.test.ts
+++ b/src/backend/modules/traffic/__tests__/bot-classifier.test.ts
@@ -183,12 +183,12 @@ describe('classifyTrafficRequest', () => {
             })).toBe('human');
         });
 
-        it('does not flag /wpsomething outside a probe pattern', () => {
-            // '/wp-' and '/wp' as a full segment are probes; but ensure
-            // ordinary content slugs that merely contain "wp" elsewhere pass.
+        it('does not flag paths that merely contain "wp" outside a probe pattern', () => {
+            // '/wp-' and the exact segment '/wp' are probes; ordinary content
+            // slugs embedding "wp" (here inside "newport") must pass.
             expect(classifyTrafficRequest({
                 userAgent: CHROME_UA,
-                path: '/blog/how-to-swap-trx',
+                path: '/blog/newport-energy-review',
                 referer: null,
                 secFetchSite: null
             })).toBe('human');

--- a/src/backend/modules/traffic/__tests__/traffic.service.test.ts
+++ b/src/backend/modules/traffic/__tests__/traffic.service.test.ts
@@ -83,7 +83,9 @@ const sampleEvent: ITrafficEvent = {
     sec_ch_ua_platform: null,
     sec_fetch_dest: null,
     sec_fetch_mode: null,
-    sec_fetch_site: null
+    sec_fetch_site: null,
+    cf_ray: null,
+    cf_ipcountry: null
 };
 
 describe('TrafficService', () => {

--- a/src/backend/modules/traffic/api/traffic.controller.ts
+++ b/src/backend/modules/traffic/api/traffic.controller.ts
@@ -42,6 +42,7 @@ const KNOWN_BOT_CLASSES = new Set([
     'ai_crawler',
     'social_unfurler',
     'uptime_probe',
+    'scanner',
     'bot_other',
     'unclassified'
 ]);

--- a/src/backend/modules/traffic/migrations/014_traffic_events_cloudflare_columns.ts
+++ b/src/backend/modules/traffic/migrations/014_traffic_events_cloudflare_columns.ts
@@ -46,10 +46,7 @@ export const migration: IMigration = {
 
         await context.clickhouse.exec(`
             ALTER TABLE traffic_events
-                ADD COLUMN IF NOT EXISTS cf_ray Nullable(String) AFTER sec_fetch_site
-        `);
-        await context.clickhouse.exec(`
-            ALTER TABLE traffic_events
+                ADD COLUMN IF NOT EXISTS cf_ray Nullable(String) AFTER sec_fetch_site,
                 ADD COLUMN IF NOT EXISTS cf_ipcountry LowCardinality(Nullable(String)) AFTER cf_ray
         `);
 

--- a/src/backend/modules/traffic/migrations/014_traffic_events_cloudflare_columns.ts
+++ b/src/backend/modules/traffic/migrations/014_traffic_events_cloudflare_columns.ts
@@ -1,0 +1,58 @@
+import type { IMigration, IMigrationContext } from '@/types';
+
+/**
+ * Add Cloudflare edge columns (`cf_ray`, `cf_ipcountry`) to the ClickHouse
+ * `traffic_events` table.
+ *
+ * **Why this migration exists.**
+ * Production traffic showed vulnerability scanners (probe paths like `/.env`,
+ * encoded path traversal) landing in analytics with spoofed google.com
+ * referrers. The single most important question that data could not answer
+ * was *how the request reached the origin*: through Cloudflare (a WAF-tuning
+ * problem) or direct-to-origin (a firewall problem). `cf_ray` answers it —
+ * the Next.js middleware forwards the `CF-Ray` header on the bootstrap call,
+ * so a NULL on a production row means the request bypassed Cloudflare.
+ * `cf_ipcountry` stores Cloudflare's authoritative edge-derived country
+ * alongside the local GeoIP `country` so the two sources can be compared.
+ *
+ * **Idempotent.** `ADD COLUMN IF NOT EXISTS` is a no-op on re-run. Both
+ * columns sit outside the table's `ORDER BY (timestamp, candidate_uid)` key,
+ * so adding them is a pure metadata operation with no data rewrite.
+ *
+ * **Skip behavior.** Skipped with a warning when `CLICKHOUSE_HOST` is unset,
+ * matching migrations 010/012/013 and `TrafficService`'s no-op posture.
+ *
+ * **Rollback.**
+ * ```sql
+ * ALTER TABLE traffic_events DROP COLUMN cf_ray;
+ * ALTER TABLE traffic_events DROP COLUMN cf_ipcountry;
+ * ```
+ * Forward-only by project convention.
+ */
+export const migration: IMigration = {
+    id: '014_traffic_events_cloudflare_columns',
+    description:
+        'Add Nullable(String) cf_ray and LowCardinality(Nullable(String)) cf_ipcountry columns to the ' +
+        'ClickHouse traffic_events table so analytics can distinguish Cloudflare-proxied traffic from ' +
+        'direct-to-origin hits and compare edge geo against local GeoIP.',
+    target: 'clickhouse',
+    dependencies: ['module:traffic:010_create_traffic_events_table'],
+
+    async up(context: IMigrationContext): Promise<void> {
+        if (!context.clickhouse) {
+            console.log('[Migration 014] ClickHouse not configured — skipping traffic_events Cloudflare columns add');
+            return;
+        }
+
+        await context.clickhouse.exec(`
+            ALTER TABLE traffic_events
+                ADD COLUMN IF NOT EXISTS cf_ray Nullable(String) AFTER sec_fetch_site
+        `);
+        await context.clickhouse.exec(`
+            ALTER TABLE traffic_events
+                ADD COLUMN IF NOT EXISTS cf_ipcountry LowCardinality(Nullable(String)) AFTER cf_ray
+        `);
+
+        console.log('[Migration 014] Added traffic_events.cf_ray and traffic_events.cf_ipcountry');
+    }
+};

--- a/src/backend/modules/traffic/services/bot-classifier.ts
+++ b/src/backend/modules/traffic/services/bot-classifier.ts
@@ -30,6 +30,11 @@
  * - `uptime_probe` — UptimeRobot, Pingdom, StatusCake, BetterUptime,
  *   New Relic synthetics. Synthetic monitoring; high cardinality with
  *   low analytic value, broken out so dashboards can subtract it.
+ * - `scanner` — vulnerability probes identified by *request* signals
+ *   rather than the UA (scanners lie in the UA): probe paths like
+ *   `/.env` / `/wp-login.php` / encoded path traversal, or a spoofed
+ *   search-engine `Referer` with no `Sec-Fetch-Site` header. Assigned
+ *   by `classifyTrafficRequest`, never by the UA-only classifier.
  * - `bot_other` — `isbot` returned true but no explicit rule matched.
  *   Captures the long tail without forcing it into a misleading family.
  *
@@ -73,6 +78,7 @@ export type BotClass =
     | 'ai_crawler'
     | 'social_unfurler'
     | 'uptime_probe'
+    | 'scanner'
     | 'bot_other';
 
 /**
@@ -210,4 +216,160 @@ export function classifyUserAgent(userAgent: string | null | undefined): BotClas
     }
 
     return 'human';
+}
+
+/**
+ * Request-level signals available only at the traffic-event write site.
+ * The UA alone cannot expose a scanner that fakes a browser UA — but the
+ * requested path and the referrer/Sec-Fetch consistency can.
+ */
+export interface ITrafficRequestSignals {
+    /** Raw `User-Agent` header value, or null/undefined. */
+    userAgent: string | null | undefined;
+    /** Sanitized landing path (query/hash already stripped). */
+    path: string | null | undefined;
+    /** Raw `Referer` header value, or null/undefined. */
+    referer: string | null | undefined;
+    /** Raw `Sec-Fetch-Site` header value, or null/undefined. */
+    secFetchSite: string | null | undefined;
+}
+
+/**
+ * Lowercased path fragments that identify vulnerability probes. TronRelic
+ * serves none of these — no PHP, no WordPress, no exposed dotfiles — so a
+ * request for any of them is a scanner by definition, regardless of how
+ * browser-like its UA looks. Match is `includes` on the lowercased path.
+ */
+const SCANNER_PATH_FRAGMENTS: readonly string[] = [
+    '/.env',
+    '/.git',
+    '/.aws',
+    '/.ssh',
+    '/.docker',
+    '/.vscode',
+    '/wp-',
+    '/wordpress',
+    '/xmlrpc',
+    '/phpmyadmin',
+    '/phpinfo',
+    '.php',
+    '.asp',
+    '.jsp',
+    '/web-inf',
+    '/etc/passwd',
+    '/etc/apache2',
+    '/var/www',
+    '.aws/credentials',
+    'application.properties',
+    '/cgi-bin',
+    '/actuator',
+    '/owa/',
+    '/vendor/phpunit',
+    '/wlwmanifest'
+];
+
+/**
+ * Exact-path probes (matched against the whole lowercased path, optionally
+ * with a trailing slash) that are too short to safely `includes`-match —
+ * `/wp` as a fragment would also hit legitimate slugs containing "wp".
+ */
+const SCANNER_EXACT_PATHS: ReadonlySet<string> = new Set([
+    '/wp',
+    '/cms',
+    '/backup',
+    '/old',
+    '/config'
+]);
+
+/**
+ * Path-traversal / encoding-evasion markers, checked against the *raw*
+ * (pre-decode) lowercased path. `../` never appears in a legitimate
+ * TronRelic route, and the encoded forms (`%2e%2e`, overlong UTF-8
+ * `%c0%af`, fullwidth-solidus `%ef%bc%8f`) exist solely to slip
+ * traversal past WAF pattern matching.
+ */
+const TRAVERSAL_FRAGMENTS: readonly string[] = [
+    '../',
+    '..%2f',
+    '%2e%2e',
+    '%252e',
+    '%c0%af',
+    '%ef%bc%8f'
+];
+
+/**
+ * Referrer domains scanners routinely spoof to masquerade as organic
+ * search traffic. Matched against the lowercased `Referer` value.
+ */
+const SPOOF_TARGET_REFERRERS: readonly string[] = [
+    'google.',
+    'bing.com',
+    'duckduckgo.com',
+    'yahoo.',
+    'baidu.com',
+    'yandex.'
+];
+
+/**
+ * True when the requested path pattern-matches a vulnerability probe.
+ *
+ * @param path - Sanitized landing path (may still carry encoded traversal).
+ * @returns True for probe paths (dotfiles, CMS probes, traversal encodings).
+ */
+function isScannerPath(path: string | null | undefined): boolean {
+    let hit = false;
+    if (path) {
+        const p = path.slice(0, MAX_UA_LENGTH).toLowerCase();
+        const exact = p.endsWith('/') && p.length > 1 ? p.slice(0, -1) : p;
+        hit =
+            SCANNER_EXACT_PATHS.has(exact) ||
+            SCANNER_PATH_FRAGMENTS.some(fragment => p.includes(fragment)) ||
+            TRAVERSAL_FRAGMENTS.some(fragment => p.includes(fragment));
+    }
+    return hit;
+}
+
+/**
+ * True when the `Referer` claims a search-engine origin but the request
+ * carries no `Sec-Fetch-Site` header. Every browser that has shipped since
+ * ~2023 sends `Sec-Fetch-Site: cross-site` on a genuine click-through from
+ * Google/Bing; curl-style scanners spoofing the Referer send no Sec-Fetch
+ * headers at all. Gated on search-engine referrers specifically (the
+ * domains scanners actually spoof) so a rare legacy browser arriving from
+ * an arbitrary site is not misclassified.
+ *
+ * @param referer - Raw `Referer` header value.
+ * @param secFetchSite - Raw `Sec-Fetch-Site` header value.
+ * @returns True when the referrer is a spoof-target domain and Sec-Fetch is absent.
+ */
+function isSpoofedSearchReferrer(
+    referer: string | null | undefined,
+    secFetchSite: string | null | undefined
+): boolean {
+    let spoofed = false;
+    if (referer && !secFetchSite) {
+        const ref = referer.slice(0, MAX_UA_LENGTH).toLowerCase();
+        spoofed = SPOOF_TARGET_REFERRERS.some(domain => ref.includes(domain));
+    }
+    return spoofed;
+}
+
+/**
+ * Classify a traffic event using the full request context. Scanner
+ * heuristics (probe paths, spoofed search referrers) run first because
+ * scanners deliberately defeat UA-based classification with fake browser
+ * UAs; everything that isn't a scanner falls through to the UA-only
+ * {@link classifyUserAgent} pipeline unchanged.
+ *
+ * @param signals - Request-level signals collected at the write site.
+ * @returns One of the seven `BotClass` enum values. Never null.
+ */
+export function classifyTrafficRequest(signals: ITrafficRequestSignals): BotClass {
+    let result: BotClass;
+    if (isScannerPath(signals.path) || isSpoofedSearchReferrer(signals.referer, signals.secFetchSite)) {
+        result = 'scanner';
+    } else {
+        result = classifyUserAgent(signals.userAgent);
+    }
+    return result;
 }

--- a/src/backend/modules/traffic/services/bot-classifier.ts
+++ b/src/backend/modules/traffic/services/bot-classifier.ts
@@ -184,6 +184,14 @@ const RULES: ReadonlyArray<{ class: BotClass; fragments: readonly string[] }> = 
 const MAX_UA_LENGTH = 500;
 
 /**
+ * Cap for the other request-signal inputs (path, referrer) before
+ * lowercasing/matching. Same rationale as `MAX_UA_LENGTH` — bound CPU on
+ * hostile inputs in the request path — but a separate constant so scanner
+ * detection is not silently retuned by a future UA-specific change.
+ */
+const MAX_SIGNAL_LENGTH = 500;
+
+/**
  * Classify a User-Agent header value into one of the six `BotClass`
  * buckets.
  *
@@ -319,7 +327,7 @@ const SPOOF_TARGET_REFERRERS: readonly string[] = [
 function isScannerPath(path: string | null | undefined): boolean {
     let hit = false;
     if (path) {
-        const p = path.slice(0, MAX_UA_LENGTH).toLowerCase();
+        const p = path.slice(0, MAX_SIGNAL_LENGTH).toLowerCase();
         const exact = p.endsWith('/') && p.length > 1 ? p.slice(0, -1) : p;
         hit =
             SCANNER_EXACT_PATHS.has(exact) ||
@@ -331,12 +339,16 @@ function isScannerPath(path: string | null | undefined): boolean {
 
 /**
  * True when the `Referer` claims a search-engine origin but the request
- * carries no `Sec-Fetch-Site` header. Every browser that has shipped since
- * ~2023 sends `Sec-Fetch-Site: cross-site` on a genuine click-through from
- * Google/Bing; curl-style scanners spoofing the Referer send no Sec-Fetch
- * headers at all. Gated on search-engine referrers specifically (the
- * domains scanners actually spoof) so a rare legacy browser arriving from
- * an arbitrary site is not misclassified.
+ * carries no `Sec-Fetch-Site` header. Chromium (including Android WebView
+ * in-app browsers) has sent `Sec-Fetch-Site: cross-site` on genuine
+ * click-throughs since 2019, and WebKit since iOS 16.4 (2023); curl-style
+ * scanners spoofing the Referer send no Sec-Fetch headers at all. Gated on
+ * search-engine referrers specifically (the domains scanners actually
+ * spoof) so a legacy browser arriving from an arbitrary site is not
+ * misclassified. Accepted residual: a pre-16.4 iOS browser arriving from
+ * a real search click is mislabeled — the cost is one first-touch
+ * analytics label, and its same-origin `page` events still classify
+ * as human.
  *
  * @param referer - Raw `Referer` header value.
  * @param secFetchSite - Raw `Sec-Fetch-Site` header value.
@@ -348,7 +360,7 @@ function isSpoofedSearchReferrer(
 ): boolean {
     let spoofed = false;
     if (referer && !secFetchSite) {
-        const ref = referer.slice(0, MAX_UA_LENGTH).toLowerCase();
+        const ref = referer.slice(0, MAX_SIGNAL_LENGTH).toLowerCase();
         spoofed = SPOOF_TARGET_REFERRERS.some(domain => ref.includes(domain));
     }
     return spoofed;

--- a/src/backend/modules/traffic/services/geo.service.ts
+++ b/src/backend/modules/traffic/services/geo.service.ts
@@ -230,6 +230,15 @@ export function getDeviceCategory(userAgent: string | undefined): DeviceCategory
  * @returns Client IP address
  */
 export function getClientIP(req: { ip?: string; headers: Record<string, string | string[] | undefined> }): string | undefined {
+    // Prefer Cloudflare's CF-Connecting-IP: it is set by the edge to the
+    // true client address and, unlike X-Forwarded-For, cannot be seeded by
+    // the client itself (Cloudflare strips/overwrites it on ingress).
+    const cfConnecting = req.headers['cf-connecting-ip'];
+    if (cfConnecting) {
+        const ip = Array.isArray(cfConnecting) ? cfConnecting[0] : cfConnecting;
+        return ip.trim();
+    }
+
     // Check X-Forwarded-For header (from reverse proxy)
     const forwarded = req.headers['x-forwarded-for'];
     if (forwarded) {

--- a/src/backend/modules/traffic/services/geo.service.ts
+++ b/src/backend/modules/traffic/services/geo.service.ts
@@ -230,13 +230,22 @@ export function getDeviceCategory(userAgent: string | undefined): DeviceCategory
  * @returns Client IP address
  */
 export function getClientIP(req: { ip?: string; headers: Record<string, string | string[] | undefined> }): string | undefined {
-    // Prefer Cloudflare's CF-Connecting-IP: it is set by the edge to the
-    // true client address and, unlike X-Forwarded-For, cannot be seeded by
-    // the client itself (Cloudflare strips/overwrites it on ingress).
+    // Prefer Cloudflare's CF-Connecting-IP: for traffic that transits the
+    // Cloudflare edge it is set to the true client address and, unlike
+    // X-Forwarded-For, cannot be forged by the client (the edge overwrites
+    // it on ingress). It is honored only when CF-Ray is also present —
+    // a spoofer can send both together, so this gate is consistency
+    // hygiene, not a security boundary; the real enforcement is
+    // allow-listing Cloudflare's published IP ranges at the origin
+    // firewall. Where that is not enforced the only exposure is poisoned
+    // analytics geo: this value feeds country derivation and an admin
+    // audit-log field, never rate limiting or geo-blocking.
     const cfConnecting = req.headers['cf-connecting-ip'];
-    if (cfConnecting) {
-        const ip = Array.isArray(cfConnecting) ? cfConnecting[0] : cfConnecting;
-        return ip.trim();
+    if (cfConnecting && req.headers['cf-ray']) {
+        const raw = Array.isArray(cfConnecting) ? cfConnecting[0] : cfConnecting;
+        // Defensive: the header is single-valued from Cloudflare, but a
+        // misbehaving hop could comma-join — take the first entry.
+        return raw.split(',')[0].trim();
     }
 
     // Check X-Forwarded-For header (from reverse proxy)

--- a/src/backend/modules/traffic/services/traffic.service.ts
+++ b/src/backend/modules/traffic/services/traffic.service.ts
@@ -1810,7 +1810,11 @@ export function buildTrafficEvent(
     const secFetchMode = readSingleHeader(headers['sec-fetch-mode']);
     const secFetchSite = readSingleHeader(headers['sec-fetch-site']);
     const cfRay = readSingleHeader(headers['cf-ray']);
-    const cfIpCountry = normalizeCfCountry(readSingleHeader(headers['cf-ipcountry']));
+    // Trust CF-IPCountry only when CF-Ray attests the hop was Cloudflare.
+    // A direct-to-origin client can spoof both together, so this is row
+    // consistency (cf columns populate as a set), not a security boundary —
+    // the real enforcement is the origin firewall allow-listing Cloudflare.
+    const cfIpCountry = cfRay ? normalizeCfCountry(readSingleHeader(headers['cf-ipcountry'])) : null;
 
     const utm = inputs.utm ?? {};
     const path = inputs.landingPath ?? (typeof req.path === 'string' ? req.path : '/');

--- a/src/backend/modules/traffic/services/traffic.service.ts
+++ b/src/backend/modules/traffic/services/traffic.service.ts
@@ -41,7 +41,7 @@
 import type { Request } from 'express';
 import type { IClickHouseService, ISystemLogService } from '@/types';
 import { getClientIP, getCountryFromIP, getDeviceCategory } from './geo.service.js';
-import { classifyUserAgent, type BotClass } from './bot-classifier.js';
+import { classifyTrafficRequest, type BotClass } from './bot-classifier.js';
 import { UUID_V4_REGEX } from '../api/traffic-cookies.js';
 
 /**
@@ -127,6 +127,23 @@ export interface ITrafficEvent {
     sec_fetch_dest: string | null;
     sec_fetch_mode: string | null;
     sec_fetch_site: string | null;
+
+    /**
+     * Cloudflare ray id (`CF-Ray` header) when the request traversed the
+     * Cloudflare proxy, else `null`. A `null` here on production traffic
+     * means the request hit the origin directly, bypassing Cloudflare —
+     * the signal that distinguishes proxied scanners (a WAF-tuning
+     * problem) from direct-to-origin scanners (a firewall problem).
+     * Additive column (migration 014).
+     */
+    cf_ray: string | null;
+    /**
+     * Cloudflare's authoritative edge-derived country (`CF-IPCountry`
+     * header, ISO-3166 alpha-2), else `null`. Kept alongside the local
+     * GeoIP-derived `country` so the two sources can be compared.
+     * Additive column (migration 014).
+     */
+    cf_ipcountry: string | null;
 }
 
 /**
@@ -585,7 +602,9 @@ export class TrafficService {
                 sec_ch_ua_platform,
                 sec_fetch_dest,
                 sec_fetch_mode,
-                sec_fetch_site
+                sec_fetch_site,
+                cf_ray,
+                cf_ipcountry
             FROM ${TABLE_NAME}
             WHERE candidate_uid = {candidateUid:UUID}
             ${eventFilter}
@@ -1790,8 +1809,11 @@ export function buildTrafficEvent(
     const secFetchDest = readSingleHeader(headers['sec-fetch-dest']);
     const secFetchMode = readSingleHeader(headers['sec-fetch-mode']);
     const secFetchSite = readSingleHeader(headers['sec-fetch-site']);
+    const cfRay = readSingleHeader(headers['cf-ray']);
+    const cfIpCountry = normalizeCfCountry(readSingleHeader(headers['cf-ipcountry']));
 
     const utm = inputs.utm ?? {};
+    const path = inputs.landingPath ?? (typeof req.path === 'string' ? req.path : '/');
 
     return {
         event_type: eventType,
@@ -1801,16 +1823,18 @@ export function buildTrafficEvent(
         referral_code: inputs.referralCode ?? null,
         duration_ms: inputs.durationMs ?? null,
 
-        path: inputs.landingPath ?? (typeof req.path === 'string' ? req.path : '/'),
+        path,
         referer: referer ?? null,
         original_referrer: inputs.originalReferrer ?? null,
 
         user_agent: userAgent ?? null,
         accept_language: acceptLanguage ?? null,
 
-        country: getCountryFromIP(getClientIP({ ip: req.ip, headers })),
+        // Cloudflare's edge-derived country is authoritative when present;
+        // the local GeoIP lookup covers direct-to-origin and dev traffic.
+        country: cfIpCountry ?? getCountryFromIP(getClientIP({ ip: req.ip, headers })),
         device: getDeviceCategory(userAgent),
-        bot_class: classifyUserAgent(userAgent),
+        bot_class: classifyTrafficRequest({ userAgent, path, referer, secFetchSite }),
 
         utm_source: utm.source ?? null,
         utm_medium: utm.medium ?? null,
@@ -1823,8 +1847,31 @@ export function buildTrafficEvent(
         sec_ch_ua_platform: secChUaPlatform ?? null,
         sec_fetch_dest: secFetchDest ?? null,
         sec_fetch_mode: secFetchMode ?? null,
-        sec_fetch_site: secFetchSite ?? null
+        sec_fetch_site: secFetchSite ?? null,
+
+        cf_ray: cfRay ?? null,
+        cf_ipcountry: cfIpCountry
     };
+}
+
+/**
+ * Normalize the `CF-IPCountry` header into a storable ISO-3166 alpha-2
+ * code. Cloudflare emits `XX` (unknown) and `T1` (Tor) sentinels that are
+ * not countries — collapsing them to `null` keeps the geo dimension clean
+ * while the raw proxied/direct signal still lives in `cf_ray`.
+ *
+ * @param value - Raw `CF-IPCountry` header value.
+ * @returns Uppercase alpha-2 code, or `null` for sentinels/malformed input.
+ */
+function normalizeCfCountry(value: string | undefined): string | null {
+    let country: string | null = null;
+    if (value) {
+        const v = value.trim().toUpperCase();
+        if (/^[A-Z]{2}$/.test(v) && v !== 'XX' && v !== 'T1') {
+            country = v;
+        }
+    }
+    return country;
 }
 
 /**

--- a/src/frontend/middleware.ts
+++ b/src/frontend/middleware.ts
@@ -72,11 +72,14 @@ const FORWARDED_HEADERS = [
     'sec-fetch-dest',
     'sec-fetch-mode',
     'sec-fetch-site',
-    // Cloudflare edge headers. `cf-ray` proves the request traversed the
-    // Cloudflare proxy (its absence on production traffic means a
-    // direct-to-origin hit), `cf-ipcountry` is the edge's authoritative
-    // geo, and `cf-connecting-ip` is the true client address the backend's
-    // getClientIP prefers over the spoofable X-Forwarded-For chain.
+    // Cloudflare edge headers, forwarded verbatim. `cf-ray` marks a request
+    // that traversed the Cloudflare proxy (absent on direct-to-origin hits),
+    // `cf-ipcountry` is the edge geo, and `cf-connecting-ip` is the client
+    // address the backend's getClientIP prefers over the spoofable
+    // X-Forwarded-For chain. These are unverified client-supplied headers a
+    // direct-to-origin client can forge, so cf-ray is consistency hygiene,
+    // not a trust boundary — the origin firewall allow-listing Cloudflare's
+    // ranges is authoritative.
     'cf-ray',
     'cf-ipcountry',
     'cf-connecting-ip'

--- a/src/frontend/middleware.ts
+++ b/src/frontend/middleware.ts
@@ -71,7 +71,15 @@ const FORWARDED_HEADERS = [
     'sec-ch-ua-platform',
     'sec-fetch-dest',
     'sec-fetch-mode',
-    'sec-fetch-site'
+    'sec-fetch-site',
+    // Cloudflare edge headers. `cf-ray` proves the request traversed the
+    // Cloudflare proxy (its absence on production traffic means a
+    // direct-to-origin hit), `cf-ipcountry` is the edge's authoritative
+    // geo, and `cf-connecting-ip` is the true client address the backend's
+    // getClientIP prefers over the spoofable X-Forwarded-For chain.
+    'cf-ray',
+    'cf-ipcountry',
+    'cf-connecting-ip'
 ] as const;
 
 /** UTM keys we accept from the URL. Anything else is dropped. */

--- a/src/frontend/modules/traffic/components/admin/CrawlerDashboard/CrawlerDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/CrawlerDashboard/CrawlerDashboard.tsx
@@ -49,6 +49,7 @@ const BOT_CLASS_SERIES: Array<{ key: string; label: string; cssVar: string; fall
     { key: 'ai_crawler', label: 'AI crawler', cssVar: '--chart-color-5', fallback: '#8b5cf6' },
     { key: 'social_unfurler', label: 'Social unfurler', cssVar: '--chart-color-3', fallback: '#f59e0b' },
     { key: 'uptime_probe', label: 'Uptime probe', cssVar: '--chart-color-6', fallback: '#06b6d4' },
+    { key: 'scanner', label: 'Scanner', cssVar: '--chart-color-4', fallback: '#ef4444' },
     { key: 'bot_other', label: 'Other bots', cssVar: '--chart-color-8', fallback: '#f97316' },
     { key: 'unclassified', label: 'Unclassified', cssVar: '--chart-color-9', fallback: '#14b8a6' }
 ];
@@ -59,6 +60,7 @@ const PATH_BOT_CLASSES: Array<{ key: string; label: string }> = [
     { key: 'search_engine', label: 'Search engine' },
     { key: 'social_unfurler', label: 'Social unfurler' },
     { key: 'uptime_probe', label: 'Uptime probe' },
+    { key: 'scanner', label: 'Scanner' },
     { key: 'bot_other', label: 'Other bots' },
     { key: 'human', label: 'Human' }
 ];


### PR DESCRIPTION
## Why

Production analytics showed vulnerability scanners landing in the `human` bucket with spoofed `google.com` referrers, inflating Traffic Sources (Google Search Console reported only single-digit real referrals). Scanners send fake browser User-Agents, so the UA-only classifier could not catch them, and the data could not answer whether a request reached the origin through Cloudflare or bypassed it.

## What

**Scanner classification.** New `scanner` `BotClass` and `classifyTrafficRequest()` that runs request-level heuristics before UA classification: probe paths (`/.env`, `/.git`, `/wp*`, encoded traversal like `%c0%af`/`%252e`, `WEB-INF`, `.php`), and referrer-consistency (a search-engine `Referer` with no `Sec-Fetch-Site` header is spoofed). `buildTrafficEvent` uses it, so scanners drop out of the dashboard's humans-only filter. The crawler dashboard and API allow-list render the new `Scanner` series.

**Cloudflare signal capture.** Migration 014 adds `cf_ray` and `cf_ipcountry` to `traffic_events`. The Next.js middleware forwards `cf-ray`, `cf-ipcountry`, and `cf-connecting-ip`; `getClientIP` prefers `CF-Connecting-IP` over the spoofable `X-Forwarded-For`; `country` prefers Cloudflare's edge geo. A NULL `cf_ray` on a production row now means the request bypassed Cloudflare.

## Notes

- Migration 014 is operator-triggered — run from `/system/database` after deploy.
- 15 new classifier tests; full traffic module suite (128) and backend/frontend typechecks pass.