### PR TITLE
feat(identity,ui): shared AccountPicker + admin account-search endpoint

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delphian/tronrelic-types",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "description": "Core type definitions for the TronRelic platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/types/src/identity/IAccountDirectoryService.ts
+++ b/packages/types/src/identity/IAccountDirectoryService.ts
@@ -42,6 +42,26 @@ export interface IAccountSummary {
 }
 
 /**
+ * Minimal account projection for pickers and search results.
+ *
+ * The narrow shape a UI needs to identify and choose an account — id plus the
+ * two human-readable labels. Deliberately smaller than {@link IAccountSummary}
+ * (no groups, wallet, verification, or timestamps): search endpoints and the
+ * shared `AccountPicker` traffic in this shape so neither leaks auth-internal
+ * fields to admin surfaces that only need to name a person.
+ */
+export interface IAccountMatch {
+    /** Better Auth user id — the opaque value a caller stores/selects. */
+    id: string;
+
+    /** Account email, the primary label. */
+    email: string;
+
+    /** Display name, or null when unset. */
+    name: string | null;
+}
+
+/**
  * Options for paginated/filtered account listing.
  */
 export interface IListAccountsOptions {

--- a/packages/types/src/identity/index.ts
+++ b/packages/types/src/identity/index.ts
@@ -19,6 +19,7 @@ export type {
 export type {
     IAccountDirectoryService,
     IAccountSummary,
+    IAccountMatch,
     IListAccountsOptions,
     IListAccountsResult
 } from './IAccountDirectoryService.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -65,7 +65,7 @@ export type {
     INotificationAuditRecord,
     INotificationAuditQuery
 } from './notifications/index.js';
-export type { IWalletService, ILinkedWallet, WalletAction, IWalletChallenge, IWalletMutationInput, IAccountDirectoryService, IAccountSummary, IListAccountsOptions, IListAccountsResult, IUserSettingsService, IUserSettingDefinition } from './identity/index.js';
+export type { IWalletService, ILinkedWallet, WalletAction, IWalletChallenge, IWalletMutationInput, IAccountDirectoryService, IAccountSummary, IAccountMatch, IListAccountsOptions, IListAccountsResult, IUserSettingsService, IUserSettingDefinition } from './identity/index.js';
 export type { IUserGroup, ICreateUserGroupInput, IUpdateUserGroupInput, IUserGroupService } from './user/index.js';
 export type { ITronGridService, ITronGridAccountResponse, ITronGridAccountPermission } from './tron-grid/index.js';
 export type { ITrc10, ITrc10FrozenSupply } from './trc10/index.js';

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -223,6 +223,22 @@ export interface IUIComponents {
     }>;
 
     /**
+     * Admin account picker — a searchable control for selecting a Better Auth
+     * account by name/email. Self-contained: it queries the admin
+     * account-search endpoint itself, so a consumer only binds value/onChange.
+     * `value` is the selected account id (or null); `onChange` receives the new
+     * id, or null when cleared. Admin-gated by that endpoint — use only on admin
+     * surfaces. Lets a plugin choose an account (e.g. a bot author) without
+     * reimplementing account search.
+     */
+    AccountPicker: ComponentType<{
+        value: string | null;
+        onChange: (accountId: string | null) => void;
+        disabled?: boolean;
+        placeholder?: string;
+    }>;
+
+    /**
      * Table wrapper matching the core `/system/*` admin tables.
      *
      * Compose with `Thead`, `Tbody`, `Tr`, `Th`, `Td` to get the same

--- a/src/backend/modules/identity/IdentityModule.ts
+++ b/src/backend/modules/identity/IdentityModule.ts
@@ -37,7 +37,7 @@ import { AccountsController } from './api/accounts.controller.js';
 import { UserSettingsController } from './api/user-settings.controller.js';
 import { createWalletRouter } from './api/wallet.routes.js';
 import { createAdminUserGroupRouter } from './api/user-group.routes.js';
-import { createAdminAccountsRouter } from './api/accounts.routes.js';
+import { createAdminAccountsRouter, createAdminAccountSearchRouter } from './api/accounts.routes.js';
 import { createUserSettingsRouter } from './api/user-settings.routes.js';
 import { requireAdmin } from '../../api/middleware/admin-auth.js';
 
@@ -289,6 +289,14 @@ export class IdentityModule implements IModule<IIdentityModuleDependencies> {
         const adminAccountsRouter: Router = createAdminAccountsRouter(this.accountsController, this.groupController);
         this.app.use('/api/admin/users', requireAdmin, adminAccountsRouter);
         this.logger.info('Admin accounts router mounted at /api/admin/users');
+
+        // Admin account-search router at the dedicated literal `/api/admin/accounts`
+        // prefix — kept off the `/api/admin/users` `/:id` catch-all above so its
+        // `/search` route is not captured as an id. Backs the shared
+        // `context.ui.AccountPicker` typeahead used by admin surfaces.
+        const adminAccountSearchRouter: Router = createAdminAccountSearchRouter(this.accountsController);
+        this.app.use('/api/admin/accounts', requireAdmin, adminAccountSearchRouter);
+        this.logger.info('Admin account-search router mounted at /api/admin/accounts');
 
         // Publish the BA-keyed services for late-binding discovery. Published in
         // identity's run() — which precedes notifications' run() and any runtime

--- a/src/backend/modules/identity/README.md
+++ b/src/backend/modules/identity/README.md
@@ -10,7 +10,7 @@ Owns Better Auth and everything keyed by the Better Auth user id: the auth insta
 | Module class | `src/backend/modules/identity/IdentityModule.ts` |
 | Admin page | `/system/users` (menu item `Users`, order 25, registered in `run()`) |
 | Service registry names | `'user-groups'`, `'wallets'`, `'accounts'`, `'user-settings'` |
-| Mounted routes | `/api/auth/*`, `/api/user/wallets/*`, `/api/user/settings`, `/api/admin/users/groups/*`, `/api/admin/users` (accounts) |
+| Mounted routes | `/api/auth/*`, `/api/user/wallets/*`, `/api/user/settings`, `/api/admin/users/groups/*`, `/api/admin/users` (accounts), `/api/admin/accounts/search` |
 | Types package | `@delphian/tronrelic-types` → `IWalletService`, `IAccountDirectoryService`, `IUserGroupService`, `IUserSettingsService` |
 | Auth collections | `module_user_auth_users` / `_sessions` / `_accounts` / `_verifications` / `_passkeys` |
 | Owned collections | `module_user_wallets`, `module_user_groups`, `module_user_settings` |
@@ -107,12 +107,13 @@ First consumer: the notifications module persists per-user opt-outs here under t
 | GET | `/api/admin/users` | `requireAdmin` | Paginated / searched account summaries (`IAccountSummary[]` + total) |
 | GET | `/api/admin/users/:id` | `requireAdmin` | One account summary, or 404 |
 | PUT | `/api/admin/users/:id/groups` | `requireAdmin` | Set an account's group membership |
+| GET | `/api/admin/accounts/search?q=` | `requireAdmin` | Typeahead account search → `{ accounts: IAccountMatch[] }`; backs `context.ui.AccountPicker` |
 
 `/api/admin/users` is a `/:id` catch-all, so it mounts **last**. The literal-segment routers must mount ahead of it: the groups router here, and the traffic module's `/api/admin/users/{traffic,analytics}` routers (TrafficModule runs before this module). Without that order the catch-all would shadow `traffic`, `analytics`, and `groups`.
 
 ## Lifecycle
 
-**`init()`** constructs (in order) `GroupService`, `WalletService`, `UserGroupService` (seeds the `admin` group), `AccountDirectoryService`, `UserSettingsService`, and the Better Auth instance, then wires the auth facade and builds the wallet + group + user-settings controllers. **`run()`** registers the `Users` menu item under the System container, mounts `/api/auth/*`, the wallet router, the user-settings router, the admin group router, and the admin accounts router (`/api/admin/users`, the `/:id` catch-all, last), then registers `'user-groups'`, `'wallets'`, `'accounts'`, `'user-settings'`.
+**`init()`** constructs (in order) `GroupService`, `WalletService`, `UserGroupService` (seeds the `admin` group), `AccountDirectoryService`, `UserSettingsService`, and the Better Auth instance, then wires the auth facade and builds the wallet + group + user-settings controllers. **`run()`** registers the `Users` menu item under the System container, mounts `/api/auth/*`, the wallet router, the user-settings router, the admin group router, the admin accounts router (`/api/admin/users`, the `/:id` catch-all, last), and the admin account-search router (`/api/admin/accounts`, a dedicated literal prefix), then registers `'user-groups'`, `'wallets'`, `'accounts'`, `'user-settings'`.
 
 ## Related
 

--- a/src/backend/modules/identity/api/accounts.controller.ts
+++ b/src/backend/modules/identity/api/accounts.controller.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Request, Response } from 'express';
-import type { ISystemLogService } from '@/types';
+import type { ISystemLogService, IAccountMatch, IAccountSummary } from '@/types';
 import type { AccountDirectoryService } from '../services/account-directory.service.js';
 import { parsePositiveInt, parseNonNegativeInt } from '../../../api/query-params.js';
 
@@ -22,6 +22,28 @@ const DEFAULT_LIMIT = 50;
 
 /** Hard ceiling on page size — mirrors the service ceiling. */
 const MAX_LIMIT = 200;
+
+/** Page size for the typeahead account search — small, it feeds a dropdown. */
+const ACCOUNT_SEARCH_LIMIT = 10;
+
+/**
+ * A Better Auth user id is a 24-char hex ObjectId string. When the query is
+ * exactly that, resolve it directly instead of substring-scanning email/name —
+ * so a picker re-opened on a stored id resolves its label in one exact read.
+ */
+const BA_USER_ID_PATTERN = /^[0-9a-f]{24}$/i;
+
+/**
+ * Narrow an {@link IAccountSummary} to the {@link IAccountMatch} projection the
+ * picker/search surface exposes — dropping auth-internal fields (groups,
+ * wallet, verification, timestamps) an account chooser never needs.
+ *
+ * @param account - The full directory summary.
+ * @returns The minimal id/email/name match.
+ */
+function toAccountMatch(account: IAccountSummary): IAccountMatch {
+    return { id: account.id, email: account.email, name: account.name };
+}
 
 /**
  * Controller for admin account-directory endpoints.
@@ -64,6 +86,44 @@ export class AccountsController {
         } catch (error) {
             this.logger.error({ err: error }, 'Failed to list accounts');
             res.status(500).json({ error: 'InternalError', message: 'Failed to list accounts' });
+        }
+
+        return;
+    }
+
+    /**
+     * GET /api/admin/accounts/search?q=
+     *
+     * Typeahead account search backing admin account pickers (e.g. the shared
+     * `context.ui.AccountPicker`). Returns the minimal {@link IAccountMatch}
+     * projection — never the full summary — so admin choosers only see
+     * id/email/name. An exact 24-hex query resolves the one account by id (the
+     * re-open-on-stored-id case); anything else is a capped substring search.
+     * An empty query returns no matches rather than the whole directory.
+     *
+     * @param req - Express request; reads the `q` query param.
+     * @param res - Express response.
+     * @returns Resolves once the response has been written.
+     */
+    async searchAccounts(req: Request, res: Response): Promise<void> {
+        const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+        if (!q) {
+            res.json({ accounts: [] });
+            return;
+        }
+
+        try {
+            if (BA_USER_ID_PATTERN.test(q)) {
+                const account = await this.accountDirectory.getAccount(q);
+                res.json({ accounts: account ? [toAccountMatch(account)] : [] });
+                return;
+            }
+
+            const { accounts } = await this.accountDirectory.listAccounts({ search: q, limit: ACCOUNT_SEARCH_LIMIT });
+            res.json({ accounts: accounts.map(toAccountMatch) });
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to search accounts');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to search accounts' });
         }
 
         return;

