### PR TITLE
feat(traffic): auto-refresh admin dashboards on a shared clock

### DIFF
--- a/src/frontend/app/(core)/system/traffic/page.tsx
+++ b/src/frontend/app/(core)/system/traffic/page.tsx
@@ -101,7 +101,10 @@ export default function SystemTrafficPage() {
     // the page level) and threading the signal down as a prop keeps a single
     // timer driving every aggregate surface instead of each panel owning its
     // own; it pauses while the tab is hidden.
-    const dashboardRefresh = useAutoRefresh(DASHBOARD_REFRESH_MS);
+    const dashboardRefresh = useAutoRefresh(
+        DASHBOARD_REFRESH_MS,
+        activeTab === 'analytics' || activeTab === 'crawlers'
+    );
 
     /**
      * Memoized custom date range built from the date input values.

--- a/src/frontend/app/(core)/system/traffic/page.tsx
+++ b/src/frontend/app/(core)/system/traffic/page.tsx
@@ -11,7 +11,8 @@ import {
     GscSettings,
     IgnoredUsers,
     PeriodPicker,
-    toDateInputValue
+    toDateInputValue,
+    useAutoRefresh
 } from '../../../../modules/traffic';
 import type { VisitorsView } from '../../../../modules/traffic';
 import { adminGetLiveVisitors } from '../../../../modules/traffic/api';
@@ -33,6 +34,16 @@ const VISITOR_VIEWS: ReadonlyArray<{ id: VisitorsView; label: string; title: str
 
 /** Polling interval for the live-visitor counter (ms). */
 const LIVE_POLL_MS = 30_000;
+
+/**
+ * Auto-refresh cadence for the aggregate dashboards (ms). Slower than the live
+ * counter: these are heavier ClickHouse aggregations and their numbers move on
+ * a coarser timescale, so a minute keeps them current without adding query
+ * pressure. The Visitors explorer and SEO tabs are intentionally excluded —
+ * the former holds pagination/drill-down state a refresh would disrupt, the
+ * latter serves daily, multi-day-lagged data that cannot change within a tick.
+ */
+const DASHBOARD_REFRESH_MS = 60_000;
 
 /**
  * System traffic administration page with tabbed interface.
@@ -85,6 +96,12 @@ export default function SystemTrafficPage() {
 
     // Live visitors (last 5 minutes), polled while the page is open.
     const [liveVisitors, setLiveVisitors] = useState<number | null>(null);
+
+    // Shared refresh clock for the aggregate dashboards. Ticking here (once, at
+    // the page level) and threading the signal down as a prop keeps a single
+    // timer driving every aggregate surface instead of each panel owning its
+    // own; it pauses while the tab is hidden.
+    const dashboardRefresh = useAutoRefresh(DASHBOARD_REFRESH_MS);
 
     /**
      * Memoized custom date range built from the date input values.
@@ -233,7 +250,7 @@ export default function SystemTrafficPage() {
 
             <div className={styles.content}>
                 {activeTab === 'analytics' && (
-                    <AnalyticsDashboard period={period} customRange={customRange} includeBots={includeBots} />
+                    <AnalyticsDashboard period={period} customRange={customRange} includeBots={includeBots} refreshSignal={dashboardRefresh} />
                 )}
                 {activeTab === 'visitors' && (
                     <VisitorsExplorer
@@ -245,8 +262,8 @@ export default function SystemTrafficPage() {
                 )}
                 {activeTab === 'crawlers' && (
                     <div className={styles.crawler_stack}>
-                        <CrawlerDashboard />
-                        <TrafficDashboard />
+                        <CrawlerDashboard refreshSignal={dashboardRefresh} />
+                        <TrafficDashboard refreshSignal={dashboardRefresh} />
                     </div>
                 )}
                 {activeTab === 'seo' && <GscKeywords />}

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
@@ -192,12 +192,23 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
      * Fetch all analytics data for the selected period. Runs all requests in
      * parallel for performance.
      *
+     * A monotonic request-id ref guards against stale in-flight responses:
+     * rapidly changing the period, range, or bot filter — or a slow background
+     * tick resolving after a newer foreground load — leaves an older request to
+     * finish last, and without the guard its `Promise.all` would overwrite every
+     * panel with data for the wrong window. Each call captures an incremented id
+     * and only writes state while that id is still current, mirroring the
+     * Crawler/Traffic dashboards. The current request also owns the page-level
+     * loading flag so a superseding background tick can't strand it on.
+     *
      * @param background - When true this is an auto-refresh tick, not a
      *   control-driven load: keep the current data on screen (no loading blank)
      *   and preserve any open traffic-source drill-down instead of resetting it,
      *   so a periodic refresh never disrupts what the operator is reading.
      */
+    const reqIdRef = useRef(0);
     const fetchAll = useCallback(async (background = false) => {
+        const reqId = ++reqIdRef.current;
         if (!background) {
             setLoading(true);
             setExpandedSource(null);
@@ -224,6 +235,10 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
                 adminGetAnalyticsOverview(),
             ]);
 
+            // Drop this response if a newer fetch has superseded it, so a slower
+            // earlier request can never overwrite fresher data.
+            if (reqId !== reqIdRef.current) return;
+
             setFunnel(funnelRes.stages);
             setTrafficSources(sourcesRes.sources);
             setTrafficTotal(sourcesRes.total);
@@ -236,7 +251,10 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
         } catch (error) {
             console.error('Failed to fetch analytics:', error);
         } finally {
-            if (!background) {
+            // Only the latest request clears loading — guarding by id (not by the
+            // background flag) lets a superseding background tick clear a blank a
+            // superseded foreground load left set, avoiding a stranded spinner.
+            if (reqId === reqIdRef.current) {
                 setLoading(false);
             }
         }

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
@@ -24,7 +24,7 @@
 
 'use client';
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import {
     Users, MousePointerClick,
     Globe, Smartphone, BarChart3, Target, ChevronDown, ChevronRight
@@ -120,6 +120,13 @@ interface IAnalyticsDashboardProps {
     customRange?: ICustomDateRange;
     /** Whether classified bot rows are included. */
     includeBots: boolean;
+    /**
+     * Page-level auto-refresh signal. Each increment triggers a background
+     * refetch that swaps data in place — no loading blank and no collapse of an
+     * open traffic-source drill-down, unlike a control-driven (foreground)
+     * reload. Omitted disables periodic refresh.
+     */
+    refreshSignal?: number;
 }
 
 /**
@@ -129,9 +136,10 @@ interface IAnalyticsDashboardProps {
  * headline, conversion funnel, traffic sources, landing pages, geography,
  * devices, campaigns, and retention data for the globally selected window.
  *
- * @param props - Global period, custom range, and bot-filter selection.
+ * @param props - Global period, custom range, and bot-filter selection, plus
+ *   the shared auto-refresh signal that drives periodic in-place reloads.
  */
-export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyticsDashboardProps) {
+export function AnalyticsDashboard({ period, customRange, includeBots, refreshSignal }: IAnalyticsDashboardProps) {
     const [loading, setLoading] = useState(true);
 
     // Data state
@@ -181,13 +189,20 @@ export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyt
     }, [expandedSource, sourceDetails, period, customRange, excludeBots]);
 
     /**
-     * Fetch all analytics data for the selected period.
-     * Runs all requests in parallel for performance.
+     * Fetch all analytics data for the selected period. Runs all requests in
+     * parallel for performance.
+     *
+     * @param background - When true this is an auto-refresh tick, not a
+     *   control-driven load: keep the current data on screen (no loading blank)
+     *   and preserve any open traffic-source drill-down instead of resetting it,
+     *   so a periodic refresh never disrupts what the operator is reading.
      */
-    const fetchAll = useCallback(async () => {
-        setLoading(true);
-        setExpandedSource(null);
-        setSourceDetails({});
+    const fetchAll = useCallback(async (background = false) => {
+        if (!background) {
+            setLoading(true);
+            setExpandedSource(null);
+            setSourceDetails({});
+        }
         try {
             const [
                 funnelRes,
@@ -221,13 +236,34 @@ export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyt
         } catch (error) {
             console.error('Failed to fetch analytics:', error);
         } finally {
-            setLoading(false);
+            if (!background) {
+                setLoading(false);
+            }
         }
     }, [period, customRange, excludeBots]);
 
+    // Foreground load: runs on mount and whenever a control (period, range, bot
+    // filter) changes, showing the loading state.
     useEffect(() => {
         fetchAll();
     }, [fetchAll]);
+
+    // Background auto-refresh: re-pull in place on each page-level refresh tick.
+    // The latest fetchAll is read through a ref so this effect depends only on
+    // refreshSignal — depending on fetchAll directly would both double-fetch on
+    // every control change and, worse, let a tick fire a stale-closure fetch for
+    // the previously-selected window. A mount guard skips the initial signal so
+    // the foreground effect owns the first load.
+    const fetchAllRef = useRef(fetchAll);
+    fetchAllRef.current = fetchAll;
+    const didMountRef = useRef(false);
+    useEffect(() => {
+        if (!didMountRef.current) {
+            didMountRef.current = true;
+            return;
+        }
+        fetchAllRef.current(true);
+    }, [refreshSignal]);
 
     /** Build chart series for the retention line chart. */
     const retentionSeries: ChartSeries[] = [
@@ -263,7 +299,7 @@ export function AnalyticsDashboard({ period, customRange, includeBots }: IAnalyt
     return (
         <div className={styles.dashboard}>
             {/* Overview headline — KPI strip + unified trend (owns its fetch) */}
-            <OverviewTrend period={period} customRange={customRange} includeBots={includeBots} />
+            <OverviewTrend period={period} customRange={customRange} includeBots={includeBots} refreshSignal={refreshSignal} />
 
             {loading ? (
                 <div className={styles.loading}>Loading analytics data...</div>

--- a/src/frontend/modules/traffic/components/admin/CrawlerDashboard/CrawlerDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/CrawlerDashboard/CrawlerDashboard.tsx
@@ -130,7 +130,7 @@ export function CrawlerDashboard({ refreshSignal }: ICrawlerDashboardProps) {
                 setTrendError(err instanceof Error ? err.message : 'Failed to load');
             }
         } finally {
-            if (reqId === trendReqId.current && !background) {
+            if (reqId === trendReqId.current) {
                 setTrendLoading(false);
             }
         }
@@ -158,7 +158,7 @@ export function CrawlerDashboard({ refreshSignal }: ICrawlerDashboardProps) {
                 setPathsError(err instanceof Error ? err.message : 'Failed to load');
             }
         } finally {
-            if (reqId === pathsReqId.current && !background) {
+            if (reqId === pathsReqId.current) {
                 setPathsLoading(false);
             }
         }

--- a/src/frontend/modules/traffic/components/admin/CrawlerDashboard/CrawlerDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/CrawlerDashboard/CrawlerDashboard.tsx
@@ -20,7 +20,7 @@
  * client-only.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Bot, Route } from 'lucide-react';
 import { LineChart } from '../../../../../features/charts/components/LineChart';
 import type { ChartSeries } from '../../../../../features/charts/components/LineChart';
@@ -78,11 +78,23 @@ function resolveCSSColor(varName: string, fallback: string): string {
     return value || fallback;
 }
 
+interface ICrawlerDashboardProps {
+    /**
+     * Page-level auto-refresh signal. Each increment refreshes both panels in
+     * place — no loading blank, and a transient failure keeps the prior data
+     * rather than flashing an error. Omitted disables periodic refresh.
+     */
+    refreshSignal?: number;
+}
+
 /**
  * Crawler visibility dashboard — bot-class trend chart plus the top paths
  * fetched by a selected bot class.
+ *
+ * @param props - The shared auto-refresh signal driving periodic in-place
+ *   reloads of both panels.
  */
-export function CrawlerDashboard() {
+export function CrawlerDashboard({ refreshSignal }: ICrawlerDashboardProps) {
     const [sinceHours, setSinceHours] = useState<number>(168);
     const [pathBotClass, setPathBotClass] = useState<string>('ai_crawler');
 
@@ -95,39 +107,83 @@ export function CrawlerDashboard() {
     const [pathsError, setPathsError] = useState<string | null>(null);
     const [pathsLoading, setPathsLoading] = useState(true);
 
-    // Trend fetch — re-runs when the window changes. Cleanup flag guards
-    // against a slower earlier response landing after a faster later one.
-    useEffect(() => {
-        let active = true;
-        setTrendLoading(true);
-        setTrendError(null);
-
-        adminGetBotTrend(sinceHours)
-            .then(data => {
-                if (active) {
-                    setTrend(data.points);
-                    setClickhouseEnabled(data.clickhouseEnabled);
-                }
-            })
-            .catch(err => { if (active) setTrendError(err instanceof Error ? err.message : 'Failed to load'); })
-            .finally(() => { if (active) setTrendLoading(false); });
-
-        return () => { active = false; };
+    // Trend fetch. A request-id ref supersedes stale in-flight responses so a
+    // slower earlier request cannot overwrite a faster later one (the guard the
+    // previous cleanup flag provided). A `background` refresh swaps data in
+    // place: no loading blank, and a transient failure keeps the prior chart
+    // rather than flashing an error over good data.
+    const trendReqId = useRef(0);
+    const fetchTrend = useCallback(async (background = false): Promise<void> => {
+        const reqId = ++trendReqId.current;
+        if (!background) {
+            setTrendLoading(true);
+            setTrendError(null);
+        }
+        try {
+            const data = await adminGetBotTrend(sinceHours);
+            if (reqId === trendReqId.current) {
+                setTrend(data.points);
+                setClickhouseEnabled(data.clickhouseEnabled);
+            }
+        } catch (err) {
+            if (reqId === trendReqId.current && !background) {
+                setTrendError(err instanceof Error ? err.message : 'Failed to load');
+            }
+        } finally {
+            if (reqId === trendReqId.current && !background) {
+                setTrendLoading(false);
+            }
+        }
     }, [sinceHours]);
 
-    // Paths fetch — re-runs when the window or selected bot class changes.
-    useEffect(() => {
-        let active = true;
-        setPathsLoading(true);
-        setPathsError(null);
+    // Foreground trend load: mount and window changes.
+    useEffect(() => { fetchTrend(); }, [fetchTrend]);
 
-        adminGetBotPaths(pathBotClass, { sinceHours, limit: 15 })
-            .then(data => { if (active) setPaths(data.buckets); })
-            .catch(err => { if (active) setPathsError(err instanceof Error ? err.message : 'Failed to load'); })
-            .finally(() => { if (active) setPathsLoading(false); });
-
-        return () => { active = false; };
+    // Paths fetch — same request-id / background contract as the trend fetch,
+    // re-running when the window or selected bot class changes.
+    const pathsReqId = useRef(0);
+    const fetchPaths = useCallback(async (background = false): Promise<void> => {
+        const reqId = ++pathsReqId.current;
+        if (!background) {
+            setPathsLoading(true);
+            setPathsError(null);
+        }
+        try {
+            const data = await adminGetBotPaths(pathBotClass, { sinceHours, limit: 15 });
+            if (reqId === pathsReqId.current) {
+                setPaths(data.buckets);
+            }
+        } catch (err) {
+            if (reqId === pathsReqId.current && !background) {
+                setPathsError(err instanceof Error ? err.message : 'Failed to load');
+            }
+        } finally {
+            if (reqId === pathsReqId.current && !background) {
+                setPathsLoading(false);
+            }
+        }
     }, [pathBotClass, sinceHours]);
+
+    // Foreground paths load: mount, window changes, and bot-class changes.
+    useEffect(() => { fetchPaths(); }, [fetchPaths]);
+
+    // Background auto-refresh: refresh both panels in place on each page-level
+    // tick. Latest fetchers read via refs so this depends only on refreshSignal
+    // (avoids double-fetch on control changes and stale-window ticks); the mount
+    // guard leaves the first load to the foreground effects.
+    const fetchTrendRef = useRef(fetchTrend);
+    fetchTrendRef.current = fetchTrend;
+    const fetchPathsRef = useRef(fetchPaths);
+    fetchPathsRef.current = fetchPaths;
+    const didMountRef = useRef(false);
+    useEffect(() => {
+        if (!didMountRef.current) {
+            didMountRef.current = true;
+            return;
+        }
+        fetchTrendRef.current(true);
+        fetchPathsRef.current(true);
+    }, [refreshSignal]);
 
     // Build one chart series per bot class that has at least one event in
     // the window — all-zero series only add legend noise. Color resolution

--- a/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
+++ b/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
@@ -168,7 +168,12 @@ export function OverviewTrend({ period, customRange, includeBots, refreshSignal 
         }];
     }, [trend, metric]);
 
-    if (error) {
+    // Only blank to the error card when there is no data to show. A failed
+    // background auto-refresh (a refreshSignal tick) leaves the prior `trend`
+    // in state, so keep the loaded panel visible rather than replacing good
+    // data with an error over a transient failure (stale-while-revalidate,
+    // matching the sibling dashboards' background-refresh contract).
+    if (error && !trend) {
         return <Card padding="md"><p className={styles.error}>{error}</p></Card>;
     }
     if (!trend) {

--- a/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
+++ b/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
@@ -118,15 +118,22 @@ interface IOverviewTrendProps {
     customRange?: ICustomDateRange;
     /** Whether classified bot rows are included. */
     includeBots: boolean;
+    /**
+     * Page-level auto-refresh signal. Each increment re-pulls the trend in
+     * place; the prior data stays visible (dimmed via `isFetching`) so the
+     * periodic refresh never flashes a loading state. Omitted disables it.
+     */
+    refreshSignal?: number;
 }
 
 /**
  * KPI strip + unified trend chart for the Analytics tab.
  *
- * @param props - Global period/bot-filter selection from the page controls.
+ * @param props - Global period/bot-filter selection from the page controls,
+ *   plus the shared auto-refresh signal that drives periodic in-place reloads.
  * @returns The rendered overview headline.
  */
-export function OverviewTrend({ period, customRange, includeBots }: IOverviewTrendProps) {
+export function OverviewTrend({ period, customRange, includeBots, refreshSignal }: IOverviewTrendProps) {
     const [trend, setTrend] = useState<IOverviewTrend | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [metric, setMetric] = useState<TrendMetric>('visitors');
@@ -142,7 +149,7 @@ export function OverviewTrend({ period, customRange, includeBots }: IOverviewTre
             .catch(err => { if (active) setError(err instanceof Error ? err.message : 'Failed to load'); })
             .finally(() => { if (active) setIsFetching(false); });
         return () => { active = false; };
-    }, [period, customRange, includeBots]);
+    }, [period, customRange, includeBots, refreshSignal]);
 
     const series: BarChartSeries[] = useMemo(() => {
         if (!trend || trend.series.length === 0) return [];

--- a/src/frontend/modules/traffic/components/admin/TrafficDashboard/TrafficDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/TrafficDashboard/TrafficDashboard.tsx
@@ -28,7 +28,7 @@
  * failing query for one dimension does not block the rest of the dashboard.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Bot, Globe, MapPin, RefreshCw } from 'lucide-react';
 import { Button } from '../../../../../components/ui/Button';
 import { Card } from '../../../../../components/ui/Card';
@@ -81,7 +81,24 @@ function useNumberFormatter(): (n: number) => string {
     }, []);
 }
 
-export function TrafficDashboard() {
+interface ITrafficDashboardProps {
+    /**
+     * Page-level auto-refresh signal. Each increment refreshes all four panels
+     * in place — no loading blank, and a transient failure keeps the prior data
+     * rather than flashing an error. Distinct from the manual Refresh button,
+     * which deliberately shows the loading state. Omitted disables it.
+     */
+    refreshSignal?: number;
+}
+
+/**
+ * ClickHouse traffic_events dashboard — bot-class breakdown, classifier-gap
+ * samples, and top landing paths / countries over a selectable window.
+ *
+ * @param props - The shared auto-refresh signal driving periodic in-place
+ *   reloads of every panel.
+ */
+export function TrafficDashboard({ refreshSignal }: ITrafficDashboardProps) {
     const [sinceHours, setSinceHours] = useState<number>(24);
     // Bumped by the Refresh button to re-trigger the fetch effect under
     // the same cleanup-flag guard used for window changes. Avoids a
@@ -114,76 +131,95 @@ export function TrafficDashboard() {
         []
     );
 
-    useEffect(() => {
-        // Cleanup-flag guard against stale fetch results: clicking the
-        // window picker rapidly (e.g. 24h -> 7d -> 1h) starts overlapping
-        // requests, and a slower earlier response can land after a
-        // faster later one. Without this guard, the dashboard would
-        // briefly display data for a window the user has already left.
-        // The flag also covers the Refresh-while-fetching case via
-        // refreshNonce because the effect re-runs through the same
-        // cleanup path.
-        let active = true;
+    // Fetch all four panels. A request-id ref supersedes stale in-flight
+    // responses so a slower earlier request (e.g. clicking 24h -> 7d -> 1h)
+    // cannot overwrite a faster later one — the ordering guard the previous
+    // cleanup flag provided, but reusable outside a single effect.
+    //
+    // `background` distinguishes an auto-refresh tick from a control-driven or
+    // manual reload: a background refresh swaps data in place (no loading blank)
+    // and, on a transient failure, keeps the prior panel rather than flashing an
+    // error over good data. Foreground reloads keep the original blank-then-load
+    // behaviour so the manual Refresh button still reads as an action.
+    const reqIdRef = useRef(0);
+    const fetchAll = useCallback(async (background = false): Promise<void> => {
+        const reqId = ++reqIdRef.current;
         const params = `?sinceHours=${sinceHours}`;
+        const isCurrent = (): boolean => reqId === reqIdRef.current;
 
-        // Reset loading and error state up-front so a previously-failed
-        // panel renders the loading state during refresh rather than
-        // continuing to display the stale error (PanelBody renders error
-        // before loading).
-        setSummaryLoading(true);
-        setBotOtherLoading(true);
-        setTopPathsLoading(true);
-        setTopCountriesLoading(true);
-        setSummaryError(null);
-        setBotOtherError(null);
-        setTopPathsError(null);
-        setTopCountriesError(null);
+        if (!background) {
+            // Reset loading and error state up-front so a previously-failed panel
+            // renders the loading state during refresh rather than continuing to
+            // display the stale error (PanelBody renders error before loading).
+            setSummaryLoading(true);
+            setBotOtherLoading(true);
+            setTopPathsLoading(true);
+            setTopCountriesLoading(true);
+            setSummaryError(null);
+            setBotOtherError(null);
+            setTopPathsError(null);
+            setTopCountriesError(null);
+        }
 
-        // Fire all four reads in parallel — they're independent endpoints
-        // and the loading-per-panel UX hides any tail latency.
+        // Fire all four reads in parallel — they're independent endpoints and
+        // the loading-per-panel UX hides any tail latency.
         const summaryPromise = fetch(`${baseUrl}/summary${params}`)
             .then(async r => {
                 if (!r.ok) throw new Error(`Failed to load summary (${r.status})`);
                 return r.json() as Promise<SummaryResponse>;
             })
-            .then(data => { if (active) { setSummary(data); setSummaryError(null); } })
-            .catch(err => { if (active) setSummaryError(err instanceof Error ? err.message : 'Failed to load'); })
-            .finally(() => { if (active) setSummaryLoading(false); });
+            .then(data => { if (isCurrent()) { setSummary(data); setSummaryError(null); } })
+            .catch(err => { if (isCurrent() && !background) setSummaryError(err instanceof Error ? err.message : 'Failed to load'); })
+            .finally(() => { if (isCurrent() && !background) setSummaryLoading(false); });
 
         const botOtherPromise = fetch(`${baseUrl}/bot-other-samples${params}&limit=15`)
             .then(async r => {
                 if (!r.ok) throw new Error(`Failed to load bot_other (${r.status})`);
                 return r.json() as Promise<AggregateResponse>;
             })
-            .then(data => { if (active) { setBotOther(data); setBotOtherError(null); } })
-            .catch(err => { if (active) setBotOtherError(err instanceof Error ? err.message : 'Failed to load'); })
-            .finally(() => { if (active) setBotOtherLoading(false); });
+            .then(data => { if (isCurrent()) { setBotOther(data); setBotOtherError(null); } })
+            .catch(err => { if (isCurrent() && !background) setBotOtherError(err instanceof Error ? err.message : 'Failed to load'); })
+            .finally(() => { if (isCurrent() && !background) setBotOtherLoading(false); });
 
         const topPathsPromise = fetch(`${baseUrl}/top-paths${params}&limit=15`)
             .then(async r => {
                 if (!r.ok) throw new Error(`Failed to load paths (${r.status})`);
                 return r.json() as Promise<AggregateResponse>;
             })
-            .then(data => { if (active) { setTopPaths(data); setTopPathsError(null); } })
-            .catch(err => { if (active) setTopPathsError(err instanceof Error ? err.message : 'Failed to load'); })
-            .finally(() => { if (active) setTopPathsLoading(false); });
+            .then(data => { if (isCurrent()) { setTopPaths(data); setTopPathsError(null); } })
+            .catch(err => { if (isCurrent() && !background) setTopPathsError(err instanceof Error ? err.message : 'Failed to load'); })
+            .finally(() => { if (isCurrent() && !background) setTopPathsLoading(false); });
 
         const topCountriesPromise = fetch(`${baseUrl}/top-countries${params}&limit=15`)
             .then(async r => {
                 if (!r.ok) throw new Error(`Failed to load countries (${r.status})`);
                 return r.json() as Promise<AggregateResponse>;
             })
-            .then(data => { if (active) { setTopCountries(data); setTopCountriesError(null); } })
-            .catch(err => { if (active) setTopCountriesError(err instanceof Error ? err.message : 'Failed to load'); })
-            .finally(() => { if (active) setTopCountriesLoading(false); });
+            .then(data => { if (isCurrent()) { setTopCountries(data); setTopCountriesError(null); } })
+            .catch(err => { if (isCurrent() && !background) setTopCountriesError(err instanceof Error ? err.message : 'Failed to load'); })
+            .finally(() => { if (isCurrent() && !background) setTopCountriesLoading(false); });
 
-        // The await-all isn't required for cleanup correctness — each
-        // chain self-guards via `active`. It's kept off the effect
-        // signature deliberately: useEffect can't return a Promise.
-        void Promise.all([summaryPromise, botOtherPromise, topPathsPromise, topCountriesPromise]);
+        await Promise.all([summaryPromise, botOtherPromise, topPathsPromise, topCountriesPromise]);
+    }, [baseUrl, sinceHours]);
 
-        return () => { active = false; };
-    }, [baseUrl, sinceHours, refreshNonce]);
+    // Foreground load: mount, window changes, and the manual Refresh button
+    // (via refreshNonce). Shows the loading state.
+    useEffect(() => { fetchAll(); }, [fetchAll, refreshNonce]);
+
+    // Background auto-refresh: re-pull all panels in place on each page-level
+    // tick. Latest fetchAll read via a ref so this depends only on refreshSignal
+    // (avoids double-fetch on control changes and stale-window ticks); the mount
+    // guard leaves the first load to the foreground effect.
+    const fetchAllRef = useRef(fetchAll);
+    fetchAllRef.current = fetchAll;
+    const didMountRef = useRef(false);
+    useEffect(() => {
+        if (!didMountRef.current) {
+            didMountRef.current = true;
+            return;
+        }
+        fetchAllRef.current(true);
+    }, [refreshSignal]);
 
     const clickhouseDisabledNotice = summary && !summary.clickhouseEnabled;
 

--- a/src/frontend/modules/traffic/components/admin/TrafficDashboard/TrafficDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/TrafficDashboard/TrafficDashboard.tsx
@@ -170,7 +170,7 @@ export function TrafficDashboard({ refreshSignal }: ITrafficDashboardProps) {
             })
             .then(data => { if (isCurrent()) { setSummary(data); setSummaryError(null); } })
             .catch(err => { if (isCurrent() && !background) setSummaryError(err instanceof Error ? err.message : 'Failed to load'); })
-            .finally(() => { if (isCurrent() && !background) setSummaryLoading(false); });
+            .finally(() => { if (isCurrent()) setSummaryLoading(false); });
 
         const botOtherPromise = fetch(`${baseUrl}/bot-other-samples${params}&limit=15`)
             .then(async r => {
@@ -179,7 +179,7 @@ export function TrafficDashboard({ refreshSignal }: ITrafficDashboardProps) {
             })
             .then(data => { if (isCurrent()) { setBotOther(data); setBotOtherError(null); } })
             .catch(err => { if (isCurrent() && !background) setBotOtherError(err instanceof Error ? err.message : 'Failed to load'); })
-            .finally(() => { if (isCurrent() && !background) setBotOtherLoading(false); });
+            .finally(() => { if (isCurrent()) setBotOtherLoading(false); });
 
         const topPathsPromise = fetch(`${baseUrl}/top-paths${params}&limit=15`)
             .then(async r => {
@@ -188,7 +188,7 @@ export function TrafficDashboard({ refreshSignal }: ITrafficDashboardProps) {
             })
             .then(data => { if (isCurrent()) { setTopPaths(data); setTopPathsError(null); } })
             .catch(err => { if (isCurrent() && !background) setTopPathsError(err instanceof Error ? err.message : 'Failed to load'); })
-            .finally(() => { if (isCurrent() && !background) setTopPathsLoading(false); });
+            .finally(() => { if (isCurrent()) setTopPathsLoading(false); });
 
         const topCountriesPromise = fetch(`${baseUrl}/top-countries${params}&limit=15`)
             .then(async r => {
@@ -197,7 +197,7 @@ export function TrafficDashboard({ refreshSignal }: ITrafficDashboardProps) {
             })
             .then(data => { if (isCurrent()) { setTopCountries(data); setTopCountriesError(null); } })
             .catch(err => { if (isCurrent() && !background) setTopCountriesError(err instanceof Error ? err.message : 'Failed to load'); })
-            .finally(() => { if (isCurrent() && !background) setTopCountriesLoading(false); });
+            .finally(() => { if (isCurrent()) setTopCountriesLoading(false); });
 
         await Promise.all([summaryPromise, botOtherPromise, topPathsPromise, topCountriesPromise]);
     }, [baseUrl, sinceHours]);

--- a/src/frontend/modules/traffic/hooks/useAutoRefresh.ts
+++ b/src/frontend/modules/traffic/hooks/useAutoRefresh.ts
@@ -37,16 +37,22 @@ import { useEffect, useState } from 'react';
  * @param intervalMs - Milliseconds between ticks while the tab is visible. The
  *   caller owns the cadence so different surfaces (e.g. a fast live counter vs.
  *   slower dashboards) can pick their own rate; changing it restarts the clock.
+ * @param enabled - Whether the clock runs. Defaults to true so existing callers
+ *   are unaffected. Pass false to pause ticking entirely (e.g. while the host
+ *   page shows a tab whose child does not consume the signal), sparing the page
+ *   needless re-renders; the returned signal holds its last value until
+ *   re-enabled.
  * @returns A counter that increments on every tick — feed it to fetch-effect
  *   dependency arrays to drive a periodic, in-place refresh.
  */
-export function useAutoRefresh(intervalMs: number): number {
+export function useAutoRefresh(intervalMs: number, enabled = true): number {
     const [signal, setSignal] = useState(0);
 
     useEffect(() => {
         // SSR guard: the hosting page is a client component, but keep the hook
         // safe to call in any render environment by no-oping without a document.
-        if (typeof document === 'undefined') {
+        // Also no-op when disabled so a paused clock issues no ticks or fetches.
+        if (typeof document === 'undefined' || !enabled) {
             return;
         }
 
@@ -95,7 +101,7 @@ export function useAutoRefresh(intervalMs: number): number {
             stop();
             document.removeEventListener('visibilitychange', handleVisibility);
         };
-    }, [intervalMs]);
+    }, [intervalMs, enabled]);
 
     return signal;
 }

--- a/src/frontend/modules/traffic/hooks/useAutoRefresh.ts
+++ b/src/frontend/modules/traffic/hooks/useAutoRefresh.ts
@@ -1,0 +1,101 @@
+/**
+ * useAutoRefresh Hook
+ *
+ * A single shared "refresh clock" for the traffic admin dashboards. The
+ * aggregate analytics panels fetch once on mount and otherwise sit frozen until
+ * an operator changes a control, so an admin watching the page sees stale
+ * numbers with no indication they are stale. This hook emits a monotonically
+ * increasing signal on a fixed interval; consumers add that signal to their
+ * fetch effect's dependencies to re-pull data in place — flash-free, keeping
+ * the prior data visible while the refetch lands rather than blanking to a
+ * loading state (the SSR + Live Updates intent applied to a client-gated admin
+ * surface).
+ *
+ * To keep this off the ClickHouse query path when nobody is looking, the clock
+ * pauses whenever the browser tab is hidden and fires one immediate refresh the
+ * moment it becomes visible again — so a returning admin sees current data at
+ * once rather than waiting out a full interval on stale numbers.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Emit an incrementing refresh signal on an interval, paused while hidden.
+ *
+ * Consumers treat the returned number as an opaque "refetch now" trigger: pass
+ * it into a fetch effect's dependency array so the effect re-runs each tick.
+ * The value itself carries no meaning beyond "it changed" — it exists so React
+ * can distinguish one tick from the next.
+ *
+ * The interval only runs while `document.visibilityState === 'visible'`, and
+ * regaining visibility bumps the signal immediately, so a backgrounded tab
+ * neither polls the backend nor leaves the operator on stale data when they
+ * return.
+ *
+ * @param intervalMs - Milliseconds between ticks while the tab is visible. The
+ *   caller owns the cadence so different surfaces (e.g. a fast live counter vs.
+ *   slower dashboards) can pick their own rate; changing it restarts the clock.
+ * @returns A counter that increments on every tick — feed it to fetch-effect
+ *   dependency arrays to drive a periodic, in-place refresh.
+ */
+export function useAutoRefresh(intervalMs: number): number {
+    const [signal, setSignal] = useState(0);
+
+    useEffect(() => {
+        // SSR guard: the hosting page is a client component, but keep the hook
+        // safe to call in any render environment by no-oping without a document.
+        if (typeof document === 'undefined') {
+            return;
+        }
+
+        let timer: ReturnType<typeof setInterval> | undefined;
+
+        /**
+         * Start the tick interval if it is not already running. Idempotent so a
+         * visibility change that fires while already visible cannot stack timers.
+         */
+        const start = (): void => {
+            if (timer === undefined) {
+                timer = setInterval(() => setSignal(previous => previous + 1), intervalMs);
+            }
+        };
+
+        /**
+         * Stop the tick interval so a hidden tab issues no background fetches.
+         */
+        const stop = (): void => {
+            if (timer !== undefined) {
+                clearInterval(timer);
+                timer = undefined;
+            }
+        };
+
+        /**
+         * React to tab visibility: pause while hidden, and on return fire one
+         * immediate refresh before resuming the interval so the operator never
+         * stares at data that went stale while the tab was backgrounded.
+         */
+        const handleVisibility = (): void => {
+            if (document.visibilityState === 'visible') {
+                setSignal(previous => previous + 1);
+                start();
+            } else {
+                stop();
+            }
+        };
+
+        if (document.visibilityState === 'visible') {
+            start();
+        }
+        document.addEventListener('visibilitychange', handleVisibility);
+
+        return () => {
+            stop();
+            document.removeEventListener('visibilitychange', handleVisibility);
+        };
+    }, [intervalMs]);
+
+    return signal;
+}

--- a/src/frontend/modules/traffic/index.ts
+++ b/src/frontend/modules/traffic/index.ts
@@ -14,6 +14,7 @@
  * ├── index.ts          # Barrel exports (this file)
  * ├── api/              # Admin analytics + GSC client
  * ├── components/       # admin/* dashboard panels
+ * ├── hooks/            # Shared dashboard hooks (auto-refresh clock)
  * └── lib/              # Device icon helper
  * ```
  */
@@ -34,6 +35,12 @@ export { TrafficDashboard } from './components';
 export { CrawlerDashboard } from './components';
 export { OverviewTrend } from './components';
 export { PeriodPicker, toDateInputValue } from './components';
+
+// =============================================================================
+// Hooks — shared dashboard behavior
+// =============================================================================
+
+export { useAutoRefresh } from './hooks/useAutoRefresh';
 
 // =============================================================================
 // API client


### PR DESCRIPTION
Adds a shared `useAutoRefresh` hook for the traffic admin dashboards. It emits an incrementing signal on a fixed interval, pauses while the browser tab is hidden, and fires one immediate refresh on return so a returning operator sees current data at once.

The traffic page ticks a single clock at 60s and threads the signal into the Analytics, Crawler, and Traffic dashboards as a `refreshSignal` prop; each refetches in place — keeping prior data visible while the refetch lands rather than blanking to a loading state. The Visitors explorer (holds pagination/drill-down state) and SEO tabs (daily, multi-day-lagged data) are intentionally excluded.