### PR TITLE
feat(ai-tools): per-run query tool allowlist + article SEO timestamps

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delphian/tronrelic-types",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "description": "Core type definitions for the TronRelic platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/types/src/plugin/IPageConfig.ts
+++ b/packages/types/src/plugin/IPageConfig.ts
@@ -59,6 +59,20 @@ export interface IPluginPageMetadata {
     /** Open Graph type; use 'article' for time-stamped content. */
     ogType?: 'website' | 'article';
 
+    /**
+     * ISO 8601 first-publication timestamp for `article:published_time`.
+     * Only meaningful with `ogType: 'article'`; the catch-all route threads it
+     * into the Open Graph article tags so time-stamped content exposes its
+     * publish date to crawlers and social scrapers, not only inside JSON-LD.
+     */
+    publishedTime?: string;
+
+    /**
+     * ISO 8601 last-modification timestamp for `article:modified_time`.
+     * Pairs with {@link publishedTime}; same article-only semantics.
+     */
+    modifiedTime?: string;
+
     /** Canonical URL override for search-engine signal consolidation. */
     canonical?: string;
 
@@ -206,6 +220,20 @@ export interface IPageConfig {
      * Use 'article' for time-stamped content like blog posts or news.
      */
     ogType?: 'website' | 'article';
+
+    /**
+     * ISO 8601 first-publication timestamp for time-stamped pages, emitted as
+     * `article:published_time` when `ogType` is `'article'`. Wildcard pages
+     * typically supply this per-request via `serverMetadataFetcher` instead of
+     * declaring it statically here.
+     */
+    publishedTime?: string;
+
+    /**
+     * ISO 8601 last-modification timestamp, emitted as `article:modified_time`.
+     * Pairs with {@link publishedTime}.
+     */
+    modifiedTime?: string;
 
     /**
      * Optional canonical URL override.

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.module.scss
@@ -430,6 +430,39 @@
     gap: var(--gap-sm);
 }
 
+/* Per-run tool allowlist, tucked into a disclosure between the textarea and the
+   toolbar so it never crowds the composer. Collapsed by default (the run gets no
+   tools); opening it reveals the picker and the scoped trifecta badge. */
+.composer_tools {
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    padding: var(--padding-sm);
+}
+
+.composer_tools_summary {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    cursor: pointer;
+    font-size: var(--font-size-body-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text);
+}
+
+.composer_tools_body {
+    margin-top: var(--gap-sm);
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+}
+
+.composer_tools_hint {
+    margin: 0;
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+}
+
 .composer_send {
     margin-left: auto;
 }

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
@@ -11,6 +11,13 @@
  * reopened into the transcript. Like the sibling tabs this is an interactive
  * admin client surface, not an SSR-first public component — loading states are
  * appropriate for its secondary data and user-triggered sends.
+ *
+ * A per-run tool allowlist (a collapsed disclosure in the composer) narrows which
+ * tools the next send may call. It defaults to no tools — least privilege — so a
+ * manual query is inert until the operator deliberately grants a tool for that
+ * run. Being one-shot, it has no three-state contract to preserve: the explicit
+ * selection is sent verbatim on every send (`[]` = no tools; a name list = that
+ * subset), and a scoped lethal-trifecta preview updates while the disclosure is open.
  */
 
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
@@ -21,7 +28,7 @@ import remarkGfm from 'remark-gfm';
 import remarkRehype from 'remark-rehype';
 import rehypeSanitize from 'rehype-sanitize';
 import rehypeStringify from 'rehype-stringify';
-import type { IAiConversationMessage, IAiQueryRecord, IAiStreamChunk, IAiTranscriptSegment, IModelInfo, ISavedPrompt, IToolInvocationRecord } from '@/types';
+import type { IAiConversationMessage, IAiQueryRecord, IAiStreamChunk, IAiToolInfo, IAiTranscriptSegment, IModelInfo, ISavedPrompt, IToolInvocationRecord, ITrifectaStatus } from '@/types';
 import { Stack } from '../../../../../components/layout';
 import { Card } from '../../../../../components/ui/Card';
 import { Button } from '../../../../../components/ui/Button';
@@ -39,11 +46,15 @@ import {
     getConversation,
     getQueryModels,
     listActivity,
+    listTools,
+    getTrifectaPreview,
     type IStreamAck
 } from '../../../../../modules/ai-tools';
 import { SavedPromptsPanel } from './SavedPromptsPanel';
 import { InvocationDetailPanel } from '../components/InvocationDetailPanel';
 import { InvocationTable } from '../components/InvocationTable';
+import { ToolAllowlistPicker } from '../components/ToolAllowlistPicker';
+import { RunTrifectaBadge } from '../components/RunTrifectaBadge';
 import pageStyles from '../page.module.scss';
 import styles from './QueryTab.module.scss';
 
@@ -374,6 +385,21 @@ export function QueryTab() {
     const [error, setError] = useState<string | null>(null);
     const [models, setModels] = useState<IModelInfo[]>([]);
     const [modelOverride, setModelOverride] = useState<string>('');
+    /** The full tool registry (enabled + disabled), backing the per-run allowlist picker. */
+    const [tools, setTools] = useState<IAiToolInfo[]>([]);
+    /**
+     * Tool names the next send is allowed to call. Defaults to none — a manual
+     * query does nothing dangerous unless the operator grants a tool for that
+     * run. Sent verbatim to the governor on every send: `[]` = no tools, a list =
+     * that subset (no three-state contract, since a one-shot run persists nothing).
+     */
+    const [toolSelection, setToolSelection] = useState<string[]>([]);
+    /** Whether the composer's Tools disclosure is open; gates the trifecta preview so it runs only when visible. */
+    const [toolsOpen, setToolsOpen] = useState(false);
+    /** Scoped lethal-trifecta verdict for the current selection, or null before the first preview resolves. */
+    const [trifecta, setTrifecta] = useState<ITrifectaStatus | null>(null);
+    /** Whether a trifecta preview request is in flight (drives the badge's pending state). */
+    const [trifectaLoading, setTrifectaLoading] = useState(false);
     const [copiedTurnId, setCopiedTurnId] = useState<string | null>(null);
     const [view, setView] = useState<'chat' | 'history'>('chat');
     const [conversations, setConversations] = useState<ConversationGroup[]>([]);
@@ -461,6 +487,57 @@ export function QueryTab() {
         })();
         return () => { cancelled = true; };
     }, []);
