### PR TITLE
fix(widgets): correct widget-zone collapse sizing and world-clocks wrap

### DIFF
--- a/src/frontend/components/widgets/WidgetZone.module.scss
+++ b/src/frontend/components/widgets/WidgetZone.module.scss
@@ -84,72 +84,68 @@
     flex: var(--item-grow, 1) 1 0;
 }
 
-// Responsive collapse. Each class flips the inner flex container to a
-// column once its wrapper is narrower than the named breakpoint, and resets
-// its own *direct* weighted children (the child combinator keeps a zone's
-// collapse from reaching into a nested group's children) to natural,
-// full-width stacking — `flex: 0 0 auto` undoes the zero-basis grow that
-// only makes sense on a row's main axis. `align-self: stretch` is the
-// load-bearing half: once the container is a column the cross axis is
-// horizontal, so item width is governed by alignment, not flex; without it a
-// row preset's `align-items: center` (or flex-start/flex-end) leaves the
-// collapsed weighted items at content width instead of spanning the column.
-// It is a no-op under the `stretch` default. The breakpoint variable must be
-// interpolated (`#{…}`) inside `@container` or Sass silently drops the
+// Responsive collapse. Each class flips the inner flex container to a column
+// once its wrapper is narrower than the named breakpoint. The five variants
+// differ only in the breakpoint, so they share one mixin — the breakpoint must
+// be interpolated (`#{…}`) inside `@container` or Sass silently drops the
 // condition.
