### PR TITLE
docs: backend module READMEs + traffic chart refinements

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -103,7 +103,7 @@ Each detailed document addresses a single concern: discovery and implementation 
 
 ### Cross-Referencing Patterns
 
-Link liberally but provide context describing what the reader will find. Use relative paths—never hardcode repository URLs. Good links describe the destination: "For API discovery techniques, see [market-fetcher-discovery.md](./market-fetcher-discovery.md)." Bad links leave readers guessing: "See market-fetcher-discovery.md for more information."
+Link liberally but provide context describing what the reader will find. Use relative paths—never hardcode repository URLs. Good links describe the destination: "For hydration error prevention and the `<ClientTime>` API, see [ui-ssr-hydration.md](./frontend/ui/ui-ssr-hydration.md)." Bad links leave readers guessing: "See ui-ssr-hydration.md for more information."
 
 ### Migrating to Directories
 

--- a/docs/plugins/plugins-catalog.md
+++ b/docs/plugins/plugins-catalog.md
@@ -1,55 +1,36 @@
 # Plugin Catalog
 
-Index of every plugin shipped under `src/plugins/` plus the per-market integrations bundled inside `trp-resource-markets`.
+Index of every plugin shipped under `src/plugins/`.
 
 ## Why This Matters
 
-Agents and operators routinely waste effort building features the platform already ships. Before scoping a new plugin, scan this catalog: a similar observer, admin surface, or service registry provider may already exist. The market sub-table covers the dominant integration surface — `trp-resource-markets` aggregates 18 separate marketplaces and is the most common place new TRON pricing sources land.
+Agents and operators routinely waste effort building features the platform already ships. Before scoping a new plugin, scan this catalog: a similar observer, admin surface, or service registry provider may already exist. Each plugin's colocated README is its canonical contract — this table only routes.
 
 ## Plugins
 
 | Plugin | Purpose | README |
 |--------|---------|--------|
+| trp-address-labels | TRON address identity: entity attribution (CEX hot/cold/deposit wallets first) via source providers, curation gate, and the `address-labels` registry service, so feeds render "→ Binance" instead of raw addresses. | [README](../../src/plugins/trp-address-labels/README.md) |
 | trp-ai-assistant | Admin-only Claude API console; streams answers and runs Batch jobs at 50% cost; other plugins register template variables and tools through the service registry. | [README](../../src/plugins/trp-ai-assistant/README.md) |
 | trp-bazi-fortune | 八字命理 Four Pillars readings keyed off each wallet's on-chain `create_time`; daily Wu Xing fortune via Beijing-time pillars. | [README](../../src/plugins/trp-bazi-fortune/README.md) |
+| trp-blog | Admin-authored public blog at `/blog`; AI-proposed posts held in the central curation queue, direct admin authoring at `/system/blog`. | [README](../../src/plugins/trp-blog/README.md) |
 | trp-delegation-pools | Detects distributed energy pools by flagging delegations signed with permission ID ≥ 3; ranks operators by delegation volume. | [README](../../src/plugins/trp-delegation-pools/README.md) |
 | trp-dust-tracker | Detects address-poisoning attacks; scores incoming dust against a 48h counterparty cache; rolls up to minute/hour/day/month. | [README](../../src/plugins/trp-dust-tracker/README.md) |
+| trp-files | Platform-wide file inventory: one service, one collection, one upload policy; publishes `IFileService` as `'files'`. | [README](../../src/plugins/trp-files/README.md) |
 | trp-forum | Wallet-signed posts (TronLink `signMessageV2`); shrinking randomly-positioned canvas, 7-day expiry, emoji reactions. | [README](../../src/plugins/trp-forum/README.md) |
-| trp-image-gen | Admin-only image generation; pluggable provider backends (`NanoBananaProvider` first); publishes `IImageGenerationService` and registers per-provider AI tools with `ai-assistant`. | [README](../../src/plugins/trp-image-gen/README.md) |
+| trp-image-gen | Admin-only image generation; pluggable provider backends (`NanoBananaProvider` first); publishes `IImageGenerationService` and registers per-provider AI tools. | [README](../../src/plugins/trp-image-gen/README.md) |
 | trp-memo-tracker | Indexes UTF-8 memos across six contract types; live feed for everyone, search and history gated on verified wallet. | [README](../../src/plugins/trp-memo-tracker/README.md) |
-| trp-resource-markets | Aggregates 18 TRON energy markets into one normalized `MarketSnapshot`; SUN-per-energy comparisons across hour/day/week rentals. | [docs/markets.md](../../src/plugins/trp-resource-markets/docs/markets.md) |
+| trp-reddit-bot | One content-router `publish` sink per subreddit (approved `core:social-post` fans out through curation + syndication) plus a read-only subreddit AI tool; credentials in admin-editable plugin config. | [README](../../src/plugins/trp-reddit-bot/README.md) |
+| trp-resource-markets | Aggregates 18 TRON energy markets into one normalized `MarketSnapshot`; SUN-per-energy comparisons across hour/day/week rentals. Per-market fetcher catalog lives in the README. | [README](../../src/plugins/trp-resource-markets/README.md) |
 | trp-resource-tracker | Observes `DelegateResourceContract` / `UnDelegateResourceContract`; raw retention 2d, summations 6mo, optional whale-delegation flagging. | [README](../../src/plugins/trp-resource-tracker/README.md) |
 | trp-telegram-bot | Telegram webhook bot serving `/price` market lookups; IP allowlist, secret token, per-user rate limit. | [README](../../src/plugins/trp-telegram-bot/README.md) |
-| trp-whale-alerts | Real-time whale transaction detection and alert dispatch for the TRON network. | [package.json](../../src/plugins/trp-whale-alerts/package.json) |
+| trp-themes | Site-wide CSS theme management: admins create themes from a CSS template and enable any subset; every visitor sees the same result. | [README](../../src/plugins/trp-themes/README.md) |
+| trp-trc10-authority | Authority on TRC10 token creation: observes `AssetIssueContract`, resolves new tokens against TronGrid, serves a public newest-tokens listing, and offers TronLink-based minting. | [README](../../src/plugins/trp-trc10-authority/README.md) |
+| trp-whale-alerts | Whale transfer detection: `TransferContract` observer against an admin-configured threshold; `/whales` dashboard, homepage widget, `whale-alerts:large-transfer` WebSocket room. | [README](../../src/plugins/trp-whale-alerts/README.md) |
 | trp-x-poster | Service-registry `x-poster` provider; `postTweet` (immediate or scheduled), `readTimelines`, image upload via X v1.1 media. | [README](../../src/plugins/trp-x-poster/README.md) |
-
-## Markets (under trp-resource-markets)
-
-Each market lives at `src/plugins/trp-resource-markets/src/markets/<name>/` with a fetcher and a README. Several READMEs are stub templates ("Market Type: Unknown") — those entries reflect what the README itself says.
-
-| Market | Purpose | README |
-|--------|---------|--------|
-| api-trx | apitrx.com — API-first platform; HTML pricing table scraped from `/en/pages/price.html`, no auth. | [README](../../src/plugins/trp-resource-markets/src/markets/api-trx/README.md) |
-| arc-vaults | arcvaults.com — flash energy SPA scraped via headless Playwright; recent purchases via `/api/recent-energy-purchases`. | [README](../../src/plugins/trp-resource-markets/src/markets/arc-vaults/README.md) |
-| brutus-finance | Stub README — endpoint and market type not yet specified. | [README](../../src/plugins/trp-resource-markets/src/markets/brutus-finance/README.md) |
-| catfee | Stub README — endpoint and market type not yet specified. | [README](../../src/plugins/trp-resource-markets/src/markets/catfee/README.md) |
-| ergon | Stub README — endpoint and market type not yet specified. | [README](../../src/plugins/trp-resource-markets/src/markets/ergon/README.md) |
-| feee-io | Stub README — endpoint and market type not yet specified. | [README](../../src/plugins/trp-resource-markets/src/markets/feee-io/README.md) |
-| mefree-net | Stub README — endpoint and market type not yet specified. | [README](../../src/plugins/trp-resource-markets/src/markets/mefree-net/README.md) |
-| rent-tron | renttron.com — single flat 1-hour rate; OpenAPI-documented `GET /api/prices`, no auth. | [README](../../src/plugins/trp-resource-markets/src/markets/rent-tron/README.md) |
-| tron-energize | Stub README — endpoint and market type not yet specified. | [README](../../src/plugins/trp-resource-markets/src/markets/tron-energize/README.md) |
-| tron-energy-market | P2P marketplace only — endpoint not yet specified. | [README](../../src/plugins/trp-resource-markets/src/markets/tron-energy-market/README.md) |
-| tron-energy | Stub README — endpoint and market type not yet specified. | [README](../../src/plugins/trp-resource-markets/src/markets/tron-energy/README.md) |
-| tron-fee-energy-rental | Stub README — endpoint and market type not yet specified. | [README](../../src/plugins/trp-resource-markets/src/markets/tron-fee-energy-rental/README.md) |
-| tron-lending | tronlending.xyz — 8×6 pricing matrix (1–30d × 1M–100M energy) via Playwright; REST endpoints supply pool balances. | [README](../../src/plugins/trp-resource-markets/src/markets/tron-lending/README.md) |
-| tron-pulse | P2P marketplace only — endpoint not yet specified. | [README](../../src/plugins/trp-resource-markets/src/markets/tron-pulse/README.md) |
-| tron-save | tronsave.io — GraphQL hybrid (platform + P2P); three parallel queries against `api-dashboard.tronsave.io/graphql`. | [README](../../src/plugins/trp-resource-markets/src/markets/tron-save/README.md) |
-| tronify | Stub README — endpoint and market type not yet specified. | [README](../../src/plugins/trp-resource-markets/src/markets/tronify/README.md) |
-| tronzap | tronzap.com — direct-recharge with volume tiers; POST `direct-recharge-info`, no auth, TRX-per-1000-energy pricing. | [README](../../src/plugins/trp-resource-markets/src/markets/tronzap/README.md) |
-| zuuu | zuuu.io — single POST `/api/buy/buyinfo` returns flash/hourly/multi-day tiers; SUN-per-1-energy pricing. | [README](../../src/plugins/trp-resource-markets/src/markets/zuuu/README.md) |
 
 ## Further Reading
 
 - [plugins.md](./plugins.md) — Plugin system overview, lifecycle, extension surfaces
 - [plugins-system-architecture.md](./plugins-system-architecture.md) — Package layout, manifests, the new-plugin walkthrough
-- [trp-resource-markets/docs/markets.md](../../src/plugins/trp-resource-markets/docs/markets.md) — Market system architecture, normalization, fetcher discovery
+- [trp-resource-markets/README.md](../../src/plugins/trp-resource-markets/README.md) — Market system architecture, normalization, per-market fetcher catalog