+
+    // Load the tool registry once for the per-run allowlist picker. Secondary
+    // data on an interactive surface — a quiet failure leaves the picker empty,
+    // which only means the run gets no tools (the default), never a broken chat.
+    useEffect(() => {
+        let cancelled = false;
+        void (async () => {
+            try {
+                const list = await listTools();
+                if (!cancelled) {
+                    setTools(list);
+                }
+            } catch {
+                /* picker shows no options; the run simply gets no tools */
+            }
+        })();
+        return () => { cancelled = true; };
+    }, []);
+
+    // Preview the lethal-trifecta posture of the current selection, but only
+    // while the Tools disclosure is open — a closed disclosure needs no preview,
+    // so an operator who never opens it pays for no requests. Debounced so rapid
+    // toggling issues one request. The verdict is server-computed (it folds in
+    // provider server-tools and secret variables an allowlist cannot gate), so
+    // this only renders what the preview endpoint returns.
+    useEffect(() => {
+        if (!toolsOpen) {
+            return;
+        }
+        let cancelled = false;
+        setTrifectaLoading(true);
+        const timer = setTimeout(() => {
+            void (async () => {
+                try {
+                    const status = await getTrifectaPreview(toolSelection);
+                    if (!cancelled) {
+                        setTrifecta(status);
+                    }
+                } catch {
+                    if (!cancelled) {
+                        setTrifecta(null);
+                    }
+                } finally {
+                    if (!cancelled) {
+                        setTrifectaLoading(false);
+                    }
+                }
+            })();
+        }, 350);
+        return () => { cancelled = true; clearTimeout(timer); };
+    }, [toolSelection, toolsOpen]);
 
     /**
      * Mutate a single turn in place by id. Used by the stream handler to append
@@ -688,7 +765,10 @@ export function QueryTab() {
                 model: modelOverride || undefined,
                 messages: priorMessages,
                 conversationId,
-                stream: true
+                stream: true,
+                // Sent verbatim: `[]` grants no tools (the default), a name list
+                // grants that subset. The governor enforces it for this run.
+                toolAllowlist: toolSelection
             });
             // The streaming path acks immediately; the answer arrives over the
             // socket. A non-ack shape would mean the server didn't stream —
@@ -708,7 +788,7 @@ export function QueryTab() {
                 error: err instanceof Error ? err.message : 'Failed to submit query'
             });
         }
-    }, [input, streaming, messages, modelOverride, updateTurn]);
+    }, [input, streaming, messages, modelOverride, toolSelection, updateTurn]);
 
     /**
      * Abort the in-flight streaming query via the backend cancel route. The
@@ -1095,6 +1175,30 @@ export function QueryTab() {
                             aria-label="Message input"
                             disabled={streaming}
                         />
+                        <details
+                            className={styles.composer_tools}
+                            onToggle={(e) => setToolsOpen(e.currentTarget.open)}
+                        >
+                            <summary className={styles.composer_tools_summary}>
+                                <Wrench size={16} />
+                                Tools — {toolSelection.length === 0
+                                    ? 'none (default)'
+                                    : `${toolSelection.length} selected`}
+                            </summary>
+                            <div className={styles.composer_tools_body}>
+                                <p className={styles.composer_tools_hint}>
+                                    Tools this query may call. Defaults to none — grant only what this run
+                                    needs. Naming a tool that is disabled or removed fails the run.
+                                </p>
+                                <ToolAllowlistPicker
+                                    tools={tools}
+                                    selected={toolSelection}
+                                    onChange={setToolSelection}
+                                    disabled={streaming}
+                                />
+                                <RunTrifectaBadge status={trifecta} loading={trifectaLoading} />
+                            </div>
+                        </details>
                         <div className={styles.composer_toolbar}>
                             {models.length > 0 && (
                                 <Select

--- a/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/QueryTab.tsx
@@ -776,6 +776,11 @@ export function QueryTab() {
             if (!(ack as IStreamAck).success) {
                 throw new Error('Server did not start a streaming query.');
             }
+            // Per-run grant consumed: clear the allowlist once the governor has
+            // accepted this run so a later ordinary message cannot silently
+            // reuse a previously granted side-effecting tool. Honors the
+            // "grant only what this run needs" contract this picker advertises.
+            setToolSelection([]);
         } catch (err) {
             streamingTurnIdRef.current = null;
             activeQueryIdRef.current = null;
@@ -1187,8 +1192,10 @@ export function QueryTab() {
                             </summary>
                             <div className={styles.composer_tools_body}>
                                 <p className={styles.composer_tools_hint}>
-                                    Tools this query may call. Defaults to none — grant only what this run
-                                    needs. Naming a tool that is disabled or removed fails the run.
+                                    Registry tools this query may call. Defaults to none — grant only what
+                                    this run needs. Provider-hosted tools (web search / fetch), when enabled
+                                    for the model, still run regardless of this selection. Naming a tool
+                                    that is disabled or removed fails the run.
                                 </p>
                                 <ToolAllowlistPicker
                                     tools={tools}

--- a/src/frontend/app/[...slug]/page.tsx
+++ b/src/frontend/app/[...slug]/page.tsx
@@ -260,6 +260,8 @@ export async function generateMetadata({ params }: { params: Promise<IPageParams
             ogImage: dynamic.ogImage ?? pluginPage.ogImage,
             ogType: dynamic.ogType ?? pluginPage.ogType,
             canonical: dynamic.canonical ?? pluginPage.canonical,
+            publishedTime: dynamic.publishedTime ?? pluginPage.publishedTime,
+            modifiedTime: dynamic.modifiedTime ?? pluginPage.modifiedTime,
             noindex: dynamic.noindex ?? pluginPage.noindex
         };
 
@@ -277,6 +279,8 @@ export async function generateMetadata({ params }: { params: Promise<IPageParams
                 path: slug,
                 image: seo.ogImage,
                 type: seo.ogType,
+                publishedTime: seo.publishedTime,
+                modifiedTime: seo.modifiedTime,
                 keywords: seo.keywords,
                 canonical: seo.canonical
             });

--- a/src/frontend/app/[...slug]/page.tsx
+++ b/src/frontend/app/[...slug]/page.tsx
@@ -321,7 +321,13 @@ export async function generateMetadata({ params }: { params: Promise<IPageParams
                                 alt: seo.title ?? 'TronRelic'
                             }]
                         }
-                        : {})
+                        : {}),
+                    // Mirror buildMetadata: emit article timestamps whenever
+                    // present. Next renders article:published_time/modified_time
+                    // only under type:'article', so the ungated spread is
+                    // harmless and keeps both metadata paths consistent.
+                    ...(seo.publishedTime ? { publishedTime: seo.publishedTime } : {}),
+                    ...(seo.modifiedTime ? { modifiedTime: seo.modifiedTime } : {})
                 };
             }
         }

--- a/src/frontend/modules/ai-tools/api/client.ts
+++ b/src/frontend/modules/ai-tools/api/client.ts
@@ -376,6 +376,12 @@ export async function clearPolicy(name: string): Promise<void> {
  * backend scopes `ai-tools:query-stream` chunks to that single socket instead of
  * broadcasting globally, so other admin sessions never receive this query's
  * deltas. Required for a streaming request.
+ *
+ * `toolAllowlist` narrows which tools this one run may call, enforced at the
+ * governor. Unlike a saved prompt (which persists a three-state field), an
+ * ad-hoc query has nothing to persist, so the composer always sends the explicit
+ * array: `[]` grants no tools (the safe default), a name list grants that subset.
+ * Omit entirely to leave the run at the contract default (all enabled tools).
  */
 export interface IQueryRequest {
     prompt: string;
@@ -385,6 +391,7 @@ export interface IQueryRequest {
     stream?: boolean;
     messages?: IAiConversationMessage[];
     conversationId?: string;
+    toolAllowlist?: string[];
 }
 
 /**


### PR DESCRIPTION
## Per-run tool allowlist

The AI-tools QueryTab composer gains a collapsed **Tools** disclosure that scopes which tools the next send may call. It defaults to **none** (least privilege): a manual query is inert until the operator deliberately grants a tool for that run. Because a one-shot query persists nothing, there is no three-state contract — the explicit selection is sent verbatim as `toolAllowlist` on every send (`[]` = no tools, a name list = that subset). A scoped lethal-trifecta preview renders while the disclosure is open, debounced, and only fires when visible.

## Article SEO timestamps

`publishedTime`/`modifiedTime` (ISO 8601) are threaded through `IPageConfig`/`IPluginPageMetadata` and the catch-all `[...slug]` route so `ogType: 'article'` pages emit `article:published_time` / `article:modified_time` Open Graph tags — exposing publish dates to crawlers and social scrapers, not only inside JSON-LD. Wildcard pages typically supply these per-request via `serverMetadataFetcher`.

Types bumped to 6.7.0.