### PR TITLE
feat(ai-tools): persist and forward per-prompt tool allowlist

### DIFF
--- a/src/backend/modules/ai-tools/__tests__/ai-tools.controller.test.ts
+++ b/src/backend/modules/ai-tools/__tests__/ai-tools.controller.test.ts
@@ -13,7 +13,7 @@
  * branch) out of scope.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { AiToolsController } from '../api/ai-tools.controller.js';
 
 /**
@@ -135,6 +135,30 @@ describe('AiToolsController — toolAllowlist wiring', () => {
             const res = createMockResponse();
 
             await controller.query({ body: { prompt: 'hi', stream: false, toolAllowlist: ['ok', 7] } } as any, res);
+
+            expect(res._status).toBe(400);
+            expect(provider.query).not.toHaveBeenCalled();
+        });
+
+        it('rejects an allowlist with a blank / whitespace-only entry with 400', async () => {
+            const provider = { query: vi.fn(async (_opts: any) => ({ responseText: 'ok' })) };
+            const providers = { getActive: vi.fn(() => provider) };
+            const { controller } = makeController({ providers });
+            const res = createMockResponse();
+
+            await controller.query({ body: { prompt: 'hi', stream: false, toolAllowlist: ['ok', '  '] } } as any, res);
+
+            expect(res._status).toBe(400);
+            expect(provider.query).not.toHaveBeenCalled();
+        });
+
+        it('rejects an allowlist entry with leading/trailing whitespace with 400', async () => {
+            const provider = { query: vi.fn(async (_opts: any) => ({ responseText: 'ok' })) };
+            const providers = { getActive: vi.fn(() => provider) };
+            const { controller } = makeController({ providers });
+            const res = createMockResponse();
+
+            await controller.query({ body: { prompt: 'hi', stream: false, toolAllowlist: [' padded '] } } as any, res);
 
             expect(res._status).toBe(400);
             expect(provider.query).not.toHaveBeenCalled();

--- a/src/backend/modules/ai-tools/__tests__/ai-tools.controller.test.ts
+++ b/src/backend/modules/ai-tools/__tests__/ai-tools.controller.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @file ai-tools.controller.test.ts
+ *
+ * Focused controller tests for the per-prompt tool-allowlist wiring: that
+ * `savePrompt` forwards a client-supplied `toolAllowlist` into the saved-prompts
+ * service (create and update), and that the interactive `query` handler
+ * re-validates the selector and forwards a valid one to the active provider.
+ *
+ * The controller has twelve constructor dependencies; only `savedPrompts`,
+ * `providers`, `history`, `systemPrompts`, and `resolveEndUser` are exercised
+ * here, so the rest are inert stubs. Only the non-streaming query path is
+ * driven, keeping the WebSocket singleton (used exclusively by the streaming
+ * branch) out of scope.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AiToolsController } from '../api/ai-tools.controller.js';
+
+/**
+ * Build a mock Express response capturing status + json.
+ *
+ * @returns A response double with `_status` / `_json` accessors and spies.
+ */
+function createMockResponse() {
+    const res: any = {
+        _status: 200,
+        _json: undefined as unknown,
+        status: vi.fn((code: number) => {
+            res._status = code;
+            return res;
+        }),
+        json: vi.fn((body: unknown) => {
+            res._json = body;
+            return res;
+        })
+    };
+    return res;
+}
+
+/**
+ * Construct the controller with inert stubs, overriding only the dependencies a
+ * given test needs.
+ *
+ * @param overrides - Partial map of the named dependencies to inject.
+ * @returns The controller plus the resolved dependency doubles.
+ */
+function makeController(overrides: Record<string, any> = {}) {
+    const savedPrompts = overrides.savedPrompts ?? {
+        create: vi.fn(async () => ({})),
+        update: vi.fn(async () => ({})),
+        list: vi.fn(async () => [])
+    };
+    const providers = overrides.providers ?? { getActive: vi.fn(() => null) };
+    const history = overrides.history ?? { append: vi.fn(async () => {}) };
+    const systemPrompts = overrides.systemPrompts ?? { compose: vi.fn(async () => 'SYS') };
+    const resolveEndUser = overrides.resolveEndUser ?? vi.fn(async () => null);
+
+    const controller = new AiToolsController(
+        {} as any, // registry
+        {} as any, // policy
+        {} as any, // audit
+        {} as any, // approvals
+        {} as any, // governor
+        providers as any,
+        history as any,
+        savedPrompts as any,
+        {} as any, // promptVariables
+        systemPrompts as any,
+        resolveEndUser as any,
+        {} as any // screenConfig
+    );
+
+    return { controller, savedPrompts, providers, history, systemPrompts, resolveEndUser };
+}
+
+describe('AiToolsController — toolAllowlist wiring', () => {
+    describe('savePrompt', () => {
+        it('forwards toolAllowlist to create on a new prompt', async () => {
+            const { controller, savedPrompts } = makeController();
+            const req: any = { body: { name: 'N', prompt: 'P', toolAllowlist: ['a', 'b'] }, userId: 'admin-1' };
+            const res = createMockResponse();
+
+            await controller.savePrompt(req, res);
+
+            expect(savedPrompts.create).toHaveBeenCalledTimes(1);
+            expect(savedPrompts.create.mock.calls[0][0]).toMatchObject({ toolAllowlist: ['a', 'b'] });
+        });
+
+        it('forwards toolAllowlist to update on an existing prompt (incl. [] and null)', async () => {
+            const { controller, savedPrompts } = makeController();
+            const res = createMockResponse();
+
+            await controller.savePrompt({ body: { id: 'p1', toolAllowlist: [] } } as any, res);
+            expect(savedPrompts.update.mock.calls[0][1]).toMatchObject({ toolAllowlist: [] });
+
+            await controller.savePrompt({ body: { id: 'p1', toolAllowlist: null } } as any, res);
+            expect(savedPrompts.update.mock.calls[1][1]).toMatchObject({ toolAllowlist: null });
+        });
+
+        it('maps a service SavedPromptValidationError to its status code', async () => {
+            // A malformed allowlist is rejected by the service's validator; the
+            // controller's existing catch maps SavedPromptValidationError → 400.
+            const { SavedPromptValidationError } = await import('../services/saved-prompts.service.js');
+            const savedPrompts = {
+                create: vi.fn(async () => { throw new SavedPromptValidationError('toolAllowlist must be an array of tool-name strings'); }),
+                update: vi.fn(),
+                list: vi.fn(async () => [])
+            };
+            const { controller } = makeController({ savedPrompts });
+            const res = createMockResponse();
+
+            await controller.savePrompt({ body: { name: 'N', prompt: 'P', toolAllowlist: 'nope' } } as any, res);
+
+            expect(res._status).toBe(400);
+        });
+    });
+
+    describe('query (non-streaming)', () => {
+        it('rejects a non-array toolAllowlist with 400 before touching the provider', async () => {
+            const provider = { query: vi.fn(async (_opts: any) => ({ responseText: 'ok' })) };
+            const providers = { getActive: vi.fn(() => provider) };
+            const { controller } = makeController({ providers });
+            const res = createMockResponse();
+
+            await controller.query({ body: { prompt: 'hi', stream: false, toolAllowlist: 'all' } } as any, res);
+
+            expect(res._status).toBe(400);
+            expect(provider.query).not.toHaveBeenCalled();
+        });
+
+        it('rejects an allowlist with a non-string entry with 400', async () => {
+            const provider = { query: vi.fn(async (_opts: any) => ({ responseText: 'ok' })) };
+            const providers = { getActive: vi.fn(() => provider) };
+            const { controller } = makeController({ providers });
+            const res = createMockResponse();
+
+            await controller.query({ body: { prompt: 'hi', stream: false, toolAllowlist: ['ok', 7] } } as any, res);
+
+            expect(res._status).toBe(400);
+            expect(provider.query).not.toHaveBeenCalled();
+        });
+
+        it('forwards a valid toolAllowlist to the provider query', async () => {
+            const provider = { query: vi.fn(async (_opts: any) => ({ responseText: 'ok' })) };
+            const providers = { getActive: vi.fn(() => provider) };
+            const { controller } = makeController({ providers });
+            const res = createMockResponse();
+
+            await controller.query({ body: { prompt: 'hi', stream: false, toolAllowlist: ['tool-x'] } } as any, res);
+
+            expect(provider.query).toHaveBeenCalledTimes(1);
+            expect(provider.query.mock.calls[0][0]).toMatchObject({ prompt: 'hi', toolAllowlist: ['tool-x'] });
+        });
+
+        it('omits toolAllowlist (undefined → all tools) when the body has none', async () => {
+            const provider = { query: vi.fn(async (_opts: any) => ({ responseText: 'ok' })) };
+            const providers = { getActive: vi.fn(() => provider) };
+            const { controller } = makeController({ providers });
+            const res = createMockResponse();
+
+            await controller.query({ body: { prompt: 'hi', stream: false } } as any, res);
+
+            expect(provider.query).toHaveBeenCalledTimes(1);
+            expect(provider.query.mock.calls[0][0].toolAllowlist).toBeUndefined();
+        });
+    });
+});

