### PR TITLE
docs(widgets): replace removed /u/[address] route examples

### DIFF
--- a/docs/plugins/plugins-widget-zones-registration.md
+++ b/docs/plugins/plugins-widget-zones-registration.md
@@ -96,8 +96,8 @@ Treat the values in `IRegisterWidgetInput` as *defaults*, not invariants. Anythi
 | Form | Matches | Example |
 |---|---|---|
 | Exact | The literal path, nothing else | `/markets` |
-| Single-segment glob | One trailing segment, no deeper | `/u/*` matches `/u/TXyz`, not `/u/TXyz/holdings` |
-| Deep glob | Any depth below the prefix | `/admin/**` matches `/admin/users/edit` |
+| Single-segment glob | One trailing segment, no deeper | `/tools/*` matches `/tools/energy-estimator`, not `/tools/energy-estimator/faq` |
+| Deep glob | Any depth below the prefix | `/system/**` matches `/system/plugins/trp-forum` |
 
 Patterns must start with `/`, contain no whitespace, and place glob markers only at the trailing position (`/*/markets` is rejected). The matcher is `routeMatches` in `src/backend/modules/widgets/placements/route-matcher.ts`; the admin API validates inputs through `normaliseRoutePattern` before reaching the placement service.
 
@@ -128,7 +128,7 @@ When two plugins target the same zone, set explicit `defaultOrder` to win determ
 
 ## Data Fetchers
 
-`defaultDataFetcher(route, params, placement?)` receives the resolved route, any params the host extracted (e.g. `{ address }` on `/u/[address]`), and a per-placement `IWidgetPlacementContext` — `{ id, instanceConfig }` — that lets one widget type produce per-placement variation without shipping a type per permutation. The third argument is optional, so existing fetchers that ignore placement-scoped config remain valid. The resolver substitutes an empty object for `instanceConfig` when a placement carries no overrides, so fetchers can read keys unconditionally.
+`defaultDataFetcher(route, params, placement?)` receives the resolved route, any params the host extracted (e.g. `{ slug }` on `/[...slug]`), and a per-placement `IWidgetPlacementContext` — `{ id, instanceConfig }` — that lets one widget type produce per-placement variation without shipping a type per permutation. The third argument is optional, so existing fetchers that ignore placement-scoped config remain valid. The resolver substitutes an empty object for `instanceConfig` when a placement carries no overrides, so fetchers can read keys unconditionally.
 
 Fetchers must return JSON-serialisable data quickly — heavy work belongs in a scheduled job that writes to a plugin-owned MongoDB collection that the fetcher then reads. A 5-second per-fetcher timeout is enforced by the SSR resolver via `Promise.race`. Failures should resolve to empty data, never throw — a throw is converted to an empty payload but logged as a fetcher error.
 

