### PR TITLE
feat(ai-tools): reveal a prompt variable's current resolved value

### DIFF
--- a/packages/types/src/ai-tools/IPromptVariable.ts
+++ b/packages/types/src/ai-tools/IPromptVariable.ts
@@ -132,6 +132,30 @@ export interface IPromptVariableInfo {
 }
 
 /**
+ * One variable resolved to its *current* runtime value, returned when an admin
+ * expands a row in the variable panel to inspect what a `{%name%}` token holds
+ * right now. Unlike {@link IPromptVariableInfo} (metadata only, never the value),
+ * this carries the resolved `content` — the live text a `dynamic` resolver
+ * produces this instant, or a `static` variable's stored constant — so an
+ * operator can audit exactly what the model would receive without composing a
+ * query. Fetched on demand per row, never bulk-listed, because the value may be
+ * large or `secret`.
+ */
+export interface IResolvedPromptVariable {
+    /** Kebab-case identifier without the `{%%}` delimiters. */
+    name: string;
+
+    /** The `{%name%}` reference pattern, echoed for the UI header. */
+    pattern: string;
+
+    /** The variable's current resolved value at the moment of the request. */
+    content: string;
+
+    /** UTF-8 byte size of {@link content}. */
+    sizeBytes: number;
+}
+
+/**
  * One expanded variable's metadata, returned alongside the expanded text so the
  * query composer can show what each `{%name%}` resolved to and how large it is
  * before the prompt is sent.

--- a/packages/types/src/ai-tools/index.ts
+++ b/packages/types/src/ai-tools/index.ts
@@ -33,6 +33,7 @@ export type {
     IPromptVariableDefinition,
     IStaticPromptVariable,
     IPromptVariableInfo,
+    IResolvedPromptVariable,
     IExpandedPromptVariable,
     PromptVariableKind
 } from './IPromptVariable.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -111,6 +111,7 @@ export type {
     IPromptVariableDefinition,
     IStaticPromptVariable,
     IPromptVariableInfo,
+    IResolvedPromptVariable,
     IExpandedPromptVariable,
     PromptVariableKind,
     IPromptVariableRegistry,

--- a/src/backend/modules/ai-tools/api/ai-tools.controller.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.controller.ts
@@ -312,6 +312,40 @@ export class AiToolsController {
     };
 
     /**
+     * GET /variables/:name/value — resolve a single variable to its *current*
+     * runtime value so an admin can inspect what a `{%name%}` token holds right
+     * now, without composing a query. A dynamic resolver runs live here, so the
+     * value reflects this instant; a static variable returns its stored constant.
+     *
+     * Kept off the bulk `listVariables` payload deliberately: a resolved value may
+     * be large or `secret`, so it is fetched only when an operator expands the row
+     * that needs it. Admin-gated and rate-limited by the router — the same posture
+     * that already lets an admin create, edit, and classify these variables.
+     *
+     * A resolver that currently throws is itself the "current state" the admin is
+     * inspecting, so its message is surfaced (502) rather than hidden; an unknown
+     * name is a 404.
+     */
+    revealVariable = async (req: Request, res: Response): Promise<void> => {
+        const name = req.params.name;
+        try {
+            const content = await this.promptVariables.resolve(name);
+            res.json({
+                variable: {
+                    name,
+                    pattern: `{%${name}%}`,
+                    content,
+                    sizeBytes: Buffer.byteLength(content, 'utf-8')
+                }
+            });
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : 'Failed to resolve variable.';
+            const status = message.startsWith('Unknown prompt variable') ? 404 : 502;
+            res.status(status).json({ error: message });
+        }
+    };
+
+    /**
      * Map a prompt-variable failure to a response: a caller-actionable
      * {@link PromptVariableValidationError} carries its own status code (400/404/409);
      * anything else is a 500 with a generic message.

--- a/src/backend/modules/ai-tools/api/ai-tools.router.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.router.ts
@@ -34,6 +34,7 @@ export function createAiToolsAdminRouter(controller: AiToolsController): Router 
     router.put('/screen-config', controller.setScreenConfig);
 
     router.get('/variables', controller.listVariables);
+    router.get('/variables/:name/value', controller.revealVariable);
     router.post('/variables', controller.createVariable);
     router.patch('/variables/:name', controller.updateVariable);
     router.delete('/variables/:name', controller.deleteVariable);

--- a/src/frontend/app/(core)/system/ai-tools/page.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/page.module.scss
@@ -423,6 +423,40 @@
     text-decoration: underline;
 }
 
+/* Variable row disclosure: the `{%name%}` pattern rendered as a bare, keyboard-
+ * focusable button with a leading chevron. Clicking it reveals the variable's
+ * current resolved value in an expanded row beneath. */
+.reveal_toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-2xs);
+    padding: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+    color: var(--color-text);
+}
+
+.reveal_toggle:hover {
+    color: var(--color-primary);
+}
+
+/* The chevron hugs the pattern and stays muted so the identifier reads first. */
+.reveal_toggle svg {
+    flex: 0 0 auto;
+    color: var(--color-text-subtle);
+}
+
+/* Expanded-row body wrapping the resolved value: a caption line plus the value
+ * block, stacked with the same rhythm as the detail-panel sections. */
+.reveal_panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+}
+
 /* One-line description teaser: clamp to a single line with an ellipsis so a long
  * model-facing description never blows the row height — the full text lives in
  * the slide-over. */

