### PR TITLE
feat(ai-tools): link tool invocations to transcript and per-conversation feed

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delphian/tronrelic-types",
-  "version": "4.26.0",
+  "version": "4.27.0",
   "description": "Core type definitions for the TronRelic platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/types/src/ai-tools/IToolInvocationContext.ts
+++ b/packages/types/src/ai-tools/IToolInvocationContext.ts
@@ -86,6 +86,19 @@ export interface IToolInvocationContext {
     /** Per-query id, when one was supplied — links the call to its run. */
     queryId?: string;
 
+    /**
+     * Per-call correlation id, when the provider supplies one — the id of the
+     * individual tool-call the model emitted this turn. Provider-neutral: every
+     * tool-calling LLM issues an opaque id pairing a tool call with its result
+     * (the same value core already models as `IAiTranscriptSegment` `tool_use.id`
+     * / `tool_result.toolUseId`), so this is not vendor-specific. Unlike
+     * `conversationId` (run group) and `queryId` (run), this identifies a single
+     * call, so a provider must pass a per-call context rather than reuse one
+     * across the turn's calls. The governor copies it onto the audit record,
+     * which is what lets a transcript's tool segment link to its exact audit row.
+     */
+    toolUseId?: string;
+
     /** Plugin or module id that initiated a programmatic query, when applicable. */
     callerPluginId?: string;
 

--- a/packages/types/src/ai-tools/IToolInvocationRecord.ts
+++ b/packages/types/src/ai-tools/IToolInvocationRecord.ts
@@ -47,6 +47,17 @@ export interface IToolInvocationRecord {
     /** Per-query id, when supplied — links the call to its run. */
     queryId?: string;
 
+    /**
+     * Per-call correlation id, when the provider supplied one — the id of the
+     * individual tool-call the model emitted. Provider-neutral: it is the same
+     * opaque id core models as `IAiTranscriptSegment` `tool_use.id` /
+     * `tool_result.toolUseId`, so a persisted transcript segment and this audit
+     * row can be joined exactly (matched on `toolUseId`) rather than by ordinal
+     * or tool name. Absent on legacy records and on any path a provider did not
+     * thread the id through.
+     */
+    toolUseId?: string;
+
     /** Arguments passed to the handler, redacted according to `capability.sensitivity`. */
     input: Record<string, unknown>;
 

--- a/src/backend/modules/ai-tools/api/ai-tools.controller.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.controller.ts
@@ -787,6 +787,12 @@ export class AiToolsController {
         if (typeof req.query.status === 'string') {
             query.status = req.query.status as ToolInvocationStatus;
         }
+        if (typeof req.query.conversationId === 'string') {
+            query.conversationId = req.query.conversationId;
+        }
+        if (typeof req.query.queryId === 'string') {
+            query.queryId = req.query.queryId;
+        }
         if (typeof req.query.limit === 'string') {
             const parsed = Number.parseInt(req.query.limit, 10);
             if (!Number.isNaN(parsed)) {

--- a/src/backend/modules/ai-tools/services/ai-tool-governor.ts
+++ b/src/backend/modules/ai-tools/services/ai-tool-governor.ts
@@ -635,6 +635,13 @@ export class AiToolGovernor implements IAiToolGovernor {
         if (ctx.queryId) {
             record.queryId = ctx.queryId;
         }
+        if (ctx.toolUseId) {
+            // The provider-neutral per-call id, when the provider threaded one
+            // through. It pairs this audit row to its transcript tool_use/
+            // tool_result segment so a UI can deep-link a specific call to its
+            // exact record instead of guessing by ordinal or tool name.
+            record.toolUseId = ctx.toolUseId;
+        }
         if (ctx.endUser?.userId?.trim()) {
             // Attribute the call to the end user it ran on behalf of, distinct
             // from the actor that drove it — so a user-scoped tool's audit trail

--- a/src/backend/modules/ai-tools/services/tool-audit-store.ts
+++ b/src/backend/modules/ai-tools/services/tool-audit-store.ts
@@ -32,6 +32,14 @@ export interface IToolInvocationQuery {
     aiProviderId?: string;
     triggerPath?: ToolTriggerPath;
     status?: ToolInvocationStatus;
+    /**
+     * Scope to one conversation's tool calls. The Query tab's per-conversation
+     * "tools used" feed passes this so it can show the same audit rows the
+     * Activity tab does, filtered to the thread being viewed.
+     */
+    conversationId?: string;
+    /** Scope to one run's tool calls (a single query turn within a conversation). */
+    queryId?: string;
     limit?: number;
     offset?: number;
 }
@@ -82,6 +90,10 @@ export class ToolAuditStore {
         await this.database.createIndex(COLLECTION, { createdAt: -1 });
         await this.database.createIndex(COLLECTION, { toolName: 1, createdAt: -1 });
         await this.database.createIndex(COLLECTION, { status: 1, createdAt: -1 });
+        // Backs the Query tab's per-conversation "tools used" feed — a
+        // conversationId-scoped read newest-first. Sparse because only calls
+        // driven from a multi-turn chat carry a conversationId.
+        await this.database.createIndex(COLLECTION, { conversationId: 1, createdAt: -1 }, { sparse: true });
     }
 
     /**
@@ -126,6 +138,12 @@ export class ToolAuditStore {
         }
         if (query.status) {
             filter.status = query.status;
+        }
+        if (query.conversationId) {
+            filter.conversationId = query.conversationId;
+        }
+        if (query.queryId) {
+            filter.queryId = query.queryId;
         }
 
         const limit = Math.min(Math.max(1, query.limit ?? 50), 200);

--- a/src/frontend/app/(core)/system/ai-tools/components/InvocationTable.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/InvocationTable.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+/**
+ * @fileoverview The invocation audit feed's row table, extracted so the Activity
+ * tab (global feed) and the Query tab's per-conversation "tools used" feed render
+ * an identical surface — same columns, same status colouring, same click-to-open
+ * behaviour. Keeping one table means a column added here appears on both feeds and
+ * the two can never drift. The parent owns selection state and the detail
+ * slide-over; this component only lists rows and reports a click.
+ */
+
+import type { IToolInvocationRecord } from '@/types';
+import { Badge } from '../../../../../components/ui/Badge';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
+import { ClientTime } from '../../../../../components/ui/ClientTime';
+import { statusTone } from './InvocationDetailPanel';
+import styles from '../page.module.scss';
+
+/**
+ * Render the invocation audit rows for a set of records. The row is deliberately
+ * terminal-triage only (time, tool, provider, actor, trigger, status, duration);
+ * the full record lives behind the click, in the caller's slide-over.
+ *
+ * @param props.records - The audit records to list, already ordered by the caller.
+ * @param props.onSelect - Invoked with the clicked record so the caller can open
+ *   its detail panel — selection lives in the parent so the same detail slide-over
+ *   serves whatever surface hosts the table.
+ * @returns The scrollable rows table.
+ */
+export function InvocationTable({ records, onSelect }: {
+    records: IToolInvocationRecord[];
+    onSelect: (record: IToolInvocationRecord) => void;
+}) {
+    return (
+        <div className="table-scroll">
+            <Table>
+                <Thead>
+                    <Tr>
+                        <Th width="shrink" className={styles.col_time}>Time</Th>
+                        <Th>Tool</Th>
+                        <Th width="shrink">AI Provider</Th>
+                        <Th width="shrink">Actor</Th>
+                        <Th width="shrink">Trigger</Th>
+                        <Th width="shrink">Status</Th>
+                        <Th width="shrink">Duration</Th>
+                    </Tr>
+                </Thead>
+                <Tbody>
+                    {records.map(record => (
+                        <Tr
+                            key={record.id}
+                            className={styles.tool_row}
+                            hasError={record.status === 'error'}
+                            onClick={() => onSelect(record)}
+                        >
+                            <Td muted className={styles.col_time}><ClientTime date={record.createdAt} format="datetime" /></Td>
+                            <Td><span className={styles.tool_name}>{record.toolName}</span></Td>
+                            <Td muted>{record.aiProviderId}</Td>
+                            <Td muted>{record.actor.kind}{record.actor.id ? ` · ${record.actor.id}` : ''}</Td>
+                            <Td muted>{record.triggerPath}</Td>
+                            <Td><Badge tone={statusTone(record.status)}>{record.status}</Badge></Td>
+                            <Td muted>{record.durationMs}ms</Td>
+                        </Tr>
+                    ))}
+                </Tbody>
+            </Table>
+        </div>
+    );
+}

--- a/src/frontend/app/(core)/system/ai-tools/components/InvocationTable.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/InvocationTable.tsx
@@ -54,7 +54,15 @@ export function InvocationTable({ records, onSelect }: {
                             onClick={() => onSelect(record)}
                         >
                             <Td muted className={styles.col_time}><ClientTime date={record.createdAt} format="datetime" /></Td>
-                            <Td><span className={styles.tool_name}>{record.toolName}</span></Td>
+                            <Td>
+                                <button
+                                    type="button"
+                                    className={styles.tool_name_button}
+                                    onClick={(event) => { event.stopPropagation(); onSelect(record); }}
+                                >
+                                    {record.toolName}
+                                </button>
+                            </Td>
                             <Td muted>{record.aiProviderId}</Td>
                             <Td muted>{record.actor.kind}{record.actor.id ? ` · ${record.actor.id}` : ''}</Td>
                             <Td muted>{record.triggerPath}</Td>

--- a/src/frontend/app/(core)/system/ai-tools/tabs/ActivityTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/ActivityTab.tsx
@@ -15,14 +15,12 @@ import type { IToolInvocationRecord, IAiToolInfo, ToolInvocationStatus, ToolTrig
 import { Stack } from '../../../../../components/layout';
 import { Button } from '../../../../../components/ui/Button';
 import { Select } from '../../../../../components/ui/Select';
-import { Badge } from '../../../../../components/ui/Badge';
-import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
 import { Pagination } from '../../../../../components/ui/Pagination';
 import { SlideOver } from '../../../../../components/ui/SlideOver';
-import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { getSocket } from '../../../../../lib/socketClient';
 import { listActivity, listTools, type IActivityQuery } from '../../../../../modules/ai-tools';
-import { InvocationDetailPanel, statusTone } from '../components/InvocationDetailPanel';
+import { InvocationDetailPanel } from '../components/InvocationDetailPanel';
+import { InvocationTable } from '../components/InvocationTable';
 import styles from '../page.module.scss';
 
 /** Page size for the feed. */
@@ -166,39 +164,7 @@ export function ActivityTab() {
                 ? <div className={styles.placeholder}>No invocations match the current filters.</div>
                 : (
                     <>
-                        <div className="table-scroll">
-                            <Table>
-                                <Thead>
-                                    <Tr>
-                                        <Th width="shrink" className={styles.col_time}>Time</Th>
-                                        <Th>Tool</Th>
-                                        <Th width="shrink">AI Provider</Th>
-                                        <Th width="shrink">Actor</Th>
-                                        <Th width="shrink">Trigger</Th>
-                                        <Th width="shrink">Status</Th>
-                                        <Th width="shrink">Duration</Th>
-                                    </Tr>
-                                </Thead>
-                                <Tbody>
-                                    {items.map(record => (
-                                        <Tr
-                                            key={record.id}
-                                            className={styles.tool_row}
-                                            hasError={record.status === 'error'}
-                                            onClick={() => setSelectedRecord(record)}
-                                        >
-                                            <Td muted className={styles.col_time}><ClientTime date={record.createdAt} format="datetime" /></Td>
-                                            <Td><span className={styles.tool_name}>{record.toolName}</span></Td>
-                                            <Td muted>{record.aiProviderId}</Td>
-                                            <Td muted>{record.actor.kind}{record.actor.id ? ` · ${record.actor.id}` : ''}</Td>
-                                            <Td muted>{record.triggerPath}</Td>
-                                            <Td><Badge tone={statusTone(record.status)}>{record.status}</Badge></Td>
-                                            <Td muted>{record.durationMs}ms</Td>
-                                        </Tr>
-                                    ))}
-                                </Tbody>
-                            </Table>
-                        </div>
+                        <InvocationTable records={items} onSelect={setSelectedRecord} />
                         <div className={styles.pager}>
                             <Pagination
                                 total={total}

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
@@ -643,6 +643,36 @@
     color: var(--color-text);
 }
 
+/* Pushes the "audit detail" affordance to the right of the tool-call header so a
+   governed call links to its exact invocation record. */
+.tool_call_action {
+    margin-left: auto;
+}
+
+/* Collapsible "tools used in this conversation" feed — the Activity-tab surface
+   scoped to the open chat, tucked into a disclosure so it never competes with the
+   transcript until an operator opens it. */
+.tools_used {
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    padding: var(--padding-sm);
+}
+
+.tools_used_summary {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    cursor: pointer;
+    font-size: var(--font-size-body-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text);
+}
+
+.tools_used_body {
+    margin-top: var(--gap-sm);
+}
+
 .tool_payload {
     margin: var(--gap-xs) 0 0 0;
     padding: var(--padding-xs);

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
@@ -14,14 +14,14 @@
  */
 
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
-import { Send, Bot, User, AlertCircle, X, Copy, CheckCircle, Plus, History, MessageSquare, RefreshCw, ChevronDown, ChevronRight, Brain, Wrench, CornerDownRight } from 'lucide-react';
+import { Send, Bot, User, AlertCircle, X, Copy, CheckCircle, Plus, History, MessageSquare, RefreshCw, ChevronDown, ChevronRight, Brain, Wrench, CornerDownRight, Info } from 'lucide-react';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkGfm from 'remark-gfm';
 import remarkRehype from 'remark-rehype';
 import rehypeSanitize from 'rehype-sanitize';
 import rehypeStringify from 'rehype-stringify';
-import type { IAiConversationMessage, IAiQueryRecord, IAiStreamChunk, IAiTranscriptSegment, IModelInfo, ISavedPrompt } from '@/types';
+import type { IAiConversationMessage, IAiQueryRecord, IAiStreamChunk, IAiTranscriptSegment, IModelInfo, ISavedPrompt, IToolInvocationRecord } from '@/types';
 import { Stack } from '../../../../../components/layout';
 import { Card } from '../../../../../components/ui/Card';
 import { Button } from '../../../../../components/ui/Button';
@@ -31,15 +31,19 @@ import { Badge } from '../../../../../components/ui/Badge';
 import { IconButton } from '../../../../../components/ui/IconButton';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { getSocket } from '../../../../../lib/socketClient';
+import { SlideOver } from '../../../../../components/ui/SlideOver';
 import {
     submitQuery,
     cancelQuery,
     getQueryHistory,
     getConversation,
     getQueryModels,
+    listActivity,
     type IStreamAck
 } from '../../../../../modules/ai-tools';
 import { SavedPromptsPanel } from './SavedPromptsPanel';
+import { InvocationDetailPanel } from '../components/InvocationDetailPanel';
+import { InvocationTable } from '../components/InvocationTable';
 import pageStyles from '../page.module.scss';
 import styles from './QueryTab.module.scss';
 
@@ -211,9 +215,19 @@ function formatToolPayload(value: unknown): string {
  * the prose reads identically whether live or replayed.
  *
  * @param segments - The turn's ordered transcript segments.
+ * @param recordsById - The conversation's audit records keyed by their `toolUseId`,
+ *   so a tool_use segment can resolve its exact invocation record. Absent (or a
+ *   miss) simply renders the call without a detail affordance — legacy records and
+ *   the pre-`toolUseId` provider degrade gracefully rather than breaking.
+ * @param onSelectRecord - Opens the matched record's detail panel. Omitted when the
+ *   host has no detail surface (nothing becomes clickable).
  * @returns The rendered transcript.
  */
-function AssistantSegments({ segments }: { segments: IAiTranscriptSegment[] }) {
+function AssistantSegments({ segments, recordsById, onSelectRecord }: {
+    segments: IAiTranscriptSegment[];
+    recordsById?: Map<string, IToolInvocationRecord>;
+    onSelectRecord?: (record: IToolInvocationRecord) => void;
+}) {
     return (
         <div className={styles.segments}>
             {segments.map((segment, index) => {
@@ -228,12 +242,28 @@ function AssistantSegments({ segments }: { segments: IAiTranscriptSegment[] }) {
                     );
                 }
                 if (segment.type === 'tool_use') {
+                    // Resolve this call's exact audit record by the provider-neutral
+                    // toolUseId. A hit turns the header into a link to the full
+                    // invocation detail (status, duration, cost, forensic error,
+                    // screen verdict) the transcript alone can't show.
+                    const auditRecord = segment.id ? recordsById?.get(segment.id) : undefined;
                     return (
                         <div key={index} className={styles.tool_call}>
                             <div className={styles.tool_call_header}>
                                 <Wrench size={14} />
                                 <span className={styles.tool_call_name}>{segment.name || 'tool'}</span>
                                 {segment.server && <Badge tone="info">server</Badge>}
+                                {auditRecord && onSelectRecord && (
+                                    <Button
+                                        variant="ghost"
+                                        size="xs"
+                                        className={styles.tool_call_action}
+                                        onClick={() => onSelectRecord(auditRecord)}
+                                        aria-label={`View the audit record for the ${segment.name || 'tool'} call`}
+                                    >
+                                        <Info size={14} /> Details
+                                    </Button>
+                                )}
                             </div>
                             <pre className={styles.tool_payload}>{formatToolPayload(segment.input)}</pre>
                         </div>
@@ -353,6 +383,29 @@ export function QueryTab() {
     const [savedPrompts, setSavedPrompts] = useState<ISavedPrompt[]>([]);
     /** Conversation ids whose full opening prompt is expanded inline in the history list. */
     const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
+    /**
+     * Tool-invocation audit records for the open conversation, loaded from the
+     * Activity feed scoped by conversationId. Backs the transcript's per-call
+     * "Details" deep-links and the "tools used" summary feed.
+     */
+    const [conversationRecords, setConversationRecords] = useState<IToolInvocationRecord[]>([]);
+    /** The audit record whose detail slide-over is open, or null when closed. */
+    const [selectedRecord, setSelectedRecord] = useState<IToolInvocationRecord | null>(null);
+    /**
+     * Audit records keyed by their provider-neutral `toolUseId`, so a transcript
+     * tool_use segment resolves to its exact invocation record in O(1). Records
+     * without a `toolUseId` (legacy, or the pre-`toolUseId` provider) are skipped
+     * — their calls simply render without a detail link.
+     */
+    const toolRecordsById = useMemo(() => {
+        const map = new Map<string, IToolInvocationRecord>();
+        for (const record of conversationRecords) {
+            if (record.toolUseId) {
+                map.set(record.toolUseId, record);
+            }
+        }
+        return map;
+    }, [conversationRecords]);
 
     /** The queryId whose stream chunks the handler currently accepts. */
     const activeQueryIdRef = useRef<string | null>(null);
@@ -417,6 +470,26 @@ export function QueryTab() {
     }, []);
 
     /**
+     * Load a conversation's tool-invocation audit records so the transcript's tool
+     * calls can deep-link to their exact invocation detail and the "tools used"
+     * feed can list them. Secondary data — a failure just leaves the audit
+     * affordances absent, never blocks the chat. Reads the same admin-gated feed
+     * the Activity tab uses, scoped by conversationId.
+     *
+     * @param conversationId - The conversation whose tool calls to load.
+     */
+    const refreshConversationActivity = useCallback(async (conversationId: string) => {
+        try {
+            const page = await listActivity({ conversationId, limit: 200 });
+            if (isMountedRef.current) {
+                setConversationRecords(page.records);
+            }
+        } catch {
+            /* secondary data — the transcript still renders without audit links */
+        }
+    }, []);
+
+    /**
      * Route an incoming stream chunk to the pending assistant turn. Filters by
      * the active queryId so a stale or unrelated query's chunks are ignored —
      * the backend broadcasts `ai-tools:query-stream` globally, so this client
@@ -448,13 +521,20 @@ export function QueryTab() {
             });
             streamingTurnIdRef.current = null;
             activeQueryIdRef.current = null;
+            // The turn produced its audit records as it ran; pull them so the
+            // just-completed tool calls gain their "Details" deep-link and the
+            // tools-used feed reflects this turn without reopening from history.
+            const settledConversationId = conversationIdRef.current;
+            if (settledConversationId) {
+                void refreshConversationActivity(settledConversationId);
+            }
         } else if (chunk.type === 'error') {
             setStreaming(false);
             updateTurn(turnId, { pending: false, error: chunk.error || 'An unknown error occurred' });
             streamingTurnIdRef.current = null;
             activeQueryIdRef.current = null;
         }
-    }, [updateTurn]);
+    }, [updateTurn, refreshConversationActivity]);
 
     // Subscribe to the global stream event once; correlation happens in the
     // handler. The shared socket is reused across the app, so only detach our
@@ -585,6 +665,8 @@ export function QueryTab() {
         streamingTurnIdRef.current = null;
         activeQueryIdRef.current = null;
         conversationIdRef.current = null;
+        setConversationRecords([]);
+        setSelectedRecord(null);
     }, [streaming]);
 
     /**
@@ -711,13 +793,18 @@ export function QueryTab() {
             activeQueryIdRef.current = null;
             conversationIdRef.current = conversationId;
             setMessages(rebuilt);
+            setSelectedRecord(null);
             setView('chat');
+            // Load this conversation's tool-call audit records so the transcript's
+            // tool calls link to their exact invocation detail and the tools-used
+            // feed populates. Fire-and-forget: it must not gate reopening the chat.
+            void refreshConversationActivity(conversationId);
         } catch (err) {
             if (isMountedRef.current) {
                 setHistoryError(err instanceof Error ? err.message : 'Failed to open conversation');
             }
         }
-    }, []);
+    }, [refreshConversationActivity]);
 
     /**
      * Ctrl/Cmd+Enter submits from the composer.
@@ -855,7 +942,8 @@ export function QueryTab() {
                                             ) : turn.segments && turn.segments.length > 0 ? (
                                                 // A settled turn (live `done` or reopened from history) renders its
                                                 // full transcript — thinking, tool calls, results, and text in order.
-                                                <AssistantSegments segments={turn.segments} />
+                                                // The audit-record map lets each tool call deep-link to its record.
+                                                <AssistantSegments segments={turn.segments} recordsById={toolRecordsById} onSelectRecord={setSelectedRecord} />
                                             ) : (
                                                 <div
                                                     className={styles.turn_markdown}
@@ -954,6 +1042,16 @@ export function QueryTab() {
                         </div>
                     </div>
                 </Card>
+                {conversationRecords.length > 0 && (
+                    <details className={styles.tools_used}>
+                        <summary className={styles.tools_used_summary}>
+                            <Wrench size={16} /> Tools used in this conversation ({conversationRecords.length})
+                        </summary>
+                        <div className={styles.tools_used_body}>
+                            <InvocationTable records={conversationRecords} onSelect={setSelectedRecord} />
+                        </div>
+                    </details>
+                )}
                 <SavedPromptsPanel
                     prompts={savedPrompts}
                     onPromptsChange={setSavedPrompts}
@@ -1042,6 +1140,15 @@ export function QueryTab() {
                         )}
                 </Stack>
             )}
+
+            <SlideOver
+                open={selectedRecord !== null}
+                onClose={() => setSelectedRecord(null)}
+                label={selectedRecord ? `Invocation ${selectedRecord.toolName}` : undefined}
+                title={selectedRecord ? <span className={styles.tool_call_name}>{selectedRecord.toolName}</span> : null}
+            >
+                {selectedRecord && <InvocationDetailPanel record={selectedRecord} />}
+            </SlideOver>
         </div>
     );
 }

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
@@ -481,7 +481,11 @@ export function QueryTab() {
     const refreshConversationActivity = useCallback(async (conversationId: string) => {
         try {
             const page = await listActivity({ conversationId, limit: 200 });
-            if (isMountedRef.current) {
+            // Drop out-of-order responses: a slower fetch for a conversation the
+            // operator has since navigated away from must not overwrite the
+            // active conversation's records (which back the "Tools used" feed and
+            // the transcript's per-call "Details" deep-links).
+            if (isMountedRef.current && conversationId === conversationIdRef.current) {
                 setConversationRecords(page.records);
             }
         } catch {
@@ -793,6 +797,13 @@ export function QueryTab() {
             activeQueryIdRef.current = null;
             conversationIdRef.current = conversationId;
             setMessages(rebuilt);
+            // Drop the previous conversation's audit records up front so the
+            // "Tools used" summary and the transcript's tool-detail lookup never
+            // show the prior thread's tools during this conversation's in-flight
+            // activity fetch — or permanently, if that fetch fails. The clear
+            // lives here, not in refreshConversationActivity, because the live
+            // streaming `done` path shares that refresh and must not flash empty.
+            setConversationRecords([]);
             setSelectedRecord(null);
             setView('chat');
             // Load this conversation's tool-call audit records so the transcript's

--- a/src/frontend/modules/ai-tools/api/client.ts
+++ b/src/frontend/modules/ai-tools/api/client.ts
@@ -71,6 +71,10 @@ export interface IActivityQuery {
     aiProviderId?: string;
     triggerPath?: ToolTriggerPath;
     status?: ToolInvocationStatus;
+    /** Scope to one conversation's tool calls — backs the Query tab's per-conversation feed. */
+    conversationId?: string;
+    /** Scope to one run's tool calls. */
+    queryId?: string;
     limit?: number;
     offset?: number;
 }


### PR DESCRIPTION
## Summary

Threads a provider-neutral per-call `toolUseId` through the AI tool audit trail and adds conversation/query-scoped filtering, so a specific tool call can be deep-linked from a transcript segment to its exact audit row rather than matched by ordinal or tool name.

## Changes

- **Types** — add optional `toolUseId` to `IToolInvocationContext` (provider supplies) and `IToolInvocationRecord` (governor persists). It is the same opaque id core already models as `IAiTranscriptSegment` `tool_use.id` / `tool_result.toolUseId`, so audit rows and transcript segments join exactly.
- **Governor** — copies `ctx.toolUseId` onto the persisted record when the provider threads one through.
- **Audit store** — `IToolInvocationQuery` gains `conversationId`/`queryId`; adds a sparse `conversationId` newest-first index backing the Query tab's per-conversation "tools used" feed.
- **Controller** — accepts `conversationId`/`queryId` query params on the invocations endpoint.
- **Frontend** — extract a shared `InvocationTable` consumed by both the Activity and Query tabs; the Query tab renders a per-conversation tools-used feed.

## Notes

`toolUseId` is absent on legacy records and on any path a provider did not thread the id through. `packages/types` version bumped for the new optional fields.