--- a/src/backend/modules/identity/api/accounts.routes.ts
+++ b/src/backend/modules/identity/api/accounts.routes.ts
@@ -45,3 +45,24 @@ export function createAdminAccountsRouter(
 
     return router;
 }
+
+/**
+ * Create the admin account-search router.
+ *
+ * Mounted at the dedicated literal prefix `/api/admin/accounts` (with
+ * `requireAdmin` at the parent), deliberately separate from the
+ * `/api/admin/users` accounts router: that one is a `/:id` catch-all, so a
+ * `/search` route added there would be captured as an id. A distinct prefix
+ * also gives account pickers a stable, module-neutral URL. Backs the shared
+ * `context.ui.AccountPicker` typeahead.
+ *
+ * @param controller - Account-directory read controller.
+ * @returns Configured admin account-search router.
+ */
+export function createAdminAccountSearchRouter(controller: AccountsController): Router {
+    const router = Router();
+
+    router.get('/search', controller.searchAccounts.bind(controller));
+
+    return router;
+}

--- a/src/frontend/components/ui/AccountPicker/AccountPicker.module.scss
+++ b/src/frontend/components/ui/AccountPicker/AccountPicker.module.scss
@@ -1,0 +1,139 @@
+/**
+ * AccountPicker styles.
+ *
+ * A debounced account search box with a floating results dropdown, plus the
+ * compact "selected account" row shown once a value is chosen. Scoped to this
+ * component; references design tokens only. Mirrors the traffic ignore-list
+ * picker's token choices so admin account controls read consistently.
+ */
+
+.search {
+    position: relative;
+}
+
+.search_input {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+}
+
+.search_icon {
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+}
+
+.search_field {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+/* Results dropdown floats over following content so it does not shift layout. */
+.results {
+    position: absolute;
+    z-index: var(--z-index-dropdown);
+    left: 0;
+    right: 0;
+    margin: var(--gap-2xs) 0 0;
+    padding: 0;
+    list-style: none;
+    background: var(--color-surface);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+}
+
+.results_note {
+    padding: var(--padding-xs) var(--padding-sm);
+    font-size: var(--font-size-caption);
+    color: var(--color-text-subtle);
+}
+
+.result {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--gap-2xs);
+    width: 100%;
+    padding: var(--padding-xs) var(--padding-sm);
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+    transition: background var(--transition-fast);
+}
+
+.result:hover:not(:disabled) {
+    background: var(--color-surface-muted);
+}
+
+.result:disabled {
+    cursor: default;
+    opacity: var(--opacity-60);
+}
+
+.result_email {
+    color: var(--color-text);
+    font-size: var(--font-size-body-sm);
+}
+
+.result_name {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-caption);
+}
+
+/* Compact selected-account row shown once a value is chosen. */
+.selected {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    padding: var(--padding-xs) var(--padding-sm);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-muted);
+}
+
+.selected_main {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.selected_label {
+    color: var(--color-text);
+    font-size: var(--font-size-body-sm);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.selected_sub {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-caption);
+}
+
+.clear {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    padding: var(--padding-2xs);
+    color: var(--color-text-muted);
+    background: none;
+    border: none;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.clear:hover:not(:disabled) {
+    background: var(--color-surface);
+    color: var(--color-text);
+}
+
+.clear:disabled {
+    cursor: default;
+    opacity: var(--opacity-60);
+}

--- a/src/frontend/components/ui/AccountPicker/AccountPicker.tsx
+++ b/src/frontend/components/ui/AccountPicker/AccountPicker.tsx
@@ -16,7 +16,7 @@
  * permitted loading case (not primary page content), per the SSR rules.
  */
 
-import { useState, useEffect, useCallback, useId } from 'react';
+import { useState, useEffect, useCallback, useId, useRef } from 'react';
 import { Search, X } from 'lucide-react';
 import type { IAccountMatch } from '@/types';
 import { Input } from '../Input';
@@ -72,7 +72,22 @@ export function AccountPicker({ value, onChange, disabled, placeholder }: Accoun
     const [results, setResults] = useState<IAccountMatch[]>([]);
     const [searching, setSearching] = useState(false);
     const [selected, setSelected] = useState<IAccountMatch | null>(null);
+    const [isOpen, setIsOpen] = useState(false);
     const listId = useId();
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    // Dismiss the floating results dropdown when the admin clicks outside the
+    // picker, so a stale absolutely-positioned overlay can't linger over — and
+    // swallow clicks meant for — the form controls beneath it.
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent): void => {
+            if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, []);
 
     // Resolve a label for an externally-supplied value (e.g. a settings page
     // re-opened on a stored id). The exact-id search path returns the one
@@ -187,14 +202,18 @@ export function AccountPicker({ value, onChange, disabled, placeholder }: Accoun
 
     // Search state: debounced typeahead with a results dropdown.
     return (
-        <div className={styles.search}>
+        <div className={styles.search} ref={containerRef}>
             <div className={styles.search_input}>
                 <Search size={16} aria-hidden="true" className={styles.search_icon} />
                 <Input
                     type="text"
                     className={styles.search_field}
                     value={query}
-                    onChange={(e) => setQuery(e.target.value)}
+                    onChange={(e) => {
+                        setQuery(e.target.value);
+                        setIsOpen(true);
+                    }}
+                    onFocus={() => setIsOpen(true)}
                     placeholder={placeholder ?? 'Search accounts by email, name, or paste a user id'}
                     aria-label="Search accounts"
                     aria-controls={listId}
@@ -202,7 +221,7 @@ export function AccountPicker({ value, onChange, disabled, placeholder }: Accoun
                 />
             </div>
 
-            {(results.length > 0 || searching) && (
+            {isOpen && (results.length > 0 || searching) && (
                 <ul className={styles.results} id={listId} role="listbox" aria-label="Account search results">
                     {searching && <li className={styles.results_note}>Searching…</li>}
                     {!searching &&

--- a/src/frontend/components/ui/AccountPicker/AccountPicker.tsx
+++ b/src/frontend/components/ui/AccountPicker/AccountPicker.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+/**
+ * AccountPicker — a reusable admin control for selecting one Better Auth
+ * account by email/name.
+ *
+ * Exposed to plugins as `context.ui.AccountPicker` so any admin surface (e.g.
+ * the forum's publish-sink author) can choose an account without reimplementing
+ * account search. It is self-contained: it queries the admin-gated
+ * `/admin/accounts/search` endpoint itself and traffics only in the account id
+ * via `value`/`onChange`, so a consumer wires two props and nothing else.
+ *
+ * Admin-only by construction — the search endpoint is gated by `requireAdmin`,
+ * and the same-origin session cookie authorizes the logged-in admin. This is a
+ * user-triggered search control, so a transient "Searching…" state is the
+ * permitted loading case (not primary page content), per the SSR rules.
+ */
+
+import { useState, useEffect, useCallback, useId } from 'react';
+import { Search, X } from 'lucide-react';
+import type { IAccountMatch } from '@/types';
+import { Input } from '../Input';
+import { adminSearchAccounts } from '../../../lib/api';
+import styles from './AccountPicker.module.scss';
+
+/** Debounce (ms) before a search fires as the admin types — matches the traffic ignore-list picker. */
+const SEARCH_DEBOUNCE_MS = 300;
+
+/** Minimum term length before searching, so the dropdown doesn't flash on one keystroke. */
+const MIN_QUERY_LENGTH = 2;
+
+/**
+ * Props for {@link AccountPicker}. Kept structurally identical to the
+ * `context.ui.AccountPicker` contract in `IUIComponents` so the core component
+ * and the plugin-facing type never drift.
+ */
+export interface AccountPickerProps {
+    /** Currently-selected account id, or null when nothing is chosen. */
+    value: string | null;
+
+    /** Fired with the newly-selected account id, or null when cleared. */
+    onChange: (accountId: string | null) => void;
+
+    /** Disables the control (e.g. while a parent form is saving). */
+    disabled?: boolean;
+
+    /** Placeholder for the search field; a sensible default is used when omitted. */
+    placeholder?: string;
+}
+
+/**
+ * Render the label for a resolved match: name when present, else email, else
+ * the bare id (a deleted/unresolvable account still shows *something* stable).
+ *
+ * @param match - The resolved account, or a stub carrying only the id.
+ * @returns A human-readable primary label.
+ */
+function primaryLabel(match: IAccountMatch): string {
+    return match.name || match.email || match.id;
+}
+
+/**
+ * Searchable single-account picker. When a value is set it shows the resolved
+ * account with a clear affordance; otherwise it shows a debounced search box
+ * whose results select an account on click.
+ *
+ * @param props - See {@link AccountPickerProps}.
+ * @returns The rendered picker.
+ */
+export function AccountPicker({ value, onChange, disabled, placeholder }: AccountPickerProps) {
+    const [query, setQuery] = useState('');
+    const [results, setResults] = useState<IAccountMatch[]>([]);
+    const [searching, setSearching] = useState(false);
+    const [selected, setSelected] = useState<IAccountMatch | null>(null);
+    const listId = useId();
+
+    // Resolve a label for an externally-supplied value (e.g. a settings page
+    // re-opened on a stored id). The exact-id search path returns the one
+    // account; on miss we still stub the id so the selection stays visible and
+    // clearable rather than silently blank.
+    useEffect(() => {
+        if (!value) {
+            setSelected(null);
+            return;
+        }
+        if (selected?.id === value) {
+            return;
+        }
+        let active = true;
+        adminSearchAccounts(value)
+            .then((matches) => {
+                if (active) {
+                    setSelected(matches.find((m) => m.id === value) ?? { id: value, email: '', name: null });
+                }
+            })
+            .catch(() => {
+                if (active) {
+                    setSelected({ id: value, email: '', name: null });
+                }
+            });
+        return () => {
+            active = false;
+        };
+    }, [value, selected?.id]);
+
+    // Debounced account search. Clears results for a blank/short term so the
+    // dropdown does not flash on a single keystroke. The per-run `active` guard
+    // (cleared on every query change and on unmount) drops a stale in-flight
+    // search so only the latest term's results land.
+    useEffect(() => {
+        const term = query.trim();
+        if (term.length < MIN_QUERY_LENGTH) {
+            setResults([]);
+            setSearching(false);
+            return;
+        }
+        setSearching(true);
+        let active = true;
+        const timer = setTimeout(async () => {
+            try {
+                const matches = await adminSearchAccounts(term);
+                if (active) {
+                    setResults(matches);
+                }
+            } catch {
+                if (active) {
+                    setResults([]);
+                }
+            } finally {
+                if (active) {
+                    setSearching(false);
+                }
+            }
+        }, SEARCH_DEBOUNCE_MS);
+        return () => {
+            active = false;
+            clearTimeout(timer);
+        };
+    }, [query]);
+
+    /**
+     * Commit a chosen account: notify the parent, show it as selected, and reset
+     * the search box so re-opening starts clean.
+     *
+     * @param match - The account the admin clicked.
+     */
+    const handleSelect = useCallback(
+        (match: IAccountMatch): void => {
+            onChange(match.id);
+            setSelected(match);
+            setQuery('');
+            setResults([]);
+        },
+        [onChange]
+    );
+
+    /** Clear the selection, returning the control to its search state. */
+    const handleClear = useCallback((): void => {
+        onChange(null);
+        setSelected(null);
+        setQuery('');
+        setResults([]);
+    }, [onChange]);
+
+    // Selected state: show the resolved account with a clear button.
+    if (value && selected) {
+        return (
+            <div className={styles.selected}>
+                <span className={styles.selected_main}>
+                    <span className={styles.selected_label}>{primaryLabel(selected)}</span>
+                    {selected.name && selected.email && (
+                        <span className={styles.selected_sub}>{selected.email}</span>
+                    )}
+                </span>
+                <button
+                    type="button"
+                    className={styles.clear}
+                    onClick={handleClear}
+                    disabled={disabled}
+                    aria-label="Clear selected account"
+                >
+                    <X size={14} aria-hidden="true" />
+                </button>
+            </div>
+        );
+    }
+
+    // Search state: debounced typeahead with a results dropdown.
+    return (
+        <div className={styles.search}>
+            <div className={styles.search_input}>
+                <Search size={16} aria-hidden="true" className={styles.search_icon} />
+                <Input
+                    type="text"
+                    className={styles.search_field}
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder={placeholder ?? 'Search accounts by email, name, or paste a user id'}
+                    aria-label="Search accounts"
+                    aria-controls={listId}
+                    disabled={disabled}
+                />
+            </div>
+
+            {(results.length > 0 || searching) && (
+                <ul className={styles.results} id={listId} role="listbox" aria-label="Account search results">
+                    {searching && <li className={styles.results_note}>Searching…</li>}
+                    {!searching &&
+                        results.map((account) => (
+                            <li key={account.id} role="option" aria-selected={false}>
+                                <button
+                                    type="button"
+                                    className={styles.result}
+                                    onClick={() => handleSelect(account)}
+                                    disabled={disabled}
+                                >
+                                    <span className={styles.result_email}>{account.email || '(no email)'}</span>
+                                    {account.name && <span className={styles.result_name}>{account.name}</span>}
+                                </button>
+                            </li>
+                        ))}
+                    {!searching && results.length === 0 && (
+                        <li className={styles.results_note}>No matching accounts.</li>
+                    )}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/src/frontend/components/ui/AccountPicker/index.ts
+++ b/src/frontend/components/ui/AccountPicker/index.ts
@@ -1,0 +1,2 @@
+export { AccountPicker } from './AccountPicker';
+export type { AccountPickerProps } from './AccountPicker';

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import type { IAccountMatch } from '@/types';
 import { getServerSideApiUrl } from './api-url';
 
 export const apiClient = axios.create({
@@ -8,6 +9,21 @@ export const apiClient = axios.create({
   baseURL: typeof window === 'undefined' ? `${getServerSideApiUrl()}/api` : '/api',
   timeout: 5000
 });
+
+/**
+ * Typeahead search over Better Auth accounts for admin pickers (the shared
+ * `AccountPicker`). Hits the admin-gated identity endpoint; in the browser the
+ * relative `/api` base sends the same-origin session cookie, so an admin caller
+ * is authorized without extra wiring. Passing an exact 24-hex user id resolves
+ * that one account, which is how a picker re-labels a stored selection.
+ *
+ * @param q - Search term: an email/name substring, or an exact account id.
+ * @returns Matching accounts (id/email/name); empty on no match or a blank term.
+ */
+export async function adminSearchAccounts(q: string): Promise<IAccountMatch[]> {
+  const response = await apiClient.get('/admin/accounts/search', { params: { q } });
+  return (response.data as { accounts?: IAccountMatch[] }).accounts ?? [];
+}
 
 export async function getLatestTransactions(limit = 50) {
   const response = await apiClient.get('/blockchain/transactions/latest', {

--- a/src/frontend/lib/frontendPluginContext.tsx
+++ b/src/frontend/lib/frontendPluginContext.tsx
@@ -22,6 +22,7 @@ import { Select } from '../components/ui/Select';
 import { ClientTime } from '../components/ui/ClientTime';
 import { Tooltip } from '../components/ui/Tooltip';
 import { LazyIconPickerModal as IconPickerModal } from '../components/ui/IconPickerModal';
+import { AccountPicker } from '../components/ui/AccountPicker';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../components/ui/Table';
 import { useModal as useModalHook } from '../components/ui/ModalProvider';
 import { useToast as useToastHook } from '../components/ui/ToastProvider';
@@ -343,6 +344,7 @@ export function FrontendPluginContextProvider({ children }: { children: React.Re
             ClientTime,
             Tooltip,
             IconPickerModal,
+            AccountPicker,
             Table,
             Thead,
             Tbody,
@@ -445,6 +447,7 @@ export function createPluginContext(pluginId: string): IFrontendPluginContext {
         ClientTime,
         Tooltip,
         IconPickerModal,
+        AccountPicker,
         Table,
         Thead,
         Tbody,


### PR DESCRIPTION
Adds a reusable `context.ui.AccountPicker` so plugin admin surfaces can select a Better Auth account by email/name without reimplementing account search.

## What
- **Types** (`@delphian/tronrelic-types` → 6.6.0): `AccountPicker` added to `IUIComponents`; new `IAccountMatch` projection re-exported through the barrels.
- **Identity**: `GET /api/admin/accounts/search` — admin-gated, mounted at a dedicated literal `/api/admin/accounts` prefix (off the `/api/admin/users/:id` catch-all), backed by the existing `'accounts'` service. Returns a thin `{ id, email, name }` projection.
- **Frontend**: self-contained `AccountPicker` component (debounced search) wired into both `context.ui` literals; `adminSearchAccounts` client helper.

## Why
First consumer is the trp-forum publish-sink settings page (separate repo), which needs an account chooser for the sink author. The picker is generic and available to every plugin admin surface.

## Verification
`typecheck:backend` and `typecheck:frontend` green. (The monolithic `npm run typecheck` OOMs on this monorepo — pre-existing infra limit — hence the split checks.)