### PR TITLE
feat(image-gen): add referenceImage option for image-to-image editing

### DIFF
--- a/docs/plugins/plugins-frontend-context.md
+++ b/docs/plugins/plugins-frontend-context.md
@@ -74,6 +74,12 @@ const onGenerate = async () => {
 
 Like the picker, this is **core interface, provider-delivered**: core owns `useImageGen`, the enabled image-generation provider plugin registers the concrete generator via `registerProvider` (last registration wins), and `isAvailable` is reactive so a consumer hides its "generate" control when no provider is enabled. `generate` resolves `null` when no provider is registered and rejects when a registered provider fails — surface that reason to the user. The generator persists the image the moment it is produced, so the returned selection is immediately usable; discarding it is a consumer-side UI choice, not an un-save.
 
+**Reference image (image-to-image edit).** Pass an optional `referenceImage` — the same `IFileSelection` the picker or a prior generation yields — to edit or vary an existing image instead of generating from scratch. The prompt then describes the *change*, and the provider runs its edit path. The provider reads only the selection's opaque `fileId`, so the reference must already live in the platform inventory (the picker's upload and browse both satisfy this); no external URL is fetched. A provider whose active generator cannot edit **rejects** the call, so treat the reference control as optional and be ready to surface that rejection — never gate the plain prompt-only path on it.
+
+```typescript
+const image = await generate({ prompt: 'make the background deep blue', referenceImage });
+```
+
 Providers are provider-neutral by construction — never bind to one vendor's service name. To check whether *any* image provider is reachable, use `isAvailable`, not a probe of a specific plugin.
 
 ## Detail Documents

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delphian/tronrelic-types",
-  "version": "6.8.0",
+  "version": "6.9.0",
   "description": "Core type definitions for the TronRelic platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -982,12 +982,16 @@ export interface IImageGenOptions {
      * from-nothing generation. Pass the SAME {@link IFileSelection} the file
      * picker or a prior generation yields — the provider reads its opaque
      * `fileId`, so the reference must already live in the platform file
-     * inventory (no external URL is ever fetched). Omit it for ordinary
-     * prompt-only generation. A provider whose active generator cannot edit
-     * rejects the call, so a consumer that offers a reference control must be
-     * prepared to surface that rejection.
+     * inventory (no external URL is ever fetched). Omit it — or pass `null` —
+     * for ordinary prompt-only generation; `null` is accepted so a consumer
+     * holding the selection in `useState<IFileSelection | null>(null)` can pass
+     * it straight through without coercing to `undefined`, matching the
+     * `IFileSelection | null` that {@link IFilePickerClient.pick} and
+     * {@link IImageGenClient.generate} return. A provider whose active generator
+     * cannot edit rejects the call, so a consumer that offers a reference
+     * control must be prepared to surface that rejection.
      */
-    referenceImage?: IFileSelection;
+    referenceImage?: IFileSelection | null;
 
     /**
      * Provider-specific knobs (aspect ratio, style, seed, negative prompt).

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -976,6 +976,20 @@ export interface IImageGenOptions {
     prompt: string;
 
     /**
+     * Optional reference image to edit or vary instead of generating from
+     * scratch. When supplied, the prompt describes the *change* to make to this
+     * image and the provider runs its image-to-image (edit) path rather than a
+     * from-nothing generation. Pass the SAME {@link IFileSelection} the file
+     * picker or a prior generation yields — the provider reads its opaque
+     * `fileId`, so the reference must already live in the platform file
+     * inventory (no external URL is ever fetched). Omit it for ordinary
+     * prompt-only generation. A provider whose active generator cannot edit
+     * rejects the call, so a consumer that offers a reference control must be
+     * prepared to surface that rejection.
+     */
+    referenceImage?: IFileSelection;
+
+    /**
      * Provider-specific knobs (aspect ratio, style, seed, negative prompt).
      * Advisory: the active provider validates these and drops keys it does not
      * recognize, so a consumer can pass a superset without breaking on a swap.
@@ -997,7 +1011,12 @@ export interface IImageGenProvider {
     /** Id of the delivering provider plugin, for diagnostics/telemetry. */
     providerId: string;
 
-    /** Generate an image, persist it, and resolve the saved file selection. */
+    /**
+     * Generate an image, persist it, and resolve the saved file selection. When
+     * `options.referenceImage` is set the provider runs its edit path against
+     * that image instead of generating from scratch; it rejects if its active
+     * generator cannot edit.
+     */
     generate: (options: IImageGenOptions) => Promise<IFileSelection>;
 }
 


### PR DESCRIPTION
Extends the image-gen seam so consumers can edit or vary an existing image instead of always generating from scratch.

## What changed

- `IImageGenOptions` gains an optional `referenceImage: IFileSelection`. When set, the prompt describes the *change* and the provider runs its image-to-image (edit) path.
- The provider reads only the selection's opaque `fileId`, so the reference must already live in the platform file inventory (the picker's upload/browse both satisfy this); no external URL is fetched.
- A provider whose active generator cannot edit **rejects** the call, so the reference control is optional and the plain prompt-only path is never gated on it.
- `IImageGenProvider.generate` JSDoc updated to document the edit path.
- Bumps `@delphian/tronrelic-types` to 6.9.0 and documents the reference-image edit in `plugins-frontend-context.md`.

Provider-neutral by construction — consumers check `isAvailable`, never a specific vendor's service name.