### PR TITLE
feat(plugin-context): expose core Select component to plugins

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delphian/tronrelic-types",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Core type definitions for the TronRelic platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -179,6 +179,28 @@ export interface IUIComponents {
         'aria-label'?: string;
     }>;
 
+    /**
+     * Select — themed dropdown matching the Input treatment (shared input
+     * tokens plus a Lucide chevron), wrapping a native `<select>` so keyboard,
+     * accessibility, and mobile-picker behavior are preserved. Pass
+     * `<option>` / `<optgroup>` children as usual; width is intrinsic by
+     * default (sized to the selected option) — pass a `width: 100%` class to
+     * fill a container. Use instead of a bare `<select>` so plugin dropdowns
+     * match core admin surfaces.
+     */
+    Select: ComponentType<{
+        value?: string;
+        onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+        children?: React.ReactNode;
+        variant?: 'default' | 'ghost';
+        disabled?: boolean;
+        required?: boolean;
+        className?: string;
+        id?: string;
+        name?: string;
+        'aria-label'?: string;
+    }>;
+
     /** Client-side time rendering component (prevents SSR hydration mismatches) */
     ClientTime: ComponentType<{
         date: Date | string | null | undefined;
@@ -840,7 +862,7 @@ export interface IFrontendPluginContext {
     /** Plugin identifier used for namespacing events and API routes */
     pluginId: string;
 
-    /** UI component library (Card, Badge, Button, IconButton, Switch, Input, Skeleton, ClientTime, Tooltip, IconPickerModal, Table family) */
+    /** UI component library (Card, Badge, Button, IconButton, Switch, Input, Select, Skeleton, ClientTime, Tooltip, IconPickerModal, Table family) */
     ui: IUIComponents;
 
     /** Layout component library (Page, PageHeader, Stack, Grid, Section, SubMenu) */

--- a/src/frontend/lib/frontendPluginContext.tsx
+++ b/src/frontend/lib/frontendPluginContext.tsx
@@ -18,6 +18,7 @@ import { Button } from '../components/ui/Button';
 import { IconButton } from '../components/ui/IconButton';
 import { Switch } from '../components/ui/Switch';
 import { Input } from '../components/ui/Input';
+import { Select } from '../components/ui/Select';
 import { ClientTime } from '../components/ui/ClientTime';
 import { Tooltip } from '../components/ui/Tooltip';
 import { LazyIconPickerModal as IconPickerModal } from '../components/ui/IconPickerModal';
@@ -338,6 +339,7 @@ export function FrontendPluginContextProvider({ children }: { children: React.Re
             // the contract advertises, so the cast is sound and contains a TS-only
             // metadata quirk without widening the published plugin contract.
             Input: Input as IUIComponents['Input'],
+            Select,
             ClientTime,
             Tooltip,
             IconPickerModal,
@@ -439,6 +441,7 @@ export function createPluginContext(pluginId: string): IFrontendPluginContext {
         // trips the invariant check against the narrowed contract; the runtime
         // component is fully compatible, so the cast is sound.
         Input: Input as IUIComponents['Input'],
+        Select,
         ClientTime,
         Tooltip,
         IconPickerModal,


### PR DESCRIPTION
Exposes the core themed `Select` dropdown through the frontend plugin context so plugin dropdowns match core admin surfaces instead of falling back to a bare native `<select>`.

- Adds `Select` to `IUIComponents` in `@delphian/tronrelic-types` with the same prop shape as the core component (value/onChange/variant/disabled/required/className/id/name/aria-label).
- Wires `Select` through both plugin context builders (`FrontendPluginContextProvider` and `createPluginContext`).
- Bumps `@delphian/tronrelic-types` to 6.2.0.