### PR TITLE
Remove verified wallet profile pages from sitemap

### DIFF
--- a/src/backend/api/routes/sitemap.router.ts
+++ b/src/backend/api/routes/sitemap.router.ts
@@ -8,7 +8,6 @@
  * Returns:
  * - Published CMS page slugs with updatedAt timestamps
  * - Active plugin page paths
- * - Verified wallet addresses for user profile pages
  *
  * Cached for 10 minutes to avoid repeated database queries from
  * sitemap.xml requests.
@@ -26,7 +25,6 @@ interface SitemapCache {
 interface SitemapData {
     pages: Array<{ slug: string; updatedAt: string }>;
     pluginPages: string[];
-    profiles: string[];
 }
 
 /** Cache TTL in milliseconds (10 minutes). */
@@ -60,14 +58,13 @@ export function sitemapRouter(database: IDatabaseService): Router {
                 return;
             }
 
-            // Fetch all three data sources in parallel
-            const [pages, pluginPages, profiles] = await Promise.all([
+            // Fetch both data sources in parallel
+            const [pages, pluginPages] = await Promise.all([
                 fetchPublishedPages(database),
-                fetchPluginPages(database),
-                fetchVerifiedProfiles(database)
+                fetchPluginPages(database)
             ]);
 
-            const data: SitemapData = { pages, pluginPages, profiles };
+            const data: SitemapData = { pages, pluginPages };
 
             // Cache the result
             cache = { data, expiresAt: Date.now() + CACHE_TTL_MS };
@@ -134,45 +131,6 @@ async function fetchPluginPages(
         return plugins
             .map(p => `/${p.id as string}`)
             .filter(path => path.length > 1);
-    } catch (error) {
-        console.error('Failed to fetch sitemap data:', error);
-        return [];
-    }
-}
-
-/** Maximum total profile addresses to include in sitemap. */
-const MAX_PROFILE_ADDRESSES = 1000;
-
-/**
- * Fetch verified wallet addresses for user profile pages.
- *
- * Only includes users with at least one cryptographically verified wallet.
- * Capped at 1000 total addresses (not users) to prevent sitemap bloat,
- * since users can have multiple verified wallets.
- *
- * @param database - Database service
- * @returns Array of wallet address strings (max 1000)
- */
-async function fetchVerifiedProfiles(
-    database: IDatabaseService
-): Promise<string[]> {
-    try {
-        const collection = database.getCollection('users');
-        const users = await collection
-            .find(
-                { wallets: { $elemMatch: { verified: true } } },
-                { projection: { wallets: 1 } }
-            )
-            .limit(MAX_PROFILE_ADDRESSES)
-            .toArray();
-
-        const addresses = users.flatMap(user =>
-            ((user.wallets ?? []) as Array<{ address: string; verified: boolean }>)
-                .filter(w => w.verified)
-                .map(w => w.address)
-        );
-
-        return addresses.slice(0, MAX_PROFILE_ADDRESSES);
     } catch (error) {
         console.error('Failed to fetch sitemap data:', error);
         return [];

--- a/src/frontend/app/sitemap.ts
+++ b/src/frontend/app/sitemap.ts
@@ -7,7 +7,6 @@ import { absoluteUrl } from '../lib/seo';
 interface SitemapData {
   pages: Array<{ slug: string; updatedAt: string }>;
   pluginPages: string[];
-  profiles: string[];
 }
 
 /** Static routes that always appear in the sitemap. */
@@ -29,8 +28,8 @@ const staticPathSet = new Set(staticRoutes.map(r => r.path));
 /**
  * Fetch dynamic sitemap data from the backend.
  *
- * Calls the public /api/sitemap-data endpoint which returns published CMS pages,
- * active plugin pages, and verified user profiles in a single request.
+ * Calls the public /api/sitemap-data endpoint which returns published CMS pages
+ * and active plugin pages in a single request.
  * Fails gracefully — returns empty data if the backend is unavailable.
  *
  * @returns Dynamic sitemap entries or empty defaults
@@ -45,13 +44,13 @@ async function fetchDynamicData(): Promise<SitemapData> {
 
     if (!response.ok) {
       console.warn(`Sitemap data fetch failed: ${response.status}`);
-      return { pages: [], pluginPages: [], profiles: [] };
+      return { pages: [], pluginPages: [] };
     }
 
     return await response.json() as SitemapData;
   } catch (error) {
     console.warn('Failed to fetch sitemap data:', error);
-    return { pages: [], pluginPages: [], profiles: [] };
+    return { pages: [], pluginPages: [] };
   }
 }
 
@@ -110,20 +109,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         priority: 0.7
       });
       seenPaths.add(path);
-    }
-  }
-
-  // User profile pages (verified wallet addresses)
-  for (const address of dynamicData.profiles) {
-    const profilePath = `/u/${address}`;
-    if (!seenPaths.has(profilePath)) {
-      entries.push({
-        url: absoluteUrl(siteUrl, profilePath),
-        lastModified: now,
-        changeFrequency: 'weekly',
-        priority: 0.4
-      });
-      seenPaths.add(profilePath);
     }
   }
 

--- a/src/frontend/app/sitemap.ts
+++ b/src/frontend/app/sitemap.ts
@@ -60,7 +60,6 @@ async function fetchDynamicData(): Promise<SitemapData> {
  * Combines hardcoded core routes with dynamically discovered content:
  * - Published CMS pages (articles, documentation, announcements)
  * - Active plugin pages (resource-markets, whale tracking, etc.)
- * - Verified user profile pages (/u/{address})
  *
  * Dynamic entries are fetched from the backend's /api/sitemap-data endpoint
  * which caches results for 10 minutes. Static entries that overlap with


### PR DESCRIPTION
Drops the `/u/<address>` profile entries from the sitemap and removes the `fetchVerifiedProfiles` query that backed them.

The sitemap now covers published CMS pages and active plugin pages only. The backend no longer scans the `users` collection on every cache miss, and the frontend no longer emits profile URLs.

`npm run typecheck` passes.