### PR TITLE
feat(syndication): add scheduler.legDelivered hook on successful delivery

### DIFF
--- a/docs/system/system-hooks.md
+++ b/docs/system/system-hooks.md
@@ -78,6 +78,7 @@ See `src/backend/hooks/registry.ts` for the live list. Today:
 | `ai.toolInvoke` | `ai.tool` | `series` | 100 | Inspect a governed AI tool call before it runs (after schema validation). Throw `HookAbortError` to veto or hold; the governor surfaces the abort to the model as a denial. For compliance / lethal-trifecta gating. |
 | `ai.toolInvoked` | `ai.tool` | `observer` | 200 | Fired after a governed AI tool call completes, with the full `IToolInvocationRecord`. For audit fan-out, alerting, and lethal-trifecta watch; cannot change the outcome. |
 | `http.walletLinked` | `http.api` | `observer` | 100 | Fired after a user verifies (links) a TRON wallet on their profile and it is persisted. Carries `IWalletLinkedContext` (`{ userId, address }`). For modules reacting to new verified ownership — account-history enrolls the address into its backfill; cannot change the link outcome. |
+| `scheduler.legDelivered` | `scheduler.tick` | `observer` | 100 | Fired when the syndication relay successfully delivers a publish leg to its sink — one firing per leg. Carries `ISyndicationDeliveredContext` (sink, delivered descriptor, and provider coordinates `typeId` + `ref` so a subscriber can load the full record). A `refused` settle does not fire it; cannot change the outcome. |
 
 Adding a seam is a PR to `registry.ts`: declare the descriptor with its types, then wire core to invoke it via `hookRegistry.invoke(descriptor, input, seed?)`. The bar to add is intentionally higher than the bar to use — that asymmetry is what keeps the surface small.
 

--- a/packages/types/src/hooks/ICoreHooks.ts
+++ b/packages/types/src/hooks/ICoreHooks.ts
@@ -34,6 +34,7 @@ import type { IHeadFragment } from '../ssr/IHeadFragment.js';
 import type { IAiToolInvokeContext } from '../ai-tools/IAiToolHookContext.js';
 import type { IToolInvocationRecord } from '../ai-tools/IToolInvocationRecord.js';
 import type { IWalletLinkedContext } from './IWalletLinkedContext.js';
+import type { ISyndicationDeliveredContext } from './ISyndicationDeliveredContext.js';
 
 /**
  * SSR-phase declared seams. Mirrors the `HOOKS.ssr` object in core's
@@ -104,17 +105,34 @@ export interface ICoreHttpHooks {
 }
 
 /**
+ * Scheduler-phase declared seams. Mirrors the `HOOKS.scheduler` object in core's
+ * `registry.ts`. These seams fire from inside a scheduler job tick, so the admin
+ * timeline groups them under the `scheduler.tick` track.
+ */
+export interface ICoreSchedulerHooks {
+    /**
+     * Observer seam fired when the syndication relay successfully delivers a
+     * publish leg to its sink — one firing per leg, inside the
+     * `syndication:relay` tick. Carries the sink, the delivered descriptor, and
+     * the provider content coordinates (`typeId` + `ref`) so a subscriber can
+     * load the full underlying content by hand. A `refused` settle does not fire
+     * this; handlers cannot change the outcome.
+     */
+    readonly legDelivered: HookDescriptor<ISyndicationDeliveredContext, void, 'observer'>;
+}
+
+/**
  * Aggregate shape of every declared seam, grouped by pipeline phase.
  *
- * The remaining phases (`websocket`, `scheduler`, `observer`) are declared as
- * empty marker objects so adding the first seam in those phases is a one-line
- * interface extension instead of a structural surprise for existing consumers.
+ * The remaining phases (`websocket`, `observer`) are declared as empty marker
+ * objects so adding the first seam in those phases is a one-line interface
+ * extension instead of a structural surprise for existing consumers.
  */
 export interface ICoreHooks {
     readonly ssr: ICoreSsrHooks;
     readonly ai: ICoreAiHooks;
     readonly http: ICoreHttpHooks;
     readonly websocket: Readonly<Record<string, never>>;
-    readonly scheduler: Readonly<Record<string, never>>;
+    readonly scheduler: ICoreSchedulerHooks;
     readonly observer: Readonly<Record<string, never>>;
 }

