### PR TITLE
fix(curation): truncate long publish-sink names in the destination picker

### DIFF
--- a/src/frontend/app/(core)/system/curation/page.module.scss
+++ b/src/frontend/app/(core)/system/curation/page.module.scss
@@ -147,6 +147,10 @@
 .review_rail {
     display: flex;
     flex-direction: column;
+    /* Honor the fixed rail track: a grid item defaults to min-width:auto, so a
+       long sink name (a Telegram channel title) would blow the column past its
+       max-width-sm track and defeat the .dest_label ellipsis. */
+    min-width: 0;
     padding-top: var(--gap-md);
     border-top: var(--border-width-thin) solid var(--color-border);
 }
@@ -176,6 +180,10 @@
     margin: 0;
     padding: 0;
     border: none;
+    /* A <fieldset> carries an intrinsic min-width:min-content that ignores flex
+       and grid shrinking; without this override the picker refuses to narrow
+       below its widest sink name, cascading the overflow up the rail. */
+    min-width: 0;
 }
 
 .picker_legend {


### PR DESCRIPTION
## Summary

The `/system/curation` destination picker wrapped long publish-sink names (e.g. the Telegram channel title) across multiple lines instead of truncating them to a single line.

The `.dest_label` ellipsis rules (`nowrap` + `overflow: hidden` + `text-overflow: ellipsis`) and the `title` hover tooltip were already correct. The names still overflowed because two ancestors refused to shrink below their content:

- **`.review_rail`** — a grid item pinned to the `max-width-sm` track, but its default `min-width: auto` let the long name blow the column wider.
- **`.picker`** — a `<fieldset>`, which carries an intrinsic `min-width: min-content` that overrides flex/grid shrinking unless explicitly set to `0`.

Adding `min-width: 0` to both lets the fixed rail width hold, so the sink name truncates with an ellipsis. The full name already surfaces on hover via the existing `title` attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)