### PR TITLE
style(ui): halve main content vertical padding

### DIFF
--- a/src/frontend/app/primitives.scss
+++ b/src/frontend/app/primitives.scss
@@ -57,10 +57,11 @@
     --spacing-8: 1.1rem;    /* 17.6px - table cells, alerts */
     --spacing-9: 1.25rem;   /* 20px - card padding sm, stat grids */
     --spacing-10: 1.5rem;   /* 24px - stack-lg, common grid gaps */
+    --spacing-11: 1.75rem;  /* 28px - main padding bottom */
     --spacing-12: 2rem;     /* 32px - large card padding */
     --spacing-14: 2.5rem;   /* 40px - page gaps */
     --spacing-15: 3rem;     /* 48px - main padding horizontal */
-    --spacing-16: 3.5rem;   /* 56px - main padding bottom */
+    --spacing-16: 3.5rem;   /* 56px */
 
     /* Container Padding (responsive) */
     --container-padding-mobile: 1.25rem;   /* 20px */

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -404,10 +404,10 @@
     --page-header-bg-position: bottom right;
 
     /* Main Content Area Padding (top / sides / bottom) */
-    --main-padding-lg: var(--spacing-14) var(--spacing-15) var(--spacing-16);   /* desktop */
-    --main-padding-md: var(--spacing-12) var(--spacing-10) var(--spacing-15);   /* tablet */
-    --main-padding-sm: var(--spacing-10) var(--spacing-9) var(--spacing-14);    /* mobile */
-    --main-padding-xs: var(--spacing-4) var(--spacing-4) var(--spacing-7);      /* mobile-sm */
+    --main-padding-lg: var(--spacing-9) var(--spacing-15) var(--spacing-11);    /* desktop:   20px / 48px / 28px */
+    --main-padding-md: var(--spacing-7) var(--spacing-10) var(--spacing-10);    /* tablet:    16px / 24px / 24px */
+    --main-padding-sm: var(--spacing-5) var(--spacing-9) var(--spacing-9);      /* mobile:    12px / 20px / 20px */
+    --main-padding-xs: var(--spacing-1) var(--spacing-4) var(--spacing-4);      /* mobile-sm:  4px /  8px /  8px */
 
     /* Site-wide Body Background Image */
     --body-bg-image: none;


### PR DESCRIPTION
Cuts the top and bottom values of every `--main-padding-*` token in half across all four breakpoints, tightening the page against the header and footer. Horizontal gutters are untouched, so the desktop content box stays 1344px.

| Token | Before (top/sides/bottom) | After |
|---|---|---|
| `--main-padding-lg` (desktop) | 40 / 48 / 56 | **20** / 48 / **28** |
| `--main-padding-md` (tablet) | 32 / 24 / 48 | **16** / 24 / **24** |
| `--main-padding-sm` (mobile) | 24 / 20 / 40 | **12** / 20 / **20** |
| `--main-padding-xs` (mobile-sm) | 8 / 8 / 16 | **4** / 8 / **8** |

## Why `--spacing-11` is new

Every halved value maps onto an existing step of the foundation spacing scale except the 28px desktop bottom. Rather than bake a literal `1.75rem` into a Layer 2 token — which the composition rules in `ui-design-token-layers.md` push against — this adds `--spacing-11: 1.75rem` to `primitives.scss`, in the previously free slot between `--spacing-10` (24px) and `--spacing-12` (32px).

## Note on `--spacing-16`

`--spacing-16` (56px) existed only to serve `--main-padding-lg`'s bottom and is now unreferenced anywhere in `app/`, `components/`, `modules/`, `features/`, or `src/plugins/`. It is left defined (a gap in the foundation scale is harmless, and themes may override it) with only its now-false "main padding bottom" comment dropped. Happy to remove it if reviewers prefer.

Verified with `tsc --noEmit` (clean) and a standalone `sass` compile of `globals.scss` confirming the emitted token values.