### PR TITLE
feat(traffic): per-bucket countries in trend tooltip + analytics table/layout fixes

### DIFF
--- a/src/backend/modules/traffic/__tests__/traffic.service.test.ts
+++ b/src/backend/modules/traffic/__tests__/traffic.service.test.ts
@@ -703,10 +703,14 @@ describe('TrafficService', () => {
             const sqls: string[] = [];
             ch.query = async <T>(sql: string): Promise<T[]> => {
                 sqls.push(sql);
-                // The top-paths query is the more specific `GROUP BY bucket, path`
-                // and must be matched before the series' `GROUP BY bucket`.
+                // The top-paths/top-countries queries are the more specific
+                // `GROUP BY bucket, <dim>` and must be matched before the
+                // series' plain `GROUP BY bucket`.
                 if (sql.includes('GROUP BY bucket, path')) {
                     return [{ bucket: '2026-06-01 05:00:00', path: '/markets', hits: '4' }] as T[];
+                }
+                if (sql.includes('GROUP BY bucket, country')) {
+                    return [{ bucket: '2026-06-01 05:00:00', country: 'US', hits: '5' }] as T[];
                 }
                 if (sql.includes('GROUP BY bucket')) {
                     return [{ bucket: '2026-06-01 05:00:00', visitors: '3', pageviews: '7' }] as T[];
@@ -722,16 +726,19 @@ describe('TrafficService', () => {
 
             expect(out.granularity).toBe('hour');
             expect(sqls.some(s => s.includes('toStartOfHour(timestamp)'))).toBe(true);
-            // The top-paths query is scoped to interactive page rows, same as
-            // the series, so bot-only bootstrap paths never surface.
+            // The top-paths and top-countries queries are scoped to interactive
+            // page rows, same as the series, so bot-only bootstrap dimensions
+            // never surface.
             expect(sqls.some(s => s.includes('GROUP BY bucket, path') && s.includes("event_type = 'page'"))).toBe(true);
+            expect(sqls.some(s => s.includes('GROUP BY bucket, country') && s.includes("event_type = 'page'") && s.includes('country IS NOT NULL'))).toBe(true);
             // 00:00 through 24:00 inclusive — 25 hourly buckets, one populated.
             expect(out.series).toHaveLength(25);
-            // The populated bucket carries its ranked top paths as metadata.
+            // The populated bucket carries its ranked top paths and countries as metadata.
             expect(out.series.find(p => p.bucket === '2026-06-01T05:00:00.000Z'))
-                .toEqual({ bucket: '2026-06-01T05:00:00.000Z', visitors: 3, pageviews: 7, topPaths: [{ path: '/markets', hits: 4 }] });
-            // Zero-traffic buckets carry an empty path list, never undefined.
+                .toEqual({ bucket: '2026-06-01T05:00:00.000Z', visitors: 3, pageviews: 7, topPaths: [{ path: '/markets', hits: 4 }], topCountries: [{ country: 'US', hits: 5 }] });
+            // Zero-traffic buckets carry empty breakdown lists, never undefined.
             expect(out.series.find(p => p.bucket === '2026-06-01T02:00:00.000Z')?.topPaths).toEqual([]);
+            expect(out.series.find(p => p.bucket === '2026-06-01T02:00:00.000Z')?.topCountries).toEqual([]);
             expect(out.series.filter(p => p.visitors === 0)).toHaveLength(24);
             expect(out.current.visitors).toBe(10);
             // sessions = 0 → bounce rate is 0, not NaN.

--- a/src/backend/modules/traffic/services/traffic.service.ts
+++ b/src/backend/modules/traffic/services/traffic.service.ts
@@ -395,6 +395,14 @@ export interface IOverviewTrendPath {
     hits: number;
 }
 
+/** One country and its interactive hit count within a trend bucket. */
+export interface IOverviewTrendCountry {
+    /** ISO-3166 alpha-2 country of the `page` events. */
+    country: string;
+    /** Interactive `page` events from this country in the bucket. */
+    hits: number;
+}
+
 /** One time bucket of the overview trend series. */
 export interface IOverviewTrendPoint {
     /** Bucket start — ISO-8601 UTC for hour buckets, `YYYY-MM-DD` for days. */
@@ -410,6 +418,13 @@ export interface IOverviewTrendPoint {
      * visitors — a path is the URL a `page` beacon reported.
      */
     topPaths: IOverviewTrendPath[];
+    /**
+     * The bucket's most-active countries (top 3 by `page`-event count,
+     * descending), same page-view measure as {@link topPaths} so the whole
+     * tooltip stays in one commensurable unit. Distinct from the Geo panel's
+     * windowed distinct-visitor count by design. Empty for zero-traffic buckets.
+     */
+    topCountries: IOverviewTrendCountry[];
 }
 
 /**
@@ -1778,13 +1793,27 @@ export class TrafficService {
             ORDER BY bucket ASC, hits DESC, path ASC
             LIMIT 3 BY bucket
         `;
+        // Top 3 countries per bucket for the tooltip — same construction and
+        // measure as the paths query (page-event counts within just this
+        // bucket, `page` rows only so bot-only bootstrap countries never
+        // surface). NULL country is dropped so a hover lists only nameable
+        // origins. `LIMIT 3 BY bucket` bounds the payload to 3 × bucket count.
+        const countriesSql = `
+            SELECT ${bucketExpr} AS bucket, country, count() AS hits
+            FROM ${TABLE_NAME}
+            WHERE ${clause}${botFilter} AND event_type = 'page' AND country IS NOT NULL
+            GROUP BY bucket, country
+            ORDER BY bucket ASC, hits DESC, country ASC
+            LIMIT 3 BY bucket
+        `;
 
         try {
-            const [current, previous, seriesRows, pathRows] = await Promise.all([
+            const [current, previous, seriesRows, pathRows, countryRows] = await Promise.all([
                 fetchKpis(currentRange),
                 fetchKpis(previousRange),
                 this.clickhouse.query<{ bucket: string; visitors: string | number; pageviews: string | number }>(seriesSql, params),
-                this.clickhouse.query<{ bucket: string; path: string; hits: string | number }>(pathsSql, params)
+                this.clickhouse.query<{ bucket: string; path: string; hits: string | number }>(pathsSql, params),
+                this.clickhouse.query<{ bucket: string; country: string; hits: string | number }>(countriesSql, params)
             ]);
 
             // Zero-fill every bucket in the window, then overlay the rows.
@@ -1800,7 +1829,7 @@ export class TrafficService {
             const buckets = new Map<string, IOverviewTrendPoint>();
             for (let ms = floorUtc; ms <= until.getTime(); ms += stepMs) {
                 const key = keyFor(ms);
-                buckets.set(key, { bucket: key, visitors: 0, pageviews: 0, topPaths: [] });
+                buckets.set(key, { bucket: key, visitors: 0, pageviews: 0, topPaths: [], topCountries: [] });
             }
             for (const row of seriesRows) {
                 const key = granularity === 'hour'
@@ -1822,6 +1851,17 @@ export class TrafficService {
                 const point = buckets.get(key);
                 if (point) {
                     point.topPaths.push({ path: String(row.path), hits: Number(row.hits) });
+                }
+            }
+            // Overlay the per-bucket top countries — same ordering guarantee as
+            // paths (rows arrive hits-desc, appending preserves rank).
+            for (const row of countryRows) {
+                const key = granularity === 'hour'
+                    ? clickHouseDateToIso(String(row.bucket))
+                    : String(row.bucket);
+                const point = buckets.get(key);
+                if (point) {
+                    point.topCountries.push({ country: String(row.country), hits: Number(row.hits) });
                 }
             }
 

--- a/src/frontend/modules/traffic/api/client.ts
+++ b/src/frontend/modules/traffic/api/client.ts
@@ -679,6 +679,14 @@ export interface IOverviewTrendPath {
     hits: number;
 }
 
+/** One country and its interactive hit count within a trend bucket. */
+export interface IOverviewTrendCountry {
+    /** ISO-3166 alpha-2 country of the `page` events. */
+    country: string;
+    /** Interactive `page` events from this country in the bucket. */
+    hits: number;
+}
+
 /** One time bucket of the overview trend series. */
 export interface IOverviewTrendPoint {
     /** Bucket start — ISO-8601 UTC for hours, `YYYY-MM-DD` for days. */
@@ -687,6 +695,8 @@ export interface IOverviewTrendPoint {
     pageviews: number;
     /** Top 3 most-hit paths in the bucket (hits desc); [] when zero-traffic. */
     topPaths: IOverviewTrendPath[];
+    /** Top 3 most-active countries in the bucket (hits desc); [] when zero-traffic. */
+    topCountries: IOverviewTrendCountry[];
 }
 
 /** Unified dashboard headline: KPIs + previous window + zero-filled series. */

--- a/src/frontend/modules/traffic/api/index.ts
+++ b/src/frontend/modules/traffic/api/index.ts
@@ -68,6 +68,7 @@ export type {
     IAnalyticsOverview,
     IOverviewKpis,
     IOverviewTrendPath,
+    IOverviewTrendCountry,
     IOverviewTrendPoint,
     IOverviewTrend,
     IIgnoredUser,

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.module.scss
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.module.scss
@@ -148,6 +148,31 @@
     font-variant-numeric: tabular-nums;
 }
 
+/*
+ * Numeric headers must right-align over their right-aligned cells. The base
+ * `.table th { text-align: left }` rule outranks a bare `.table__number`
+ * (both single-class, but `.table th` also matches the element, giving it the
+ * higher specificity), so without this the header sat left while the numbers
+ * sat right — header and content visibly out of column. Re-qualify with the
+ * table ancestor to win the cascade.
+ */
+.table th.table__number {
+    text-align: right;
+}
+
+/*
+ * Truncate an overflowing cell to one ellipsized line instead of wrapping.
+ * `max-width: 0` lets the auto table layout hand this column only the space
+ * left after the fixed numeric and bar columns, then clip the overflow — used
+ * by the landing-pages path column, whose URLs would otherwise wrap.
+ */
+.table__truncate {
+    max-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .table__bar_cell {
     width: 4.5rem;
 }

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
@@ -268,38 +268,38 @@ export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyt
                 <div className={styles.loading}>Loading analytics data...</div>
             ) : (
                 <>
-                    {/* Conversion Funnel */}
-                    {funnel.length > 0 && (
-                        <Card>
-                            <h3 className={styles.section_title}>
-                                <Target size={16} className={styles.section_title__icon} />
-                                Conversion Funnel
-                            </h3>
-                            <div className={styles.funnel}>
-                                {funnel.map(stage => (
-                                    <div
-                                        key={stage.stage}
-                                        className={styles.funnel_stage}
-                                        title="Counts are unique visitors (browser identities / tids), not accounts. One person logged in from two browsers or devices counts as two logged-in visitors but one account, so these stages nest under Visitors and never exceed it."
-                                    >
-                                        <span className={styles.funnel_stage__label}>{stage.stage}</span>
-                                        <div className={styles.funnel_stage__bar_wrapper}>
-                                            <div
-                                                className={styles.funnel_stage__bar}
-                                                style={{ width: `${stage.percentage}%` }}
-                                            />
-                                        </div>
-                                        <span className={styles.funnel_stage__stats}>
-                                            {stage.count.toLocaleString()} ({stage.percentage}%)
-                                        </span>
-                                    </div>
-                                ))}
-                            </div>
-                        </Card>
-                    )}
-
-                    {/* Traffic Sources + Top Landing Pages side by side */}
+                    {/* Conversion Funnel + Traffic Sources side by side */}
                     <div className={styles.split_grid}>
+                        {/* Conversion Funnel */}
+                        {funnel.length > 0 && (
+                            <Card>
+                                <h3 className={styles.section_title}>
+                                    <Target size={16} className={styles.section_title__icon} />
+                                    Conversion Funnel
+                                </h3>
+                                <div className={styles.funnel}>
+                                    {funnel.map(stage => (
+                                        <div
+                                            key={stage.stage}
+                                            className={styles.funnel_stage}
+                                            title="Counts are unique visitors (browser identities / tids), not accounts. One person logged in from two browsers or devices counts as two logged-in visitors but one account, so these stages nest under Visitors and never exceed it."
+                                        >
+                                            <span className={styles.funnel_stage__label}>{stage.stage}</span>
+                                            <div className={styles.funnel_stage__bar_wrapper}>
+                                                <div
+                                                    className={styles.funnel_stage__bar}
+                                                    style={{ width: `${stage.percentage}%` }}
+                                                />
+                                            </div>
+                                            <span className={styles.funnel_stage__stats}>
+                                                {stage.count.toLocaleString()} ({stage.percentage}%)
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </Card>
+                        )}
+
                         {/* Traffic Sources */}
                         <Card>
                             <h3
@@ -545,7 +545,10 @@ export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyt
                                 )}
                             </div>
                         </Card>
+                    </div>
 
+                    {/* Top Landing Pages + Geographic Distribution side by side */}
+                    <div className={styles.split_grid}>
                         {/* Top Landing Pages */}
                         <Card>
                             <h3
@@ -574,7 +577,7 @@ export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyt
                                             <tbody>
                                                 {landingPages.map(p => (
                                                     <tr key={p.path}>
-                                                        <td>{p.path}</td>
+                                                        <td className={styles.table__truncate} title={p.path}>{p.path}</td>
                                                         <td className={styles.table__number}>{p.visitors.toLocaleString()}</td>
                                                         <td className={styles.table__bar_cell}>
                                                             <div
@@ -590,10 +593,7 @@ export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyt
                                 )}
                             </div>
                         </Card>
-                    </div>
 
-                    {/* Geography + Devices side by side */}
-                    <div className={styles.split_grid}>
                         {/* Geographic Distribution */}
                         <Card>
                             <h3 className={styles.section_title}>
@@ -634,37 +634,37 @@ export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyt
                                 )}
                             </div>
                         </Card>
-
-                        {/* Device Breakdown */}
-                        <Card>
-                            <h3 className={styles.section_title}>
-                                <Smartphone size={16} className={styles.section_title__icon} />
-                                Device Breakdown
-                            </h3>
-                            <div>
-                                {devices.length === 0 ? (
-                                    <div className={styles.empty_state}>No device data for this period</div>
-                                ) : (
-                                    <div className={styles.funnel}>
-                                        {devices.map(d => (
-                                            <div key={d.device} className={styles.funnel_stage}>
-                                                <span className={styles.funnel_stage__label}>{d.device}</span>
-                                                <div className={styles.funnel_stage__bar_wrapper}>
-                                                    <div
-                                                        className={styles.funnel_stage__bar}
-                                                        style={{ width: `${d.percentage}%` }}
-                                                    />
-                                                </div>
-                                                <span className={styles.funnel_stage__stats}>
-                                                    {d.count.toLocaleString()} ({d.percentage}%)
-                                                </span>
-                                            </div>
-                                        ))}
-                                    </div>
-                                )}
-                            </div>
-                        </Card>
                     </div>
+
+                    {/* Device Breakdown */}
+                    <Card>
+                        <h3 className={styles.section_title}>
+                            <Smartphone size={16} className={styles.section_title__icon} />
+                            Device Breakdown
+                        </h3>
+                        <div>
+                            {devices.length === 0 ? (
+                                <div className={styles.empty_state}>No device data for this period</div>
+                            ) : (
+                                <div className={styles.funnel}>
+                                    {devices.map(d => (
+                                        <div key={d.device} className={styles.funnel_stage}>
+                                            <span className={styles.funnel_stage__label}>{d.device}</span>
+                                            <div className={styles.funnel_stage__bar_wrapper}>
+                                                <div
+                                                    className={styles.funnel_stage__bar}
+                                                    style={{ width: `${d.percentage}%` }}
+                                                />
+                                            </div>
+                                            <span className={styles.funnel_stage__stats}>
+                                                {d.count.toLocaleString()} ({d.percentage}%)
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    </Card>
 
                     {/* Campaign Performance */}
                     {campaigns.length > 0 && (

--- a/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
+++ b/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
@@ -28,7 +28,7 @@ import { BarChart } from '../../../../../features/charts/components/BarChart';
 import type { BarChartSeries } from '../../../../../features/charts/components/BarChart';
 import { Card } from '../../../../../components/ui/Card';
 import { adminGetOverviewTrend } from '../../../api';
-import type { AnalyticsPeriod, ICustomDateRange, IOverviewTrend, IOverviewTrendPath } from '../../../api';
+import type { AnalyticsPeriod, ICustomDateRange, IOverviewTrend, IOverviewTrendPath, IOverviewTrendCountry } from '../../../api';
 import styles from './OverviewTrend.module.scss';
 
 /** Chart-switchable metrics. */
@@ -152,11 +152,12 @@ export function OverviewTrend({ period, customRange, includeBots }: IOverviewTre
             color: metric === 'visitors'
                 ? resolveCSSColor('--color-primary', '#4b8cff')
                 : resolveCSSColor('--color-success', '#57d48c'),
-            // Carry each bucket's top paths as point metadata so the shared
-            // BarChart tooltip can surface "what did they hit?" via our
-            // renderer. The paths are page-hit counts and identical for both
-            // metric modes (a bucket's URLs don't change with the y-measure).
-            data: trend.series.map(p => ({ date: p.bucket, value: p[metric], metadata: { topPaths: p.topPaths } }))
+            // Carry each bucket's top paths and countries as point metadata so
+            // the shared BarChart tooltip can surface "what did they view, and
+            // from where?" via our renderer. Both are page-view counts and
+            // identical for both metric modes (a bucket's breakdown doesn't
+            // change with the y-measure).
+            data: trend.series.map(p => ({ date: p.bucket, value: p[metric], metadata: { topPaths: p.topPaths, topCountries: p.topCountries } }))
         }];
     }, [trend, metric]);
 
@@ -172,29 +173,58 @@ export function OverviewTrend({ period, customRange, includeBots }: IOverviewTre
     const viewsPerVisit = current.visitors > 0 ? current.pageviews / current.visitors : 0;
     const prevViewsPerVisit = previous.visitors > 0 ? previous.pageviews / previous.visitors : 0;
     const numberFormatter = new Intl.NumberFormat();
+    // Phrase the bucket granularity for the tooltip heading so the ranked paths
+    // read as a single-bar slice ("this hour"/"this day"), not a window-wide or
+    // first-touch total. This is the metric-disambiguation the landing-pages
+    // panel already carries via its "(first-touch)" subtitle: these counts are
+    // page *views* within just the hovered bucket, a different measure from the
+    // panel's distinct first-touch visitors, so they are not meant to reconcile.
+    const bucketScopeLabel = trend.granularity === 'hour' ? 'this hour' : 'this day';
 
     /**
-     * Render a hovered bucket's most-hit paths inside the chart tooltip.
-     * Surfaces "what did they hit?" in place so an operator reading the trend
-     * need not cross-reference the landing-pages panel for the same window.
+     * Render a hovered bucket's most-viewed paths and most-active countries
+     * inside the chart tooltip. Surfaces "what did they view, and from where?"
+     * in place so an operator reading the trend need not cross-reference the
+     * landing-pages or geo panels — while each heading names the metric (views)
+     * and its bucket scope so neither count is misread as a window total, a
+     * first-touch landing count, or the geo panel's distinct-visitor figure.
+     * Both breakdowns share the bucket's page-view measure, so they are
+     * commensurable with the bar and with each other.
      *
-     * @param metadata - The hovered bar's point metadata; its `topPaths` is the
-     *   server-ranked path list the series attached for this bucket.
-     * @returns The ranked path block, or null for a bucket that recorded no hits.
+     * @param metadata - The hovered bar's point metadata; `topPaths` and
+     *   `topCountries` are the server-ranked lists the series attached for this
+     *   bucket.
+     * @returns The ranked breakdown blocks, or null for a bucket with neither.
      */
-    const renderTooltipPaths = (metadata: Record<string, any>): React.ReactNode => {
+    const renderTooltipMetadata = (metadata: Record<string, any>): React.ReactNode => {
         const paths = (metadata?.topPaths ?? []) as IOverviewTrendPath[];
-        if (paths.length === 0) return null;
+        const countries = (metadata?.topCountries ?? []) as IOverviewTrendCountry[];
+        if (paths.length === 0 && countries.length === 0) return null;
         return (
-            <div className={styles.tooltip_paths}>
-                <span className={styles.tooltip_paths__heading}>Top pages</span>
-                {paths.map(p => (
-                    <div key={p.path} className={styles.tooltip_paths__row}>
-                        <span className={styles.tooltip_paths__path}>{p.path}</span>
-                        <span className={styles.tooltip_paths__hits}>{numberFormatter.format(p.hits)}</span>
+            <>
+                {paths.length > 0 && (
+                    <div className={styles.tooltip_paths}>
+                        <span className={styles.tooltip_paths__heading}>Most viewed · {bucketScopeLabel}</span>
+                        {paths.map(p => (
+                            <div key={p.path} className={styles.tooltip_paths__row}>
+                                <span className={styles.tooltip_paths__path}>{p.path}</span>
+                                <span className={styles.tooltip_paths__hits}>{numberFormatter.format(p.hits)}</span>
+                            </div>
+                        ))}
                     </div>
-                ))}
-            </div>
+                )}
+                {countries.length > 0 && (
+                    <div className={styles.tooltip_paths}>
+                        <span className={styles.tooltip_paths__heading}>Top countries · {bucketScopeLabel}</span>
+                        {countries.map(c => (
+                            <div key={c.country} className={styles.tooltip_paths__row}>
+                                <span className={styles.tooltip_paths__path}>{c.country}</span>
+                                <span className={styles.tooltip_paths__hits}>{numberFormatter.format(c.hits)}</span>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </>
         );
     };
 
@@ -274,7 +304,7 @@ export function OverviewTrend({ period, customRange, includeBots }: IOverviewTre
                 height={280}
                 yAxisMin={0}
                 yAxisFormatter={(v) => numberFormatter.format(Math.round(v))}
-                tooltipMetadataFormatter={renderTooltipPaths}
+                tooltipMetadataFormatter={renderTooltipMetadata}
                 emptyLabel="No traffic recorded in this period."
             />
             <p className={styles.footnote}>


### PR DESCRIPTION
## Trend tooltip

- The OverviewTrend bar tooltip's paths block is now headed **"Most viewed · this hour/day"** — it names the metric (page views) and the bucket scope, so the count is no longer misread as a window-wide total or a first-touch landing figure (it is neither).
- Adds a parallel **"Top countries · this hour/day"** block. Both blocks use the same per-bucket page-view measure, so they are commensurable with the bar and with each other. Backend `getOverviewTrend` gains a top-countries query mirroring top-paths (`page` rows only, `country IS NOT NULL`, `LIMIT 3 BY bucket`) plus a `topCountries` field on the trend point. Types are module-local, so no `@delphian/tronrelic-types` bump.

Note: countries here count **views**, not the Geo panel's distinct-visitor measure — the same relationship the paths block already has to the Top Landing Pages panel, made unambiguous by the scoped heading.

## Analytics dashboard

- **Re-pair above 768px** by moving the `split_grid` boundaries: Conversion Funnel + Traffic Sources side by side, and Top Landing Pages + Geographic Distribution side by side. Device Breakdown is now a standalone full-width card. `split_grid` already stacks below `$breakpoint-mobile-lg` and goes 2-up at/above.
- **Header/cell alignment fix.** `.table th` (specificity 0,1,1) outranked the bare `.table__number` (0,1,0), so numeric *headers* rendered left over their right-aligned *cells*. Fixed with a `.table th.table__number` override — corrects Traffic Sources, Top Landing, and Geo.
- **Landing-page path truncation.** Long paths ellipsize on one line (`max-width:0` + `text-overflow`) with the full path on `title` hover, instead of wrapping.

Verified: backend + frontend typecheck clean, all 51 traffic service tests pass. Not yet visually confirmed in-browser (no running app/ClickHouse in the authoring session).