--- a/packages/types/src/hooks/ISyndicationDeliveredContext.ts
+++ b/packages/types/src/hooks/ISyndicationDeliveredContext.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Payload for the `scheduler.legDelivered` observer hook.
+ *
+ * A syndication leg is one durable delivery of one approved content item to one
+ * external sink. Successful delivery is a domain fact other components want to
+ * react to — record an audit row, bump a per-sink success metric, kick a
+ * downstream workflow — without the syndication relay learning about them. The
+ * relay fires this observer seam once per leg the moment a sink reports success,
+ * from inside the `syndication:relay` scheduler tick.
+ *
+ * The payload is built to be self-sufficient for a subscriber that wants to load
+ * the full underlying content by hand. It carries the rendered `descriptor` that
+ * was actually delivered (a faithful, decision-time snapshot), plus the provider
+ * content coordinates — `typeId` names the owning content type and `ref` is the
+ * opaque pointer that type resolves back to its own record (e.g. `{ postId }` for
+ * the blog type). A subscriber that knows the provider can read `ref` to fetch
+ * the live record; core never interprets `ref`'s shape.
+ *
+ * @module types/hooks/ISyndicationDeliveredContext
+ */
+
+import type { IContentDescriptor } from '../content/IContentDescriptor.js';
+
+/**
+ * Context handed to handlers of the `scheduler.legDelivered` hook — the sink and
+ * content of one successfully delivered syndication leg.
+ */
+export interface ISyndicationDeliveredContext {
+    /** The content-router sink id the leg was delivered to. */
+    sinkId: string;
+
+    /**
+     * Human-readable sink label, best-effort. Present only while the sink is
+     * still registered at delivery time; absent otherwise. Use `sinkId` as the
+     * stable key.
+     */
+    sinkLabel?: string;
+
+    /**
+     * The owning content type id (e.g. the blog type). With `ref`, the complete
+     * coordinate a subscriber needs to resolve the provider's own record.
+     */
+    typeId: string;
+
+    /**
+     * The opaque provider pointer, resolved verbatim by the owning content type
+     * back to its record (e.g. `{ postId: '...' }`). Core never interprets it.
+     */
+    ref: Record<string, unknown>;
+
+    /**
+     * The rendered content descriptor that was delivered to the sink — the
+     * decision-time snapshot frozen into the outbox leg, not a live re-render.
+     */
+    descriptor: IContentDescriptor;
+
+    /** The delivered leg id (the outbox row id); uniquely identifies this delivery. */
+    legId: string;
+
+    /** Stable id of the originating record (e.g. the curation item id). */
+    originId: string;
+
+    /** What produced the originating request (e.g. `'curation'`); audit/grouping only. */
+    originKind: string;
+
+    /** The stable `(originId, sinkId)` idempotency key handed to the sink. */
+    idempotencyKey: string;
+
+    /** Delivery attempt number that succeeded (1 on first-try success). */
+    attempt: number;
+}

--- a/packages/types/src/hooks/index.ts
+++ b/packages/types/src/hooks/index.ts
@@ -35,6 +35,8 @@ export type {
 
 export type { IPluginHooks } from './IPluginHooks.js';
 
-export type { ICoreHooks, ICoreSsrHooks, ICoreAiHooks, ICoreHttpHooks } from './ICoreHooks.js';
+export type { ICoreHooks, ICoreSsrHooks, ICoreAiHooks, ICoreHttpHooks, ICoreSchedulerHooks } from './ICoreHooks.js';
 
 export type { IWalletLinkedContext } from './IWalletLinkedContext.js';
+
+export type { ISyndicationDeliveredContext } from './ISyndicationDeliveredContext.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -199,7 +199,9 @@ export type {
     ICoreSsrHooks,
     ICoreAiHooks,
     ICoreHttpHooks,
-    IWalletLinkedContext
+    ICoreSchedulerHooks,
+    IWalletLinkedContext,
+    ISyndicationDeliveredContext
 } from './hooks/index.js';
 export { HookAbortError, isHookAbortError } from './hooks/index.js';
 export type { IHeadFragment, HeadFragmentTag, ISsrHeadContext } from './ssr/index.js';

--- a/packages/types/src/syndication/ISyndicationService.ts
+++ b/packages/types/src/syndication/ISyndicationService.ts
@@ -81,6 +81,20 @@ export interface ISyndicationRequest {
     /** What produced this request (e.g. `'curation'`); audit/grouping only. */
     originKind: string;
 
+    /**
+     * The owning content type id (e.g. the blog type). Frozen into every leg's
+     * row alongside `ref` so a delivery-success subscriber can identify the
+     * provider and load the full underlying record by hand.
+     */
+    typeId: string;
+
+    /**
+     * The opaque provider pointer the owning content type resolves back to its
+     * own record (e.g. `{ postId: '...' }`). Frozen into every leg's row; never
+     * interpreted by syndication.
+     */
+    ref: Record<string, unknown>;
+
     /** The canonical IR frozen into every leg's outbox row. */
     descriptor: IContentDescriptor;
 

--- a/src/backend/hooks/__tests__/hooks.test.ts
+++ b/src/backend/hooks/__tests__/hooks.test.ts
@@ -530,4 +530,11 @@ describe('HOOKS registry — production seams', () => {
         expect(HOOKS.http.walletLinked.phase).toBe('http.api');
         expect(HOOKS.http.walletLinked.order).toBe(100);
     });
+
+    it('declares scheduler.legDelivered as an observer under scheduler.tick at order 100', () => {
+        expect(HOOKS.scheduler.legDelivered.id).toBe('scheduler.legDelivered');
+        expect(HOOKS.scheduler.legDelivered.kind).toBe('observer');
+        expect(HOOKS.scheduler.legDelivered.phase).toBe('scheduler.tick');
+        expect(HOOKS.scheduler.legDelivered.order).toBe(100);
+    });
 });

--- a/src/backend/hooks/registry.ts
+++ b/src/backend/hooks/registry.ts
@@ -21,7 +21,7 @@
  * @module backend/hooks/registry
  */
 