--- a/src/frontend/app/(core)/system/ai-tools/tabs/VariablesSection.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/VariablesSection.tsx
@@ -13,8 +13,8 @@
  * is acceptable here.
  */
 
-import { useCallback, useEffect, useState } from 'react';
-import { AlertCircle, Pencil, Plus, Trash2, X } from 'lucide-react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
+import { AlertCircle, ChevronDown, ChevronRight, Pencil, Plus, Trash2, X } from 'lucide-react';
 import type { AiToolSensitivity, IPromptVariableInfo } from '@/types';
 import { Stack } from '../../../../../components/layout';
 import { Badge } from '../../../../../components/ui/Badge';
@@ -26,6 +26,7 @@ import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Ta
 import { useToast } from '../../../../../components/ui/ToastProvider';
 import {
     listVariables,
+    resolveVariable,
     createVariable,
     updateVariable,
     deleteVariable,
@@ -41,6 +42,23 @@ const SENSITIVITIES: AiToolSensitivity[] = ['public', 'internal', 'secret'];
 const EMPTY_FORM = { name: '', category: '', description: '', content: '', sensitivity: 'secret' as AiToolSensitivity };
 
 /**
+ * Per-row reveal state for an expanded variable. Holds the async lifecycle of the
+ * on-demand `resolveVariable` fetch so the expanded panel can show a spinner, the
+ * live value, or the resolver's own failure — a broken dynamic resolver is itself
+ * the "current state" the admin came to inspect, so its error is shown, not hidden.
+ */
+interface IRevealState {
+    /** True while the value is being fetched. */
+    loading: boolean;
+    /** The resolved live value, once fetched. */
+    content?: string;
+    /** UTF-8 byte size of the resolved value. */
+    sizeBytes?: number;
+    /** Failure message when the resolve (or its resolver) failed. */
+    error?: string;
+}
+
+/**
  * Variables management section.
  *
  * @param props.onChanged - Called after any mutation so the page refreshes the
@@ -52,6 +70,7 @@ export function VariablesSection({ onChanged }: { onChanged: () => void }) {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [busyName, setBusyName] = useState<string | null>(null);
+    const [revealed, setRevealed] = useState<Record<string, IRevealState>>({});
     const [editingName, setEditingName] = useState<string | null>(null);
     const [formOpen, setFormOpen] = useState(false);
     const [form, setForm] = useState(EMPTY_FORM);
@@ -83,6 +102,33 @@ export function VariablesSection({ onChanged }: { onChanged: () => void }) {
             setBusyName(null);
         }
     }, [load, onChanged, push]);
+
+    /**
+     * Toggle the reveal panel for one variable. Collapsing simply drops the cached
+     * value; expanding fetches the *current* runtime value fresh every time (so a
+     * re-expand re-resolves — the point is "what does it hold right now"). The
+     * resolve is on-demand rather than part of the bulk list because a value may be
+     * large or `secret`, so it is fetched only for the row the admin opens.
+     *
+     * @param name - The variable whose live value to reveal or hide.
+     */
+    const toggleReveal = useCallback(async (name: string) => {
+        if (revealed[name]) {
+            setRevealed(prev => {
+                const next = { ...prev };
+                delete next[name];
+                return next;
+            });
+            return;
+        }
+        setRevealed(prev => ({ ...prev, [name]: { loading: true } }));
+        try {
+            const resolved = await resolveVariable(name);
+            setRevealed(prev => ({ ...prev, [name]: { loading: false, content: resolved.content, sizeBytes: resolved.sizeBytes } }));
+        } catch (err) {
+            setRevealed(prev => ({ ...prev, [name]: { loading: false, error: err instanceof Error ? err.message : String(err) } }));
+        }
+    }, [revealed]);
 
     const handleDelete = useCallback(async (name: string) => {
         setBusyName(name);
@@ -244,10 +290,23 @@ export function VariablesSection({ onChanged }: { onChanged: () => void }) {
                                     </Tr>
                                 </Thead>
                                 <Tbody>
-                                    {variables.map(variable => (
-                                        <Tr key={variable.name}>
+                                    {variables.map(variable => {
+                                        const reveal = revealed[variable.name];
+                                        const open = reveal !== undefined;
+                                        return (
+                                        <Fragment key={variable.name}>
+                                        <Tr>
                                             <Td>
-                                                <div className={styles.tool_name}>{variable.pattern}</div>
+                                                <button
+                                                    type="button"
+                                                    className={styles.reveal_toggle}
+                                                    onClick={() => void toggleReveal(variable.name)}
+                                                    aria-expanded={open}
+                                                    aria-label={`${open ? 'Hide' : 'Reveal'} current value of ${variable.name}`}
+                                                >
+                                                    {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                                                    <span className={styles.tool_name}>{variable.pattern}</span>
+                                                </button>
                                                 <div className={styles.tool_desc}>{variable.description}</div>
                                             </Td>
                                             <Td muted>{variable.category}</Td>
@@ -291,7 +350,31 @@ export function VariablesSection({ onChanged }: { onChanged: () => void }) {
                                                 )}
                                             </Td>
                                         </Tr>
-                                    ))}
+                                        {open && (
+                                            <Tr isExpanded>
+                                                <Td colSpan={5}>
+                                                    {reveal.loading
+                                                        ? <span className={styles.placeholder}>Resolving current value…</span>
+                                                        : reveal.error
+                                                            ? (
+                                                                <div className="alert" role="alert">
+                                                                    <AlertCircle size={16} style={{ color: 'var(--color-danger)', verticalAlign: 'text-bottom' }} /> {reveal.error}
+                                                                </div>
+                                                            )
+                                                            : (
+                                                                <div className={styles.reveal_panel}>
+                                                                    <div className={styles.detail_section_title}>
+                                                                        Current value · {reveal.sizeBytes ?? 0} bytes · {variable.sensitivity}
+                                                                    </div>
+                                                                    <pre className={styles.args_block}>{reveal.content ? reveal.content : '(empty)'}</pre>
+                                                                </div>
+                                                            )}
+                                                </Td>
+                                            </Tr>
+                                        )}
+                                        </Fragment>
+                                        );
+                                    })}
                                 </Tbody>
                             </Table>
                         </div>

--- a/src/frontend/app/(core)/system/ai-tools/tabs/VariablesSection.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/VariablesSection.tsx
@@ -13,7 +13,7 @@
  * is acceptable here.
  */
 
-import { Fragment, useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { AlertCircle, ChevronDown, ChevronRight, Pencil, Plus, Trash2, X } from 'lucide-react';
 import type { AiToolSensitivity, IPromptVariableInfo } from '@/types';
 import { Stack } from '../../../../../components/layout';
@@ -71,6 +71,11 @@ export function VariablesSection({ onChanged }: { onChanged: () => void }) {
     const [error, setError] = useState<string | null>(null);
     const [busyName, setBusyName] = useState<string | null>(null);
     const [revealed, setRevealed] = useState<Record<string, IRevealState>>({});
+    // Monotonic per-variable request token. Each expand bumps its slot before
+    // awaiting resolveVariable; the post-await commit drops any response whose
+    // captured token is no longer current, so an earlier fetch that resolves
+    // after a re-expand cannot overwrite the newer request's value.
+    const revealSeqRef = useRef<Record<string, number>>({});
     const [editingName, setEditingName] = useState<string | null>(null);
     const [formOpen, setFormOpen] = useState(false);
     const [form, setForm] = useState(EMPTY_FORM);
@@ -121,12 +126,22 @@ export function VariablesSection({ onChanged }: { onChanged: () => void }) {
             });
             return;
         }
+        const seq = (revealSeqRef.current[name] ?? 0) + 1;
+        revealSeqRef.current[name] = seq;
         setRevealed(prev => ({ ...prev, [name]: { loading: true } }));
         try {
             const resolved = await resolveVariable(name);
-            setRevealed(prev => ({ ...prev, [name]: { loading: false, content: resolved.content, sizeBytes: resolved.sizeBytes } }));
+            // Drop this response if a newer expand of the same row superseded it
+            // (`seq` no longer current) — otherwise an earlier fetch resolving
+            // after a re-expand would overwrite the newer request's value. The
+            // `?.loading` check additionally ignores a response for a row the
+            // admin collapsed mid-fetch, so a late promise cannot re-add and
+            // reopen a row they closed (possibly re-surfacing a secret).
+            if (revealSeqRef.current[name] !== seq) return;
+            setRevealed(prev => (prev[name]?.loading ? { ...prev, [name]: { loading: false, content: resolved.content, sizeBytes: resolved.sizeBytes } } : prev));
         } catch (err) {
-            setRevealed(prev => ({ ...prev, [name]: { loading: false, error: err instanceof Error ? err.message : String(err) } }));
+            if (revealSeqRef.current[name] !== seq) return;
+            setRevealed(prev => (prev[name]?.loading ? { ...prev, [name]: { loading: false, error: err instanceof Error ? err.message : String(err) } } : prev));
         }
     }, [revealed]);
 

--- a/src/frontend/modules/ai-tools/api/client.ts
+++ b/src/frontend/modules/ai-tools/api/client.ts
@@ -22,6 +22,7 @@ import type {
     IAiQueryResult,
     IModelInfo,
     IPromptVariableInfo,
+    IResolvedPromptVariable,
     IStaticPromptVariableInput,
     IStaticPromptVariableUpdate,
     ISavedPrompt,
@@ -177,6 +178,23 @@ export async function listProviders(): Promise<IAiProviderInfo[]> {
 export async function listVariables(): Promise<IPromptVariableInfo[]> {
     const data = await parse<{ variables: IPromptVariableInfo[] }>(await fetch(`${BASE}/variables`), 'load variables');
     return data.variables;
+}
+
+/**
+ * Resolve one variable to its current runtime value for on-demand inspection —
+ * what a `{%name%}` token holds right now. Fetched per row when an admin expands
+ * it, kept off the bulk {@link listVariables} payload because the value may be
+ * large or `secret`.
+ *
+ * @param name - The variable name (without the `{%%}` delimiters).
+ * @returns The variable's live resolved value and its byte size.
+ */
+export async function resolveVariable(name: string): Promise<IResolvedPromptVariable> {
+    const data = await parse<{ variable: IResolvedPromptVariable }>(
+        await fetch(`${BASE}/variables/${encodeURIComponent(name)}/value`),
+        'reveal variable'
+    );
+    return data.variable;
 }
 
 /**


### PR DESCRIPTION
Adds an admin-gated way to inspect what a `{%name%}` prompt-variable token holds *right now*, without composing a query.

## What
- **New endpoint** `GET /variables/:name/value` (`revealVariable`) resolves a single variable to its current runtime value. A dynamic resolver runs live; a static variable returns its stored constant. Unknown name → 404; a throwing resolver surfaces its own message → 502, because a broken resolver *is* the current state the admin is inspecting.
- **New type** `IResolvedPromptVariable` (name, pattern, content, sizeBytes) exported from the types package.
- **UI** — each row's `{%name%}` pattern becomes a keyboard-focusable disclosure button with a chevron; expanding fetches the live value on demand and renders it (with byte size and sensitivity), a spinner while loading, or the resolver's error.

## Why
The resolved value is deliberately kept off the bulk `listVariables` payload because it may be large or `secret`; it is fetched only for the row an operator opens. Admin-gated and rate-limited by the existing router posture.