-.collapse_mobile_sm {
-    @container widget-layout (max-width: #{$breakpoint-mobile-sm}) {
+//
+// Three declarations do the work once the container is a column:
+//
+// `flex: 0 0 auto` on the *direct* weighted children (the child combinator
+// keeps a zone's collapse from reaching into a nested group's children) undoes
+// the zero-basis grow that only makes sense on a row's main axis, letting each
+// stack at its natural height. `align-self: stretch` is the load-bearing half:
+// once the container is a column the cross axis is horizontal, so item width is
+// governed by alignment, not flex; without it a row preset's
+// `align-items: center` (or flex-start/flex-end) leaves the collapsed weighted
+// items at content width instead of spanning the column. It is a no-op under the
+// `stretch` default.
+//
+// `width: 100%` on *every* direct item is the fix for a subtle intrinsic-sizing
+// bug. `align-self: stretch` sizes an item to the column's width, but that width
+// is not *definite*. A widget whose root sets `container-type: inline-size` (to
+// run its own container queries — e.g. the dust-tracker chart) needs a definite
+// inline size, or the flex column's content-height pass lays that widget out at
+// a degenerate width, wraps its rows (chart header, legend), and inflates the
+// item ~100px past the height it actually renders — dead space below the widget.
+// An explicit `width: 100%` makes the inline size definite and the phantom
+// height vanishes. Harmless for plain widgets, and scoped to the collapsed
+// column so it never reaches the row layout, where full-width items would
+// collapse a side-by-side row into a stack.
+@mixin collapse-to-column($breakpoint) {
+    @container widget-layout (max-width: #{$breakpoint}) {
         flex-direction: column;
+
+        > .item {
+            width: 100%;
+        }
 
         > .item_weighted {
             flex: 0 0 auto;
             align-self: stretch;
         }
     }
+}
+
+.collapse_mobile_sm {
+    @include collapse-to-column($breakpoint-mobile-sm);
 }
 
 .collapse_mobile_md {
-    @container widget-layout (max-width: #{$breakpoint-mobile-md}) {
-        flex-direction: column;
-
-        > .item_weighted {
-            flex: 0 0 auto;
-            align-self: stretch;
-        }
-    }
+    @include collapse-to-column($breakpoint-mobile-md);
 }
 
 .collapse_mobile_lg {
-    @container widget-layout (max-width: #{$breakpoint-mobile-lg}) {
-        flex-direction: column;
-
-        > .item_weighted {
-            flex: 0 0 auto;
-            align-self: stretch;
-        }
-    }
+    @include collapse-to-column($breakpoint-mobile-lg);
 }
 
 .collapse_tablet {
-    @container widget-layout (max-width: #{$breakpoint-tablet}) {
-        flex-direction: column;
-
-        > .item_weighted {
-            flex: 0 0 auto;
-            align-self: stretch;
-        }
-    }
+    @include collapse-to-column($breakpoint-tablet);
 }
 
 .collapse_desktop {
-    @container widget-layout (max-width: #{$breakpoint-desktop}) {
-        flex-direction: column;
-
-        > .item_weighted {
-            flex: 0 0 auto;
-            align-self: stretch;
-        }
-    }
+    @include collapse-to-column($breakpoint-desktop);
 }
 
 .item_title {

--- a/src/frontend/components/widgets/WorldClocksWidget.module.scss
+++ b/src/frontend/components/widgets/WorldClocksWidget.module.scss
@@ -6,9 +6,19 @@
  * are operator-controlled per placement: the component sets the
  * `--world-clocks-*` custom properties from the SSR `instanceConfig`, and the
  * rules below consume them with fallbacks matching the schema defaults
- * (single non-wrapping, left-aligned row at the medium token gap). Because
- * spacing is now an explicit operator choice, there is no responsive gap
- * override — honouring the chosen value beats silently retightening it.
+ * (single non-wrapping, left-aligned row at the medium token gap).
+ *
+ * The operator's choice is honoured at every width except one: below the
+ * mobile breakpoint a `nowrap` row cannot fit a narrow phone and forces the
+ * whole page to scroll horizontally, distorting every zone the widget shares.
+ * Page integrity outranks the placement's spacing preference, so the container
+ * query at the foot of this file overrides `flex-wrap` to `wrap` (and tightens
+ * the gap) once the widget's zone is narrower than the breakpoint. That query
+ * targets the `widget-layout` container established by `WidgetZone`'s
+ * `.zone_container` / `.group_container` wrappers: a flex container cannot
+ * query its own width, so `.clocks` measures the zone that holds it, exactly
+ * as the zone-collapse rules do. (An earlier revision queried a `world-clocks`
+ * container that nothing ever established, so it never fired.)
  */
 
 @use '../../app/breakpoints' as *;
@@ -48,8 +58,15 @@
     white-space: nowrap;
 }
 
-@container world-clocks (max-width: #{$breakpoint-mobile-md}) {
+@container widget-layout (max-width: #{$breakpoint-mobile}) {
     .clocks {
+        /* Force wrapping below the mobile breakpoint regardless of the
+         * operator's `--world-clocks-wrap`: a single row that overflows a
+         * phone breaks the whole page, and reflowing onto multiple lines is
+         * the lesser evil. `.item { min-width: 0 }` in WidgetZone lets the row
+         * shrink so the clocks reflow to fill the width rather than collapsing
+         * one-per-line. */
+        flex-wrap: wrap;
         gap: var(--gap-sm);
     }
 }


### PR DESCRIPTION
## Summary

Two related fixes to widget responsive layout, both SCSS-only.

**WidgetZone collapse sizing.** The five `.collapse_*` variants were duplicated blocks differing only in breakpoint; they now share a single `collapse-to-column($breakpoint)` mixin. The collapsed column also gains `width: 100%` on every direct `.item`. `align-self: stretch` sizes an item to the column width but that width is not *definite*; a widget whose root sets `container-type: inline-size` (e.g. the dust-tracker chart) then lays out at a degenerate width, wraps its own rows, and inflates the item ~100px past its rendered height — dead space below the widget. An explicit `width: 100%` makes the inline size definite and the phantom height vanishes. Scoped to the collapsed column so it never reaches the row layout.

**WorldClocksWidget mobile wrap.** The mobile container query targeted a `world-clocks` container that nothing ever established, so it never fired. Repointed at the real `widget-layout` container (established by WidgetZone's wrappers, the same container the zone-collapse rules measure) and forces `flex-wrap: wrap` below the mobile breakpoint. A `nowrap` row on a narrow phone forces the whole page to scroll horizontally; page integrity outranks the placement's spacing preference.

Type check passes.