-import type { IHeadFragment, ISsrHeadContext, IAiToolInvokeContext, IToolInvocationRecord, IWalletLinkedContext } from '@/types';
+import type { IHeadFragment, ISsrHeadContext, IAiToolInvokeContext, IToolInvocationRecord, IWalletLinkedContext, ISyndicationDeliveredContext } from '@/types';
 import { defineHook } from './define-hook.js';
 
 /**
@@ -140,7 +140,30 @@ export const HOOKS = {
         })
     },
     websocket: {} as Record<string, never>,
-    scheduler: {} as Record<string, never>,
+    scheduler: {
+        /**
+         * Observer fired when the syndication relay successfully delivers a
+         * publish leg to its sink — one firing per leg, inside the
+         * `syndication:relay` tick that won the claim. Carries the sink id and
+         * label, the delivered content descriptor (the decision-time snapshot
+         * frozen into the outbox row), and the provider content coordinates
+         * (`typeId` + `ref`) so a subscriber can load the full underlying record
+         * by hand. A `refused` settle is a settled "will not" and does NOT fire
+         * this — only a genuine delivery does. Observer semantics keep a
+         * reactor's failure isolated: it can never change or undo the delivery.
+         */
+        legDelivered: defineHook<ISyndicationDeliveredContext, void, 'observer'>({
+            id: 'scheduler.legDelivered',
+            kind: 'observer',
+            phase: 'scheduler.tick',
+            order: 100,
+            description:
+                'Fired when the syndication relay successfully delivers a publish leg to its sink. Carries ' +
+                'the sink, the delivered descriptor, and the provider content coordinates (typeId + ref) so ' +
+                'a subscriber can load the full content. For delivery audit, metrics, and downstream fan-out ' +
+                '— handlers cannot change the outcome.'
+        })
+    },
     observer: {} as Record<string, never>
 } as const;
 

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -441,7 +441,7 @@ async function bootstrapInit(): Promise<BootstrapContext> {
     // it instead of delivering inline best-effort; it resolves the service lazily
     // at decide-time, so init order relative to curation does not matter. Receives
     // the scheduler service so its relay job can register.
-    await syndicationModule.init({ database: coreDatabase, serviceRegistry, scheduler: schedulerService, app });
+    await syndicationModule.init({ database: coreDatabase, serviceRegistry, hookRegistry, scheduler: schedulerService, app });
     // The ai-tools module owns the built-in dynamic prompt variables (lifted out
     // of trp-ai-assistant), so it needs the core services those resolvers read.
     // All are singletons wired by initializeCoreServices() above; the resolvers

--- a/src/backend/modules/curation/services/curation-service.ts
+++ b/src/backend/modules/curation/services/curation-service.ts
@@ -734,6 +734,8 @@ export class CurationService implements ICurationService {
                             await syndication.enqueue({
                                 originId: id,
                                 originKind: 'curation',
+                                typeId: existing.typeId,
+                                ref: existing.ref,
                                 descriptor: decisionPreview,
                                 legs: selected.map((d) => ({ sinkId: d.sink.id, dest: d.dest }))
                             });

--- a/src/backend/modules/syndication/README.md
+++ b/src/backend/modules/syndication/README.md
@@ -12,7 +12,8 @@ Durable `publish`-family delivery for the content router. Curation (and any futu
 | Admin API base | `/api/admin/system/syndication` (admin-gated at mount) |
 | Owned collection | `module_syndication_outbox` |
 | Scheduler job | `syndication:relay` — `*/1 * * * *` (every minute) |
-| Types package | `@delphian/tronrelic-types` → `ISyndicationService`, `ISyndicationRequest`, `ISyndicationLeg`, `ISyndicationLegView`, `SyndicationLegStatus`, `SYNDICATION_SERVICE` |
+| Fires hook | `scheduler.legDelivered` (observer) once per leg on successful delivery |
+| Types package | `@delphian/tronrelic-types` → `ISyndicationService`, `ISyndicationRequest`, `ISyndicationLeg`, `ISyndicationLegView`, `SyndicationLegStatus`, `ISyndicationDeliveredContext`, `SYNDICATION_SERVICE` |
 | Bootstrap order | Inits after curation (resolved lazily, so order is non-binding); runs after curation and **before** scheduler (so the relay job registers before the scheduler ticks) |
 | Frontend | None yet — operator surface is REST-only |
 
@@ -43,7 +44,7 @@ The honest contract — and the rule every consumer **must** assume — is **at-
 | `retry(legId)` | Requeue a dead-lettered leg with a fresh budget. No-op (false) for any non-dead leg. |
 | `getStats()` | Per-status leg counts. |
 
-`ISyndicationRequest` = `{ originId, originKind, descriptor, legs: [{ sinkId, dest? }] }`. `originId` is the stable identity of the originating record (a curation item id) and **is** the idempotency base; `originKind` is audit/grouping metadata only and must never feed routing or authorization.
+`ISyndicationRequest` = `{ originId, originKind, typeId, ref, descriptor, legs: [{ sinkId, dest? }] }`. `originId` is the stable identity of the originating record (a curation item id) and **is** the idempotency base; `originKind` is audit/grouping metadata only and must never feed routing or authorization. `typeId` + `ref` are the provider content coordinates — the owning content type id and its opaque record pointer (e.g. `{ postId }`) — frozen so the delivery-success hook can hand subscribers what they need to load the full underlying record.
 
 ## Outbox Schema — `module_syndication_outbox`
 
@@ -52,6 +53,7 @@ The honest contract — and the rule every consumer **must** assume — is **at-
 | `_id` | Leg id (uuid). |
 | `idempotencyKey` | `${originId}::${sinkId}`. **Unique index** — the enqueue-dedupe and receiver-dedupe key. |
 | `originId` / `originKind` | Originating record id / producer label. |
+| `typeId` / `ref` | Provider content coordinates, **frozen at enqueue** — owning content type id and its opaque record pointer. Carried to the delivery-success hook; never interpreted here. |
 | `sinkId` | Content-router sink the leg delivers to. |
 | `descriptor` | The canonical IR, **frozen at enqueue** so delivery survives a later source edit. |
 | `dest` | Per-destination config handed verbatim to `deliver`. |
@@ -72,8 +74,8 @@ The honest contract — and the rule every consumer **must** assume — is **at-
 3. **Claim — CAS.** Each leg is claimed with an `updateMany` filtered on its current `(status, attempts)`, setting `delivering` and the next `attempts`. The filter is the concurrency guard: two overlapping ticks cannot both win — exactly one sees a modified count of 1. Atomicity comes from the CAS filter, not an `$inc`.
 4. **Deliver.** Resolve the sink from the **live** router by id and call `deliver(descriptor, dest, { idempotencyKey, attempt })`. A sink registered (or re-enabled) after enqueue still delivers.
 5. **Settle, one of:**
-   - resolves `void` → `delivered` (terminal).
-   - resolves `IContentSinkRefusal` → `refused` (terminal — a settled "will not", reason recorded, **never retried**).
+   - resolves `void` → `delivered` (terminal), then fires the `scheduler.legDelivered` hook (see below).
+   - resolves `IContentSinkRefusal` → `refused` (terminal — a settled "will not", reason recorded, **never retried**). Does **not** fire the delivered hook.
    - throws → `failed` with `nextAttemptAt = now + backoffMs(attempt)` while budget remains, else `dead` (dead-letter, terminal).
    - sink not currently registered → treated as a **retryable** failure (a disabled plugin may return), counting toward the budget.
 
@@ -84,6 +86,12 @@ Each leg's claim-and-deliver is isolated, so one fault never aborts the tick. Th
 ## Idempotency — the Receiver's Obligation
 
 The relay hands every `deliver` an `IContentDeliveryContext` (`{ idempotencyKey, attempt }`) as its optional third argument. A sink whose wire protocol supports a client-supplied idempotency key (or an upsert) **must** use it so a retried row cannot double-post. A sink whose protocol offers no such hook (Telegram `sendMessage`) ignores it, and the at-least-once guarantee stands — a retry may duplicate. The platform never inspects the key; it only supplies it. The third argument is optional, so every existing two-argument sink remains valid unchanged.
+
+## Delivery-Success Hook — `scheduler.legDelivered`
+
+On a successful `delivered` settle the relay fires the `scheduler.legDelivered` observer hook (phase `scheduler.tick`) once per leg, so modules and plugins can audit, count, or fan out from a confirmed sinking without the relay knowing about them. Observer semantics isolate a reactor's failure — the invoke never throws back into the relay, so a misbehaving subscriber cannot re-open or duplicate a settled delivery. A `refused` settle does **not** fire it.
+
+The payload (`ISyndicationDeliveredContext`) is self-sufficient for a subscriber that wants the full content by hand: `sinkId` (+ best-effort `sinkLabel`), the delivered `descriptor` (the decision-time snapshot), the provider coordinates `typeId` + `ref`, and `legId` / `originId` / `originKind` / `idempotencyKey` / `attempt`. A subscriber that knows the provider resolves `ref` (e.g. `{ postId }`) against that content type's own store to load the live record — core never interprets `ref`. See [system-hooks.md](../../../../docs/system/system-hooks.md) for the registry and observer contract.
 
 ## Curation Integration
 

--- a/src/backend/modules/syndication/SyndicationModule.ts
+++ b/src/backend/modules/syndication/SyndicationModule.ts
@@ -24,6 +24,7 @@ import type { Express } from 'express';
 import type {
     IContentRouter,
     IDatabaseService,
+    IHookRegistry,
     IModule,
     IModuleMetadata,
     ISchedulerService,
@@ -53,6 +54,8 @@ export interface ISyndicationModuleDependencies {
     database: IDatabaseService;
     /** Service registry to publish `'syndication'` on and to resolve the content router. */
     serviceRegistry: IServiceRegistry;
+    /** Core hook registry the relay invokes `scheduler.legDelivered` on after a successful delivery. */
+    hookRegistry: IHookRegistry;
     /**
      * Scheduler the relay job registers on. Nullable, matching the platform
      * convention: a deployment with the scheduler disabled (`ENABLE_SCHEDULER`
@@ -78,6 +81,7 @@ export class SyndicationModule implements IModule<ISyndicationModuleDependencies
 
     private database!: IDatabaseService;
     private serviceRegistry!: IServiceRegistry;
+    private hookRegistry!: IHookRegistry;
     private scheduler: ISchedulerService | null = null;
     private app!: Express;
 
@@ -97,6 +101,7 @@ export class SyndicationModule implements IModule<ISyndicationModuleDependencies
 
         this.database = dependencies.database;
         this.serviceRegistry = dependencies.serviceRegistry;
+        this.hookRegistry = dependencies.hookRegistry;
         this.scheduler = dependencies.scheduler;
         this.app = dependencies.app;
 
@@ -109,7 +114,7 @@ export class SyndicationModule implements IModule<ISyndicationModuleDependencies
             throw new Error("SyndicationModule requires the 'content-router' service to be published before init");
         }
 
-        this.service = new SyndicationService(this.logger, this.database, contentRouter);
+        this.service = new SyndicationService(this.logger, this.database, contentRouter, this.hookRegistry);
         await this.service.ensureIndexes();
         this.controller = new SyndicationController(this.service);
 

--- a/src/backend/modules/syndication/__tests__/syndication-module.test.ts
+++ b/src/backend/modules/syndication/__tests__/syndication-module.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { Express } from 'express';
-import type { IContentRouter, ISchedulerService } from '@/types';
+import type { IContentRouter, IHookRegistry, ISchedulerService } from '@/types';
 import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
 import { createMockServiceRegistry } from '../../../tests/vitest/mocks/service-registry.js';
 import { CONTENT_ROUTER_SERVICE } from '../../../services/content-router.js';
@@ -27,8 +27,9 @@ function makeDeps(withScheduler = true) {
     const serviceRegistry = createMockServiceRegistry({ [CONTENT_ROUTER_SERVICE]: router });
     const scheduler = { register: vi.fn(), disable: vi.fn(), unregister: vi.fn() } as unknown as ISchedulerService;
     const app = { use: vi.fn() } as unknown as Express;
+    const hookRegistry = { invoke: vi.fn().mockResolvedValue(undefined) } as unknown as IHookRegistry;
     return {
-        deps: { database: createMockDatabaseService(), serviceRegistry, scheduler: withScheduler ? scheduler : null, app },
+        deps: { database: createMockDatabaseService(), serviceRegistry, hookRegistry, scheduler: withScheduler ? scheduler : null, app },
         scheduler,
         app,
         serviceRegistry

--- a/src/backend/modules/syndication/__tests__/syndication-service.test.ts
+++ b/src/backend/modules/syndication/__tests__/syndication-service.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { IContentRouter, IContentSink, ISystemLogService } from '@/types';
+import type { IContentRouter, IContentSink, IHookRegistry, ISystemLogService } from '@/types';
 import { createMockDatabaseService } from '../../../tests/vitest/mocks/database-service.js';
 import { SyndicationService } from '../services/syndication-service.js';
 import { SYNDICATION_OUTBOX_COLLECTION } from '../database/ISyndicationOutboxDocument.js';
@@ -51,6 +51,17 @@ function makeSink(id: string, deliver: IContentSink['deliver']): IContentSink {
     return { id, kind: 'publish', accepts: ['body'], reach: { egress: 'external', audience: 'public' }, deliver };
 }
 
+/**
+ * A hook-registry stub exposing only `invoke` — the sole registry method the
+ * relay calls (to fire `scheduler.legDelivered` on success). Returned as a
+ * `vi.fn` so a test can assert the delivered-hook fired with its payload.
+ *
+ * @returns A hook-registry stub.
+ */
+function makeHookRegistry(): IHookRegistry {
+    return { invoke: vi.fn().mockResolvedValue(undefined) } as unknown as IHookRegistry;
+}
+
 describe('SyndicationService', () => {
     let db: ReturnType<typeof createMockDatabaseService>;
 
@@ -61,11 +72,13 @@ describe('SyndicationService', () => {
     describe('enqueue', () => {
         it('creates one pending leg per destination with a deterministic idempotency key', async () => {
             const { router } = makeRouter([]);
-            const service = new SyndicationService(makeLogger(), db, router);
+            const service = new SyndicationService(makeLogger(), db, router, makeHookRegistry());
 
             const result = await service.enqueue({
                 originId: 'item-1',
                 originKind: 'curation',
+                typeId: 'blog',
+                ref: { postId: 'p1' },
                 descriptor: { body: 'hello' },
                 legs: [{ sinkId: 'core:internal-publish' }, { sinkId: 'telegram-bot:channel-42', dest: { chatId: 42 } }]
             });
@@ -82,16 +95,16 @@ describe('SyndicationService', () => {
 
         it('is idempotent on a duplicate-key collision — no second row, existing id returned', async () => {
             const { router } = makeRouter([]);
-            const service = new SyndicationService(makeLogger(), db, router);
+            const service = new SyndicationService(makeLogger(), db, router, makeHookRegistry());
 
             const first = await service.enqueue({
-                originId: 'item-1', originKind: 'curation', descriptor: { body: 'x' }, legs: [{ sinkId: 'sink-a' }]
+                originId: 'item-1', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'x' }, legs: [{ sinkId: 'sink-a' }]
             });
 
             // Simulate the unique index rejecting the re-insert.
             db.injectError(SYNDICATION_OUTBOX_COLLECTION, 'insertOne', Object.assign(new Error('dup'), { code: 11000 }));
             const second = await service.enqueue({
-                originId: 'item-1', originKind: 'curation', descriptor: { body: 'x' }, legs: [{ sinkId: 'sink-a' }]
+                originId: 'item-1', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'x' }, legs: [{ sinkId: 'sink-a' }]
             });
 
             expect(db.getCollectionData(SYNDICATION_OUTBOX_COLLECTION)).toHaveLength(1);
@@ -103,8 +116,8 @@ describe('SyndicationService', () => {
         it('delivers a pending leg and marks it delivered, passing the idempotency key and attempt', async () => {
             const deliver = vi.fn().mockResolvedValue(undefined);
             const { router } = makeRouter([makeSink('sink-a', deliver)]);
-            const service = new SyndicationService(makeLogger(), db, router);
-            await service.enqueue({ originId: 'o1', originKind: 'curation', descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a', dest: { k: 1 } }] });
+            const service = new SyndicationService(makeLogger(), db, router, makeHookRegistry());
+            await service.enqueue({ originId: 'o1', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a', dest: { k: 1 } }] });
 
             const attempted = await service.runRelayOnce();
 
@@ -115,23 +128,49 @@ describe('SyndicationService', () => {
             expect(row.attempts).toBe(1);
         });
 
-        it('records a sink refusal as refused (terminal), carrying the reason verbatim', async () => {
+        it('fires scheduler.legDelivered on success with the sink, descriptor, and provider coordinates', async () => {
+            const deliver = vi.fn().mockResolvedValue(undefined);
+            const { router } = makeRouter([makeSink('sink-a', deliver)]);
+            const hooks = makeHookRegistry();
+            const service = new SyndicationService(makeLogger(), db, router, hooks);
+            await service.enqueue({ originId: 'o1', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a' }] });
+
+            await service.runRelayOnce();
+
+            expect(hooks.invoke).toHaveBeenCalledTimes(1);
+            const [descriptor, payload] = (hooks.invoke as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+            expect(descriptor.id).toBe('scheduler.legDelivered');
+            expect(payload).toMatchObject({
+                sinkId: 'sink-a',
+                typeId: 'blog',
+                ref: { postId: 'p1' },
+                descriptor: { body: 'hi' },
+                originId: 'o1',
+                originKind: 'curation',
+                idempotencyKey: 'o1::sink-a',
+                attempt: 1
+            });
+        });
+
+        it('records a sink refusal as refused (terminal), carrying the reason verbatim, and does not fire the delivered hook', async () => {
             const deliver = vi.fn().mockResolvedValue({ refused: true, reason: 'not for telegram' });
             const { router } = makeRouter([makeSink('sink-a', deliver)]);
-            const service = new SyndicationService(makeLogger(), db, router);
-            await service.enqueue({ originId: 'o1', originKind: 'curation', descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a' }] });
+            const hooks = makeHookRegistry();
+            const service = new SyndicationService(makeLogger(), db, router, hooks);
+            await service.enqueue({ originId: 'o1', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a' }] });
 
             await service.runRelayOnce();
 
             const [row] = await service.getLegs('o1');
             expect(row.status).toBe('refused');
             expect(row.reason).toBe('not for telegram');
+            expect(hooks.invoke).not.toHaveBeenCalled();
         });
 
         it('treats an unregistered sink as a retryable failure, not a terminal one', async () => {
             const { router } = makeRouter([]); // no sink registered
-            const service = new SyndicationService(makeLogger(), db, router, { maxAttempts: 3 });
-            await service.enqueue({ originId: 'o1', originKind: 'curation', descriptor: { body: 'hi' }, legs: [{ sinkId: 'absent' }] });
+            const service = new SyndicationService(makeLogger(), db, router, makeHookRegistry(), { maxAttempts: 3 });
+            await service.enqueue({ originId: 'o1', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'hi' }, legs: [{ sinkId: 'absent' }] });
 
             await service.runRelayOnce();
 
@@ -145,8 +184,8 @@ describe('SyndicationService', () => {
         it('retries a failing leg with backoff and dead-letters it once the budget is exhausted', async () => {
             const deliver = vi.fn().mockRejectedValue(new Error('boom'));
             const { router } = makeRouter([makeSink('sink-a', deliver)]);
-            const service = new SyndicationService(makeLogger(), db, router, { maxAttempts: 3 });
-            await service.enqueue({ originId: 'o1', originKind: 'curation', descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a' }] });
+            const service = new SyndicationService(makeLogger(), db, router, makeHookRegistry(), { maxAttempts: 3 });
+            await service.enqueue({ originId: 'o1', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a' }] });
 
             // Attempt 1 fails → failed with a future nextAttemptAt.
             await service.runRelayOnce();
@@ -178,8 +217,8 @@ describe('SyndicationService', () => {
         it('reclaims a leg stuck in delivering and delivers it', async () => {
             const deliver = vi.fn().mockResolvedValue(undefined);
             const { router } = makeRouter([makeSink('sink-a', deliver)]);
-            const service = new SyndicationService(makeLogger(), db, router, { claimStaleMs: 1000 });
-            await service.enqueue({ originId: 'o1', originKind: 'curation', descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a' }] });
+            const service = new SyndicationService(makeLogger(), db, router, makeHookRegistry(), { claimStaleMs: 1000 });
+            await service.enqueue({ originId: 'o1', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a' }] });
 
             // Simulate a crash mid-delivery: status delivering, updatedAt long past.
             const rows = db.getCollectionData(SYNDICATION_OUTBOX_COLLECTION);
@@ -211,8 +250,8 @@ describe('SyndicationService', () => {
                 return undefined;
             });
             const { router } = makeRouter([makeSink('sink-a', deliver)]);
-            const service = new SyndicationService(makeLogger(), db, router);
-            await service.enqueue({ originId: 'o1', originKind: 'curation', descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a' }] });
+            const service = new SyndicationService(makeLogger(), db, router, makeHookRegistry());
+            await service.enqueue({ originId: 'o1', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a' }] });
 
             await service.runRelayOnce();
 
@@ -229,8 +268,8 @@ describe('SyndicationService', () => {
         it('retry() requeues a dead-lettered leg and is a no-op for a live one', async () => {
             const deliver = vi.fn().mockRejectedValue(new Error('boom'));
             const { router } = makeRouter([makeSink('sink-a', deliver)]);
-            const service = new SyndicationService(makeLogger(), db, router, { maxAttempts: 1 });
-            const { legIds } = await service.enqueue({ originId: 'o1', originKind: 'curation', descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a' }] });
+            const service = new SyndicationService(makeLogger(), db, router, makeHookRegistry(), { maxAttempts: 1 });
+            const { legIds } = await service.enqueue({ originId: 'o1', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a' }] });
             await service.runRelayOnce(); // maxAttempts 1 → dead immediately
 
             expect((await service.getLegs('o1'))[0].status).toBe('dead');
@@ -244,9 +283,9 @@ describe('SyndicationService', () => {
 
         it('getStats counts legs by status and getLegsForOrigins groups by origin', async () => {
             const { router } = makeRouter([]);
-            const service = new SyndicationService(makeLogger(), db, router);
-            await service.enqueue({ originId: 'o1', originKind: 'curation', descriptor: { body: 'a' }, legs: [{ sinkId: 's1' }, { sinkId: 's2' }] });
-            await service.enqueue({ originId: 'o2', originKind: 'curation', descriptor: { body: 'b' }, legs: [{ sinkId: 's1' }] });
+            const service = new SyndicationService(makeLogger(), db, router, makeHookRegistry());
+            await service.enqueue({ originId: 'o1', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'a' }, legs: [{ sinkId: 's1' }, { sinkId: 's2' }] });
+            await service.enqueue({ originId: 'o2', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'b' }, legs: [{ sinkId: 's1' }] });
 
             expect((await service.getStats()).pending).toBe(3);
             const grouped = await service.getLegsForOrigins(['o1', 'o2', 'absent']);

--- a/src/backend/modules/syndication/__tests__/syndication-service.test.ts
+++ b/src/backend/modules/syndication/__tests__/syndication-service.test.ts
@@ -250,7 +250,8 @@ describe('SyndicationService', () => {
                 return undefined;
             });
             const { router } = makeRouter([makeSink('sink-a', deliver)]);
-            const service = new SyndicationService(makeLogger(), db, router, makeHookRegistry());
+            const hooks = makeHookRegistry();
+            const service = new SyndicationService(makeLogger(), db, router, hooks);
             await service.enqueue({ originId: 'o1', originKind: 'curation', typeId: 'blog', ref: { postId: 'p1' }, descriptor: { body: 'hi' }, legs: [{ sinkId: 'sink-a' }] });
 
             await service.runRelayOnce();
@@ -261,6 +262,9 @@ describe('SyndicationService', () => {
             expect(row.status).toBe('delivering');
             expect(row.attempts).toBe(5);
             expect(row.idempotencyKey).toBe('o1::sink-a');
+            // And because that settle was a CAS no-op, the losing attempt must not
+            // have fired the delivered hook — the winning tick will.
+            expect(hooks.invoke).not.toHaveBeenCalled();
         });
     });
 

--- a/src/backend/modules/syndication/database/ISyndicationOutboxDocument.ts
+++ b/src/backend/modules/syndication/database/ISyndicationOutboxDocument.ts
@@ -41,6 +41,20 @@ export interface ISyndicationOutboxDocument {
     /** What produced the request (e.g. `'curation'`); audit/grouping only. */
     originKind: string;
 
+    /**
+     * The owning content type id (e.g. the blog type). Frozen from the origin so
+     * a delivery-success subscriber can identify the provider without re-reading
+     * the source. With `ref`, the complete coordinate to load the full record.
+     */
+    typeId: string;
+
+    /**
+     * The opaque provider pointer the owning content type resolves back to its
+     * own record (e.g. `{ postId: '...' }`). Frozen at enqueue, never interpreted
+     * by syndication — forwarded verbatim to delivery-success subscribers.
+     */
+    ref: Record<string, unknown>;
+
     /** The content-router sink id this leg delivers to. */
     sinkId: string;
 

--- a/src/backend/modules/syndication/services/syndication-service.ts
+++ b/src/backend/modules/syndication/services/syndication-service.ts
@@ -34,6 +34,7 @@ import type {
     IContentRouter,
     IContentSink,
     IDatabaseService,
+    IHookRegistry,
     ISyndicationEnqueueResult,
     ISyndicationLegView,
     ISyndicationRequest,
@@ -46,6 +47,7 @@ import {
     SYNDICATION_OUTBOX_COLLECTION,
     type ISyndicationOutboxDocument
 } from '../database/ISyndicationOutboxDocument.js';
+import { HOOKS } from '../../../hooks/registry.js';
 import { backoffMs } from './syndication-backoff.js';
 
 /** Default retry budget — a leg dead-letters after this many attempts. */
@@ -88,12 +90,16 @@ export class SyndicationService implements ISyndicationService {
      * @param contentRouter - The live sink registry; the relay resolves a leg's
      *        sink by id at delivery time so a sink registered (or re-enabled)
      *        after enqueue still delivers.
+     * @param hookRegistry - The core hook registry the relay invokes
+     *        `scheduler.legDelivered` on after a successful delivery, so
+     *        subscribers can audit or react to the delivered content.
      * @param options - Optional tuning overrides; all default.
      */
     constructor(
         private readonly logger: ISystemLogService,
         private readonly database: IDatabaseService,
         private readonly contentRouter: IContentRouter,
+        private readonly hookRegistry: IHookRegistry,
         options?: ISyndicationServiceOptions
     ) {
         this.maxAttempts = options?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
@@ -151,6 +157,8 @@ export class SyndicationService implements ISyndicationService {
                 idempotencyKey: key,
                 originId: request.originId,
                 originKind: request.originKind,
+                typeId: request.typeId,
+                ref: request.ref,
                 sinkId: leg.sinkId,
                 descriptor: request.descriptor,
                 dest: leg.dest ?? {},
@@ -302,6 +310,24 @@ export class SyndicationService implements ISyndicationService {
                 await this.settleTerminal(leg._id, claimToken, 'refused', { reason: result.reason });
             } else {
                 await this.settleTerminal(leg._id, claimToken, 'delivered', {});
+                // Announce the successful sinking so subscribers can audit, count,
+                // or fan out — carrying the sink, the delivered descriptor, and the
+                // provider coordinates (typeId + ref) needed to load the full
+                // record. Observer semantics isolate reactor failures: the invoke
+                // never throws back into the relay, so a misbehaving subscriber
+                // cannot re-open or duplicate a settled delivery.
+                await this.hookRegistry.invoke(HOOKS.scheduler.legDelivered, {
+                    sinkId: leg.sinkId,
+                    sinkLabel: sink.label,
+                    typeId: leg.typeId,
+                    ref: leg.ref,
+                    descriptor: leg.descriptor,
+                    legId: leg._id,
+                    originId: leg.originId,
+                    originKind: leg.originKind,
+                    idempotencyKey: leg.idempotencyKey,
+                    attempt
+                });
             }
         } catch (error) {
             await this.settleFailureOrDead(leg, claimToken, attempt, error instanceof Error ? error.message : String(error));

--- a/src/backend/modules/syndication/services/syndication-service.ts
+++ b/src/backend/modules/syndication/services/syndication-service.ts
@@ -309,25 +309,34 @@ export class SyndicationService implements ISyndicationService {
                 // A settled "will not" — terminal, never retried.
                 await this.settleTerminal(leg._id, claimToken, 'refused', { reason: result.reason });
             } else {
-                await this.settleTerminal(leg._id, claimToken, 'delivered', {});
+                const settled = await this.settleTerminal(leg._id, claimToken, 'delivered', {});
                 // Announce the successful sinking so subscribers can audit, count,
                 // or fan out — carrying the sink, the delivered descriptor, and the
                 // provider coordinates (typeId + ref) needed to load the full
                 // record. Observer semantics isolate reactor failures: the invoke
                 // never throws back into the relay, so a misbehaving subscriber
                 // cannot re-open or duplicate a settled delivery.
-                await this.hookRegistry.invoke(HOOKS.scheduler.legDelivered, {
-                    sinkId: leg.sinkId,
-                    sinkLabel: sink.label,
-                    typeId: leg.typeId,
-                    ref: leg.ref,
-                    descriptor: leg.descriptor,
-                    legId: leg._id,
-                    originId: leg.originId,
-                    originKind: leg.originKind,
-                    idempotencyKey: leg.idempotencyKey,
-                    attempt
-                });
+                //
+                // Gate on the terminal CAS: fire only when this attempt actually
+                // settled the row (modified count 1). If its claim was reclaimed as
+                // stale and re-won by a later tick, the settle is a no-op and this
+                // losing attempt must stay silent — the winning tick fires the hook —
+                // so a slow-sink/multi-instance race cannot emit a duplicate or false
+                // delivered event.
+                if (settled === 1) {
+                    await this.hookRegistry.invoke(HOOKS.scheduler.legDelivered, {
+                        sinkId: leg.sinkId,
+                        sinkLabel: sink.label,
+                        typeId: leg.typeId,
+                        ref: leg.ref,
+                        descriptor: leg.descriptor,
+                        legId: leg._id,
+                        originId: leg.originId,
+                        originKind: leg.originKind,
+                        idempotencyKey: leg.idempotencyKey,
+                        attempt
+                    });
+                }
             }
         } catch (error) {
             await this.settleFailureOrDead(leg, claimToken, attempt, error instanceof Error ? error.message : String(error));
@@ -362,15 +371,18 @@ export class SyndicationService implements ISyndicationService {
      *        that scopes the write to the attempt that is still the live owner.
      * @param status - The terminal status to set.
      * @param patch - Extra fields (a `reason` for a refusal).
-     * @returns Resolves when the leg is updated.
+     * @returns The number of legs the CAS modified: 1 when this attempt was still
+     *        the live owner and settled the row, 0 when its claim had been
+     *        superseded (a stale-token no-op). The delivered branch gates its
+     *        `legDelivered` hook on this so a losing attempt stays silent.
      */
     private async settleTerminal(
         legId: string,
         claimToken: string,
         status: Extract<SyndicationLegStatus, 'delivered' | 'refused'>,
         patch: { reason?: string }
-    ): Promise<void> {
-        await this.database.updateMany<ISyndicationOutboxDocument>(
+    ): Promise<number> {
+        return this.database.updateMany<ISyndicationOutboxDocument>(
             SYNDICATION_OUTBOX_COLLECTION,
             { _id: legId, claimToken },
             { $set: { status, claimToken: undefined, updatedAt: new Date(), ...patch } }


### PR DESCRIPTION
## What

Adds a `scheduler.legDelivered` **observer** hook that fires once per publish leg the moment the syndication relay settles it `delivered` (inside the `syndication:relay` tick). Subscribers can audit, count, or fan out from a confirmed sinking without the relay knowing about them. A `refused` settle does not fire it, and observer isolation means a reactor throwing can never re-open or duplicate a settled delivery.

## Payload — `ISyndicationDeliveredContext`

Self-sufficient for a subscriber that wants to load the full underlying content by hand: `sinkId` (+ best-effort `sinkLabel`), the delivered `descriptor` (the decision-time snapshot), the provider coordinates `typeId` + `ref`, and `legId` / `originId` / `originKind` / `idempotencyKey` / `attempt`. A subscriber that knows the provider resolves `ref` (e.g. `{ postId }`) against that content type's own store; core never interprets `ref`.

## Why `typeId` + `ref` are now frozen on the leg

The outbox previously discarded the origin `ref` at enqueue, keeping only the rendered descriptor — which is not a stable content identifier. To carry provider coordinates to the delivery-success hook, `typeId` + `ref` are frozen onto each outbox leg at enqueue, threaded from the curation item through `ISyndicationRequest`.

## Changes

- `packages/types`: new `ISyndicationDeliveredContext`; `ICoreHooks` gains `ICoreSchedulerHooks`; `ISyndicationRequest` gains `typeId` + `ref`; barrels updated.
- `src/backend/hooks/registry.ts`: the `scheduler.legDelivered` descriptor (phase `scheduler.tick`, order 100).
- Syndication: outbox freezes `typeId`/`ref`; `SyndicationService` takes `IHookRegistry` and invokes the hook on the `delivered` branch; module + bootstrap inject `hookRegistry`.
- Curation: `decide()` passes `existing.typeId`/`existing.ref` into `enqueue`.
- Tests: fires-on-delivery + not-on-refusal service tests, module deps, hook contract test.
- Docs: syndication README + `system-hooks.md` declared-seams table.

## Notes

- No migration: the outbox is transient; a leg enqueued pre-deploy and delivered post-deploy fires the hook with `typeId`/`ref` undefined — harmless, self-clears within one relay cycle.
- `@delphian/tronrelic-types` version not bumped; no plugin consumes the new type yet.