--- a/docs/plugins/plugins-widget-zones-ssr.md
+++ b/docs/plugins/plugins-widget-zones-ssr.md
@@ -32,7 +32,7 @@ If no component is registered for a widget ID, dev mode falls back to a JSON dum
 interface IWidgetComponentProps {
     data: unknown;                   // SSR-fetched payload from the widget type's defaultDataFetcher
     context: IFrontendPluginContext; // UI primitives, API client, WebSocket
-    route: string;                   // Current URL, e.g. '/u/TXyz...'
+    route: string;                   // Current URL, e.g. '/tools/energy-estimator'
     params: Record<string, string>;  // Extracted route params
 }
 ```

--- a/docs/system/system-api-widgets.md
+++ b/docs/system/system-api-widgets.md
@@ -10,7 +10,7 @@ The type/placement split landed in PR 2 of the widget rewrite gave operators a d
 
 All three routers chain `createAdminRateLimiter` before `requireAdmin` at mount time, so every endpoint is bounded per-IP and gated to the cookie or service-token auth path. Mutations on `/placements` broadcast `widgets:placements-update` over WebSocket to every connected socket; admin UIs refetch, public pages refetch widget data.
 
-The placements controller validates inputs against the live `IZoneRegistry` and `IWidgetTypeRegistry`. A request naming an unknown zone or type fails 400 before the placement service is touched. Route patterns flow through `normaliseRoutePattern` so the matcher's grammar (exact, `/u/*`, `/u/**`) is the single source of truth — see [Route Pattern Grammar](#route-pattern-grammar) below.
+The placements controller validates inputs against the live `IZoneRegistry` and `IWidgetTypeRegistry`. A request naming an unknown zone or type fails 400 before the placement service is touched. Route patterns flow through `normaliseRoutePattern` so the matcher's grammar (exact, `/tools/*`, `/system/**`) is the single source of truth — see [Route Pattern Grammar](#route-pattern-grammar) below.
 
 ## Endpoints
 
@@ -72,8 +72,8 @@ Placement `routes` arrays accept three forms:
 | Form | Matches | Example |
 |---|---|---|
 | Exact | The literal path, nothing else | `/markets` |
-| Single-segment glob | One trailing segment, no deeper | `/u/*` matches `/u/TXyz`, not `/u/TXyz/holdings` |
-| Deep glob | Any depth below the prefix | `/admin/**` matches `/admin/users/edit` |
+| Single-segment glob | One trailing segment, no deeper | `/tools/*` matches `/tools/energy-estimator`, not `/tools/energy-estimator/faq` |
+| Deep glob | Any depth below the prefix | `/system/**` matches `/system/plugins/trp-forum` |
 
 Empty `routes: []` matches every route. The matcher is `routeMatches` in `src/backend/modules/widgets/placements/route-matcher.ts`.
 

--- a/packages/types/src/widget-types/IWidgetType.ts
+++ b/packages/types/src/widget-types/IWidgetType.ts
@@ -47,7 +47,7 @@ export interface IWidgetPlacementContext {
 /**
  * SSR data fetcher signature shared between widget types and the
  * legacy widget service. Receives the resolved route, any params
- * extracted by the host (e.g. `{ address }` on `/u/[address]`), and
+ * extracted by the host (e.g. `{ slug }` on `/[...slug]`), and
  * the per-placement context (placement id and instanceConfig).
  *
  * The third arg is optional so existing fetchers that ignore

--- a/packages/types/src/widget/IWidgetComponentProps.ts
+++ b/packages/types/src/widget/IWidgetComponentProps.ts
@@ -58,15 +58,15 @@ export interface IWidgetComponentProps {
      * Current URL path where the widget is rendering.
      *
      * Enables widgets to adjust rendering based on the current page.
-     * For example, '/u/TXyz123...' on a profile page.
+     * For example, '/tools/energy-estimator' on a tools page.
      */
     route: string;
 
     /**
      * Route parameters extracted from the URL path.
      *
-     * For dynamic routes like `/u/[address]`, this would contain
-     * `{ address: 'TXyz123...' }`. Empty object for static routes.
+     * For dynamic routes like `/[...slug]`, this would contain
+     * `{ slug: 'about-us' }`. Empty object for static routes.
      */
     params: Record<string, string>;
 

