### PR TITLE
feat(widgets): auto-rotate network-activity metric on a timer

### DIFF
--- a/src/backend/modules/widgets/widget-types/core-widget-types.ts
+++ b/src/backend/modules/widgets/widget-types/core-widget-types.ts
@@ -674,7 +674,10 @@ function buildNetworkActivityFetcher(deps: ICoreWidgetTypeDeps): WidgetDataFetch
  * Every field is optional with an enum/default so an operator can place the
  * widget with no configuration. `title` overrides the chart heading;
  * `defaultWindow` seeds the initial window toggle; `display` selects chart
- * density ('normal' full chrome vs. 'widget' compact sparkline).
+ * density ('normal' full chrome vs. 'widget' compact sparkline). `rotate` and
+ * `rotateSeconds` drive the client-side metric auto-rotation — the component
+ * reads all of these off `instanceConfig` directly, so they never touch the
+ * SSR data fetcher.
  */
 export const NETWORK_ACTIVITY_CONFIG_SCHEMA: JSONSchema7 = {
     type: 'object',
@@ -698,6 +701,22 @@ export const NETWORK_ACTIVITY_CONFIG_SCHEMA: JSONSchema7 = {
             default: 'normal',
             title: 'Display density',
             description: "'normal' shows axes, legend, and tooltips; 'widget' is a compact sparkline."
+        },
+        rotate: {
+            type: 'boolean',
+            default: false,
+            title: 'Auto-rotate metric',
+            description:
+                'Cycle the chart through transactions, transfers, and volume on a timer until the visitor clicks a metric, which stops rotation for the rest of the session.'
+        },
+        rotateSeconds: {
+            type: 'integer',
+            minimum: 10,
+            maximum: 300,
+            default: 30,
+            title: 'Rotation interval (seconds)',
+            description:
+                'Seconds each metric is shown before advancing. Only applies when auto-rotate is enabled. Bounded 10–300.'
         }
     }
 };