--- a/docs/system/system-notifications.md
+++ b/docs/system/system-notifications.md
@@ -28,7 +28,7 @@ It still publishes its produce-and-fire service on the **service registry** (`IS
 |---------|-------|-----------|---------|
 | Category | Source (plugin/module) | No (code) | A named notification type: id, label, audience, per-channel defaults |
 | Channel | Channel provider | No (code) | A delivery transport that declares the content features it `accepts`: `toast` now; `email`, `push` later |
-| Audience | Category / call site | Snapshot in audit | Who to reach: groups, user ids, wallets |
+| Audience | Category / call site | Snapshot in audit | Who to reach: groups, user ids |
 | Preference | User | Yes | Per-user opt-out of a (category, channel) pair, plus a global mute |
 | Policy | Admin | Yes | Global enable/disable of a channel or a category |
 | Audit record | Platform | Yes | One row per blast: what fired, to whom, delivered vs suppressed |
@@ -40,11 +40,14 @@ One service goes on the registry as `'notifications'`. Its public verbs are smal
 ```typescript
 interface INotificationService {
     // Source declares a category it owns. Disposer unregisters on plugin disable.
-    registerCategory(category: INotificationCategory): Disposer;
+    registerCategory(category: INotificationCategory): NotificationDisposer;
     // Channel provider declares a transport. Toast is registered by this module; plugins add more.
-    registerChannel(channel: INotificationChannel): Disposer;
+    registerChannel(channel: INotificationChannel): NotificationDisposer;
     // Fire a notification. Returns a receipt carrying the audit id and delivered/suppressed counts.
     notify(request: INotificationRequest): Promise<INotificationReceipt>;
+    // Back the preference and admin UIs with the live registry state.
+    listCategories(): INotificationCategory[];
+    listChannels(): INotificationChannelInfo[];
 }
 ```
 
@@ -52,7 +55,7 @@ Everything else is internal to the module and reached only through its own admin
 
 ### The resolution pipeline
 
-`DispatchService.notify()` is the heart. For a request it resolves the audience to user ids and resolves the content type into a descriptor (`describe(ref)`), then computes the features the descriptor carries. The **candidate channels** are the registered channels whose `accepts` covers every one of those features — a channel that cannot render the content is not a candidate at all (and not a suppression). For each (recipient, candidate channel) it applies an ordered gate — the first failing gate suppresses that channel for that recipient, and the reason is counted in the audit:
+`DispatchService.notify()` is the heart. For a request it resolves the audience to user ids and resolves the content type into a descriptor (`describe(ref)`), then computes the features the descriptor carries. Each channel also registers a sink on the shared [content router](./system-content-types.md) with a low `accepts` floor — the **candidate channels** are those whose floor is a subset of the descriptor's present features (`accepts ⊆ present`), so nearly every channel is structurally a candidate. Fidelity is enforced later, at delivery: a candidate that cannot render the content faithfully (a toast with neither title nor body) **refuses**, and the refusal is an audited outcome, not a silent non-candidacy. For each (recipient, candidate channel) dispatch then applies an ordered gate — the first failing gate suppresses that channel for that recipient, and the reason is counted in the audit:
 
 1. Category is registered **and** admin policy has not disabled it.
 2. Channel's admin policy has not disabled it globally.
@@ -69,7 +72,7 @@ A channel is a transport behind one interface, so adding email or push later is 
 interface INotificationChannel {
     id: string;          // 'toast', later 'email', 'push'
     label: string;
-    accepts: NotificationContentFeature[];   // 'title' | 'body' | 'media' | 'fields' it can render
+    accepts: NotificationContentFeature[];   // 'title' | 'body' | 'media' | 'details' it can render
     deliver(recipients: INotificationRecipient[], message: IRenderedNotification): Promise<IChannelDeliveryResult>;
 }
 ```

--- a/docs/system/system.md
+++ b/docs/system/system.md
@@ -6,113 +6,39 @@ The system layer orchestrates blockchain sync, job scheduling, observer notifica
 
 ## Why This Matters
 
-When the system layer stalls, transactions stop indexing, market prices go stale, observers receive nothing. Use this file to find the right detail doc; read the detail doc before changing the subsystem.
+When the system layer stalls, transactions stop indexing, market prices go stale, observers receive nothing. Use this file to find the right detail doc; read the detail doc before changing the subsystem. Each component below gets one row — the linked doc is canonical.
 
 ## Components
 
-### Runtime Configuration
-
-Solves Next.js build-time env inlining so a single Docker image runs on any domain. Backend stores `siteUrl` (and TRON chain parameters) in MongoDB; the frontend SSR fetches once at startup and injects as `window.__RUNTIME_CONFIG__`. No `NEXT_PUBLIC_*` in production code. See [system-runtime-config.md](./system-runtime-config.md).
-
-### Backend Modules
-
-Non-toggleable infrastructure (Pages, Menu, Identity, Traffic, Migrations) initialized during bootstrap. Two-phase lifecycle — `init()` resolves typed DI dependencies, `run()` mounts routes — fail-fast, no degraded mode. Plugins, by contrast, are optional and runtime-toggleable. See [modules.md](./modules/modules.md), [modules-architecture.md](./modules/modules-architecture.md), [modules-creating.md](./modules/modules-creating.md).
-
-### Database Access
-
-All database I/O must flow through `IDatabaseService`; direct Mongoose imports are prohibited. The abstraction exposes three access tiers (raw collections, Mongoose models, convenience methods), auto-prefixes plugin collections (`plugin_<id>_*`) for namespace isolation, and accepts mock implementations for testing. See [system-database.md](./system-database.md).
-
-### Blockchain Sync
-
-Pulls TronGrid blocks serially with a 200ms throttle (~5 req/s) to avoid burst rate limits, enriches transactions with USD and energy data, and notifies observers asynchronously so a slow observer cannot block sync. Pending blocks are capped to prevent memory leaks; multiple TronGrid keys rotate to spread load. See [system-blockchain-sync-architecture.md](./system-blockchain-sync-architecture.md).
-
-### Scheduler
-
-Runs six built-in cron jobs, each toggleable at runtime without restart. Critical jobs — `blockchain:sync` (1m), `chain-parameters:fetch` (10m), `usdt-parameters:fetch` (10m) — drive every downstream feature; disabling any of them stales data. Safe to disable temporarily: `cache:cleanup` and `system-logs:cleanup`. Global kill via `ENABLE_SCHEDULER=false`. See [system-scheduler-operations.md](./system-scheduler-operations.md).
-
-### Monitoring API
-
-Admin-token-gated endpoints covering sync status, scheduler control, DB/Redis/server health, env config, and WebSocket diagnostics. Powers the dashboard. See [system-api.md](./system-api.md).
-
-### Dashboard
-
-Tabbed web UI at `/system` (requires `ADMIN_API_TOKEN`) for live metrics, job toggles, schedule edits, and manual sync/refresh triggers. Built on the monitoring API. See [system-dashboard.md](./system-dashboard.md).
-
-### Menu
-
-Navigation service that aggregates menu nodes from core and plugins. Supports DB-backed and memory-only entries, multiple namespaces, and emits WebSocket events when structure changes; plugins register through lifecycle hooks — no core edits. See [Menu Module README](../../src/backend/modules/menu/README.md).
-
-### Widgets
-
-Owns the widget subsystem behind one public service — `IWidgetsService`, registry name `'widgets'` — covering zone definitions, per-zone flexbox layout, placement persistence, widget-type registration (including the core `core:block-ticker`, `core:world-clocks`, and `core:raw-html` types), and the `/system/widgets` admin UI. Plugins, modules, admin controllers, and the SSR router reach widgets only through this service; there is no other entry point. See [Widgets Module README](../../src/backend/modules/widgets/README.md) and [system-api-widgets.md](./system-api-widgets.md).
-
-### Migrations
-
-Schema evolution discovered automatically from system, module, and plugin directories; topologically sorted by dependency; executed serially with MongoDB transaction wrapping (replica set required) and full audit history. See [system-database-migrations.md](./system-database-migrations.md).
-
-### Pages
-
-Markdown-authored CMS for admin-published content. `PageService` (singleton, implements `IPageService`) depends on `IStorageProvider`, so the storage backend (local FS, S3, custom) is swappable via DI. Rendered HTML cached in Redis 24h with auto-invalidation; a route blacklist prevents slugs from shadowing core routes. See [Pages Module README](../../src/backend/modules/pages/README.md).
-
-### Tools
-
-User-facing TRON utilities — address-format conversion, energy estimation, bidirectional stake calculation, signature verification, token-approval checking, timestamp/block conversion — each on its own page under the Tools menu, served from `/api/tools/*`. Stateless: no collections of its own; calculations read the shared `transactions` collection and live `ChainParametersService` values. See [Tools Module README](../../src/backend/modules/tools/README.md).
-
-### Authentication & Authorization
-
-Identity runs on Better Auth (email-OTP / OAuth / passkey), mounted at `/api/auth/*`. The `attachAuthSession` middleware resolves the session once per request onto `req.authSession`; modules and plugins gate through predicates (`isLoggedIn` / `isInGroup` / `isAdmin`, plus `hasPrimaryWallet` for plugins) rather than reading session fields. See [system-auth.md](./system-auth.md).
-
-### Identity
-
-The identity module owns Better Auth and everything keyed by the Better Auth user id: the auth instance (above), the `GroupService` (admin/group membership), the signature-proven wallet store, the account directory, and the central per-user settings store. It publishes `'accounts'`, `'wallets'`, `'user-groups'`, and `'user-settings'` on the service registry so plugins and modules reach account data without touching `module_user_auth_*` directly. The `'user-settings'` store is the single home for user-centric settings and preferences, addressed by `(userId, namespace, key)`; per-user notification opt-outs are its first consumer. See [Identity Module README](../../src/backend/modules/identity/README.md) and [system-auth.md](./system-auth.md).
-
-### Traffic
-
-The traffic module owns cookieless behavioral analytics: the ClickHouse `traffic_events` store, the `tronrelic_tid`/`tronrelic_ref` cookies, bot classification, and geo/device derivation. It backs the `/system/traffic` analytics, crawler, and SEO dashboards. See [Traffic Module README](../../src/backend/modules/traffic/README.md).
-
-### Account History
-
-Pull-based per-account transaction history. Backfills the full TronGrid history of operator-tracked TRON accounts into a ClickHouse `account_transactions` table — independent of the forward block-sync pipeline, bounded and resumable per scheduler tick — and keeps completed accounts current with a forward-sync job. Verified wallets auto-enroll through the `http.walletLinked` hook. Publishes `'account-history'` (`IAccountHistoryService`); an admin surface at `/system/account-history` plus login-gated, ownership-scoped per-wallet reads (download progress, activity summary, transaction feed) back the profile Wallets tab. Also owns the scheduled per-account balance/resource snapshots (`account_balance_snapshots` + `account_token_balances`) that anchor portfolio valuation. See [Account History Module README](../../src/backend/modules/account-history/README.md).
-
-### Price History
-
-A scheduled, local daily USD price series (TRX + tracked TRC20 tokens) in ClickHouse, so portfolio valuation never makes a live external price call on a page load. Prices are immutable: a bounded resumable backward backfill (a dense recent-window seed plus a per-day deep walk behind a swappable `IPriceHistoryProvider`, CoinGecko v1) plus a cheap daily forward append. Publishes `'price-history'` (`IPriceHistoryService`). See [Price History Module README](../../src/backend/modules/price-history/README.md).
-
-### Valuation
-
-Per-user portfolio summaries — net worth, holdings, allocation, realized/unrealized PnL, and USD balance-over-time — joined entirely from local data (the account-history ledger and balance snapshots, the price-history series, and the identity wallet set). PnL is per-user by design: a transfer between two wallets the same user owns nets out (basis-preserving), so per-wallet and per-user scopes stay coherent and additive. Owns no storage; publishes `'valuation'` (`IValuationService`); login-gated, ownership-scoped reads at `/api/valuation/me/*` back the Wallets-tab portfolio hero. See [Valuation Module README](../../src/backend/modules/valuation/README.md).
-
-### Hooks
-
-Typed extension points where core invites plugins into its own execution. Descriptors declared in `src/backend/hooks/registry.ts` are the single source of truth; the runtime registry refuses unknown descriptors, enforces per-plugin handler caps, and serves a snapshot to the `/system/hooks` admin timeline. Four archetypes (observer / series / waterfall / bail) with explicit isolation and abort semantics. See [system-hooks.md](./system-hooks.md).
-
-### AI Tools
-
-The contract and governance for tools a model can invoke during an AI query. Core owns the tool shape, the capability classes (read / write / external, sensitivity, reversibility), and the accountability and security every tool must meet — input validation, object authorization, rate/quota/cost limits, human approval for irreversible effects, and per-invocation audit — so every AI provider plugin and tool inherits the same guarantees. Provider-neutral: `trp-ai-assistant` is only the Anthropic transport. See [system-ai-tools.md](./system-ai-tools.md) and [AI Tools Module README](../../src/backend/modules/ai-tools/README.md).
-
-### Content Types
-
-The central registry of provider-owned content — the reusable noun the platform renders, holds, decides, or delivers without understanding its payload. A provider registers an `IContentType` (`typeId`, `label`, `describe(ref)` → a generic descriptor, optional `applyEdit`); pipelines bind their own verbs onto it. Constructed in bootstrap as a peer of the service and hook registries, published as `'content-types'` before module init, and introspected read-only at `/system/content-types`. Curation and notifications both consume it. See [system-content-types.md](./system-content-types.md).
-
-### Curation
-
-One core admin surface (`/system/curation`, owned by the Curation module) for every effect held for human review before it takes hold. Plugins register an `ICurationType` — a [content type](./system-content-types.md) plus required declarative `decisionStatus` bookkeeping (committed through `applyEdit`); core owns the decision and a pointer-plus-preview envelope while the type owns the payload and what approval does. It also hardens a tool's `forcesCuratorReview` into a verifiable `curationTypeId` binding the AI tool governor checks live against the published `'curation'` service. See [system-curation.md](./system-curation.md).
-
-### Notifications
-
-Category-based notification dispatch behind one published service — `INotificationService`, registry name `'notifications'`. Any module or plugin declares a category and a content type, then fires by reference (`notify({ category, typeId, ref })`); the module resolves the audience (groups/users) to recipients, resolves the content type into a descriptor, routes to the channels whose declared capabilities can render it, enforces admin policy and per-user opt-outs, and audits every blast. Delivery is identity-targeted over WebSocket `user:${id}` rooms so per-user silencing is enforced server-side. The first consumer is the AI scheduler, which toasts admins when a cron prompt runs. See [system-notifications.md](./system-notifications.md) and [Notifications Module README](../../src/backend/modules/notifications/README.md).
-
-### Syndication
-
-The durable `publish` sink family of the [content router](./system-content-routing.md). Curation enqueues approved publish legs here; the module guarantees delivery via a transactional outbox, a retrying relay (the `syndication:relay` job), an idempotency key handed to each sink, and dead-lettering — closing the dual-write hazard of in-process best-effort fan-out. The contract is at-least-once plus idempotency (effectively-once); legs are independent, with no cross-destination saga. Published `'syndication'`; operator surface at `/api/admin/system/syndication`. See [system-syndication.md](./system-syndication.md) for the delivery contract and [Syndication Module README](../../src/backend/modules/syndication/README.md) for the implementation.
-
-### Logging
-
-Pino-based logger with MongoDB persistence for historical queries. See [system-logging.md](./system-logging.md) and [Logs Module README](../../src/backend/modules/logs/README.md).
-
-### Testing
-
-Vitest with shared Mongoose mocking utilities — in-memory collections, chainable queries, error injection, operation spies — so database services exercise without a live MongoDB. See [system-testing.md](./system-testing.md).
+| Component | Purpose | Canonical docs |
+|---|---|---|
+| Runtime Configuration | One universal Docker image, any domain: `siteUrl` lives in MongoDB, SSR injects `window.__RUNTIME_CONFIG__`; no `NEXT_PUBLIC_*` | [system-runtime-config.md](./system-runtime-config.md) |
+| Backend Modules | Non-toggleable core infrastructure with a two-phase `init()`/`run()` lifecycle, typed DI, fail-fast | [modules.md](./modules/modules.md), [modules-architecture.md](./modules/modules-architecture.md), [modules-creating.md](./modules/modules-creating.md) |
+| Database Access | All DB I/O through `IDatabaseService` (three tiers, `plugin_<id>_*` prefixing); direct Mongoose imports prohibited | [system-database.md](./system-database.md) |
+| Blockchain Sync | Serial TronGrid block pull (200ms throttle), USD/energy enrichment, async observer dispatch, bounded pending queue | [system-blockchain-sync-architecture.md](./system-blockchain-sync-architecture.md) |
+| Scheduler | Six built-in cron jobs, runtime-toggleable; `blockchain:sync`, `chain-parameters:fetch`, `usdt-parameters:fetch` are critical; global kill `ENABLE_SCHEDULER=false` | [system-scheduler-operations.md](./system-scheduler-operations.md) |
+| Monitoring API | Admin-token-gated endpoints for sync status, scheduler control, health, WebSocket diagnostics | [system-api.md](./system-api.md) |
+| Dashboard | Tabbed `/system` UI (requires `ADMIN_API_TOKEN`) over the monitoring API | [system-dashboard.md](./system-dashboard.md) |
+| Auth & Authorization | Better Auth at `/api/auth/*`; `req.authSession` resolved once per request; gate via predicates (`isLoggedIn`/`isInGroup`/`isAdmin`) | [system-auth.md](./system-auth.md) |
+| Identity | Owns Better Auth, groups, signature-proven wallets, account directory, per-user settings; publishes `'accounts'`, `'wallets'`, `'user-groups'`, `'user-settings'` | [Identity README](../../src/backend/modules/identity/README.md) |
+| Menu | Navigation nodes from core and plugins; DB-backed and memory-only entries, namespaces, `menu:update` events | [Menu README](../../src/backend/modules/menu/README.md) |
+| Widgets | Zones, placements, widget-type registration behind `'widgets'` (`IWidgetsService`); `/system/widgets` admin UI | [Widgets README](../../src/backend/modules/widgets/README.md), [system-api-widgets.md](./system-api-widgets.md) |
+| Migrations | Auto-discovered schema migrations, topologically sorted, transaction-wrapped, audited | [system-database-migrations.md](./system-database-migrations.md) |
+| Pages | Markdown CMS (`IPageService` + swappable `IStorageProvider`), Redis-cached rendering, route blacklist | [Pages README](../../src/backend/modules/pages/README.md) |
+| Tools | Stateless TRON utility calculators under `/api/tools/*` (address, energy, stake, signature, approvals, timestamp) | [Tools README](../../src/backend/modules/tools/README.md) |
+| Traffic | Cookieless analytics: ClickHouse `traffic_events`, `tronrelic_tid`/`tronrelic_ref` cookies, bot/geo classification | [Traffic README](../../src/backend/modules/traffic/README.md) |
+| Account History | Pull-based per-account TronGrid backfill + forward sync into ClickHouse; balance/resource snapshots; publishes `'account-history'` | [Account History README](../../src/backend/modules/account-history/README.md) |
+| Price History | Local daily USD price series (TRX + TRC20) in ClickHouse behind `IPriceHistoryProvider`; publishes `'price-history'` | [Price History README](../../src/backend/modules/price-history/README.md) |
+| Valuation | Per-user portfolio (net worth, holdings, FIFO PnL with internal-transfer netting) joined from local data; publishes `'valuation'` | [Valuation README](../../src/backend/modules/valuation/README.md) |
+| Hooks | Typed core seams plugins contribute into; four archetypes (observer/series/waterfall/bail); `/system/hooks` timeline | [system-hooks.md](./system-hooks.md) |
+| AI Tools | Contract, capability classes, and accountability/security for model-invocable tools; provider-neutral | [system-ai-tools.md](./system-ai-tools.md), [AI Tools README](../../src/backend/modules/ai-tools/README.md) |
+| Content Types | Central registry of provider-owned content (`IContentType` → generic descriptor); published `'content-types'` | [system-content-types.md](./system-content-types.md) |
+| Content Routing | Recipient List router unifying the curation/notifications/syndication sink families | [system-content-routing.md](./system-content-routing.md) |
+| Curation | One `/system/curation` queue for effects held for human review; verifiable `curationTypeId` binding for AI tools | [system-curation.md](./system-curation.md), [Curation README](../../src/backend/modules/curation/README.md) |
+| Notifications | Category-based dispatch by content reference; audience resolution, channel capability routing, per-user opt-outs, audit | [system-notifications.md](./system-notifications.md), [Notifications README](../../src/backend/modules/notifications/README.md) |
+| Syndication | Durable publish sinks: transactional outbox, retrying relay, idempotency, dead-letter (effectively-once) | [system-syndication.md](./system-syndication.md), [Syndication README](../../src/backend/modules/syndication/README.md) |
+| Logging | Pino with MongoDB persistence for historical queries | [system-logging.md](./system-logging.md), [Logs README](../../src/backend/modules/logs/README.md) |
+| Testing | Vitest + shared Mongoose mocks (in-memory collections, chainable queries, spies) | [system-testing.md](./system-testing.md) |
 
 ## Operations Quick Start
 
@@ -120,50 +46,17 @@ Inspect health at `/system` (auth: `ADMIN_API_TOKEN`) — fastest path to blockc
 
 ## Detail Documents
 
+Docs not owned by a single component row above:
+
 | Document | Covers |
 |---|---|
-| [system-runtime-config.md](./system-runtime-config.md) | Universal Docker images, SSR config injection, `SITE_URL` |
-| [modules.md](./modules/modules.md) | Module overview, module-vs-plugin matrix, service singleton rules |
-| [modules-architecture.md](./modules/modules-architecture.md) | `IModule` interface, bootstrap order, DI, service registry |
-| [modules-creating.md](./modules/modules-creating.md) | Step-by-step new-module guide |
-| [system-auth.md](./system-auth.md) | Better Auth identity, `req.authSession`, authorization predicates |
-| [system-database.md](./system-database.md) | `IDatabaseService`, three-tier access, namespace isolation |
-| [system-blockchain-sync-architecture.md](./system-blockchain-sync-architecture.md) | Block retrieval, enrichment pipeline, observer dispatch |
-| [system-block-provider-migration.md](./system-block-provider-migration.md) | Proposed TronGrid decoupling — `IBlockProvider` design, provider research, migration plan |
-| [system-domain-types.md](./system-domain-types.md) | Source-independence rule for the types package — admission test, `IBlockTransaction`, known debt |
-| [system-scheduler-operations.md](./system-scheduler-operations.md) | Job control, cron syntax, persistence, troubleshooting |
-| [system-api.md](./system-api.md) | Admin API gateway — auth, conventions, troubleshooting, links to per-domain detail docs |
 | [system-api-overview.md](./system-api-overview.md) | `/health/*` (database, clickhouse, redis, server), `/config`, `/config/system` |
 | [system-api-blockchain.md](./system-api-blockchain.md) | Blockchain sync status, metrics, manual trigger |
 | [system-api-scheduler.md](./system-api-scheduler.md) | Scheduler status, health, job PATCH |
 | [system-api-logs.md](./system-api-logs.md) | System log query/resolve/delete endpoints |
 | [system-api-websockets.md](./system-api-websockets.md) | WebSocket admin metrics + real-time event catalog |
-| [system-api-widgets.md](./system-api-widgets.md) | Widget placements admin CRUD, zone and widget-type introspection |
-| [system-dashboard.md](./system-dashboard.md) | Dashboard tabs and controls |
-| [system-database-migrations.md](./system-database-migrations.md) | Migration discovery, transactions, REST API, admin UI |
-| [system-hooks.md](./system-hooks.md) | Declared seams, four archetypes, plugin facade, introspection, admin UI |
-| [system-content-types.md](./system-content-types.md) | The central content registry, the `IContentType`/`IContentDescriptor` contract, capability routing, `/system/content-types` |
-| [system-content-routing.md](./system-content-routing.md) | Unifying router, a Recipient List — primitive, classification vocabulary, sink contract + `kind`, gate seam, the curation/notifications/syndication sink families, the mandated-subset selector at the curation gate, and the `syndication` durable-delivery stack all shipped (`'content-router'`, `'syndication'`); only the gate's authorization policy still proposed |
-| [system-ai-tools.md](./system-ai-tools.md) | AI tool contract, capability classes, accountability and security requirements |
-| [system-curation.md](./system-curation.md) | Central curation queue, the type contract, the verifiable `curationTypeId` binding |
-| [system-notifications.md](./system-notifications.md) | Notification dispatch, the resolution pipeline, channels, per-user opt-outs, audit |
-| [system-syndication.md](./system-syndication.md) | The durable publish-sink delivery contract — at-least-once plus idempotency, the outbox→relay→idempotent-receiver→dead-letter stack, eventual outcomes |
-| [system-logging.md](./system-logging.md) | Pino, MongoDB persistence, log queries |
-| [Menu Module README](../../src/backend/modules/menu/README.md) | Menu service, plugin integration, WebSocket events |
-| [Pages Module README](../../src/backend/modules/pages/README.md) | Markdown CMS, storage providers, file uploads |
-| [Identity Module README](../../src/backend/modules/identity/README.md) | Better Auth, groups, wallet store, account directory |
-| [Traffic Module README](../../src/backend/modules/traffic/README.md) | ClickHouse traffic_events, tid/ref cookies, analytics |
-| [Account History Module README](../../src/backend/modules/account-history/README.md) | Pull-based per-account TRON history ingest into ClickHouse, forward sync, balance snapshots, `IAccountHistoryService`, admin + ownership-scoped user APIs |
-| [Price History Module README](../../src/backend/modules/price-history/README.md) | Local daily USD price series (CoinGecko-backed), two-phase backfill, `IPriceHistoryService` |
-| [Valuation Module README](../../src/backend/modules/valuation/README.md) | Per-user portfolio valuation — net worth, holdings, FIFO PnL with internal-transfer netting, balance-over-time, `IValuationService` |
-| [Tools Module README](../../src/backend/modules/tools/README.md) | TRON utility calculators — address conversion, energy/stake math, signature verification, token approvals, timestamp/block conversion |
-| [Widgets Module README](../../src/backend/modules/widgets/README.md) | `IWidgetsService`, zones, placements, widget-types, SSR router integration |
-| [Logs Module README](../../src/backend/modules/logs/README.md) | `SystemLogService` singleton, `system_logs` persistence, metadata sanitizer |
-| [AI Tools Module README](../../src/backend/modules/ai-tools/README.md) | Tool registry, governor, policy, invocation audit, human-approval queue |
-| [Curation Module README](../../src/backend/modules/curation/README.md) | `ICurationService`, the held-item lifecycle, `/system/curation` admin surface |
-| [Notifications Module README](../../src/backend/modules/notifications/README.md) | `INotificationService`, dispatch pipeline, preferences, policy, audit, channels |
-| [Syndication Module README](../../src/backend/modules/syndication/README.md) | `ISyndicationService`, transactional outbox, retrying relay, idempotency, dead-letter, curation integration |
-| [system-testing.md](./system-testing.md) | Vitest, Mongoose mocks, fixtures |
+| [system-block-provider-migration.md](./system-block-provider-migration.md) | Proposed TronGrid decoupling — `IBlockProvider` design, provider research, migration plan |
+| [system-domain-types.md](./system-domain-types.md) | Source-independence rule for the types package — admission test, `IBlockTransaction`, known debt |
 
 ## Related
 

--- a/docs/tron/tron.md
+++ b/docs/tron/tron.md
@@ -174,6 +174,6 @@ Before implementing any TRON-related feature, verify:
 
 **Related topics:**
 - [system-blockchain-sync-architecture.md](../system/system-blockchain-sync-architecture.md) - How TronRelic fetches and processes TRON blocks
-- [market-system-architecture.md](../markets/market-system-architecture.md) - How energy market pricing uses TRON parameters
+- [trp-resource-markets README](../../src/plugins/trp-resource-markets/README.md) - How energy market pricing uses TRON parameters
 - [plugins-blockchain-observers.md](../plugins/plugins-blockchain-observers.md) - How observers receive enriched TRON transactions
 - [environment.md](../environment.md) - TronGrid API key configuration and rate limiting

--- a/src/backend/modules/analytics/README.md
+++ b/src/backend/modules/analytics/README.md
@@ -1,0 +1,7 @@
+# Analytics
+
+Legacy transaction-analytics surface: `TransactionAnalyticsService` (high-amount and latest-by-type queries over `transactions`), `AccountAnalyticsService` (per-account transaction history), `FlowAnalyticsService` (inflow/outflow totals and series), `CalculatorService` (energy-estimate calculator), and `MemoService` (`transaction_memos` reads) — each Redis-cached via the shared `CacheService`.
+
+## Canonical documentation
+
+No dedicated detail doc exists yet; [system-database.md](../../../../docs/system/system-database.md) covers the `IDatabaseService`/model-registration and caching patterns every service here follows. This directory is distinct from the `tools` module's own `CalculatorService` (see [Tools Module README](../tools/README.md)) — the two are separate implementations, not shared code.

--- a/src/backend/modules/auth/README.md
+++ b/src/backend/modules/auth/README.md
@@ -1,0 +1,8 @@
+# Auth
+
+`SignatureService` implements `ISignatureService`: TRON message-signature verification and address normalization, wrapping a constructor-injected TronWeb instance. Not to be confused with the identity module, which owns Better Auth sessions and `req.authSession`.
+
+## Canonical documentation
+
+- [system-auth.md](../../../../docs/system/system-auth.md) — Better Auth identity, session resolution, and authorization predicates that gate routes across the backend
+- [Identity Module README](../identity/README.md) — the module hosting the Better Auth instance this directory's signature verification supports (wallet-linking signature proofs)

--- a/src/backend/modules/blockchain/README.md
+++ b/src/backend/modules/blockchain/README.md
@@ -1,0 +1,8 @@
+# Blockchain
+
+Owns TRON block retrieval and persistence: `TronGridClient` pulls blocks, `transaction-parse.ts` decodes embedded contracts, and `BlockchainService` enriches transactions and notifies observers before writing to MongoDB.
+
+## Canonical documentation
+
+- [system-blockchain-sync-architecture.md](../../../../docs/system/system-blockchain-sync-architecture.md) — block retrieval, enrichment pipeline, observer dispatch
+- [plugins-blockchain-observers.md](../../../../docs/plugins/plugins-blockchain-observers.md) — building observers that react to transactions this module notifies

--- a/src/backend/modules/chain-parameters/README.md
+++ b/src/backend/modules/chain-parameters/README.md
@@ -1,0 +1,7 @@
+# Chain Parameters
+
+`ChainParametersService` polls TronGrid every 10 minutes, persists TRON network parameters to MongoDB, and exposes energy/TRX conversion methods (`getEnergyFromTRX`, `getTRXFromEnergy`, `getAPY`) behind a 1-minute in-memory cache.
+
+## Canonical documentation
+
+- [tron-chain-parameters.md](../../../../docs/tron/tron-chain-parameters.md) — cached fields, conversion math, MongoDB fallback, `IChainParametersService` contract

--- a/src/backend/modules/clickhouse/README.md
+++ b/src/backend/modules/clickhouse/README.md
@@ -1,0 +1,7 @@
+# ClickHouse
+
+`ClickHouseModule` implements `IModule`, managing the ClickHouse connection lifecycle and providing `IClickHouseService` (query/insert/exec) to other modules and plugins via `getClickHouseService()`.
+
+## Canonical documentation
+
+No dedicated detail doc exists yet; [system.md](../../../../docs/system/system.md) and [system-database.md](../../../../docs/system/system-database.md) cover MongoDB access patterns that ClickHouse complements for time-series and aggregation workloads. This module is optional: it skips initialization entirely when `CLICKHOUSE_HOST` is unset, and `getClickHouseService()` returns `undefined` in that case — callers must check before use. `ClickHouseBrowserController` (`api/clickhouse-browser.controller.ts`) exposes an admin browser over ClickHouse tables, gated by `requireAdmin`.

--- a/src/backend/modules/dashboard/README.md
+++ b/src/backend/modules/dashboard/README.md
@@ -1,0 +1,8 @@
+# Dashboard
+
+`DashboardService` reads the `transactions` and `transaction_memos` collections to build the aggregate stats backing the `/system/system` overview page's data feeds.
+
+## Canonical documentation
+
+- [system-dashboard.md](../../../../docs/system/system-dashboard.md) — dashboard sections, module-owned admin pages, common diagnostic flows
+- [system-api.md](../../../../docs/system/system-api.md) — admin API gateway the dashboard's sections fetch from

--- a/src/backend/modules/database/README.md
+++ b/src/backend/modules/database/README.md
@@ -1,0 +1,8 @@
+# Database
+
+`DatabaseModule` implements `IModule`, providing the `IDatabaseService` abstraction every other module and plugin uses for MongoDB access, plus the migration system (`MigrationsService`) for schema evolution.
+
+## Canonical documentation
+
+- [system-database.md](../../../../docs/system/system-database.md) — `IDatabaseService`, three-tier access, namespace isolation
+- [system-database-migrations.md](../../../../docs/system/system-database-migrations.md) — migration discovery, transactions, REST API, admin UI

--- a/src/backend/modules/energy/README.md
+++ b/src/backend/modules/energy/README.md
@@ -1,0 +1,7 @@
+# Energy
+
+`EnergyService` fetches an account's TRON energy delegations from TronGrid (`getDelegatedResourceAccountIndex` / `getDelegatedResource`) and normalizes them into `DelegationRecord[]` for the `/api` energy-delegation endpoint.
+
+## Canonical documentation
+
+No dedicated detail doc exists yet; [tron.md](../../../../docs/tron/tron.md) covers the energy system this module reports on (staking vs. renting, `DelegateResourceContract`), and [tron-chain-parameters.md](../../../../docs/tron/tron-chain-parameters.md) covers the conversion math for pricing that energy. This module does not itself convert energy to TRX — it only surfaces raw delegation records from `TronGridClient`.

--- a/src/backend/modules/live/README.md
+++ b/src/backend/modules/live/README.md
@@ -1,0 +1,7 @@
+# Live
+
+`LiveService` reads cached account-search telemetry (`live:accounts:searches`, `telemetry:account-searches`) to serve the live activity feed consumed alongside real-time WebSocket events.
+
+## Canonical documentation
+
+- [system-api-websockets.md](../../../../docs/system/system-api-websockets.md) — WebSocket admin metrics and the real-time event catalog this module's data complements

--- a/src/backend/modules/menu/README.md
+++ b/src/backend/modules/menu/README.md
@@ -1,65 +1,69 @@
 # Menu Module
 
-The menu module manages hierarchical navigation menus with event-driven validation, real-time WebSocket updates, and support for multiple independent menu trees (namespaces). It implements the IModule interface with two-phase lifecycle initialization.
+Owns hierarchical navigation: multiple independent menu trees (namespaces), event-driven validation, per-user visibility gating, and real-time refetch signals. The in-memory tree makes every read instant; MongoDB persists only what must survive a restart.
 
-## Why This Matters
+## Agent Quick Surface
 
-Navigation is critical infrastructure that every feature depends on:
+| Surface | Value |
+|---------|-------|
+| Module id | `menu` |
+| Module class | `src/backend/modules/menu/MenuModule.ts` |
+| Service registry name | `'menu'` → `IMenuService` (also direct DI: `menuService` on module deps, `context.menuService` on plugins) |
+| Admin page | `/system/menu` (menu item `Menu`, order 50, under the System container) |
+| Mounted routes | `/api/menu/*` (public reads + `requireAdmin` mutations) |
+| Types package | `@delphian/tronrelic-types` → `IMenuService`, `IMenuNode`, `IMenuTree`, `IMenuNodeAdminView`, `IMenuEvent`, `IMenuNamespaceConfig`, `IMenuViewer` |
+| Collections | `menu_nodes`, `menu_node_overrides`, `menu_namespace_config` (legacy-unprefixed; predate the `module_*` convention) |
+| WebSocket events | `menu:update` (refetch signal), `menu:namespace-config:update` |
+| System container | `MAIN_SYSTEM_CONTAINER_ID = '000000000000000000000001'` (exported from `constants.ts` / module index) |
+| Bootstrap order | `MenuModule.init()` runs before all other feature modules so they can register menu items during their `run()` |
 
-- **Plugin integration** - Plugins register menu items automatically without touching core navigation code
-- **Real-time synchronization** - WebSocket updates ensure all connected clients see menu changes immediately
-- **Multi-context navigation** - Separate menu trees (namespaces) allow different navigation contexts without coupling
-- **Event-driven validation** - Subscribers enforce naming conventions, prevent deletions, or cascade updates through before:* and after:* events
-- **In-memory performance** - Complete menu tree cached for instant `getTree()` calls without database queries
+## Source Map
 
-Without the menu system:
-- ❌ Plugins hardcode routes in frontend navigation components
-- ❌ Menu changes require backend restarts
-- ❌ Multiple navigation contexts require separate implementations
-- ❌ Every navigation render hits the database
+| Path | Responsibility |
+|------|----------------|
+| `MenuModule.ts` | Two-phase lifecycle; seeds System container, registers `'menu'`, mounts `/api/menu` |
+| `services/menu.service.ts` | `MenuService` singleton (`setDependencies`/`getInstance`); tree cache, events, gating, overrides, WS broadcasts |
+| `api/menu.controller.ts` | Zod-validated request handlers; resolves `IMenuViewer` from `req.authSession` for gated reads |
+| `constants.ts` | `MAIN_SYSTEM_CONTAINER_ID`; `ADMIN_NAMESPACES` (empty typed extension point for namespace-level suppression) |
+| `database/IMenuNodeDocument.ts` | `menu_nodes` document (persisted nodes only) |
+| `database/IMenuNodeOverrideDocument.ts` | `menu_node_overrides` document, keyed `(namespace, url)` |
+| `database/IMenuNamespaceConfigDocument.ts` | `menu_namespace_config` document, keyed `namespace` |
+| `migrations/` | `002`–`005`: dropped obsolete collections, gating fields, `system`→`main` namespace merge |
 
-## Core Architecture
+## Service Contract: `'menu'` → `IMenuService`
 
-### Service Design
+| Method | Purpose |
+|--------|---------|
+| `initialize()` | Load `menu_nodes`, build in-memory tree, seed default Home node if empty, emit `init` → `ready` → `loaded`. Idempotent |
+| `subscribe(eventType, callback)` | Register an event subscriber (see [Events](#events)) |
+| `create(nodeData, persist=false)` | Create a node; auto-derives URL for container nodes; forces `requiresAdmin` under the System container |
+| `update(id, updates)` | Update a node (concrete `MenuService` takes trailing `persist=false`; memory-only nodes get overrides saved instead) |
+| `delete(id)` | Delete a node (concrete trailing `persist=false`). **Does not cascade** — children orphan unless a `before:delete` subscriber handles them |
+| `getTree(namespace='main')` | Full unfiltered tree (`{ roots, all, generatedAt }`) from memory |
+| `getTreeAdminView(namespace)` | Unfiltered tree projected to `IMenuNodeAdminView` with `origin` tag; caller must be admin |
+| `getTreeForUser(namespace, viewer)` | Tree filtered by `requiresGroups`/`requiresAdmin` against the viewer; `undefined` viewer = anonymous |
+| `getChildrenForUser(parentId, namespace, viewer)` | Viewer-filtered children, sorted by order |
+| `getChildren(parentId, namespace)` | Unfiltered children, sorted by order |
+| `getNode(id)` | One node from memory, or undefined |
+| `getNamespaces()` | All namespace ids in use |
+| `getNamespaceConfig(namespace)` | Rendering config (`overflow`, `icons`, `layout`, `styling`), defaults if unset |
+| `setNamespaceConfig(namespace, config)` | Merge-update config; broadcasts `menu:namespace-config:update` |
+| `deleteNamespaceConfig(namespace)` | Reset config to defaults; broadcasts |
 
-The menu service uses a singleton pattern with dependency injection for database access:
+The interface exposes `persist` only on `create`; the concrete `MenuService` (what DI and the registry both hand out) accepts it on `update`/`delete` too, and the admin controller passes `true` for all three.
 
-- **In-memory tree caching** - All nodes loaded on initialization for fast tree building
-- **Event-driven validation** - Before:* events allow subscribers to halt operations, after:* events enable logging and WebSocket broadcasting
-- **Dual persistence modes** - Admin API creates persisted database entries, plugins create memory-only runtime entries
-- **Namespace isolation** - Multiple independent menu trees share the same service
+## Events
 
-**Lifecycle events:**
-1. `init` - Service initialization begins
-2. `ready` - Service accepts API calls and plugin registrations
-3. `loaded` - Menu tree fully built and ready
+Subscribers run in registration order. `before:*` handlers can halt the operation (`event.validation.continue = false`, optional `event.validation.error`); `after:*` cannot. Only create/update/delete emit — the `reorder`/`move` members of `MenuEventType` are declared but never fired. Lifecycle events (`init`, `ready`, `loaded`) fire during `initialize()` and are **not** broadcast over WebSocket (no clients are connected during startup).
 
-### Menu Namespaces
-
-Namespaces allow multiple independent menu trees to coexist. Each maintains its own hierarchy with separate root nodes.
-
-**Common namespaces:** `main` (primary navigation, including the admin subtree), `footer`, `mobile`. Admin items live under the System container in `main` rather than in a dedicated namespace — see [The System Container](#the-system-container) below.
+| Event | Can halt | Fired |
+|-------|----------|-------|
+| `before:create` / `after:create` | Yes / No | Around node creation |
+| `before:update` / `after:update` | Yes / No | Around node update (previous state on `event.previousNode`) |
+| `before:delete` / `after:delete` | Yes / No | Around node deletion |
+| `init`, `ready`, `loaded` | No | Service startup; plugins register nodes on `ready` |
 
 ```typescript
-const namespaces = menuService.getNamespaces();
-const mainTree = menuService.getTree('main');
-```
-
-### Event-Driven Validation
-
-Menu operations emit before:* and after:* events for validation, logging, or cascading updates.
-
-| Event Type | When Emitted | Can Halt | Use Case |
-|------------|-------------|----------|----------|
-| `before:create` | Before saving new node | Yes | Validate naming, prevent duplicates |
-| `after:create` | After node created | No | Log creation, trigger side effects |
-| `before:update` | Before applying changes | Yes | Prevent breaking changes |
-| `after:update` | After changes saved | No | Update related systems |
-| `before:delete` | Before removing node | Yes | Prevent deletion, cascade delete children |
-| `after:delete` | After node removed | No | Clean up orphaned data |
-
-```typescript
-// Enforce naming convention
 menuService.subscribe('before:create', async (event) => {
     if (!event.node.label.match(/^[A-Z]/)) {
         event.validation.continue = false;
@@ -68,311 +72,124 @@ menuService.subscribe('before:create', async (event) => {
 });
 ```
 
-### Dual Persistence Modes
+## REST Endpoints
 
-**Persisted entries (persist=true):**
-- Created by admin API for manual menu customization
-- Saved to MongoDB `menu_nodes` collection
-- Survive backend restarts
+Reads are public — the frontend chrome fetches without a token; per-user gating is applied from the Better Auth session (`attachAuthSession` → `req.authSession`). `/manage` and all mutations chain a per-IP rate limiter then `requireAdmin` (Better Auth admin session or `ADMIN_API_TOKEN`). See [system-api.md](../../../../docs/system/system-api.md).
 
-**Memory-only entries (persist=false, default):**
-- Created by plugins for runtime pages
-- Stored only in-memory tree
-- Re-created by plugins on each startup
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/api/menu` | Public | Viewer-filtered tree. Query: `namespace` (default `main`). Returns `{ success, tree: { roots, all } }` |
+| GET | `/api/menu/resolve` | Public | Resolve `url` to a container node + enabled children (category landing pages). Query: `url` (required), `namespace`. Admins bypass gating; 404 when node or children absent |
+| GET | `/api/menu/namespaces` | Public | All namespace ids |
+| GET | `/api/menu/namespace/:namespace/config` | Public | `IMenuNamespaceConfig` (defaults if unset) |
+| GET | `/api/menu/manage` | `requireAdmin` | Origin-tagged full tree incl. disabled/gated rows (admin UI only) |
+| POST | `/api/menu` | `requireAdmin` | Create persisted node. Body: `label` (required), `description`, `url`, `icon`, `order`, `parent` (24-hex ObjectId), `enabled`, `requiresGroups`, `requiresAdmin` |
+| PATCH | `/api/menu/:id` | `requireAdmin` | Update node (any fields) |
+| DELETE | `/api/menu/:id` | `requireAdmin` | Delete node — no cascade |
+| PUT | `/api/menu/namespace/:namespace/config` | `requireAdmin` | Replace config. Body: `overflow`, `icons`, `layout`, `styling` |
+| DELETE | `/api/menu/namespace/:namespace/config` | `requireAdmin` | Reset config to defaults |
 
-### Order Override Persistence
+## WebSocket Events
 
-When an admin reorders a memory-only menu item (e.g., changes a plugin's menu position via the admin UI), the service saves the customization to a `menu_node_overrides` collection keyed by `(namespace, url)`. On the next startup, when the plugin re-registers the same menu item, the service looks up any saved overrides and applies them instead of the plugin's defaults. This ensures user-customized ordering survives deployments without requiring plugins to change their registration code.
+| Event | Payload | Semantics |
+|-------|---------|-----------|
+| `menu:update` | `{ event: 'after:create'\|'after:update'\|'after:delete', namespace, nodeId, timestamp }` | Refetch signal only — no tree body. Per-user gating means no single tree shape fits every client; receivers re-request `GET /api/menu?namespace=...` with their own cookie and get their filtered view. Admin-item mutations are therefore safe to broadcast globally |
+| `menu:namespace-config:update` | `{ namespace, config, timestamp }` | Config changed or reset; carries the full config (not gated) |
 
-Override persistence applies to `order`, `label`, `description`, `icon`, and `enabled` fields. Only nodes with a URL are eligible for overrides since the URL serves as the stable identity across restarts.
+## Storage
 
-### Origin Tag (Admin Reads Only)
+| Collection | Keyed by | Contents |
+|------------|----------|----------|
+| `menu_nodes` | `_id` | Persisted (`persist=true`) nodes only — admin-created entries. Memory-only nodes never appear here |
+| `menu_node_overrides` | `(namespace, url)` | Admin customizations of memory-only nodes: `order`, `label`, `description`, `icon`, `enabled`. Applied over plugin defaults on every re-registration, so customizations survive restarts without plugin code changes. URL is the stable identity — URL-less nodes are ineligible; a URL change on a memory-only node does not survive restart |
+| `menu_namespace_config` | `namespace` | Per-namespace rendering config (`overflow`, `icons`, `layout`, `styling`) |
 
-`IMenuNode` carries no flag distinguishing manual rows from plugin-registered ones, but the service tracks the distinction internally: `persistedNodeIds` holds ids loaded from or written to `menu_nodes`, and a cached set of `(namespace, url)` keys mirrors `menu_node_overrides`. Surfacing that as a stored column would be a drift hazard. Instead `getTreeAdminView()` projects the in-memory tree to `IMenuNodeAdminView` and tags each node with `origin`:
+## Node Semantics
 
-| Value | Meaning |
-|-------|---------|
-| `manual` | Persisted in `menu_nodes`. Create/update/delete survive restart. |
-| `plugin` | Memory-only, no override row. Delete removes only the in-memory copy — the plugin re-registers on next boot. |
-| `plugin-overridden` | Memory-only with an admin customization in `menu_node_overrides`. Plugin still owns lifecycle; `order`/`label`/`icon`/`description`/`enabled` survive restarts. |
+**Dual persistence.** `persist=false` (default) creates a memory-only node — plugins and modules use this for runtime pages, re-registering on every boot. `persist=true` writes to `menu_nodes` — the admin API's mode for manual entries.
 
-The origin-tagged projection is served exclusively from `GET /api/menu/manage`, a `requireAdmin`-gated endpoint. `GET /api/menu` is the universal navigation read and never changes shape based on caller privilege — every visitor, admin or not, gets the same per-user filtered, enabled-only tree. Splitting reads this way keeps the navigation chrome consistent for admin operators and confines disabled / gated rows to the editing surface where they belong. Origin is computed at read time, so it never goes stale. The admin UI at `/system/menu` renders the tag as a badge and gates the delete confirm dialog with a "will reappear on next plugin load" warning for `plugin` and `plugin-overridden` rows.
+**Origin tag (admin reads only).** `IMenuNode` carries no manual-vs-plugin flag; storing one would drift. `getTreeAdminView()` computes `origin` at read time from `persistedNodeIds` and the cached override keys, served exclusively from `GET /api/menu/manage`. `GET /api/menu` never changes shape by privilege.
 
-### Auto-Derived URLs for Container Nodes
+| Origin | Meaning |
+|--------|---------|
+| `manual` | Persisted in `menu_nodes`; CRUD survives restart |
+| `plugin` | Memory-only, no override row; delete removes only the in-memory copy — reappears on next boot |
+| `plugin-overridden` | Memory-only with a `menu_node_overrides` row; plugin owns lifecycle, overrides survive restarts |
 
-Container nodes that omit a URL receive one automatically by slugifying their label. For root-level containers, the URL is `/{slug}` (e.g., label "Tools" becomes `/tools`). For nested containers, the URL is `{parent-url}/{slug}`. This auto-derived URL serves as the stable override key and as the route for the auto-generated category landing page. Admins can change the URL at runtime through the admin API, but for memory-only/plugin-registered nodes that change does not persist across restarts via `menu_node_overrides`. Only `order`, `label`, `description`, `icon`, and `enabled` are persisted for memory-only nodes. Persisted database-backed nodes save URL changes normally.
+**Auto-derived URLs.** Container nodes that omit `url` get one by slugifying the label: `/{slug}` at root, `{parent-url}/{slug}` nested. The derived URL is the override key and the category-landing-page route. Slugification producing an empty string throws.
 
-### Category Landing Pages
-
-Every container node with children automatically gets a landing page at its URL. The page renders a card grid showing each child's icon, title, and description. This is handled by the frontend catch-all route (`[...slug]/page.tsx`) which calls `GET /api/menu/resolve?url=...` to fetch the container and its children. Plugin or custom pages registered at the same URL take precedence over the auto-generated page.
-
-### Description Field
-
-Menu nodes support an optional `description` field for short text describing the item's purpose. Descriptions appear on auto-generated category landing pages as card subtitle text. Like `label` and `icon`, descriptions are overridable by admins and persist in the `menu_node_overrides` collection.
-
-## Service Discovery
-
-MenuService is reachable two ways. Modules and plugins receive it directly via constructor / context injection (`menuService` on shared module deps, `context.menuService` on plugins). It is also published on the service registry as `'menu'` during `MenuModule.run()`, so late-binding consumers can discover it without depending on bootstrap wiring.
-
-Use the registry path when consumption is optional or happens outside the init/run boot order — for example, a plugin route handler that wants to read the menu without taking a hard dependency on the module being initialized first. Use direct injection when the consumer always needs the service at boot.
-
-```typescript
-import type { IMenuService } from '@/types';
-
-const menu = context.services.get<IMenuService>('menu');
-if (menu) {
-    const tree = menu.getTree('main');
-}
-```
-
-## Menu Node Lifecycle
-
-**Initialization:** Service loads persisted nodes from MongoDB, builds in-memory tree, creates default Home node if empty, then emits `init` → `ready` → `loaded` events.
-
-**Create:** Emits `before:create` (can halt), saves to MongoDB if `persist=true`, adds to in-memory tree, emits `after:create`, broadcasts WebSocket event.
-
-**Update:** Emits `before:update` (can halt), applies changes to MongoDB if `persist=true`, updates in-memory tree, emits `after:update`, broadcasts WebSocket event.
-
-**Delete:** Emits `before:delete` (can halt), removes from MongoDB if `persist=true`, removes from in-memory tree, emits `after:delete`, broadcasts WebSocket event. **Delete does NOT cascade by default** - subscribers must implement cascade logic.
+**Category landing pages.** Every container with children gets an auto page at its URL: the frontend catch-all route (`app/[...slug]/page.tsx`) calls `GET /api/menu/resolve?url=...` and renders a card grid of children (icon, label, `description`). A real page registered at the same URL takes precedence.
 
 ## Visibility Gating
 
-Menu nodes can be gated on two independent fields, ANDed together. The
-backend filters menu reads at request time using the Better Auth session
-resolved onto `req.authSession`. `GET /api/menu` applies this per-visitor
-filter to every caller; the origin-tagged admin view at `GET /api/menu/manage`
-(behind `requireAdmin`) returns the full tree including disabled and gated
-rows so the admin UI can render and edit them.
+Two independent node fields, ANDed. The filter lives in `getTreeForUser`/`getChildrenForUser`; the controller builds `IMenuViewer` (`{ groups, isAdmin }`) from `req.authSession` per request. Anonymous visitors pass `undefined` and see only ungated nodes.
 
 | Field | Shape | Semantics |
 |-------|-------|-----------|
-| `requiresGroups` | `string[]?` | Visible if the user is a member of *any* listed group id (OR-of-membership). Group ids reference `module_user_groups` rows managed by the identity module. |
-| `requiresAdmin` | `boolean?` | Visible only when the viewer's admin flag is true — `isAdmin(req)` derived from the Better Auth session and resolved once per request by `resolveViewer`. |
+| `requiresGroups` | `string[]?` | Visible if the viewer is in *any* listed group id (OR-of-membership; ids reference `module_user_groups`) |
+| `requiresAdmin` | `boolean?` | Visible only when the viewer's admin flag is true |
 
-The filter lives in `MenuService.getTreeForUser(namespace, user?)` and
-`getChildrenForUser(parentId, namespace, user?)`. Both are called by the
-public read endpoints (`GET /api/menu`, `GET /api/menu/resolve`) after the
-`attachAuthSession` middleware has populated `req.authSession`. Anonymous
-visitors pass `undefined` and only see nodes with no group/admin gates.
-
-The admin predicate looks up `'user-groups'` from the service registry
-lazily — the identity module registers the service in its `run()` phase, so by
-the time anyone calls `GET /api/menu` it's available. If the registry entry
-is missing (tests, or a deployment where the identity module hasn't initialized
-yet), `requiresAdmin: true` nodes are hidden from everyone except the
-shared-admin-token holder.
-
-`requiresAdmin` is **not** the same as the `requireAdmin` middleware. The
-middleware is a shared-token gate (`x-admin-token` against
-`ADMIN_API_TOKEN`) for operators and CI tooling. `requiresAdmin` is a
-per-user check keyed off cookie identity. They coexist: mutating menu
-endpoints stay behind `requireAdmin` (token-gated), while menu *reads*
-filter per-user via `requiresAdmin` so admin items remain invisible to
-ordinary visitors.
+`requiresAdmin` (per-user, cookie-identity read filter) is **not** the `requireAdmin` middleware (shared-token/admin-session gate on mutating endpoints). They coexist: mutations stay token-gated while reads filter per-user, so admin items are invisible to ordinary visitors.
 
 ### The System Container
 
-All admin menu items live as a subtree of `main` rooted at a
-hard-coded container whose id is the fixed sentinel
-`MAIN_SYSTEM_CONTAINER_ID` (a 24-hex ObjectId string exported from the
-menu module — `src/backend/modules/menu/index.ts`). The container is
-seeded by `MenuModule.run()` and every module or plugin that wants to
-register an admin item imports the constant and parents directly under
-it:
+All admin menu items live in `main` as a subtree rooted at the fixed sentinel `MAIN_SYSTEM_CONTAINER_ID`, seeded by `MenuModule.run()`. Register admin items by importing the constant and parenting under it:
 
 ```typescript
 import { MAIN_SYSTEM_CONTAINER_ID } from '../menu/index.js';
 
 await menuService.create({
-    namespace: 'main',
-    label: 'Logs',
-    url: '/system/logs',
-    icon: 'ScrollText',
-    order: 30,
-    parent: MAIN_SYSTEM_CONTAINER_ID,
-    enabled: true
+    namespace: 'main', label: 'Logs', url: '/system/logs',
+    icon: 'ScrollText', order: 30, parent: MAIN_SYSTEM_CONTAINER_ID, enabled: true
 });
 ```
 
-The id is hex (not a colon-string like `'main:system'`) because the
-controller validates `parent` and `:id` path params with
-`OBJECT_ID_REGEX` and the persistence layer wraps `parent` in
-`new ObjectId(...)` for `menu_nodes` writes. A non-hex id would force
-every admin CRUD endpoint, the persistence path, and
-`IMenuNodeDocument.parent`'s type to special-case the container —
-exactly the kind of cross-layer invariant that drifts and breaks
-silently. Constants stay symbolic in code; the wire/storage shape is
-plain ObjectId.
+The id is a 24-hex ObjectId string (not a colon-string like `'main:system'`) because the controller validates `parent`/`:id` with `OBJECT_ID_REGEX` and persistence wraps `parent` in `new ObjectId(...)` — a non-hex sentinel would force special-casing across every layer, an invariant that drifts silently.
 
-Callers do not set `requiresAdmin` themselves. `MenuService.create` and
-`MenuService.update` walk the parent chain on every write; if the
-container id appears anywhere above the node (or the node itself has
-that id), `requiresAdmin: true` is forced regardless of caller input.
-This makes the admin gate non-bypassable: a misconfigured registration,
-a forgotten flag, or an explicit `requiresAdmin: false` all still end
-up gated as long as the node lives in the System subtree. Reparenting
-INTO the subtree via `update()` applies the same rule; reparenting OUT
-preserves the flag (clearing the gate is an explicit operator decision,
-not something the engine infers from the move).
-
-There is no separate `system` namespace anymore — read protection is
-per-node via `requiresAdmin`, applied by `getTreeForUser` against the
-cookie-resolved user. The `ADMIN_NAMESPACES` constant remains in place
-as a typed extension point for any future namespace that needs
-namespace-level suppression, but is currently empty.
-
-### Real-time updates
-
-`menu:update` WebSocket events no longer ship the full tree — per-user
-gating means there is no single shape that fits every connected client.
-The event is now a refetch signal carrying `{ event, namespace, nodeId,
-timestamp }`; clients re-request `GET /api/menu` with their own cookie and
-the server returns the filtered view.
-
-## REST API Reference
-
-Navigation reads are public — the frontend chrome fetches them without an admin token, with per-user gating applied from the Better Auth session. The admin management read (`GET /api/menu/manage`) and every mutating endpoint go through `requireAdmin`, which accepts either a Better Auth admin session or `ADMIN_API_TOKEN` via `x-admin-token` / `Authorization: Bearer`. See [system-api.md](../../../../docs/system/system-api.md) for complete authentication patterns.
-
-**Public (no auth):**
-
-| Endpoint | Method | Purpose | Key Fields |
-|----------|--------|---------|------------|
-| `/api/menu` | GET | Get menu tree for namespace | Query: `namespace` (optional, defaults to 'main') |
-| `/api/menu/resolve` | GET | Resolve URL to category node with children | Query: `url` (required), `namespace` (optional) |
-| `/api/menu/namespaces` | GET | Get all namespaces | Returns array of namespace strings |
-| `/api/menu/namespace/:namespace/config` | GET | Get namespace configuration | Returns `IMenuNamespaceConfig` (defaults if unset) |
-
-**Admin (requires `requireAdmin`):**
-
-| Endpoint | Method | Purpose | Key Fields |
-|----------|--------|---------|------------|
-| `/api/menu/manage` | GET | Origin-tagged tree for the menu admin UI — includes disabled and gated rows | Query: `namespace` (optional, defaults to 'main') |
-| `/api/menu` | POST | Create persisted menu node | Body: `label` (required), `description`, `url`, `icon`, `order`, `parent`, `enabled`, `requiresGroups`, `requiresAdmin` |
-| `/api/menu/:id` | PATCH | Update menu node | Body: any fields to update |
-| `/api/menu/:id` | DELETE | Delete menu node | Does **not** cascade — children become orphans unless a `before:delete` subscriber handles them |
-| `/api/menu/namespace/:namespace/config` | PUT | Replace namespace configuration | Body: `overflow`, `icons`, `layout`, `styling` |
-| `/api/menu/namespace/:namespace/config` | DELETE | Reset namespace configuration to defaults | — |
-
-**Example response structure:**
-```json
-{
-    "success": true,
-    "tree": {
-        "roots": [{ /* IMenuNode with children */ }],
-        "all": [/* flat list */]
-    }
-}
-```
-
-## WebSocket Real-Time Updates
-
-The menu service broadcasts `menu:update` refetch signals whenever nodes are
-created, updated, or deleted. Per-user gating means the server cannot ship a
-single tree shape that fits every connected client — receivers re-request
-`GET /api/menu?namespace=...` with their own cookie and the gating filter
-returns their personalized view.
-
-**Event payload:**
-```typescript
-{
-    type: 'menu:update',
-    payload: {
-        event: 'after:create' | 'after:update' | 'after:delete',
-        namespace: string,
-        nodeId: string,
-        timestamp: string
-    }
-}
-```
-
-**Frontend subscription:**
-```typescript
-socket.on('menu:update', (payload) => {
-    // Refetch via the user's cookie context; the signal carries no tree body
-    fetch(`/api/menu?namespace=${payload.namespace}`, { credentials: 'include' })
-        .then(r => r.json())
-        .then(({ tree }) => setMenuTree(tree));
-});
-```
-
-**Admin items rely on per-user gating, not namespace suppression.** The `menu:update` signal is a refetch trigger, not a tree body, so a non-admin client refetching after an admin-item mutation receives a tree filtered by their own gating — admin entries never appear. The legacy `ADMIN_NAMESPACES` set remains in the source as a typed extension point but is currently empty.
-
-**Note:** Lifecycle events (init, ready, loaded) are NOT broadcast via WebSocket because clients are not connected during backend startup.
+Callers never set `requiresAdmin` themselves under System: `create`/`update` walk the parent chain and force `requiresAdmin: true` whenever the container appears above the node, making the gate non-bypassable even against an explicit `requiresAdmin: false`. Reparenting *into* the subtree applies the rule; reparenting *out* preserves the flag (clearing a gate is an explicit operator decision). There is no `system` namespace — `ADMIN_NAMESPACES` remains an empty typed extension point.
 
 ## Plugin Integration
 
-### Registering Plugin Pages
-
-Plugins register menu items during initialization by subscribing to the `ready` event.
+Plugins register memory-only nodes in a `menuService.subscribe('ready', ...)` callback during `init()` (core modules register directly in `run()` — the service is already up). Track created node ids and delete them in `disable()`.
 
 ```typescript
-export const myPluginBackendPlugin = definePlugin({
-    manifest: myManifest,
-
-    init: async (context: IPluginContext) => {
-        const { menuService } = context;
-
-        menuService.subscribe('ready', async () => {
-            await menuService.create({
-                namespace: 'main',
-                label: 'My Plugin',
-                url: `/plugins/${myManifest.id}`,
-                icon: 'Puzzle',
-                order: 100,
-                parent: null,
-                enabled: true
-            });
-            // persist defaults to false (memory-only)
-        });
-    }
+menuService.subscribe('ready', async () => {
+    await menuService.create({
+        namespace: 'main', label: 'My Plugin', url: `/plugins/${manifest.id}`,
+        icon: 'Puzzle', order: 100, parent: null, enabled: true
+    }); // persist defaults to false (memory-only)
 });
 ```
-
-**Cleanup pattern:** Track menu node IDs during registration, then delete them in the `disable()` hook to remove navigation entries when plugin is disabled.
 
 ## Submenu Pattern (Namespaced Tab Rows)
 
-An admin page's submenu — the in-page tab row on a surface like `/system/account-history` (tracked accounts / settings / schedules) — is just a menu, and backing it with the menu service is **the only authorized pattern for core and module admin pages.** Hand-rolled `<button>` arrays with local `activeTab` state, bare `.segmented-control` strips, and per-page `styles.tab` rows are **not permitted** for these surfaces: they duplicate the same code across pages and forfeit the per-user gating, ordering, live `menu:update` refresh, and runtime extensibility the menu service provides — a *different* plugin can even contribute a tab into the row by registering a node, which a hand-rolled array cannot.
+An admin page's submenu — the in-page tab row on a surface like `/system/account-history` — is just a menu, and backing it with the menu service is **the only authorized pattern for core and module admin pages.** Hand-rolled `<button>` arrays, `.segmented-control` strips, and per-page `styles.tab` rows are **not permitted**: they duplicate code and forfeit per-user gating, ordering, live `menu:update` refresh, and runtime extensibility — a *different* plugin can contribute a tab by registering a node, which a hand-rolled array cannot.
 
-**Reference implementation:** `/system/account-history`. `AccountHistoryModule.run()` registers the `account-history` namespace nodes; `AccountHistoryAdminClient.tsx` renders them with `MenuNavClient`. Copy that surface when building a new admin page's tab row.
+**Reference implementation:** `/system/account-history`. `AccountHistoryModule.run()` registers the `account-history` namespace nodes; `AccountHistoryAdminClient.tsx` renders them with `MenuNavClient`. Copy that surface.
 
-### How It Works
+Register each tab as a memory-only leaf in a dedicated namespace (not `main`) — keeping it out of `main` keeps tabs out of the global nav chrome. The namespace sits outside the System container, so the non-bypassable `requiresAdmin` force does **not** apply: the caller owns security and sets `requiresAdmin` per node explicitly (see [The System Container](#the-system-container)).
 
-Register each tab as a leaf node in a dedicated namespace (not `main`), memory-only (`persist=false`). Keeping it out of `main` keeps the tabs out of the global nav chrome — only the page's own submenu component reads that namespace. The namespace also sits outside the System container, so the non-bypassable `requiresAdmin` force does **not** apply: the caller owns security and sets `requiresAdmin` per node explicitly (see [The System Container](#the-system-container)).
-
-The frontend renders the row with `MenuNavClient` (`src/frontend/components/layout/MenuNav/`). Two additive, opt-in props govern behavior; both default to undefined, so existing navigation consumers are unchanged:
+The frontend renders the row with `MenuNavClient` (`src/frontend/components/layout/MenuNav/`). Two additive opt-in props; both default undefined, so existing navigation consumers are unchanged:
 
 | Prop | Effect when set |
 |------|-----------------|
-| `onItemSelect(item, event)` | Leaf clicks call this and suppress navigation, letting the page drive `activeTab` (e.g. sync a `?tab=` query param) instead of routing. |
-| `activeUrl` | Highlights the leaf whose `url` matches, bypassing pathname matching — required because the route is identical across tabs. |
+| `onItemSelect(item, event)` | Leaf clicks call this and suppress navigation — the page drives `activeTab` (e.g. a `?tab=` query param) instead of routing |
+| `activeUrl` | Highlights the leaf whose `url` matches, bypassing pathname matching — required because the route is identical across tabs |
 
-The click decision is the caller's: omit `onItemSelect` and a tab navigates like any link; provide it and the tab drives in-page state. Because `onItemSelect` is a function it cannot cross the server boundary — the consumer is the page's own client component (which already holds `activeTab` state and the SSR-fetched namespace tree), rendering `MenuNavClient` directly rather than the server `MenuNavSSR` wrapper.
-
-**Core admin pages** (modules) render `MenuNavClient` directly. **Plugins** cannot import core components across the workspace boundary, so they consume `context.layout.SubMenu` from `IFrontendPluginContext` — a thin wrapper over `MenuNavClient` with a friendlier `onSelect(item)` callback. A plugin registers its tabs in its own namespace via `context.menuService.create(...)`, fetches that namespace tree SSR-first through its `serverDataFetcher`, and renders the row with `context.layout.SubMenu`. See [plugins-frontend-context-ui.md](../../../../docs/plugins/plugins-frontend-context-ui.md#submenu--in-page-tab-navigation).
-
-### Example
+Because `onItemSelect` is a function it cannot cross the server boundary — the consumer is the page's own client component (holding `activeTab` state and the SSR-fetched namespace tree), rendering `MenuNavClient` directly rather than `MenuNavSSR`. **Core admin pages** render `MenuNavClient` directly. **Plugins** cannot import core components, so they consume `context.layout.SubMenu` (a thin wrapper with a friendlier `onSelect(item)` callback), register tabs via `context.menuService.create(...)`, and fetch the namespace tree SSR-first through `serverDataFetcher`. See [plugins-frontend-context-ui.md](../../../../docs/plugins/plugins-frontend-context-ui.md#submenu--in-page-tab-navigation).
 
 ```typescript
-// Backend: register the tabs in the page's own namespace. A core module
-// registers in `run()` (the menu service is already up); a plugin registers in
-// a `menuService.subscribe('ready', ...)` callback. Memory-only, requiresAdmin
-// per node since the namespace sits outside the System container.
+// Backend: core module in run(); plugin inside subscribe('ready', ...).
 await menuService.create({
-    namespace: 'account-history',
-    label: 'Tracked Accounts',
-    url: '/system/account-history?tab=accounts',
-    icon: 'List',
-    order: 0,
-    parent: null,
-    enabled: true,
+    namespace: 'account-history', label: 'Tracked Accounts',
+    url: '/system/account-history?tab=accounts', icon: 'List',
+    order: 0, parent: null, enabled: true,
     requiresAdmin: true // caller owns gating outside the System subtree
 });
-// ...Ingestion Settings, Schedules
 ```
 
 ```tsx
-// Frontend (core page client component): render the row as in-page tabs.
+// Frontend (core page client component)
 <MenuNavClient
     namespace="account-history"
     items={submenuTree}
@@ -382,85 +199,12 @@ await menuService.create({
 />
 ```
 
-## Pre-Implementation Checklist
+## Lifecycle
 
-Before implementing menu integration or navigation UI:
+**`init()`** (deps: `database`, `serviceRegistry`, `app`) wires the `MenuService` singleton (`setDependencies` → `getInstance`), awaits `initialize()` (loads `menu_nodes`, builds the tree, emits `init`/`ready`/`loaded`), and constructs the controller. **`run()`** publishes `'menu'` on the service registry, seeds the System container (memory-only, order 9999) and the `/system/menu` admin item, then mounts `/api/menu`. Runs before every other feature module so their `run()` registrations find the service ready.
 
-- [ ] MenuService initialized during application bootstrap
-- [ ] Plugins subscribe to `ready` event before registering menu items
-- [ ] Menu items use memory-only mode (persist=false) for runtime entries
-- [ ] Admin API uses persisted mode (persist=true) for manual entries
-- [ ] Cleanup logic implemented in plugin `disable()` hook
-- [ ] Namespace chosen appropriately for navigation context
-- [ ] Event subscribers handle validation errors gracefully
-- [ ] Frontend subscribes to `menu:update` WebSocket events
-- [ ] Access control checked in frontend before rendering menu items
-- [ ] Tests use `MockPluginDatabase` instead of real MongoDB
+## Related
 
-## Troubleshooting
-
-### Menu Items Not Appearing
-
-**Diagnosis:**
-```typescript
-const tree = menuService.getTree();
-console.log('Total nodes:', tree.all.length);
-
-const namespaces = menuService.getNamespaces();
-console.log('Namespaces:', namespaces);
-```
-
-**Resolution:**
-- Ensure `menuService.initialize()` called during bootstrap
-- Verify plugin subscribes to `ready` event (not `loaded` or `init`)
-- Check that `enabled: true` is set on menu nodes
-- Confirm frontend fetches correct namespace
-
-### WebSocket Updates Not Received
-
-**Diagnosis:**
-```typescript
-socket.on('connect', () => console.log('WebSocket connected'));
-socket.on('menu:update', (payload) => console.log('Menu update:', payload));
-```
-
-**Resolution:**
-- Verify `ENABLE_WEBSOCKETS=true` in backend environment
-- Ensure frontend subscribes to `menu:update` event
-- Check that WebSocket service is initialized
-- Confirm socket.io client is connected
-
-### Event Validation Failing
-
-**Diagnosis:**
-```typescript
-menuService.subscribe('before:create', async (event) => {
-    console.log('Validating node:', event.node);
-    if (!event.validation.continue) {
-        console.log('Validation failed:', event.validation.error);
-    }
-});
-```
-
-**Resolution:**
-- Check subscriber logic for incorrect validation conditions
-- Ensure subscribers set `validation.continue = false` only when necessary
-- Review validation error messages in exceptions
-
-### Orphaned Menu Nodes
-
-**Diagnosis:**
-```typescript
-const tree = menuService.getTree();
-const orphans = tree.all.filter(node => {
-    if (!node.parent) return false;
-    return !menuService.getNode(node.parent);
-});
-console.log('Orphaned nodes:', orphans);
-```
-
-**Resolution:**
-- Implement proper cleanup in plugin `disable()` hook
-- Subscribe to `before:delete` to cascade delete children
-- Run migration script to fix orphaned nodes (set parent to null)
-
+- [Module Architecture](../../../../docs/system/modules/modules-architecture.md) — IModule contract, bootstrap order, service registry
+- [plugins-page-registration-menu.md](../../../../docs/plugins/plugins-page-registration-menu.md) — plugin-side menu registration patterns
+- [system-api-websockets.md](../../../../docs/system/system-api-websockets.md) — real-time event catalog

--- a/src/backend/modules/notifications/README.md
+++ b/src/backend/modules/notifications/README.md
@@ -120,6 +120,12 @@ The policy and audit indexes are created in `init()`. Categories and channels ar
 | PATCH | `/api/admin/system/notifications/channels/:id` | `requireAdmin` | Enable/disable a channel |
 | GET | `/api/admin/system/notifications/history` | `requireAdmin` | Audit feed (filter: `categoryId`, `source`; paginated) |
 
+## Admin and User Surfaces
+
+`/system/notifications` has three admin tabs: **Categories** (enable/disable each, see its source and per-channel defaults), **Channels** (globally enable/disable a transport), and **History** (the audit feed, filterable by category, source, time). A fourth tab, **My Preferences**, and the `/profile` preferences panel are the same `PreferencesPanel` component — every user-configurable category with a per-channel toggle plus a global mute, writing identity's `module_user_settings` store; the pipeline reads it at dispatch.
+
+`severity` (`info` | `success` | `warning` | `danger`) drives the toast's visual tone client-side (`NotificationHandler.tsx`) — it carries no other behavior in the pipeline.
+
 ## First Consumer
 
 The `ai-tools` module registers the `ai-tools.scheduled-prompt-run` category (audience: admin group, `channelDefaults: { toast: true }`, user-silenceable) plus an `ai-tools:scheduled-prompt-run` content type, and fires `notify({ category, typeId, ref })` after every cron-scheduled prompt run — so admins see a toast when a scheduled AI prompt runs, any admin can opt out at `/profile` or the My Preferences tab, and an admin can disable the whole category for everyone.

--- a/src/backend/modules/scheduler/README.md
+++ b/src/backend/modules/scheduler/README.md
@@ -1,0 +1,8 @@
+# Scheduler
+
+`SchedulerModule` implements `IModule`, running centralized cron jobs with dynamic reconfiguration, execution tracking, and overlap protection via `SchedulerService`.
+
+## Canonical documentation
+
+- [system-scheduler-operations.md](../../../../docs/system/system-scheduler-operations.md) — job control, cron syntax, persistence, troubleshooting
+- [system-api-scheduler.md](../../../../docs/system/system-api-scheduler.md) — scheduler status, health, and job PATCH endpoints

--- a/src/backend/modules/system/README.md
+++ b/src/backend/modules/system/README.md
@@ -1,0 +1,8 @@
+# System
+
+`SystemMonitorService` probes MongoDB, Redis, and server health (uptime, memory, sync state) for the admin monitoring endpoints and dashboard.
+
+## Canonical documentation
+
+- [system-api.md](../../../../docs/system/system-api.md) — admin API gateway: auth, conventions, links to per-domain detail docs (health, blockchain, scheduler, logs, websockets, widgets)
+- [system-dashboard.md](../../../../docs/system/system-dashboard.md) — `/system/system` dashboard page that renders these health probes

--- a/src/backend/modules/tokens/README.md
+++ b/src/backend/modules/tokens/README.md
@@ -1,0 +1,7 @@
+# Tokens
+
+`TokensService` owns the `sunpump_tokens` collection and serves recently created SunPump tokens (name, symbol, contract, owner) through a Redis-cached read path.
+
+## Canonical documentation
+
+No dedicated detail doc exists yet; [system-database.md](../../../../docs/system/system-database.md) covers the `IDatabaseService` and caching patterns this module follows (register model, cache-then-query). Scope is narrow and self-contained: one collection, one read endpoint (`GET` recent SunPump tokens via `TokensController.sunpumpRecent`), no writes exposed to callers.

--- a/src/backend/modules/traffic/__tests__/traffic.service.test.ts
+++ b/src/backend/modules/traffic/__tests__/traffic.service.test.ts
@@ -710,10 +710,10 @@ describe('TrafficService', () => {
                     return [{ bucket: '2026-06-01 05:00:00', path: '/markets', hits: '4' }] as T[];
                 }
                 if (sql.includes('GROUP BY bucket, country')) {
-                    return [{ bucket: '2026-06-01 05:00:00', country: 'US', hits: '5' }] as T[];
+                    return [{ bucket: '2026-06-01 05:00:00', country: 'US', visitors: '5' }] as T[];
                 }
                 if (sql.includes('GROUP BY bucket, source')) {
-                    return [{ bucket: '2026-06-01 05:00:00', source: 'google.com', hits: '6' }] as T[];
+                    return [{ bucket: '2026-06-01 05:00:00', source: 'google.com', visitors: '6' }] as T[];
                 }
                 if (sql.includes('GROUP BY bucket')) {
                     return [{ bucket: '2026-06-01 05:00:00', visitors: '3', pageviews: '7' }] as T[];
@@ -741,7 +741,7 @@ describe('TrafficService', () => {
             expect(out.series).toHaveLength(25);
             // The populated bucket carries its ranked paths, countries, and sources as metadata.
             expect(out.series.find(p => p.bucket === '2026-06-01T05:00:00.000Z'))
-                .toEqual({ bucket: '2026-06-01T05:00:00.000Z', visitors: 3, pageviews: 7, topPaths: [{ path: '/markets', hits: 4 }], topCountries: [{ country: 'US', hits: 5 }], topSources: [{ source: 'google.com', hits: 6 }] });
+                .toEqual({ bucket: '2026-06-01T05:00:00.000Z', visitors: 3, pageviews: 7, topPaths: [{ path: '/markets', hits: 4 }], topCountries: [{ country: 'US', visitors: 5 }], topSources: [{ source: 'google.com', visitors: 6 }] });
             // Zero-traffic buckets carry empty breakdown lists, never undefined.
             expect(out.series.find(p => p.bucket === '2026-06-01T02:00:00.000Z')?.topPaths).toEqual([]);
             expect(out.series.find(p => p.bucket === '2026-06-01T02:00:00.000Z')?.topCountries).toEqual([]);

--- a/src/backend/modules/traffic/services/traffic.service.ts
+++ b/src/backend/modules/traffic/services/traffic.service.ts
@@ -395,20 +395,20 @@ export interface IOverviewTrendPath {
     hits: number;
 }
 
-/** One country and its interactive hit count within a trend bucket. */
+/** One country and its distinct-visitor count within a trend bucket. */
 export interface IOverviewTrendCountry {
-    /** ISO-3166 alpha-2 country of the `page` events. */
+    /** ISO-3166 alpha-2 country of the `page`-viewing visitors. */
     country: string;
-    /** Interactive `page` events from this country in the bucket. */
-    hits: number;
+    /** Distinct visitors (tids) located in this country in the bucket. */
+    visitors: number;
 }
 
-/** One acquisition source and its attributed page-view count within a trend bucket. */
+/** One acquisition source and its distinct-visitor count within a trend bucket. */
 export interface IOverviewTrendSource {
-    /** First-touch referrer domain (or `direct`) the bucket's views are attributed to. */
+    /** First-touch referrer domain (or `direct`) the bucket's visitors are attributed to. */
     source: string;
-    /** Bucket `page` events whose visitor first-touched from this source. */
-    hits: number;
+    /** Distinct visitors (tids) whose first touch came from this source. */
+    visitors: number;
 }
 
 /** One time bucket of the overview trend series. */
@@ -427,19 +427,22 @@ export interface IOverviewTrendPoint {
      */
     topPaths: IOverviewTrendPath[];
     /**
-     * The bucket's most-active countries (top 3 by `page`-event count,
-     * descending), same page-view measure as {@link topPaths} so the whole
-     * tooltip stays in one commensurable unit. Distinct from the Geo panel's
-     * windowed distinct-visitor count by design. Empty for zero-traffic buckets.
+     * The bucket's most-active countries (top 3 by distinct visitors,
+     * descending). Measured in DISTINCT VISITORS, not page views — a country is
+     * a property of the visitor, so a single person refreshing must not inflate
+     * it. Shares the visitor unit with the Unique-Visitors bar and the Geo panel;
+     * intentionally does not sum to the bucket's total visitors (a bucket can
+     * span several countries). Empty for zero-traffic buckets.
      */
     topCountries: IOverviewTrendCountry[];
     /**
-     * The bucket's top acquisition sources (top 3, descending), measured as
-     * `page` views attributed to each viewer's first-touch source — the same
-     * page-view unit as {@link topPaths}/{@link topCountries}, so all three
-     * blocks stay commensurable. Source can only come from the first-touch
-     * `bootstrap` row (a `page` row's referrer is the site's own domain), so
-     * this is a join, not a plain group-by. Empty for zero-traffic buckets.
+     * The bucket's top acquisition sources (top 3 by distinct visitors,
+     * descending). Measured in DISTINCT VISITORS by each visitor's first-touch
+     * origin — "where did this bucket's visitors come from?", matching
+     * {@link topCountries} and the visitor bar rather than {@link topPaths}'
+     * page-view unit. Source can only come from the first-touch `bootstrap` row
+     * (a `page` row's referrer is the site's own domain), so this is a join, not
+     * a plain group-by. Empty for zero-traffic buckets.
      */
     topSources: IOverviewTrendSource[];
 }
@@ -1810,39 +1813,50 @@ export class TrafficService {
             ORDER BY bucket ASC, hits DESC, path ASC
             LIMIT 3 BY bucket
         `;
-        // Top 3 countries per bucket for the tooltip — same construction and
-        // measure as the paths query (page-event counts within just this
-        // bucket, `page` rows only so bot-only bootstrap countries never
-        // surface). NULL country is dropped so a hover lists only nameable
-        // origins. `LIMIT 3 BY bucket` bounds the payload to 3 × bucket count.
+        // Top 3 countries per bucket for the tooltip, measured as DISTINCT
+        // VISITORS (`uniqExact(candidate_uid)`) — a country is an attribute of the
+        // visitor, so a single person refreshing a page must not inflate their
+        // country's count. This matches the module's primary-measure convention
+        // (visitors, not raw hits) used by the Geo panel and every other
+        // dashboard read; only "Most viewed" (topPaths) stays a page-view count,
+        // because a view is the thing being counted there. Scoped to `page` rows
+        // so bot-only bootstrap countries never surface; NULL country is dropped
+        // so a hover lists only nameable origins. `LIMIT 3 BY bucket` bounds the
+        // payload to 3 × bucket count.
         const countriesSql = `
-            SELECT ${bucketExpr} AS bucket, country, count() AS hits
+            SELECT ${bucketExpr} AS bucket, country, uniqExact(candidate_uid) AS visitors
             FROM ${TABLE_NAME}
             WHERE ${clause}${botFilter} AND event_type = 'page' AND country IS NOT NULL
             GROUP BY bucket, country
-            ORDER BY bucket ASC, hits DESC, country ASC
+            ORDER BY bucket ASC, visitors DESC, country ASC
             LIMIT 3 BY bucket
         `;
-        // Top 3 sources per bucket, attributed as page VIEWS by origin. Source
-        // lives only on the first-touch `bootstrap` row (a `page` row's referrer
-        // is the site's own domain), so each bucket page view is LEFT-joined to
-        // its visitor's earliest bootstrap source — `argMin(domain, timestamp)`,
-        // matching getTrafficSources' `domain(referer)`/`direct` derivation. The
-        // join is LEFT (not INNER) so a page view whose tid has no retained
-        // bootstrap row still counts: the middleware bootstrap is best-effort and
-        // swallows failures, so outages/deploys and pre-feature tids leave
-        // page-only tids permanently. Those unmatched views bucket to
-        // '(unattributed)' — a distinct sentinel, never folded into 'direct'
-        // (which means "no referrer", not "no record") — so topSources stays the
-        // SAME page-view population as topPaths/topCountries and the bar. Under
-        // this codebase's join_use_nulls=0 an unmatched source fills as '' (not
-        // NULL); if that ever flips, the guard must also test IS NULL.
-        // `LIMIT 3 BY bucket` bounds the payload.
+        // Top 3 sources per bucket, measured as DISTINCT VISITORS by first-touch
+        // origin — "where did this bucket's visitors come from?", not "how many
+        // page views arrived from each origin". A source is a property of the
+        // visitor (their first touch), so one person browsing several pages counts
+        // once for their origin, matching topCountries and the module's
+        // visitor-primary convention. Source lives only on the first-touch
+        // `bootstrap` row (a `page` row's referrer is the site's own domain), so
+        // each bucket's page-viewing visitor is LEFT-joined to their earliest
+        // bootstrap source — `argMin(domain, timestamp)`, matching
+        // getTrafficSources' `domain(referer)`/`direct` derivation. The join is
+        // LEFT (not INNER) so a visitor whose tid has no retained bootstrap row
+        // still counts: the middleware bootstrap is best-effort and swallows
+        // failures, so outages/deploys and pre-feature tids leave page-only tids
+        // permanently. Those unmatched visitors bucket to '(unattributed)' — a
+        // distinct sentinel, never folded into 'direct' (which means "no
+        // referrer", not "no record"). `candidate_uid` is carried out of the page
+        // subquery so the outer `uniqExact` can dedupe a visitor's many page rows
+        // to one per source. Under this codebase's join_use_nulls=0 an unmatched
+        // source fills as '' (not NULL); if that ever flips, the guard must also
+        // test IS NULL. `LIMIT 3 BY bucket` bounds the payload.
         const sourcesSql = `
-            SELECT bucket, source, count() AS hits
+            SELECT bucket, source, uniqExact(candidate_uid) AS visitors
             FROM (
                 SELECT
                     pv.bucket AS bucket,
+                    pv.candidate_uid AS candidate_uid,
                     if(src.source = '', '(unattributed)', src.source) AS source
                 FROM (
                     SELECT ${bucketExpr} AS bucket, candidate_uid
@@ -1858,7 +1872,7 @@ export class TrafficService {
                 ) AS src USING (candidate_uid)
             )
             GROUP BY bucket, source
-            ORDER BY bucket ASC, hits DESC, source ASC
+            ORDER BY bucket ASC, visitors DESC, source ASC
             LIMIT 3 BY bucket
         `;
 
@@ -1868,8 +1882,8 @@ export class TrafficService {
                 fetchKpis(previousRange),
                 this.clickhouse.query<{ bucket: string; visitors: string | number; pageviews: string | number }>(seriesSql, params),
                 this.clickhouse.query<{ bucket: string; path: string; hits: string | number }>(pathsSql, params),
-                this.clickhouse.query<{ bucket: string; country: string; hits: string | number }>(countriesSql, params),
-                this.clickhouse.query<{ bucket: string; source: string; hits: string | number }>(sourcesSql, params)
+                this.clickhouse.query<{ bucket: string; country: string; visitors: string | number }>(countriesSql, params),
+                this.clickhouse.query<{ bucket: string; source: string; visitors: string | number }>(sourcesSql, params)
             ]);
 
             // Zero-fill every bucket in the window, then overlay the rows.
@@ -1910,14 +1924,14 @@ export class TrafficService {
                 }
             }
             // Overlay the per-bucket top countries — same ordering guarantee as
-            // paths (rows arrive hits-desc, appending preserves rank).
+            // paths (rows arrive visitors-desc, appending preserves rank).
             for (const row of countryRows) {
                 const key = granularity === 'hour'
                     ? clickHouseDateToIso(String(row.bucket))
                     : String(row.bucket);
                 const point = buckets.get(key);
                 if (point) {
-                    point.topCountries.push({ country: String(row.country), hits: Number(row.hits) });
+                    point.topCountries.push({ country: String(row.country), visitors: Number(row.visitors) });
                 }
             }
             // Overlay the per-bucket top sources — same ordering guarantee.
@@ -1927,7 +1941,7 @@ export class TrafficService {
                     : String(row.bucket);
                 const point = buckets.get(key);
                 if (point) {
-                    point.topSources.push({ source: String(row.source), hits: Number(row.hits) });
+                    point.topSources.push({ source: String(row.source), visitors: Number(row.visitors) });
                 }
             }
 

--- a/src/backend/modules/usdt-parameters/README.md
+++ b/src/backend/modules/usdt-parameters/README.md
@@ -1,0 +1,7 @@
+# USDT Parameters
+
+`UsdtParametersService` polls TronGrid on a schedule and caches the current USDT TRC20 transfer energy cost (~65,000 units, dynamic) — the single source of truth calculators and market fetchers call instead of hardcoding the value.
+
+## Canonical documentation
+
+- [tron-chain-parameters.md](../../../../docs/tron/tron-chain-parameters.md#usdt-parameters-service) — USDT Parameters Service section, alongside the sibling Chain Parameters Service it pairs with for transfer-cost normalization

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { cn } from '../../../../lib/cn';
 import styles from './BarChart.module.css';
 
@@ -100,6 +100,15 @@ interface BarChartProps {
     yAxisMin?: number;
     /** Fixed maximum value for Y-axis (overrides auto-calculated maximum) */
     yAxisMax?: number;
+    /**
+     * Render the Y-axis on a whole-number scale: bounds snap to integer step
+     * multiples and each tick is a distinct integer. Set this for count data
+     * (visitors, pageviews) instead of rounding fractional ticks in the caller's
+     * `yAxisFormatter` — that rounding is what collapses a small domain's ticks
+     * into duplicate labels (0, 0.67, 1.33, 2 → "0, 1, 1, 2"). Off by default so
+     * continuous-value charts keep their evenly-spaced fractional ticks.
+     */
+    integerTicks?: boolean;
     /**
      * Render the legend. Defaults to the mode's behavior (`normal` shows it,
      * `widget` hides it); set explicitly to override — e.g. `true` to surface a
@@ -274,6 +283,62 @@ function resolveColor(color: string | undefined, index: number) {
 }
 
 /**
+ * Picks a "nice" whole-number step for an integer axis so gridlines land on
+ * round values a reader expects (…1, 2, 5, 10, 20, 50…) rather than arbitrary
+ * fractions. This is the piece that prevents duplicate axis labels: the default
+ * four-tick split of a small domain produces fractional values (0, 0.67, 1.33,
+ * 2) that an integer formatter collapses to repeats ("0, 1, 1, 2"). Snapping to
+ * a whole-number step guarantees every tick is a distinct integer.
+ *
+ * @param span - Height of the value domain (maxY − minY); assumed ≥ 1 so a
+ *   flat/degenerate domain still yields a usable step.
+ * @param targetTicks - Rough number of intervals wanted, tuning step coarseness.
+ * @returns A step that is a whole number ≥ 1 (1/2/5 × a power of ten).
+ */
+function niceIntegerStep(span: number, targetTicks = 3) {
+    const rough = span / targetTicks;
+    if (rough <= 1) {
+        return 1;
+    }
+    const magnitude = Math.pow(10, Math.floor(Math.log10(rough)));
+    const normalized = rough / magnitude;
+    const niceNormalized = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+    return niceNormalized * magnitude;
+}
+
+/**
+ * Snaps an auto-computed domain to whole-number bounds and emits one tick per
+ * step, so a count-based chart renders an integer axis with distinct labels.
+ * Auto bounds expand outward to the nearest step multiple (giving headroom and a
+ * top gridline that lines up with the data); a caller-pinned bound is respected
+ * as-is so an explicit `yAxisMin`/`yAxisMax` still wins. Because every tick is a
+ * multiple of an integer step, a zero baseline is always included when the domain
+ * straddles it — no separate zero-tick insertion is needed.
+ *
+ * @param minY - Lower domain bound after baseline/pinning resolution.
+ * @param maxY - Upper domain bound after baseline/pinning resolution.
+ * @param fixedMin - The caller's `yAxisMin`, if pinned — left untouched when set.
+ * @param fixedMax - The caller's `yAxisMax`, if pinned — left untouched when set.
+ * @returns The (possibly widened) integer domain plus ascending tick values.
+ */
+function niceIntegerAxis(minY: number, maxY: number, fixedMin?: number, fixedMax?: number) {
+    const step = niceIntegerStep(Math.max(maxY - minY, 1));
+    const axisMin = fixedMin !== undefined ? minY : Math.floor(minY / step) * step;
+    let axisMax = fixedMax !== undefined ? maxY : Math.ceil(maxY / step) * step;
+    if (axisMin >= axisMax) {
+        axisMax = axisMin + step;
+    }
+    const ticks: number[] = [];
+    // Guard the loop bound with a half-step epsilon so float drift cannot drop
+    // the final tick, and cap the iteration count so a pathological pinned domain
+    // (huge span, tiny step) can never spin unbounded.
+    for (let value = axisMin; value <= axisMax + step / 2 && ticks.length < 1000; value += step) {
+        ticks.push(value);
+    }
+    return { min: axisMin, max: axisMax, ticks };
+}
+
+/**
  * BarChart - Responsive SVG grouped column chart with normal and widget modes.
  *
  * Renders one column per series for each shared category (typically a time
@@ -309,6 +374,7 @@ export function BarChart({
     emptyLabel = 'Not enough data to render a chart.',
     yAxisMin: fixedYMin,
     yAxisMax: fixedYMax,
+    integerTicks = false,
     showLegend,
     layout = 'grouped'
 }: BarChartProps) {
@@ -325,6 +391,14 @@ export function BarChart({
     const [tooltipNode, setTooltipNode] = useState<HTMLDivElement | null>(null);
     const [tooltipWidth, setTooltipWidth] = useState(0);
     const [hiddenSeries, setHiddenSeries] = useState<Set<string>>(new Set());
+    const [pinned, setPinned] = useState(false);
+    // Synchronous mirror of `pinned` for the pointer-move/leave guards. A touch
+    // tap dispatches pointerdown → pointerup → pointerleave within one gesture,
+    // before React re-renders with the new `pinned` value, so a handler reading
+    // the captured `pinned` state would see it stale and clear the just-pinned
+    // tooltip. The ref updates in the same tick as the pin, so the guards see the
+    // truth immediately; `pinned` state still exists to drive the dismissal effect.
+    const pinnedRef = useRef(false);
 
     /**
      * Measures the rendered tooltip's width so its center can be clamped to keep
@@ -360,6 +434,43 @@ export function BarChart({
         observer.observe(container);
         return () => observer.disconnect();
     }, [container, chrome.minWidth]);
+
+    /**
+     * While a tooltip is pinned, dismiss it on any pointer-down outside the chart
+     * figure or on Escape — the "click anywhere else" half of the pin contract.
+     * The containment check spares interactions inside the figure: the pinning
+     * tap itself, a click on a different bar (which re-pins), the tooltip, and the
+     * legend. Only a genuine outside interaction clears the pin. The listener is
+     * bound to `document` solely while pinned, so there is no idle global handler,
+     * and it lives in an effect (client-only) so SSR is untouched.
+     */
+    useEffect(() => {
+        if (!pinned) {
+            return;
+        }
+        const dismiss = (event: PointerEvent) => {
+            const target = event.target;
+            if (container && target instanceof Node && container.contains(target)) {
+                return;
+            }
+            pinnedRef.current = false;
+            setPinned(false);
+            setTooltip(null);
+        };
+        const handleKey = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                pinnedRef.current = false;
+                setPinned(false);
+                setTooltip(null);
+            }
+        };
+        document.addEventListener('pointerdown', dismiss);
+        document.addEventListener('keydown', handleKey);
+        return () => {
+            document.removeEventListener('pointerdown', dismiss);
+            document.removeEventListener('keydown', handleKey);
+        };
+    }, [pinned, container]);
 
     /**
      * Toggles visibility of a series by ID (normal-mode legend interaction).
@@ -472,6 +583,19 @@ export function BarChart({
             } else {
                 maxY = minY + 1;
             }
+        }
+
+        // Integer-axis callers (count data) snap the domain to whole-number
+        // bounds here so both the scale and the ticks are integer-valued. Done
+        // before rangeY/scaleY so bar heights map against the snapped domain, and
+        // the resulting tick values are reused verbatim below instead of the
+        // fractional four-tick split.
+        let integerTickValues: number[] | null = null;
+        if (integerTicks) {
+            const axis = niceIntegerAxis(minY, maxY, fixedYMin, fixedYMax);
+            minY = axis.min;
+            maxY = axis.max;
+            integerTickValues = axis.ticks;
         }
 
         const rangeY = maxY - minY || 1;
@@ -602,13 +726,17 @@ export function BarChart({
             });
         });
 
-        // Y-axis ticks (normal mode): four evenly spaced, plus an explicit zero
-        // tick when the data crosses the baseline.
-        const yTicks = Array.from({ length: 4 }).map((_, index) => {
-            const value = minY + (rangeY / 3) * index;
-            return { value, y: scaleY(value) };
-        });
-        if (zeroInRange && minY < 0 && maxY > 0) {
+        // Y-axis ticks (normal mode). Integer mode uses the whole-number tick
+        // values computed above (already distinct and zero-inclusive); otherwise
+        // fall back to four evenly spaced ticks, plus an explicit zero tick when
+        // the data crosses the baseline.
+        const yTicks = integerTickValues
+            ? integerTickValues.map(value => ({ value, y: scaleY(value) }))
+            : Array.from({ length: 4 }).map((_, index) => {
+                const value = minY + (rangeY / 3) * index;
+                return { value, y: scaleY(value) };
+            });
+        if (!integerTickValues && zeroInRange && minY < 0 && maxY > 0) {
             const hasZeroTick = yTicks.some(tick => Math.abs(tick.value) < 0.0001);
             if (!hasZeroTick) {
                 yTicks.push({ value: 0, y: scaleY(0) });
@@ -632,7 +760,7 @@ export function BarChart({
             zeroInRange,
             seriesLookup
         };
-    }, [series, hiddenSeries, containerWidth, height, chrome, fixedYMin, fixedYMax, seriesColors, layout]);
+    }, [series, hiddenSeries, containerWidth, height, chrome, fixedYMin, fixedYMax, integerTicks, seriesColors, layout]);
 
     // Optional header row shared by the empty and populated renders: the
     // operator-set title on the left, caller-supplied controls (e.g. a widget's
@@ -668,14 +796,18 @@ export function BarChart({
     const { width, height: chartHeight, bars, categories, yTicks, xTicks, baselineY, seriesLookup } = chartData;
 
     /**
-     * Resolves the hovered category from the pointer X position and builds the
-     * tooltip rows for every visible series at that category. Normal mode only.
+     * Resolves the category nearest the pointer X and builds the tooltip rows for
+     * every visible series there. Shared by hover (`handlePointerMove`) and
+     * click/tap-to-pin (`handlePointerDown`) so both select a bucket identically.
+     * Normal mode only; returns null when the chart is non-interactive, has no
+     * categories, or the nearest bucket carries no visible series point.
      *
      * @param event - React pointer event from the SVG element (mouse, touch, or pen)
+     * @returns The tooltip state to display, or null to show nothing
      */
-    const handlePointerMove = (event: React.PointerEvent<SVGSVGElement>) => {
+    const resolveTooltipAt = (event: React.PointerEvent<SVGSVGElement>): TooltipState | null => {
         if (!chrome.interactive || !categories.length) {
-            return;
+            return null;
         }
 
         const bounds = event.currentTarget.getBoundingClientRect();
@@ -712,18 +844,51 @@ export function BarChart({
             .filter((item): item is TooltipDatum => Boolean(item));
 
         if (!items.length) {
-            setTooltip(null);
-            return;
+            return null;
         }
 
-        setTooltip({ x: nearest.centerX, y: chrome.margin.top, date: nearest.date, items, chartWidthPx: bounds.width });
+        return { x: nearest.centerX, y: chrome.margin.top, date: nearest.date, items, chartWidthPx: bounds.width };
     };
 
     /**
-     * Clears the tooltip when the pointer leaves the chart.
+     * Updates the hovered tooltip as the pointer moves. No-ops while a tooltip is
+     * pinned (read from `pinnedRef` synchronously so a touch tap's trailing
+     * pointermove cannot fight the pin), so a pinned bucket stays put.
+     *
+     * @param event - React pointer event from the SVG element
+     */
+    const handlePointerMove = (event: React.PointerEvent<SVGSVGElement>) => {
+        if (pinnedRef.current) {
+            return;
+        }
+        setTooltip(resolveTooltipAt(event));
+    };
+
+    /**
+     * Clears the tooltip when the pointer leaves the chart — unless it is pinned,
+     * in which case the pin owns the tooltip until an outside click or Escape.
      */
     const handlePointerLeave = () => {
+        if (pinnedRef.current) {
+            return;
+        }
         setTooltip(null);
+    };
+
+    /**
+     * Pins the tooltip to the clicked/tapped bucket so it survives pointer-out —
+     * the primary way to read a bar on touch, where hover is unreliable. Updates
+     * `pinnedRef` synchronously (guarding the same gesture's trailing move/leave)
+     * and `pinned` state to arm the outside-click/Escape dismissal effect. A tap
+     * on a bucket with no data unpins, matching a click on empty chart area.
+     *
+     * @param event - React pointer event from the SVG element (mouse or touch)
+     */
+    const handlePointerDown = (event: React.PointerEvent<SVGSVGElement>) => {
+        const next = resolveTooltipAt(event);
+        pinnedRef.current = Boolean(next);
+        setPinned(Boolean(next));
+        setTooltip(next);
     };
 
     const ariaLabel = `Bar chart: ${series.map(item => item.label).join(', ')}`;
@@ -780,6 +945,7 @@ export function BarChart({
                 preserveAspectRatio="xMinYMid meet"
                 role="img"
                 aria-label={ariaLabel}
+                onPointerDown={chrome.interactive ? handlePointerDown : undefined}
                 onPointerMove={chrome.interactive ? handlePointerMove : undefined}
                 onPointerLeave={chrome.interactive ? handlePointerLeave : undefined}
             >

--- a/src/frontend/features/charts/components/BarChart/BarChart.tsx
+++ b/src/frontend/features/charts/components/BarChart/BarChart.tsx
@@ -329,10 +329,11 @@ function niceIntegerAxis(minY: number, maxY: number, fixedMin?: number, fixedMax
         axisMax = axisMin + step;
     }
     const ticks: number[] = [];
-    // Guard the loop bound with a half-step epsilon so float drift cannot drop
-    // the final tick, and cap the iteration count so a pathological pinned domain
-    // (huge span, tiny step) can never spin unbounded.
-    for (let value = axisMin; value <= axisMax + step / 2 && ticks.length < 1000; value += step) {
+    // Guard the loop bound with a tiny epsilon so float drift cannot drop the
+    // final tick, while a full half-step would admit a tick beyond a pinned
+    // fixedMax that is not a step multiple; and cap the iteration count so a
+    // pathological pinned domain (huge span, tiny step) can never spin unbounded.
+    for (let value = axisMin; value <= axisMax + step * 1e-6 && ticks.length < 1000; value += step) {
         ticks.push(value);
     }
     return { min: axisMin, max: axisMax, ticks };

--- a/src/frontend/modules/traffic/api/client.ts
+++ b/src/frontend/modules/traffic/api/client.ts
@@ -679,20 +679,20 @@ export interface IOverviewTrendPath {
     hits: number;
 }
 
-/** One country and its interactive hit count within a trend bucket. */
+/** One country and its distinct-visitor count within a trend bucket. */
 export interface IOverviewTrendCountry {
-    /** ISO-3166 alpha-2 country of the `page` events. */
+    /** ISO-3166 alpha-2 country of the `page`-viewing visitors. */
     country: string;
-    /** Interactive `page` events from this country in the bucket. */
-    hits: number;
+    /** Distinct visitors (tids) located in this country in the bucket. */
+    visitors: number;
 }
 
-/** One acquisition source and its attributed page-view count within a trend bucket. */
+/** One acquisition source and its distinct-visitor count within a trend bucket. */
 export interface IOverviewTrendSource {
-    /** First-touch referrer domain (or `direct`) the bucket's views are attributed to. */
+    /** First-touch referrer domain (or `direct`) the bucket's visitors are attributed to. */
     source: string;
-    /** Bucket `page` events whose visitor first-touched from this source. */
-    hits: number;
+    /** Distinct visitors (tids) whose first touch came from this source. */
+    visitors: number;
 }
 
 /** One time bucket of the overview trend series. */
@@ -701,11 +701,11 @@ export interface IOverviewTrendPoint {
     bucket: string;
     visitors: number;
     pageviews: number;
-    /** Top 3 most-hit paths in the bucket (hits desc); [] when zero-traffic. */
+    /** Top 3 most-hit paths in the bucket (page views desc); [] when zero-traffic. */
     topPaths: IOverviewTrendPath[];
-    /** Top 3 most-active countries in the bucket (hits desc); [] when zero-traffic. */
+    /** Top 3 countries by distinct visitors in the bucket (desc); [] when zero-traffic. */
     topCountries: IOverviewTrendCountry[];
-    /** Top 3 acquisition sources by attributed page views (hits desc); [] when zero-traffic. */
+    /** Top 3 acquisition sources by distinct visitors in the bucket (desc); [] when zero-traffic. */
     topSources: IOverviewTrendSource[];
 }
 

--- a/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
+++ b/src/frontend/modules/traffic/components/admin/OverviewTrend/OverviewTrend.tsx
@@ -198,12 +198,13 @@ export function OverviewTrend({ period, customRange, includeBots, refreshSignal 
      * top acquisition sources inside the chart tooltip. Surfaces "what did they
      * view, from where, and how did they arrive?" in place so an operator
      * reading the trend need not cross-reference the landing-pages, geo, or
-     * traffic-sources panels — while each heading names the metric (views) and
-     * its bucket scope so no count is misread as a window total, a first-touch
-     * landing count, or a panel's distinct-visitor figure. All three blocks
-     * share the bucket's page-view measure (sources attribute each view to the
-     * viewer's first-touch origin), so they stay commensurable with the bar and
-     * with each other.
+     * traffic-sources panels. Two units coexist by design and each heading scopes
+     * its count to the bucket: "Most viewed" counts page views (a person viewing
+     * a path twice is two views), while "Top countries" and "Top sources" count
+     * DISTINCT VISITORS — a country/origin is a property of the visitor, so one
+     * person cannot inflate them. The visitor blocks therefore track the
+     * Unique-Visitors bar, and intentionally do not sum to a window total or fold
+     * into the page-view figures.
      *
      * @param metadata - The hovered bar's point metadata; `topPaths`,
      *   `topCountries`, and `topSources` are the server-ranked lists the series
@@ -234,7 +235,7 @@ export function OverviewTrend({ period, customRange, includeBots, refreshSignal 
                         {countries.map(c => (
                             <div key={c.country} className={styles.tooltip_paths__row}>
                                 <span className={styles.tooltip_paths__path}>{c.country}</span>
-                                <span className={styles.tooltip_paths__hits}>{numberFormatter.format(c.hits)}</span>
+                                <span className={styles.tooltip_paths__hits}>{numberFormatter.format(c.visitors)}</span>
                             </div>
                         ))}
                     </div>
@@ -245,7 +246,7 @@ export function OverviewTrend({ period, customRange, includeBots, refreshSignal 
                         {sources.map(s => (
                             <div key={s.source} className={styles.tooltip_paths__row}>
                                 <span className={styles.tooltip_paths__path}>{s.source}</span>
-                                <span className={styles.tooltip_paths__hits}>{numberFormatter.format(s.hits)}</span>
+                                <span className={styles.tooltip_paths__hits}>{numberFormatter.format(s.visitors)}</span>
                             </div>
                         ))}
                     </div>
@@ -329,7 +330,8 @@ export function OverviewTrend({ period, customRange, includeBots, refreshSignal 
                 series={series}
                 height={280}
                 yAxisMin={0}
-                yAxisFormatter={(v) => numberFormatter.format(Math.round(v))}
+                integerTicks
+                yAxisFormatter={(v) => numberFormatter.format(v)}
                 tooltipMetadataFormatter={renderTooltipMetadata}
                 emptyLabel="No traffic recorded in this period."
             />


### PR DESCRIPTION
## Summary

Two changesets landed together:

**Backend module documentation** — Add canonical `README.md` files for backend modules that lacked them: analytics, auth, blockchain, chain-parameters, clickhouse, dashboard, database, energy, live, scheduler, system, tokens, usdt-parameters. Trim `docs/system/system.md` and `src/backend/modules/menu/README.md` back to the summary-plus-links pattern, and touch up `plugins-catalog.md`, `documentation.md`, `tron.md`, and `notifications/README.md`.

**Traffic overview trend** — `BarChart` enhancements, `traffic.service.ts` query adjustments (with test update), and `OverviewTrend` / traffic `client.ts` wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)