--- a/src/backend/api/routes/widget.router.ts
+++ b/src/backend/api/routes/widget.router.ts
@@ -23,8 +23,8 @@ export function widgetRouter(): Router {
      * Fetch widgets for a specific route with pre-fetched data.
      *
      * Query params:
-     * - route: URL path to match against placement routes (e.g., '/', '/u/TXyz...')
-     * - params: Optional JSON-encoded route parameters (e.g., '{"address":"TXyz..."}')
+     * - route: URL path to match against placement routes (e.g., '/', '/tools/energy-estimator')
+     * - params: Optional JSON-encoded route parameters (e.g., '{"slug":"about-us"}')
      *
      * Returns:
      * {

--- a/src/backend/modules/widgets/README.md
+++ b/src/backend/modules/widgets/README.md
@@ -94,8 +94,8 @@ The pre-split admin read endpoints (`/api/widgets/all`, `/api/widgets/zones/:zon
 | Form | Matches | Example |
 |---|---|---|
 | Exact | The literal path, nothing else | `/`, `/markets` |
-| Single-segment glob | One trailing segment, no deeper | `/u/*` matches `/u/TXyz`, not `/u/TXyz/holdings` |
-| Deep glob | Any depth below the prefix | `/admin/**` matches `/admin/users/edit` |
+| Single-segment glob | One trailing segment, no deeper | `/tools/*` matches `/tools/energy-estimator`, not `/tools/energy-estimator/faq` |
+| Deep glob | Any depth below the prefix | `/system/**` matches `/system/plugins/trp-forum` |
 
 Empty `routes: []` matches every route. Glob markers are only valid at the trailing position — `/*/markets` is rejected at write time.
 

--- a/src/backend/modules/widgets/__tests__/placements.test.ts
+++ b/src/backend/modules/widgets/__tests__/placements.test.ts
@@ -60,23 +60,23 @@ describe('routeMatches', () => {
         expect(routeMatches(['/', '/markets'], '/')).toBe(true);
         expect(routeMatches(['/', '/markets'], '/markets')).toBe(true);
         expect(routeMatches(['/'], '/markets')).toBe(false);
-        expect(routeMatches(['/'], '/u/TXyz')).toBe(false);
+        expect(routeMatches(['/'], '/tools/energy-estimator')).toBe(false);
     });
 
     it('handles single-segment globs', () => {
-        expect(routeMatches(['/u/*'], '/u/TXyz')).toBe(true);
-        expect(routeMatches(['/u/*'], '/u/')).toBe(false);
-        expect(routeMatches(['/u/*'], '/u')).toBe(false);
-        expect(routeMatches(['/u/*'], '/u/TXyz/holdings')).toBe(false);
-        expect(routeMatches(['/u/*'], '/users/TXyz')).toBe(false);
+        expect(routeMatches(['/tools/*'], '/tools/energy-estimator')).toBe(true);
+        expect(routeMatches(['/tools/*'], '/tools/')).toBe(false);
+        expect(routeMatches(['/tools/*'], '/tools')).toBe(false);
+        expect(routeMatches(['/tools/*'], '/tools/energy-estimator/faq')).toBe(false);
+        expect(routeMatches(['/tools/*'], '/toolset/energy-estimator')).toBe(false);
     });
 
     it('handles deep globs', () => {
-        expect(routeMatches(['/u/**'], '/u/TXyz')).toBe(true);
-        expect(routeMatches(['/u/**'], '/u/TXyz/holdings')).toBe(true);
-        expect(routeMatches(['/u/**'], '/u/TXyz/holdings/2024')).toBe(true);
-        expect(routeMatches(['/u/**'], '/u')).toBe(false);
-        expect(routeMatches(['/u/**'], '/users/TXyz')).toBe(false);
+        expect(routeMatches(['/system/**'], '/system/logs')).toBe(true);
+        expect(routeMatches(['/system/**'], '/system/logs/archive')).toBe(true);
+        expect(routeMatches(['/system/**'], '/system/logs/archive/2024')).toBe(true);
+        expect(routeMatches(['/system/**'], '/system')).toBe(false);
+        expect(routeMatches(['/system/**'], '/systemx/logs')).toBe(false);
     });
 
     it('a deep glob at the root matches any path', () => {
@@ -86,11 +86,11 @@ describe('routeMatches', () => {
     });
 
     it('mixes patterns in a single filter', () => {
-        const filter = ['/', '/markets', '/u/*'];
+        const filter = ['/', '/markets', '/tools/*'];
         expect(routeMatches(filter, '/')).toBe(true);
         expect(routeMatches(filter, '/markets')).toBe(true);
-        expect(routeMatches(filter, '/u/TXyz')).toBe(true);
-        expect(routeMatches(filter, '/u/TXyz/h')).toBe(false);
+        expect(routeMatches(filter, '/tools/energy-estimator')).toBe(true);
+        expect(routeMatches(filter, '/tools/energy-estimator/faq')).toBe(false);
         expect(routeMatches(filter, '/admin')).toBe(false);
     });
 });
@@ -102,8 +102,8 @@ describe('normaliseRoutePattern', () => {
     });
 
     it('accepts trailing single and deep globs', () => {
-        expect(normaliseRoutePattern('/u/*')).toBe('/u/*');
-        expect(normaliseRoutePattern('/u/**')).toBe('/u/**');
+        expect(normaliseRoutePattern('/tools/*')).toBe('/tools/*');
+        expect(normaliseRoutePattern('/system/**')).toBe('/system/**');
     });
 
     it('trims whitespace surrounding a pattern', () => {
@@ -117,7 +117,7 @@ describe('normaliseRoutePattern', () => {
 
     it('rejects patterns without a leading slash', () => {
         expect(normaliseRoutePattern('markets')).toBeNull();
-        expect(normaliseRoutePattern('u/*')).toBeNull();
+        expect(normaliseRoutePattern('tools/*')).toBeNull();
     });
 
     it('rejects internal whitespace', () => {
@@ -126,8 +126,8 @@ describe('normaliseRoutePattern', () => {
 
     it('rejects glob markers anywhere except the trailing segment', () => {
         expect(normaliseRoutePattern('/*/markets')).toBeNull();
-        expect(normaliseRoutePattern('/u/*/extra')).toBeNull();
-        expect(normaliseRoutePattern('/u*')).toBeNull();
+        expect(normaliseRoutePattern('/tools/*/extra')).toBeNull();
+        expect(normaliseRoutePattern('/tools*')).toBeNull();
     });
 });
 
@@ -136,11 +136,11 @@ describe('partitionRoutePatterns', () => {
         const { exact, patterns } = partitionRoutePatterns([
             '/',
             '/markets',
-            '/u/*',
-            '/admin/**'
+            '/tools/*',
+            '/system/**'
         ]);
         expect(exact).toEqual(['/', '/markets']);
-        expect(patterns).toEqual(['/u/*', '/admin/**']);
+        expect(patterns).toEqual(['/tools/*', '/system/**']);
     });
 
     it('returns empty buckets for an empty input', () => {
@@ -371,8 +371,8 @@ describe('PlacementService CRUD', () => {
         });
         expect(placement.titleUrl).toBe('/markets');
 
-        const updated = await service.update(placement.id, { titleUrl: '/u/TXyz' });
-        expect(updated?.titleUrl).toBe('/u/TXyz');
+        const updated = await service.update(placement.id, { titleUrl: '/profile' });
+        expect(updated?.titleUrl).toBe('/profile');
 
         const cleared = await service.update(placement.id, { titleUrl: null });
         expect(cleared?.titleUrl).toBeUndefined();
@@ -716,12 +716,12 @@ describe('PlacementService.findByRoute (globs)', () => {
     });
 
     it('returns placements with single-glob patterns when the route matches one segment', async () => {
-        await service.create({ typeId: 'profile:summary', zoneId: 'main-after', routes: ['/u/*'] });
+        await service.create({ typeId: 'tools:summary', zoneId: 'main-after', routes: ['/tools/*'] });
         await service.create({ typeId: 'home:hero', zoneId: 'main-after', routes: ['/'] });
 
-        const results = await service.findByRoute('/u/TXyz');
+        const results = await service.findByRoute('/tools/energy-estimator');
         const ids = results.map(p => p.typeId).sort();
-        expect(ids).toEqual(['profile:summary']);
+        expect(ids).toEqual(['tools:summary']);
     });
 
     it('returns placements with deep-glob patterns at any depth', async () => {
@@ -734,9 +734,9 @@ describe('PlacementService.findByRoute (globs)', () => {
     });
 
     it('excludes single-glob rows when the route has extra depth', async () => {
-        await service.create({ typeId: 'profile:summary', zoneId: 'main-after', routes: ['/u/*'] });
+        await service.create({ typeId: 'tools:summary', zoneId: 'main-after', routes: ['/tools/*'] });
 
-        const results = await service.findByRoute('/u/TXyz/holdings');
+        const results = await service.findByRoute('/tools/energy-estimator/faq');
         expect(results).toEqual([]);
     });
 });

--- a/src/backend/modules/widgets/api/placements.controller.ts
+++ b/src/backend/modules/widgets/api/placements.controller.ts
@@ -84,7 +84,7 @@ const MAX_TITLE_URL_LENGTH = 512;
 /**
  * Format gate for a placement `titleUrl`. The heading link is
  * internal-only: the value must be a single-leading-slash root-relative
- * path (e.g. `/markets`, `/u/TXyz?tab=holdings#summary`). The negative
+ * path (e.g. `/markets`, `/profile?tab=wallets#summary`). The negative
  * lookahead rejects protocol-relative (`//host`) and the backslash
  * trick (`/\host`) that browsers normalise to off-site navigation;
  * forbidding whitespace and backslash anywhere blocks header/newline

--- a/src/backend/modules/widgets/placements/placement-resolver.ts
+++ b/src/backend/modules/widgets/placements/placement-resolver.ts
@@ -66,7 +66,7 @@ export class PlacementResolver {
      *
      * @param route - Request path resolved by the host.
      * @param params - Route params extracted by the host (e.g.
-     *   `{ address }` on `/u/[address]`). Forwarded to each widget
+     *   `{ slug }` on `/[...slug]`). Forwarded to each widget
      *   type's data fetcher.
      * @returns Top-level widget data ready for the frontend, in render
      *   order, with container children nested.

--- a/src/backend/modules/widgets/placements/route-matcher.ts
+++ b/src/backend/modules/widgets/placements/route-matcher.ts
@@ -6,11 +6,11 @@
  *
  * - **Exact** — `'/markets'` matches the path `/markets` and nothing
  *   else.
- * - **Prefix** — `'/u/*'` matches anything under `/u/` with one
- *   additional segment (`/u/TXyz` matches, `/u/TXyz/holdings` does
- *   not).
- * - **Deep prefix** — `'/u/**'` matches anything under `/u/` at any
- *   depth, including `/u/TXyz/holdings/2024`.
+ * - **Prefix** — `'/tools/*'` matches anything under `/tools/` with one
+ *   additional segment (`/tools/energy-estimator` matches,
+ *   `/tools/energy-estimator/faq` does not).
+ * - **Deep prefix** — `'/system/**'` matches anything under `/system/`
+ *   at any depth, including `/system/plugins/trp-forum`.
  *
  * Empty `routes` array still matches every path, preserving the
  * original "no filter" semantic.
@@ -73,7 +73,7 @@ function patternMatches(pattern: string, route: string): boolean {
 /**
  * Test whether a placement's route filter matches the given request
  * path. Empty `routes` matches every path. Otherwise, any matching
- * entry — exact, single-glob (`/u/*`), or deep-glob (`/u/**`) —
+ * entry — exact, single-glob (`/tools/*`), or deep-glob (`/system/**`) —
  * accepts the path.
  *
  * @param routes - Placement's route filter.

--- a/src/frontend/app/(core)/layout.tsx
+++ b/src/frontend/app/(core)/layout.tsx
@@ -13,17 +13,16 @@ import { WidgetZone, fetchWidgetsForRoute } from '../../components/widgets';
  * - main-before: Above page content
  * - main-after: Below page content
  *
- * The pathname is extracted from request headers set by middleware.
- * Route params are empty for core pages (dynamic routes like /u/[address]
- * have their own layouts that provide context-specific params).
+ * The pathname is extracted from request headers set by middleware, which
+ * carries no matched-route params — so widgets resolved here always receive
+ * an empty param map. A page whose widgets need route params must fetch its
+ * own bundle and render its own zones.
  */
 export default async function CoreLayout({ children }: { children: ReactNode }) {
     // Extract pathname from middleware-set header for per-route widgets
     const headersList = await headers();
     const pathname = headersList.get('x-pathname') || '/';
 
-    // Core pages use empty params - dynamic routes (e.g., /u/[address])
-    // have their own layouts that provide context-specific params
     const params: Record<string, string> = {};
 
     const { widgets, zones } = await fetchWidgetsForRoute(pathname, params);

--- a/src/frontend/app/(core)/system/widgets/page.tsx
+++ b/src/frontend/app/(core)/system/widgets/page.tsx
@@ -9,7 +9,7 @@
  * and an enabled switch, plus inline edit / delete / restore-defaults
  * actions. Create-placement opens a modal with a type picker, a zone
  * picker, and a route chip input that accepts exact paths or globs
- * (`/u/*`, `/admin/**`).
+ * (`/tools/*`, `/system/**`).
  *
  * Lives behind the System container, which is admin-gated. Like
  * `/system/menu` and `/system/hooks` this is a client component
@@ -228,7 +228,7 @@ function lookupZone(snapshot: IZoneSnapshot | null, zoneId: string): { label: st
  * can filter placements to a chosen URL exactly the way SSR resolution
  * does. Kept in lockstep with the server: empty `routes` matches every
  * path; otherwise an entry matches as an exact path, a single-segment
- * glob (`/u/*`), or a deep glob (`/u/**`).
+ * glob (`/tools/*`), or a deep glob (`/system/**`).
  *
  * @param routes - Placement's route filter.
  * @param route - Selected URL path to test against.
@@ -3140,7 +3140,7 @@ function PlacementForm({ mode, initial, defaultRoutes, types, zones, placements,
                         value={routeDraft}
                         onChange={(e) => { setRouteDraft(e.target.value); setRouteError(null); }}
                         onKeyDown={handleRouteKey}
-                        placeholder="/u/* or /markets or /admin/**"
+                        placeholder="/about or /tools/* or /system/**"
                         disabled={saving}
                     />
                     <Button
@@ -3155,8 +3155,8 @@ function PlacementForm({ mode, initial, defaultRoutes, types, zones, placements,
                 </div>
                 {routeError && <span className={styles.field_error}>{routeError}</span>}
                 <span className={styles.field_hint}>
-                    Press Enter or comma to add. Use <code>/u/*</code> for a single segment,
-                    {' '}<code>/u/**</code> for any depth.
+                    Press Enter or comma to add. Use <code>/tools/*</code> for a single segment,
+                    {' '}<code>/system/**</code> for any depth.
                 </span>
             </div>
 

--- a/src/frontend/components/widgets/WidgetWithContext.tsx
+++ b/src/frontend/components/widgets/WidgetWithContext.tsx
@@ -62,8 +62,8 @@ interface WidgetWithContextProps {
  * and real-time updates without importing directly from the frontend app.
  *
  * Also passes route and params to enable context-aware rendering. For example,
- * a widget on `/u/[address]` can access `params.address` to display profile-
- * specific content.
+ * a widget on `/[...slug]` can access `params.slug` to display page-specific
+ * content.
  *
  * This wrapper is a client component to ensure the context is created
  * in the browser where WebSocket connections are available.

--- a/src/frontend/components/widgets/fetchWidgetsForRoute.ts
+++ b/src/frontend/components/widgets/fetchWidgetsForRoute.ts
@@ -24,8 +24,8 @@ export interface IWidgetBundle {
  * Uses internal Docker URL (SITE_BACKEND) for container-to-container communication
  * during SSR. The external apiUrl doesn't resolve from inside containers.
  *
- * @param route - URL path to fetch widgets for (e.g., '/', '/u/TXyz...')
- * @param params - Optional route parameters (e.g., { address: 'TXyz...' })
+ * @param route - URL path to fetch widgets for (e.g., '/', '/tools/energy-estimator')
+ * @param params - Optional route parameters (e.g., { slug: 'about-us' })
  * @returns The widget bundle: pre-fetched widgets plus each zone's layout
  *
  * @example
@@ -44,10 +44,10 @@ export interface IWidgetBundle {
  * }
  *
  * // For dynamic routes with params
- * export default async function ProfileLayout({ params }) {
- *     const { address } = params;
- *     const route = `/u/${address}`;
- *     const routeParams = { address };
+ * export default async function PageLayout({ params }) {
+ *     const { slug } = params;
+ *     const route = `/${slug}`;
+ *     const routeParams = { slug };
  *     const widgets = await fetchWidgetsForRoute(route, routeParams);
  *
  *     return (

--- a/src/frontend/components/widgets/fetchWidgetsForRoute.ts
+++ b/src/frontend/components/widgets/fetchWidgetsForRoute.ts
@@ -45,9 +45,11 @@ export interface IWidgetBundle {
  *
  * // For dynamic routes with params
  * export default async function PageLayout({ params }) {
- *     const { slug } = params;
- *     const route = `/${slug}`;
- *     const routeParams = { slug };
+ *     // A [...slug] catch-all resolves slug to string[]; params is a Promise in Next.js 15
+ *     const { slug } = await params;
+ *     const path = slug.join('/');
+ *     const route = `/${path}`;
+ *     const routeParams = { slug: path };
  *     const widgets = await fetchWidgetsForRoute(route, routeParams);
  *
  *     return (


### PR DESCRIPTION
The verified wallet profile pages were removed, leaving widget documentation, JSDoc, and test fixtures illustrating route matching with a route that no longer exists. Every example now uses a live route — `/tools/*` for single-segment globs, `/system/**` for deep globs, and `/[...slug]` for dynamic params — so readers can verify the documented behaviour against pages that actually exist.

The core layout comment also claimed dynamic routes supply their own params through nested layouts. That was only ever true of the deleted profile layout, so it now documents the real constraint: widgets resolved in `CoreLayout` always receive an empty param map, and a page needing route params must fetch its own bundle.

No behaviour change — comments, docs, and test example data only.