--- a/src/frontend/components/widgets/NetworkActivityWidget.tsx
+++ b/src/frontend/components/widgets/NetworkActivityWidget.tsx
@@ -263,10 +263,16 @@ export function NetworkActivityWidget({ data, context, instanceConfig }: IWidget
 
     // Resolved rotation cadence, clamped to the schema bounds so a hand-edited
     // placement can't set an absurd interval that slips past server validation.
+    // `instanceConfig` is an unchecked cast, so a non-finite value (a string, an
+    // object, a BSON NaN from a DB edit) would survive `??` and clamp to NaN —
+    // and `setInterval(NaN)` coerces to 0, a hot loop that pegs the UI thread. The
+    // finite fallback closes that path before the numeric clamp.
     const rotateEnabled = config.rotate === true;
+    const requestedRotateSeconds = Number(config.rotateSeconds ?? DEFAULT_ROTATE_SECONDS);
+    const safeRotateSeconds = Number.isFinite(requestedRotateSeconds) ? requestedRotateSeconds : DEFAULT_ROTATE_SECONDS;
     const rotateIntervalMs = Math.min(
         MAX_ROTATE_SECONDS,
-        Math.max(MIN_ROTATE_SECONDS, config.rotateSeconds ?? DEFAULT_ROTATE_SECONDS)
+        Math.max(MIN_ROTATE_SECONDS, safeRotateSeconds)
     ) * 1000;
 
     // Auto-rotate the metric on a timer when the operator enabled rotation and the

--- a/src/frontend/components/widgets/NetworkActivityWidget.tsx
+++ b/src/frontend/components/widgets/NetworkActivityWidget.tsx
@@ -17,6 +17,12 @@
  * this: it auto-prefixes event names with the owner id and so cannot subscribe
  * to the un-prefixed global `block:new` event.
  *
+ * Metric auto-rotation: when the operator enables `rotate` in the placement
+ * config, the widget advances the metric on a timer (default 30s, bounded
+ * 10–300s) so an unattended chart cycles transactions → transfers → volume. The
+ * advance pauses while the tab is hidden and stops permanently the moment the
+ * visitor clicks a metric, honouring explicit interaction over the timer.
+ *
  * @module frontend/components/widgets/NetworkActivityWidget
  */
 
@@ -59,6 +65,8 @@ interface NetworkActivityConfig {
     title?: string;
     defaultWindow?: ActivityWindow;
     display?: 'normal' | 'widget';
+    rotate?: boolean;
+    rotateSeconds?: number;
 }
 
 /** Window toggle options, in display order. */
@@ -81,6 +89,12 @@ const METRICS: ReadonlyArray<{ id: ActivityMetric; label: string; color: string;
 
 /** Minimum gap between block-driven live refetches of the active window. */
 const LIVE_REFRESH_THROTTLE_MS = 60_000;
+
+/** Rotation cadence, in seconds, when config enables rotation without a value. */
+const DEFAULT_ROTATE_SECONDS = 30;
+/** Lower/upper rotation bounds mirroring the config schema, clamped defensively. */
+const MIN_ROTATE_SECONDS = 10;
+const MAX_ROTATE_SECONDS = 300;
 
 /**
  * Format a large count/volume into a compact K/M/B string for the Y-axis.
@@ -155,6 +169,10 @@ export function NetworkActivityWidget({ data, context, instanceConfig }: IWidget
     );
     const [metric, setMetric] = useState<ActivityMetric>('transactions');
     const [refreshing, setRefreshing] = useState(false);
+    // Set true the first time the visitor clicks a metric, permanently stopping
+    // auto-rotation for the session (until reload). An explicit pick outranks the
+    // timer — the operator's "rotate until touched" intent.
+    const [userPinned, setUserPinned] = useState(false);
 
     // Ref mirror of the active window so the block-driven live effect always
     // refetches the visible window without re-subscribing on every toggle, and
@@ -243,6 +261,36 @@ export function NetworkActivityWidget({ data, context, instanceConfig }: IWidget
         };
     }, [latestBlockNumber, fetchSeries]);
 
+    // Resolved rotation cadence, clamped to the schema bounds so a hand-edited
+    // placement can't set an absurd interval that slips past server validation.
+    const rotateEnabled = config.rotate === true;
+    const rotateIntervalMs = Math.min(
+        MAX_ROTATE_SECONDS,
+        Math.max(MIN_ROTATE_SECONDS, config.rotateSeconds ?? DEFAULT_ROTATE_SECONDS)
+    ) * 1000;
+
+    // Auto-rotate the metric on a timer when the operator enabled rotation and the
+    // visitor hasn't taken manual control. The advance is skipped while the tab is
+    // hidden (no point cycling an unseen chart) and the effect tears down its timer
+    // once `userPinned` flips, so a click stops rotation for the session. The
+    // functional update reads METRICS in display order without listing `metric` as
+    // a dependency, keeping the timer stable across metric changes.
+    useEffect(() => {
+        if (!rotateEnabled || userPinned) {
+            return;
+        }
+        const timer = setInterval(() => {
+            if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+                return;
+            }
+            setMetric(current => {
+                const index = METRICS.findIndex(item => item.id === current);
+                return METRICS[(index + 1) % METRICS.length].id;
+            });
+        }, rotateIntervalMs);
+        return () => clearInterval(timer);
+    }, [rotateEnabled, userPinned, rotateIntervalMs]);
+
     // Single series for the selected metric. The toggle re-slices the same
     // points rather than refetching, mirroring the resource widget.
     const series = useMemo(() => [{
@@ -293,7 +341,7 @@ export function NetworkActivityWidget({ data, context, instanceConfig }: IWidget
                         key={item.id}
                         type="button"
                         className={metric === item.id ? 'is-active' : undefined}
-                        onClick={() => setMetric(item.id)}
+                        onClick={() => { setMetric(item.id); setUserPinned(true); }}
                         aria-pressed={metric === item.id}
                     >
                         {item.label}


### PR DESCRIPTION
## Summary

Adds opt-in metric auto-rotation to the core `core:network-activity` widget. When enabled by the operator, the chart cycles transactions → transfers → volume on a timer so an unattended dashboard rotates through all three views.

## Configuration

Two optional fields added to `NETWORK_ACTIVITY_CONFIG_SCHEMA`, both read directly off `instanceConfig` (the SSR data fetcher is untouched):

- `rotate` (boolean, default `false`) — enables auto-rotation.
- `rotateSeconds` (integer, 10–300, default 30) — seconds each metric shows before advancing.

The admin config form auto-renders both from the JSON schema.

## Behavior

- Rotation is off by default; existing placements are unaffected.
- The advance pauses while the browser tab is hidden.
- A visitor clicking any metric stops rotation permanently for the session (until reload), honoring explicit interaction over the timer.
- Rotation re-slices already-fetched points client-side, so it triggers no network traffic; the ~60s block-driven data refresh is unchanged.
- Hydration-safe: metric still initializes deterministically; `document.visibilityState` is read only inside the timer callback.