### PR TITLE
feat(traffic): tooltip sources block + shared Grid layout for dashboard pairs

### DIFF
--- a/src/backend/modules/traffic/__tests__/traffic.service.test.ts
+++ b/src/backend/modules/traffic/__tests__/traffic.service.test.ts
@@ -703,14 +703,17 @@ describe('TrafficService', () => {
             const sqls: string[] = [];
             ch.query = async <T>(sql: string): Promise<T[]> => {
                 sqls.push(sql);
-                // The top-paths/top-countries queries are the more specific
-                // `GROUP BY bucket, <dim>` and must be matched before the
+                // The top-paths/top-countries/top-sources queries are the more
+                // specific `GROUP BY bucket, <dim>` and must be matched before the
                 // series' plain `GROUP BY bucket`.
                 if (sql.includes('GROUP BY bucket, path')) {
                     return [{ bucket: '2026-06-01 05:00:00', path: '/markets', hits: '4' }] as T[];
                 }
                 if (sql.includes('GROUP BY bucket, country')) {
                     return [{ bucket: '2026-06-01 05:00:00', country: 'US', hits: '5' }] as T[];
+                }
+                if (sql.includes('GROUP BY bucket, source')) {
+                    return [{ bucket: '2026-06-01 05:00:00', source: 'google.com', hits: '6' }] as T[];
                 }
                 if (sql.includes('GROUP BY bucket')) {
                     return [{ bucket: '2026-06-01 05:00:00', visitors: '3', pageviews: '7' }] as T[];
@@ -731,14 +734,18 @@ describe('TrafficService', () => {
             // never surface.
             expect(sqls.some(s => s.includes('GROUP BY bucket, path') && s.includes("event_type = 'page'"))).toBe(true);
             expect(sqls.some(s => s.includes('GROUP BY bucket, country') && s.includes("event_type = 'page'") && s.includes('country IS NOT NULL'))).toBe(true);
+            // The sources query attributes bucket page views to each viewer's
+            // first-touch bootstrap origin via a join (argMin over bootstrap rows).
+            expect(sqls.some(s => s.includes('GROUP BY bucket, source') && s.includes("event_type = 'bootstrap'") && s.includes('argMin'))).toBe(true);
             // 00:00 through 24:00 inclusive — 25 hourly buckets, one populated.
             expect(out.series).toHaveLength(25);
-            // The populated bucket carries its ranked top paths and countries as metadata.
+            // The populated bucket carries its ranked paths, countries, and sources as metadata.
             expect(out.series.find(p => p.bucket === '2026-06-01T05:00:00.000Z'))
-                .toEqual({ bucket: '2026-06-01T05:00:00.000Z', visitors: 3, pageviews: 7, topPaths: [{ path: '/markets', hits: 4 }], topCountries: [{ country: 'US', hits: 5 }] });
+                .toEqual({ bucket: '2026-06-01T05:00:00.000Z', visitors: 3, pageviews: 7, topPaths: [{ path: '/markets', hits: 4 }], topCountries: [{ country: 'US', hits: 5 }], topSources: [{ source: 'google.com', hits: 6 }] });
             // Zero-traffic buckets carry empty breakdown lists, never undefined.
             expect(out.series.find(p => p.bucket === '2026-06-01T02:00:00.000Z')?.topPaths).toEqual([]);
             expect(out.series.find(p => p.bucket === '2026-06-01T02:00:00.000Z')?.topCountries).toEqual([]);
+            expect(out.series.find(p => p.bucket === '2026-06-01T02:00:00.000Z')?.topSources).toEqual([]);
             expect(out.series.filter(p => p.visitors === 0)).toHaveLength(24);
             expect(out.current.visitors).toBe(10);
             // sessions = 0 → bounce rate is 0, not NaN.

--- a/src/backend/modules/traffic/services/traffic.service.ts
+++ b/src/backend/modules/traffic/services/traffic.service.ts
@@ -403,6 +403,14 @@ export interface IOverviewTrendCountry {
     hits: number;
 }
 
+/** One acquisition source and its attributed page-view count within a trend bucket. */
+export interface IOverviewTrendSource {
+    /** First-touch referrer domain (or `direct`) the bucket's views are attributed to. */
+    source: string;
+    /** Bucket `page` events whose visitor first-touched from this source. */
+    hits: number;
+}
+
 /** One time bucket of the overview trend series. */
 export interface IOverviewTrendPoint {
     /** Bucket start — ISO-8601 UTC for hour buckets, `YYYY-MM-DD` for days. */
@@ -425,6 +433,15 @@ export interface IOverviewTrendPoint {
      * windowed distinct-visitor count by design. Empty for zero-traffic buckets.
      */
     topCountries: IOverviewTrendCountry[];
+    /**
+     * The bucket's top acquisition sources (top 3, descending), measured as
+     * `page` views attributed to each viewer's first-touch source — the same
+     * page-view unit as {@link topPaths}/{@link topCountries}, so all three
+     * blocks stay commensurable. Source can only come from the first-touch
+     * `bootstrap` row (a `page` row's referrer is the site's own domain), so
+     * this is a join, not a plain group-by. Empty for zero-traffic buckets.
+     */
+    topSources: IOverviewTrendSource[];
 }
 
 /**
@@ -1806,14 +1823,44 @@ export class TrafficService {
             ORDER BY bucket ASC, hits DESC, country ASC
             LIMIT 3 BY bucket
         `;
+        // Top 3 sources per bucket, attributed as page VIEWS by origin. Source
+        // lives only on the first-touch `bootstrap` row (a `page` row's referrer
+        // is the site's own domain), so each bucket page view is joined to its
+        // visitor's earliest bootstrap source — `argMin(domain, timestamp)`,
+        // matching getTrafficSources' `domain(referer)`/`direct` derivation. The
+        // bootstrap side is bounded to visitors who viewed a page in the window,
+        // and page-view counts keep this commensurable with the paths/countries
+        // blocks. `LIMIT 3 BY bucket` bounds the payload.
+        const sourcesSql = `
+            SELECT bucket, source, count() AS hits
+            FROM (
+                SELECT ${bucketExpr} AS bucket, candidate_uid
+                FROM ${TABLE_NAME}
+                WHERE ${clause}${botFilter} AND event_type = 'page'
+            ) AS pv
+            INNER JOIN (
+                SELECT candidate_uid,
+                    argMin(multiIf(referer IS NULL OR referer = '', 'direct', domain(referer)), timestamp) AS source
+                FROM ${TABLE_NAME}
+                WHERE event_type = 'bootstrap' AND candidate_uid IN (
+                    SELECT candidate_uid FROM ${TABLE_NAME}
+                    WHERE ${clause}${botFilter} AND event_type = 'page'
+                )
+                GROUP BY candidate_uid
+            ) AS src USING (candidate_uid)
+            GROUP BY bucket, source
+            ORDER BY bucket ASC, hits DESC, source ASC
+            LIMIT 3 BY bucket
+        `;
 
         try {
-            const [current, previous, seriesRows, pathRows, countryRows] = await Promise.all([
+            const [current, previous, seriesRows, pathRows, countryRows, sourceRows] = await Promise.all([
                 fetchKpis(currentRange),
                 fetchKpis(previousRange),
                 this.clickhouse.query<{ bucket: string; visitors: string | number; pageviews: string | number }>(seriesSql, params),
                 this.clickhouse.query<{ bucket: string; path: string; hits: string | number }>(pathsSql, params),
-                this.clickhouse.query<{ bucket: string; country: string; hits: string | number }>(countriesSql, params)
+                this.clickhouse.query<{ bucket: string; country: string; hits: string | number }>(countriesSql, params),
+                this.clickhouse.query<{ bucket: string; source: string; hits: string | number }>(sourcesSql, params)
             ]);
 
             // Zero-fill every bucket in the window, then overlay the rows.
@@ -1829,7 +1876,7 @@ export class TrafficService {
             const buckets = new Map<string, IOverviewTrendPoint>();
             for (let ms = floorUtc; ms <= until.getTime(); ms += stepMs) {
                 const key = keyFor(ms);
-                buckets.set(key, { bucket: key, visitors: 0, pageviews: 0, topPaths: [], topCountries: [] });
+                buckets.set(key, { bucket: key, visitors: 0, pageviews: 0, topPaths: [], topCountries: [], topSources: [] });
             }
             for (const row of seriesRows) {
                 const key = granularity === 'hour'
@@ -1862,6 +1909,16 @@ export class TrafficService {
                 const point = buckets.get(key);
                 if (point) {
                     point.topCountries.push({ country: String(row.country), hits: Number(row.hits) });
+                }
+            }
+            // Overlay the per-bucket top sources — same ordering guarantee.
+            for (const row of sourceRows) {
+                const key = granularity === 'hour'
+                    ? clickHouseDateToIso(String(row.bucket))
+                    : String(row.bucket);
+                const point = buckets.get(key);
+                if (point) {
+                    point.topSources.push({ source: String(row.source), hits: Number(row.hits) });
                 }
             }
 

--- a/src/backend/modules/traffic/services/traffic.service.ts
+++ b/src/backend/modules/traffic/services/traffic.service.ts
@@ -1825,29 +1825,38 @@ export class TrafficService {
         `;
         // Top 3 sources per bucket, attributed as page VIEWS by origin. Source
         // lives only on the first-touch `bootstrap` row (a `page` row's referrer
-        // is the site's own domain), so each bucket page view is joined to its
-        // visitor's earliest bootstrap source — `argMin(domain, timestamp)`,
+        // is the site's own domain), so each bucket page view is LEFT-joined to
+        // its visitor's earliest bootstrap source — `argMin(domain, timestamp)`,
         // matching getTrafficSources' `domain(referer)`/`direct` derivation. The
-        // bootstrap side is bounded to visitors who viewed a page in the window,
-        // and page-view counts keep this commensurable with the paths/countries
-        // blocks. `LIMIT 3 BY bucket` bounds the payload.
+        // join is LEFT (not INNER) so a page view whose tid has no retained
+        // bootstrap row still counts: the middleware bootstrap is best-effort and
+        // swallows failures, so outages/deploys and pre-feature tids leave
+        // page-only tids permanently. Those unmatched views bucket to
+        // '(unattributed)' — a distinct sentinel, never folded into 'direct'
+        // (which means "no referrer", not "no record") — so topSources stays the
+        // SAME page-view population as topPaths/topCountries and the bar. Under
+        // this codebase's join_use_nulls=0 an unmatched source fills as '' (not
+        // NULL); if that ever flips, the guard must also test IS NULL.
+        // `LIMIT 3 BY bucket` bounds the payload.
         const sourcesSql = `
             SELECT bucket, source, count() AS hits
             FROM (
-                SELECT ${bucketExpr} AS bucket, candidate_uid
-                FROM ${TABLE_NAME}
-                WHERE ${clause}${botFilter} AND event_type = 'page'
-            ) AS pv
-            INNER JOIN (
-                SELECT candidate_uid,
-                    argMin(multiIf(referer IS NULL OR referer = '', 'direct', domain(referer)), timestamp) AS source
-                FROM ${TABLE_NAME}
-                WHERE event_type = 'bootstrap' AND candidate_uid IN (
-                    SELECT candidate_uid FROM ${TABLE_NAME}
+                SELECT
+                    pv.bucket AS bucket,
+                    if(src.source = '', '(unattributed)', src.source) AS source
+                FROM (
+                    SELECT ${bucketExpr} AS bucket, candidate_uid
+                    FROM ${TABLE_NAME}
                     WHERE ${clause}${botFilter} AND event_type = 'page'
-                )
-                GROUP BY candidate_uid
-            ) AS src USING (candidate_uid)
+                ) AS pv
+                LEFT JOIN (
+                    SELECT candidate_uid,
+                        argMin(multiIf(referer IS NULL OR referer = '', 'direct', domain(referer)), timestamp) AS source
+                    FROM ${TABLE_NAME}
+                    WHERE event_type = 'bootstrap' AND ${this.pageVisitorMembership(clause, botFilter)}
+                    GROUP BY candidate_uid
+                ) AS src USING (candidate_uid)
+            )
             GROUP BY bucket, source
             ORDER BY bucket ASC, hits DESC, source ASC
             LIMIT 3 BY bucket

--- a/src/frontend/modules/traffic/api/client.ts
+++ b/src/frontend/modules/traffic/api/client.ts
@@ -687,6 +687,14 @@ export interface IOverviewTrendCountry {
     hits: number;
 }
 
+/** One acquisition source and its attributed page-view count within a trend bucket. */
+export interface IOverviewTrendSource {
+    /** First-touch referrer domain (or `direct`) the bucket's views are attributed to. */
+    source: string;
+    /** Bucket `page` events whose visitor first-touched from this source. */
+    hits: number;
+}
+
 /** One time bucket of the overview trend series. */
 export interface IOverviewTrendPoint {
     /** Bucket start — ISO-8601 UTC for hours, `YYYY-MM-DD` for days. */
@@ -697,6 +705,8 @@ export interface IOverviewTrendPoint {
     topPaths: IOverviewTrendPath[];
     /** Top 3 most-active countries in the bucket (hits desc); [] when zero-traffic. */
     topCountries: IOverviewTrendCountry[];
+    /** Top 3 acquisition sources by attributed page views (hits desc); [] when zero-traffic. */
+    topSources: IOverviewTrendSource[];
 }
 
 /** Unified dashboard headline: KPIs + previous window + zero-filled series. */

--- a/src/frontend/modules/traffic/api/index.ts
+++ b/src/frontend/modules/traffic/api/index.ts
@@ -69,6 +69,7 @@ export type {
     IOverviewKpis,
     IOverviewTrendPath,
     IOverviewTrendCountry,
+    IOverviewTrendSource,
     IOverviewTrendPoint,
     IOverviewTrend,
     IIgnoredUser,

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.module.scss
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.module.scss
@@ -230,20 +230,11 @@
     color: color-mix(in srgb, var(--color-primary) 50%, var(--color-success));
 }
 
-/* Two-column grid for side-by-side sections */
-.split_grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--grid-gap-md);
-    container-type: inline-size;
-    container-name: split-grid;
-}
-
-@container split-grid (min-width: #{$breakpoint-mobile-lg}) {
-    .split_grid {
-        grid-template-columns: 1fr 1fr;
-    }
-}
+/* Side-by-side sections use the shared <Grid columns="responsive"> layout
+   primitive (components/layout/Grid). The former local `.split_grid` set
+   container-type on the same element its @container rule targeted — a query
+   container is only matched by its descendants, never itself — so the 2-column
+   rule never applied and the sections never floated. */
 
 .empty_state {
     text-align: center;

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
@@ -32,6 +32,7 @@ import {
 import { LineChart } from '../../../../../features/charts/components/LineChart';
 import type { ChartSeries } from '../../../../../features/charts/components/LineChart';
 import { Card } from '../../../../../components/ui/Card';
+import { Grid } from '../../../../../components/layout';
 import { OverviewTrend } from '../OverviewTrend';
 import {
     adminGetTrafficSources,
@@ -269,7 +270,7 @@ export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyt
             ) : (
                 <>
                     {/* Conversion Funnel + Traffic Sources side by side */}
-                    <div className={styles.split_grid}>
+                    <Grid columns="responsive">
                         {/* Conversion Funnel */}
                         {funnel.length > 0 && (
                             <Card>
@@ -545,10 +546,10 @@ export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyt
                                 )}
                             </div>
                         </Card>
-                    </div>
+                    </Grid>
 
                     {/* Top Landing Pages + Geographic Distribution side by side */}
-                    <div className={styles.split_grid}>
+                    <Grid columns="responsive">
                         {/* Top Landing Pages */}
                         <Card>
                             <h3
@@ -634,7 +635,7 @@ export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyt
                                 )}
                             </div>
                         </Card>
-                    </div>
+                    </Grid>
 
                     {/* Device Breakdown */}
                     <Card>

--- a/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
+++ b/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
@@ -28,7 +28,7 @@ import { BarChart } from '../../../../../features/charts/components/BarChart';
 import type { BarChartSeries } from '../../../../../features/charts/components/BarChart';
 import { Card } from '../../../../../components/ui/Card';
 import { adminGetOverviewTrend } from '../../../api';
-import type { AnalyticsPeriod, ICustomDateRange, IOverviewTrend, IOverviewTrendPath, IOverviewTrendCountry } from '../../../api';
+import type { AnalyticsPeriod, ICustomDateRange, IOverviewTrend, IOverviewTrendPath, IOverviewTrendCountry, IOverviewTrendSource } from '../../../api';
 import styles from './OverviewTrend.module.scss';
 
 /** Chart-switchable metrics. */
@@ -152,12 +152,12 @@ export function OverviewTrend({ period, customRange, includeBots }: IOverviewTre
             color: metric === 'visitors'
                 ? resolveCSSColor('--color-primary', '#4b8cff')
                 : resolveCSSColor('--color-success', '#57d48c'),
-            // Carry each bucket's top paths and countries as point metadata so
-            // the shared BarChart tooltip can surface "what did they view, and
-            // from where?" via our renderer. Both are page-view counts and
-            // identical for both metric modes (a bucket's breakdown doesn't
-            // change with the y-measure).
-            data: trend.series.map(p => ({ date: p.bucket, value: p[metric], metadata: { topPaths: p.topPaths, topCountries: p.topCountries } }))
+            // Carry each bucket's top paths, countries, and sources as point
+            // metadata so the shared BarChart tooltip can surface "what did they
+            // view, from where, and how did they arrive?" via our renderer. All
+            // three are page-view counts and identical for both metric modes (a
+            // bucket's breakdown doesn't change with the y-measure).
+            data: trend.series.map(p => ({ date: p.bucket, value: p[metric], metadata: { topPaths: p.topPaths, topCountries: p.topCountries, topSources: p.topSources } }))
         }];
     }, [trend, metric]);
 
@@ -182,24 +182,27 @@ export function OverviewTrend({ period, customRange, includeBots }: IOverviewTre
     const bucketScopeLabel = trend.granularity === 'hour' ? 'this hour' : 'this day';
 
     /**
-     * Render a hovered bucket's most-viewed paths and most-active countries
-     * inside the chart tooltip. Surfaces "what did they view, and from where?"
-     * in place so an operator reading the trend need not cross-reference the
-     * landing-pages or geo panels — while each heading names the metric (views)
-     * and its bucket scope so neither count is misread as a window total, a
-     * first-touch landing count, or the geo panel's distinct-visitor figure.
-     * Both breakdowns share the bucket's page-view measure, so they are
-     * commensurable with the bar and with each other.
+     * Render a hovered bucket's most-viewed paths, most-active countries, and
+     * top acquisition sources inside the chart tooltip. Surfaces "what did they
+     * view, from where, and how did they arrive?" in place so an operator
+     * reading the trend need not cross-reference the landing-pages, geo, or
+     * traffic-sources panels — while each heading names the metric (views) and
+     * its bucket scope so no count is misread as a window total, a first-touch
+     * landing count, or a panel's distinct-visitor figure. All three blocks
+     * share the bucket's page-view measure (sources attribute each view to the
+     * viewer's first-touch origin), so they stay commensurable with the bar and
+     * with each other.
      *
-     * @param metadata - The hovered bar's point metadata; `topPaths` and
-     *   `topCountries` are the server-ranked lists the series attached for this
-     *   bucket.
-     * @returns The ranked breakdown blocks, or null for a bucket with neither.
+     * @param metadata - The hovered bar's point metadata; `topPaths`,
+     *   `topCountries`, and `topSources` are the server-ranked lists the series
+     *   attached for this bucket.
+     * @returns The ranked breakdown blocks, or null for a bucket with none.
      */
     const renderTooltipMetadata = (metadata: Record<string, any>): React.ReactNode => {
         const paths = (metadata?.topPaths ?? []) as IOverviewTrendPath[];
         const countries = (metadata?.topCountries ?? []) as IOverviewTrendCountry[];
-        if (paths.length === 0 && countries.length === 0) return null;
+        const sources = (metadata?.topSources ?? []) as IOverviewTrendSource[];
+        if (paths.length === 0 && countries.length === 0 && sources.length === 0) return null;
         return (
             <>
                 {paths.length > 0 && (
@@ -220,6 +223,17 @@ export function OverviewTrend({ period, customRange, includeBots }: IOverviewTre
                             <div key={c.country} className={styles.tooltip_paths__row}>
                                 <span className={styles.tooltip_paths__path}>{c.country}</span>
                                 <span className={styles.tooltip_paths__hits}>{numberFormatter.format(c.hits)}</span>
+                            </div>
+                        ))}
+                    </div>
+                )}
+                {sources.length > 0 && (
+                    <div className={styles.tooltip_paths}>
+                        <span className={styles.tooltip_paths__heading}>Top sources · {bucketScopeLabel}</span>
+                        {sources.map(s => (
+                            <div key={s.source} className={styles.tooltip_paths__row}>
+                                <span className={styles.tooltip_paths__path}>{s.source}</span>
+                                <span className={styles.tooltip_paths__hits}>{numberFormatter.format(s.hits)}</span>
                             </div>
                         ))}
                     </div>


### PR DESCRIPTION
## Trend tooltip — third block: Top sources

The OverviewTrend bar tooltip now shows **"Top sources · this hour/day"** beside "Most viewed" and "Top countries". It measures **page views by origin**: each bucket page view is attributed to its visitor's **first-touch source** — `argMin(multiIf(referer IS NULL OR referer='', 'direct', domain(referer)), timestamp)` over `bootstrap` rows, matching `getTrafficSources`' derivation. All three tooltip blocks therefore share one commensurable page-view unit (path / country / origin slices of the same bucket views).

Source can only come from the first-touch `bootstrap` row (a `page` row's referrer is the site's own domain), so this is a **join**, not a plain group-by. The bootstrap side is bounded to visitors who viewed a page in the window (`candidate_uid IN (…in-window page…)`), so it isn't a full-table scan — but it is the heaviest of the tooltip queries and runs per overview-trend load. If it ever shows up hot on a large `traffic_events`, the follow-up is to materialize first-touch-source-per-visitor. Adds `IOverviewTrendSource` + `topSources` (module-local types, no `@delphian/tronrelic-types` bump).

## Dashboard layout — use the shared `<Grid>` primitive

Replaces the two hand-rolled `.split_grid` divs (Conversion Funnel + Traffic Sources; Top Landing Pages + Geographic Distribution) with `<Grid columns="responsive">` from `components/layout`. The old `.split_grid` set `container-type` on the **same element** its `@container` rule targeted — a query container is only matched by its descendants, never itself — so the two-column rule never applied and the sections never floated at any width. The dead class is removed. `<Grid columns="responsive">` floats/stacks on container width (auto-fit), which is the frontend docs' mandated pattern (layout via components, container-relative not viewport media queries).

Note: `columns="responsive"` flips on container width (~585px with the default `--grid-responsive-min: 280px`), not a fixed 768px viewport line.

Verified: backend + frontend typecheck clean, all 51 traffic service tests pass. Tooltip/layout not yet visually confirmed in a running app (no ClickHouse in the authoring session).