--- a/src/backend/modules/ai-tools/__tests__/saved-prompts.service.test.ts
+++ b/src/backend/modules/ai-tools/__tests__/saved-prompts.service.test.ts
@@ -115,6 +115,15 @@ function applyUpdate(target: any, update: any): void {
             target[k] = (target[k] ?? 0) + (v as number);
         }
     }
+    if (update.$unset) {
+        // `$unset` removes the field entirely (reverting it to absent/undefined),
+        // which is how the service clears a model pin or a toolAllowlist back to
+        // "all tools". The value the driver ships (`''`) is ignored — presence of
+        // the key is the instruction.
+        for (const k of Object.keys(update.$unset)) {
+            delete target[k];
+        }
+    }
 }
 
 /**
@@ -394,6 +403,83 @@ describe('SavedPromptsService', () => {
         });
     });
 
+    describe('toolAllowlist (three-state persistence)', () => {
+        it('create omits the field when no allowlist is supplied (undefined = all tools)', async () => {
+            const created = await service.create({ name: 'AllTools', prompt: 'p' });
+            expect('toolAllowlist' in created).toBe(false);
+
+            // Read back through get() to confirm nothing was persisted.
+            const persisted = await service.get(created.id);
+            expect(persisted?.toolAllowlist).toBeUndefined();
+        });
+
+        it('create round-trips an empty array as [] (no tools), not dropped or coerced', async () => {
+            const created = await service.create({ name: 'NoTools', prompt: 'p', toolAllowlist: [] });
+            expect(created.toolAllowlist).toEqual([]);
+
+            const persisted = await service.get(created.id);
+            // The sharp edge: `[]` must survive as `[]`, distinct from an absent
+            // field. The driver's ignoreUndefined never strips a real array.
+            expect(persisted?.toolAllowlist).toEqual([]);
+        });
+
+        it('create round-trips a name list verbatim', async () => {
+            const created = await service.create({ name: 'Subset', prompt: 'p', toolAllowlist: ['tool-a', 'tool-b'] });
+            expect(created.toolAllowlist).toEqual(['tool-a', 'tool-b']);
+
+            const persisted = await service.get(created.id);
+            expect(persisted?.toolAllowlist).toEqual(['tool-a', 'tool-b']);
+        });
+
+        it('create treats null as "all tools" and leaves the field absent', async () => {
+            const created = await service.create({ name: 'NullList', prompt: 'p', toolAllowlist: null });
+            expect(created.toolAllowlist).toBeUndefined();
+        });
+
+        it('update sets [] on an all-tools prompt (round-trips as [])', async () => {
+            const created = await service.create({ name: 'ToEmpty', prompt: 'p' });
+            const updated = await service.update(created.id, { toolAllowlist: [] });
+            expect(updated.toolAllowlist).toEqual([]);
+
+            const persisted = await service.get(created.id);
+            expect(persisted?.toolAllowlist).toEqual([]);
+        });
+
+        it('update sets a name list on an all-tools prompt', async () => {
+            const created = await service.create({ name: 'ToSubset', prompt: 'p' });
+            const updated = await service.update(created.id, { toolAllowlist: ['x'] });
+            expect(updated.toolAllowlist).toEqual(['x']);
+        });
+
+        it('update with null clears the allowlist back to absent (all tools)', async () => {
+            const created = await service.create({ name: 'ClearToAll', prompt: 'p', toolAllowlist: ['x', 'y'] });
+            const cleared = await service.update(created.id, { toolAllowlist: null });
+            // `null` clears via $unset — the field is absent, meaning "all tools",
+            // NOT `[]` (which would mean "no tools").
+            expect(cleared.toolAllowlist).toBeUndefined();
+
+            const persisted = await service.get(created.id);
+            expect(persisted?.toolAllowlist).toBeUndefined();
+        });
+
+        it('update preserves the allowlist when the field is omitted', async () => {
+            const created = await service.create({ name: 'Preserve', prompt: 'p', toolAllowlist: ['keep'] });
+            const updated = await service.update(created.id, { name: 'Renamed' });
+            expect(updated.toolAllowlist).toEqual(['keep']);
+        });
+
+        it('rejects a non-array allowlist on create', async () => {
+            await expect(service.create({ name: 'Bad', prompt: 'p', toolAllowlist: 'nope' as any }))
+                .rejects.toBeInstanceOf(SavedPromptValidationError);
+        });
+
+        it('rejects an allowlist with a non-string entry on update', async () => {
+            const created = await service.create({ name: 'BadEntry', prompt: 'p' });
+            await expect(service.update(created.id, { toolAllowlist: ['ok', 5 as any] }))
+                .rejects.toBeInstanceOf(SavedPromptValidationError);
+        });
+    });
+
     describe('list', () => {
         it('returns newest-updated first', async () => {
             const first = await service.create({ name: 'First', prompt: 'a' });
@@ -465,6 +551,29 @@ describe('SavedPromptsService', () => {
             const after = await service.get(created.id);
             expect(after?.scheduleEnabled).toBe(false);
             expect(after?.failureCount).toBe(5);
+            expect(after?.lastRunError).toContain('schedule paused');
+        });
+
+        it('auto-pauses with the precise upstream error when a prompt names an unregistered tool', async () => {
+            // End-to-end of the toolAllowlist failure contract: the provider fails
+            // the run before the model call when a listed tool is unregistered, and
+            // the runner forwards that precise message here verbatim. After the
+            // threshold the schedule auto-pauses, and the pause banner must still
+            // carry the precise reason so an admin sees WHY it stopped.
+            const created = await service.create({ name: 'BadTool', prompt: 'p', cron: '* * * * *', toolAllowlist: ['gone'] });
+            const preciseError = 'unregistered tool(s): "gone"';
+
+            let disabled = false;
+            for (let i = 0; i < 5; i += 1) {
+                ({ disabled } = await service.recordRunFailure(created.id, new Date().toISOString(), preciseError));
+            }
+
+            expect(disabled).toBe(true);
+            const after = await service.get(created.id);
+            expect(after?.scheduleEnabled).toBe(false);
+            expect(after?.failureCount).toBe(5);
+            // Both the precise upstream cause and the pause annotation survive.
+            expect(after?.lastRunError).toContain(preciseError);
             expect(after?.lastRunError).toContain('schedule paused');
         });
 

--- a/src/backend/modules/ai-tools/__tests__/saved-prompts.service.test.ts
+++ b/src/backend/modules/ai-tools/__tests__/saved-prompts.service.test.ts
@@ -478,6 +478,30 @@ describe('SavedPromptsService', () => {
             await expect(service.update(created.id, { toolAllowlist: ['ok', 5 as any] }))
                 .rejects.toBeInstanceOf(SavedPromptValidationError);
         });
+
+        it('rejects an allowlist with a blank / whitespace-only entry', async () => {
+            // A blank entry is never a valid tool name and would fail the whole
+            // allowlist at run time (auto-pausing a scheduled prompt), so it must
+            // fail closed at save. Guard both create and update.
+            await expect(service.create({ name: 'BlankCreate', prompt: 'p', toolAllowlist: ['ok', '  '] }))
+                .rejects.toBeInstanceOf(SavedPromptValidationError);
+
+            const created = await service.create({ name: 'BlankUpdate', prompt: 'p' });
+            await expect(service.update(created.id, { toolAllowlist: [''] }))
+                .rejects.toBeInstanceOf(SavedPromptValidationError);
+        });
+
+        it('rejects an allowlist entry with leading/trailing whitespace', async () => {
+            // A padded name (' get_transaction ') can never match the exact tool
+            // name at the registry, so it silently breaks the whole allowlist and
+            // auto-pauses the prompt — reject it at save on both create and update.
+            await expect(service.create({ name: 'PaddedCreate', prompt: 'p', toolAllowlist: [' ok '] }))
+                .rejects.toBeInstanceOf(SavedPromptValidationError);
+
+            const created = await service.create({ name: 'PaddedUpdate', prompt: 'p' });
+            await expect(service.update(created.id, { toolAllowlist: ['ok', 'trailing '] }))
+                .rejects.toBeInstanceOf(SavedPromptValidationError);
+        });
     });
 
     describe('list', () => {

--- a/src/backend/modules/ai-tools/__tests__/scheduled-prompts-runner.test.ts
+++ b/src/backend/modules/ai-tools/__tests__/scheduled-prompts-runner.test.ts
@@ -169,6 +169,56 @@ describe('runScheduledPrompts', () => {
         );
     });
 
+    it('forwards the prompt\'s toolAllowlist to the provider query', async () => {
+        const savedPrompts = createMockSavedPrompts([
+            makePrompt({
+                id: 'scoped',
+                cron: '* * * * *',
+                lastRunAt: minutesAgo(5),
+                prompt: 'run me',
+                toolAllowlist: ['tool-a', 'tool-b']
+            })
+        ]);
+
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
+
+        // The least-privilege selector rides the programmatic query so the
+        // governor enforces it (undefined would mean "all enabled tools").
+        expect(provider.query).toHaveBeenCalledWith(
+            expect.objectContaining({ prompt: 'run me', mode: 'programmatic', toolAllowlist: ['tool-a', 'tool-b'] })
+        );
+    });
+
+    it('forwards an empty toolAllowlist ([] = no tools) rather than omitting it', async () => {
+        const savedPrompts = createMockSavedPrompts([
+            makePrompt({ id: 'toolless', cron: '* * * * *', lastRunAt: minutesAgo(5), prompt: 'run', toolAllowlist: [] })
+        ]);
+
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
+
+        expect(provider.query).toHaveBeenCalledWith(
+            expect.objectContaining({ prompt: 'run', toolAllowlist: [] })
+        );
+    });
+
+    it('records the provider\'s precise unregistered-tool error verbatim as the failure reason', async () => {
+        // The provider fails the run before the model call when the allowlist
+        // names a tool that resolves to nothing (a disabled/renamed plugin). The
+        // runner must forward that precise message into recordRunFailure so it
+        // lands in lastRunError and counts toward auto-pause — not a generic error.
+        const preciseError = 'unregistered tool(s): "gone"';
+        provider.query.mockRejectedValueOnce(new Error(preciseError));
+        const savedPrompts = createMockSavedPrompts([
+            makePrompt({ id: 'bad-tool', cron: '* * * * *', lastRunAt: minutesAgo(5), toolAllowlist: ['gone'] })
+        ]);
+
+        await runScheduledPrompts(savedPrompts as any, logger as any, () => provider);
+
+        expect(savedPrompts.recordRunFailure).toHaveBeenCalledTimes(1);
+        const [, , reason] = savedPrompts.recordRunFailure.mock.calls[0];
+        expect(reason).toBe(preciseError);
+    });
+
     it('does not fire when the cron next-time is still in the future', async () => {
         const tenSecondsAgo = new Date(Date.now() - 10_000).toISOString();
         const savedPrompts = createMockSavedPrompts([

--- a/src/backend/modules/ai-tools/api/ai-tools.controller.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.controller.ts
@@ -90,8 +90,9 @@ function validateMessages(messages: unknown[]): string | null {
  * hint — so a malformed value must be rejected before it reaches the provider,
  * where a non-array would otherwise be forwarded and silently read as "all
  * tools". Legal shapes on the query path are `undefined` (omit → all enabled
- * tools) or an array of strings (`[]` for none, a name list for a subset);
- * `null` and non-arrays are rejected. Returns a descriptive error string on the
+ * tools) or an array of non-empty strings (`[]` for none, a name list for a
+ * subset); `null`, non-arrays, blank entries, and entries with leading/trailing
+ * whitespace are rejected. Returns a descriptive error string on the
  * first problem, or null when valid.
  *
  * @param value - The raw `toolAllowlist` value from the request body.
@@ -105,8 +106,11 @@ function validateToolAllowlist(value: unknown): string | null {
         return 'Body field "toolAllowlist" must be an array of tool-name strings.';
     }
     for (let i = 0; i < value.length; i += 1) {
-        if (typeof value[i] !== 'string') {
-            return `toolAllowlist[${i}] must be a string.`;
+        if (typeof value[i] !== 'string' || !value[i].trim()) {
+            return `toolAllowlist[${i}] must be a non-empty string.`;
+        }
+        if (value[i] !== value[i].trim()) {
+            return `toolAllowlist[${i}] must not have leading or trailing whitespace.`;
         }
     }
     return null;

--- a/src/backend/modules/ai-tools/api/ai-tools.controller.ts
+++ b/src/backend/modules/ai-tools/api/ai-tools.controller.ts
@@ -52,6 +52,7 @@ interface IQueryRequestBody {
     stream?: unknown;
     messages?: unknown;
     conversationId?: unknown;
+    toolAllowlist?: unknown;
 }
 
 /**
@@ -78,6 +79,34 @@ function validateMessages(messages: unknown[]): string | null {
         }
         if (typeof content !== 'string') {
             return `messages[${i}].content must be a string.`;
+        }
+    }
+    return null;
+}
+
+/**
+ * Validate a client-supplied `toolAllowlist` from a query body. The selector is
+ * a model-independent guarantee — the schema advertised to the model is only a
+ * hint — so a malformed value must be rejected before it reaches the provider,
+ * where a non-array would otherwise be forwarded and silently read as "all
+ * tools". Legal shapes on the query path are `undefined` (omit → all enabled
+ * tools) or an array of strings (`[]` for none, a name list for a subset);
+ * `null` and non-arrays are rejected. Returns a descriptive error string on the
+ * first problem, or null when valid.
+ *
+ * @param value - The raw `toolAllowlist` value from the request body.
+ * @returns An error message, or null when valid.
+ */
+function validateToolAllowlist(value: unknown): string | null {
+    if (value === undefined) {
+        return null;
+    }
+    if (!Array.isArray(value)) {
+        return 'Body field "toolAllowlist" must be an array of tool-name strings.';
+    }
+    for (let i = 0; i < value.length; i += 1) {
+        if (typeof value[i] !== 'string') {
+            return `toolAllowlist[${i}] must be a string.`;
         }
     }
     return null;
@@ -499,6 +528,18 @@ export class AiToolsController {
             messages = body.messages as IAiConversationMessage[];
         }
 
+        // `toolAllowlist` is the least-privilege selector for this run. Re-check
+        // it here — the provider forwards it straight into governor enforcement,
+        // so a malformed value must fail as a 400 rather than degrade to "all
+        // tools". undefined → omit (all enabled tools); `[]` → none; a name list
+        // → that subset (enforced at governor.invoke()).
+        const allowlistError = validateToolAllowlist(body.toolAllowlist);
+        if (allowlistError) {
+            res.status(400).json({ error: allowlistError });
+            return;
+        }
+        const toolAllowlist = body.toolAllowlist as string[] | undefined;
+
         // The admin driving this query is its end-user principal: on the
         // interactive path the operator queries on their own behalf. requireAdmin
         // set req.userId on the session path (undefined for a service-token call,
@@ -545,7 +586,7 @@ export class AiToolsController {
             // promise settles.
             provider
                 .queryStream(
-                    { prompt, queryId, model, messages, conversationId, mode: 'stream', endUser, injectedSystemPrompt },
+                    { prompt, queryId, model, messages, conversationId, mode: 'stream', endUser, injectedSystemPrompt, toolAllowlist },
                     (chunk: IAiStreamChunk) => {
                         WebSocketService.getInstance().emitToSocket(socketId, QUERY_STREAM_EVENT, chunk);
                     }
@@ -586,7 +627,7 @@ export class AiToolsController {
         // Non-streaming path: await the result and surface it directly.
         const createdAt = new Date().toISOString();
         try {
-            const result = await provider.query({ prompt, model, messages, conversationId, mode: 'programmatic', endUser, injectedSystemPrompt });
+            const result = await provider.query({ prompt, model, messages, conversationId, mode: 'programmatic', endUser, injectedSystemPrompt, toolAllowlist });
             await this.history.append(
                 buildAiQueryRecord('programmatic', prompt, conversationId, createdAt, randomUUID(), result, null)
             );
@@ -699,7 +740,7 @@ export class AiToolsController {
      * client's shared state stays current without a second round-trip.
      */
     savePrompt = async (req: Request, res: Response): Promise<void> => {
-        const { id, name, prompt, cron, scheduleEnabled, providerId, model } = (req.body ?? {}) as {
+        const { id, name, prompt, cron, scheduleEnabled, providerId, model, toolAllowlist } = (req.body ?? {}) as {
             id?: unknown;
             name?: unknown;
             prompt?: unknown;
@@ -707,6 +748,7 @@ export class AiToolsController {
             scheduleEnabled?: unknown;
             providerId?: unknown;
             model?: unknown;
+            toolAllowlist?: unknown;
         };
         try {
             const hasId = typeof id === 'string' && id.trim().length > 0;
@@ -717,7 +759,11 @@ export class AiToolsController {
                     cron: cron as string | null | undefined,
                     scheduleEnabled: scheduleEnabled as boolean | undefined,
                     providerId: providerId as string | null | undefined,
-                    model: model as string | null | undefined
+                    model: model as string | null | undefined,
+                    // Forwarded raw (undefined omit / null clear-to-all / array
+                    // set); the service's validateToolAllowlist rejects a
+                    // malformed value as a SavedPromptValidationError → 400.
+                    toolAllowlist: toolAllowlist as string[] | null | undefined
                 });
             } else {
                 // Stamp ownership from the saving admin. requireAdmin set
@@ -741,6 +787,10 @@ export class AiToolsController {
                     scheduleEnabled: scheduleEnabled as boolean | undefined,
                     providerId: typeof providerId === 'string' ? providerId : undefined,
                     model: typeof model === 'string' ? model : undefined,
+                    // Forwarded raw; the service stores an array verbatim
+                    // (`[]`/`[names]`) and treats null/undefined as "all tools"
+                    // (absent), rejecting a malformed value as a 400.
+                    toolAllowlist: toolAllowlist as string[] | null | undefined,
                     ownerUserId,
                     ownerLabel
                 });

--- a/src/backend/modules/ai-tools/services/saved-prompts.service.ts
+++ b/src/backend/modules/ai-tools/services/saved-prompts.service.ts
@@ -70,6 +70,14 @@ export interface ISavedPromptCreate {
     /** Optional model id the prompt runs on, within `providerId`'s catalog. */
     model?: string;
     /**
+     * Per-prompt tool allowlist, the least-privilege selector a scheduled run
+     * passes to the provider. Three-state: `undefined` (omitted) runs against
+     * every enabled tool; `[]` runs with no tools; a non-empty list restricts to
+     * exactly those names. Stored verbatim when an array is supplied; a `null`
+     * or non-array value is treated as "all tools" and leaves the field absent.
+     */
+    toolAllowlist?: string[] | null;
+    /**
      * Better Auth user id of the owner — the admin saving the prompt. Captured
      * once at create and never rewritten by an update: it is whose behalf a
      * scheduled run executes on, re-resolved to a live principal at fire time.
@@ -92,6 +100,15 @@ export interface ISavedPromptUpdate {
     scheduleEnabled?: boolean;
     providerId?: string | null;
     model?: string | null;
+    /**
+     * Per-prompt tool allowlist. Tri-state on update, mirroring the model pin:
+     * `undefined` omits the field (existing value preserved); `null` clears it
+     * back to "all enabled tools" (`$unset`, field absent); an array `$set`s it
+     * verbatim — `[]` meaning "no tools", a name list meaning that subset. The
+     * absent-vs-`[]` distinction is the sharp edge: `null` must not collapse to
+     * `[]`, and `[]` must round-trip as `[]` rather than being dropped.
+     */
+    toolAllowlist?: string[] | null;
 }
 
 /**
@@ -184,6 +201,7 @@ export class SavedPromptsService {
         const trimmedPrompt = assertNonEmptyString(input.prompt, 'prompt');
         const normalizedCron = validateCron(input.cron);
         validateScheduleEnabled(input.scheduleEnabled);
+        validateToolAllowlist(input.toolAllowlist);
 
         await assertNameUnique(this.database, trimmedName, null);
 
@@ -217,6 +235,15 @@ export class SavedPromptsService {
         }
         if (model) {
             created.model = model;
+        }
+
+        // Tool allowlist: attach only when the caller supplied a real array, so
+        // `[]` (no tools) and `[names]` (a subset) persist verbatim while
+        // `undefined`/`null` (all tools) leave the field absent. An empty array
+        // is a defined value, so the driver's `ignoreUndefined` default never
+        // strips it — the sharp edge is handled by the conditional, not the write.
+        if (Array.isArray(input.toolAllowlist)) {
+            created.toolAllowlist = input.toolAllowlist;
         }
 
         // Ownership is captured at create and immutable thereafter (no field on
@@ -274,6 +301,7 @@ export class SavedPromptsService {
             ? validateCron(input.cron)
             : undefined;
         validateScheduleEnabled(input.scheduleEnabled);
+        validateToolAllowlist(input.toolAllowlist);
 
         if (trimmedName !== undefined) {
             await assertNameUnique(this.database, trimmedName, id);
@@ -342,6 +370,19 @@ export class SavedPromptsService {
                 setFields.model = trimmed;
             } else {
                 unsetFields.model = '';
+            }
+        }
+
+        // Tool allowlist: like the model pin, `undefined` omits the field. But
+        // unlike the model pin, `[]` is a MEANINGFUL value ("no tools"), not a
+        // clear — so only `null` clears (via `$unset`, reverting to all tools),
+        // while any array (including `[]`) is `$set` verbatim. This is the edge
+        // the sharp comment on ISavedPromptUpdate.toolAllowlist warns about.
+        if (input.toolAllowlist !== undefined) {
+            if (input.toolAllowlist === null) {
+                unsetFields.toolAllowlist = '';
+            } else {
+                setFields.toolAllowlist = input.toolAllowlist;
             }
         }
 
@@ -519,6 +560,29 @@ function assertNonEmptyString(value: unknown, field: string): string {
 function validateScheduleEnabled(value: unknown): void {
     if (value !== undefined && typeof value !== 'boolean') {
         throw new SavedPromptValidationError('scheduleEnabled must be a boolean');
+    }
+}
+
+/**
+ * Validate the optional `toolAllowlist` selector. The three legal shapes are
+ * `undefined` (omit / all tools), `null` (clear back to all tools), and an array
+ * of strings (`[]` for no tools, a name list for a subset). Anything else — a
+ * non-array defined value, or an array holding a non-string — is rejected so a
+ * malformed selector never reaches the governor as a silent "all tools".
+ *
+ * @param value - The candidate allowlist from create/update input.
+ */
+function validateToolAllowlist(value: unknown): void {
+    if (value === undefined || value === null) {
+        return;
+    }
+    if (!Array.isArray(value)) {
+        throw new SavedPromptValidationError('toolAllowlist must be an array of tool-name strings');
+    }
+    for (const entry of value) {
+        if (typeof entry !== 'string') {
+            throw new SavedPromptValidationError('toolAllowlist entries must be strings');
+        }
     }
 }
 

--- a/src/backend/modules/ai-tools/services/saved-prompts.service.ts
+++ b/src/backend/modules/ai-tools/services/saved-prompts.service.ts
@@ -71,10 +71,12 @@ export interface ISavedPromptCreate {
     model?: string;
     /**
      * Per-prompt tool allowlist, the least-privilege selector a scheduled run
-     * passes to the provider. Three-state: `undefined` (omitted) runs against
-     * every enabled tool; `[]` runs with no tools; a non-empty list restricts to
-     * exactly those names. Stored verbatim when an array is supplied; a `null`
-     * or non-array value is treated as "all tools" and leaves the field absent.
+     * passes to the provider. Three-state: `undefined` (omitted) and `null` both
+     * run against every enabled tool (field left absent); `[]` runs with no
+     * tools; a non-empty list restricts to exactly those names. An array is
+     * validated and stored verbatim; any other defined non-array value is
+     * rejected with `SavedPromptValidationError`, never silently treated as
+     * "all tools".
      */
     toolAllowlist?: string[] | null;
     /**
@@ -566,9 +568,13 @@ function validateScheduleEnabled(value: unknown): void {
 /**
  * Validate the optional `toolAllowlist` selector. The three legal shapes are
  * `undefined` (omit / all tools), `null` (clear back to all tools), and an array
- * of strings (`[]` for no tools, a name list for a subset). Anything else — a
- * non-array defined value, or an array holding a non-string — is rejected so a
- * malformed selector never reaches the governor as a silent "all tools".
+ * of non-empty strings (`[]` for no tools, a name list for a subset). Anything
+ * else — a non-array defined value, an array holding a non-string, a blank /
+ * whitespace-only entry, or an entry with leading/trailing whitespace — is
+ * rejected so a malformed selector never reaches the governor as a silent
+ * "all tools". A blank or padded entry is never a valid tool name
+ * (`^[a-zA-Z0-9_-]{1,64}$`) and would fail the whole allowlist at run time,
+ * auto-pausing a scheduled prompt — so it fails closed here at save instead.
  *
  * @param value - The candidate allowlist from create/update input.
  */
@@ -580,8 +586,11 @@ function validateToolAllowlist(value: unknown): void {
         throw new SavedPromptValidationError('toolAllowlist must be an array of tool-name strings');
     }
     for (const entry of value) {
-        if (typeof entry !== 'string') {
-            throw new SavedPromptValidationError('toolAllowlist entries must be strings');
+        if (typeof entry !== 'string' || !entry.trim()) {
+            throw new SavedPromptValidationError('toolAllowlist entries must be non-empty strings');
+        }
+        if (entry !== entry.trim()) {
+            throw new SavedPromptValidationError('toolAllowlist entries must not have leading or trailing whitespace');
         }
     }
 }

--- a/src/backend/modules/ai-tools/services/scheduled-prompts-runner.ts
+++ b/src/backend/modules/ai-tools/services/scheduled-prompts-runner.ts
@@ -311,7 +311,11 @@ export async function runScheduledPrompts(
             // `endUser`, when the prompt records an owner, is the live principal
             // the run acts on behalf of. `model` is the optional per-query
             // override (undefined → provider's configured default).
-            const result = (await provider.query({ prompt: p.prompt, model: p.model, mode: 'programmatic', endUser, injectedSystemPrompt })) as IAiQueryResult;
+            // `toolAllowlist` is the prompt's least-privilege selector (undefined
+            // → all enabled tools, `[]` → none, a name list → that subset); a
+            // listed name that resolves to no registered tool fails the run,
+            // which the catch below records and counts toward the auto-pause.
+            const result = (await provider.query({ prompt: p.prompt, model: p.model, mode: 'programmatic', endUser, injectedSystemPrompt, toolAllowlist: p.toolAllowlist })) as IAiQueryResult;
             // Record the run in the core query history so it surfaces in the
             // Query tab beside interactive queries. Tagged `scheduled` to mark
             // it autonomous; the provider transport above stays `programmatic`,


### PR DESCRIPTION
## Summary

Stage 2 of the per-prompt AI tool allowlist. Stage 1 (merged) added `toolAllowlist` to `IAiQueryOptions`/`IToolInvocationContext`/`ISavedPrompt` (types 4.29.0) and the governor enforcement at `invoke()`. This stage wires the value **from** saved prompts and interactive/programmatic requests **into** `provider.query(...)`, so the least-privilege selector actually takes effect. Core-only — no types bump, no migration.

## Three-state persistence

`ISavedPrompt.toolAllowlist` is three-state: absent/`undefined` → all enabled tools, `[]` → no tools, `[names]` → that subset. The sharp edge is distinguishing "clear back to all tools" (field **absent**) from "no tools" (`[]`). The update path mirrors the existing `model` pin: `null` clears via `$unset` (→ absent), any array is `$set` verbatim (incl. `[]`). The Mongo driver's `ignoreUndefined` never strips a real array, so `[]` round-trips as `[]`.

## Changes

- **`saved-prompts.service.ts`** — `toolAllowlist` on the create/update inputs; `validateToolAllowlist` (rejects non-arrays / non-string entries); `create()` attaches a real array only; `update()` does `$set` (array) / `$unset` (null).
- **`ai-tools.controller.ts`** — `savePrompt` forwards to create/update; `query` re-validates the selector (400 on malformed) and forwards it to both the streaming `queryStream` and non-streaming `query` calls.
- **`scheduled-prompts-runner.ts`** — forwards `p.toolAllowlist` on the programmatic query. The existing claim-first / `recordRunFailure` / auto-pause path records an unregistered-tool failure verbatim into `lastRunError`.

## Cross-cutting, not UI-only

Enforcement is centralized in the governor; this stage feeds the value from every entry point — interactive HTTP/Query tab, scheduled runs, and programmatic `query()` from other code. A future non-Anthropic provider inherits it for free.

## Tests

Service three-state round-trips + update transitions + precise-message auto-pause; runner forwarding and verbatim error passthrough; new controller test covering `savePrompt` forwarding and `query` validation/forwarding. Typecheck clean; all 75 tests across the three suites pass.

Out of scope: Stage 3 (the `/system/ai-tools` Query-tab multiselect editor + per-run trifecta badge).