### PR TITLE
feat(frontend): expose CopyButton primitive to plugin frontend context

### DIFF
--- a/docs/plugins/plugins-frontend-context-ui.md
+++ b/docs/plugins/plugins-frontend-context-ui.md
@@ -14,7 +14,7 @@ Layout components carry typed props — `<layout.Stack gap="md">` fails compilat
 interface IFrontendPluginContext {
     pluginId: string;              // Used internally for namespacing events and API routes
     layout: ILayoutComponents;     // Page, PageHeader, Stack, Grid, Section, SubMenu
-    ui: IUIComponents;             // Card, Badge, Button, IconButton, Switch, Input, Skeleton, ClientTime, Tooltip, IconPickerModal, Table family
+    ui: IUIComponents;             // Card, Badge, Button, CopyButton, IconButton, Switch, Input, Skeleton, ClientTime, Tooltip, IconPickerModal, Table family
     charts: IChartComponents;      // LineChart, BarChart
     system: ISystemComponents;     // SchedulerMonitor (admin)
     api: IApiClient;               // get/post/put/patch/delete
@@ -78,12 +78,15 @@ const [tab, setTab] = useState('query');
 | `Badge` | `tone?: 'neutral'\|'info'\|'success'\|'warning'\|'danger'`, `title?`, `className?`, `children?` |
 | `Skeleton` | `width?`, `height?`, `className?`, `style?` |
 | `Button` | `variant?: 'primary'\|'secondary'\|'ghost'\|'danger'\|'warning'`, `size?: 'xs'\|'sm'\|'md'\|'lg'`, `loading?`, `icon?: ReactNode`, `disabled?`, `onClick?`, `type?`, `aria-label?`, `className?`, `children?` |
+| `CopyButton` | `value: string` (required), `label?`, `copiedLabel?`, `resetMs?`, `variant?`, `size?`, `disabled?`, `type?`, `aria-label?`, `className?` |
 | `IconButton` | `variant?: 'ghost'\|'primary'\|'danger'\|'success'`, `size?: 'sm'\|'md'\|'lg'`, `onClick?: (event) => void`, `disabled?`, `title?`, `type?`, **`aria-label` (required)**, `className?`, `children?` |
 | `Switch` | `on: boolean`, `onChange: (next) => void`, `onClick?: (event) => void`, `size?: 'sm'\|'md'\|'lg'`, `disabled?`, `title?`, `type?`, **`aria-label` (required)**, `className?` |
 | `Input` | `value?`, `onChange?`, `onKeyDown?`, `placeholder?`, `disabled?`, `required?`, `variant?: 'default'\|'ghost'`, `type?`, `min?`, `max?`, `step?`, `id?`, `name?`, `aria-label?`, `className?` |
 | `ClientTime` | `date: Date \| string \| null \| undefined`, `format?: 'time'\|'datetime'\|'date'`, `fallback?` |
 | `Tooltip` | `content: string`, `children: ReactNode`, `placement?: 'top'\|'bottom'` |
 | `IconPickerModal` | `selectedIcon?`, `onSelect: (iconName) => void`, `onClose: () => void` |
+
+`CopyButton` wraps `Button` to copy `value` to the clipboard on click, briefly swapping to a confirmation state (`copiedLabel`) for `resetMs`. Use it instead of hand-rolling `navigator.clipboard` — it owns the async-clipboard call, the non-secure-context fallback, the confirmation timing, and `event.stopPropagation()` so it is safe inside a clickable row. Provide `label` for a text+icon button; omit it for icon-only and set `aria-label` so the action is still announced. Set `type="button"` when placing it inside a `<form>` to avoid submitting the form.
 
 `IconButton` is for inline row actions where a bordered `Button` would dominate. `aria-label` is required because there's no visible text. The click handler receives the full event so plugin code can call `event.stopPropagation()` to avoid firing an enclosing row's click handler.
 

--- a/docs/plugins/plugins-frontend-context.md
+++ b/docs/plugins/plugins-frontend-context.md
@@ -12,7 +12,7 @@ Direct imports from `src/frontend/` break Next.js module resolution and couple p
 interface IFrontendPluginContext {
     pluginId: string;              // namespacing for events and API routes
     layout: ILayoutComponents;     // Page, PageHeader, Stack, Grid, Section, SubMenu
-    ui: IUIComponents;             // Card, Badge, Button, IconButton, Switch, Input, Skeleton, ClientTime, Tooltip, IconPickerModal, Table family
+    ui: IUIComponents;             // Card, Badge, Button, CopyButton, IconButton, Switch, Input, Skeleton, ClientTime, Tooltip, IconPickerModal, Table family
     charts: IChartComponents;      // LineChart, BarChart
     system: ISystemComponents;     // SchedulerMonitor (admin)
     api: IApiClient;               // get/post/put/patch/delete with runtime base URL

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delphian/tronrelic-types",
-  "version": "6.10.0",
+  "version": "6.11.0",
   "description": "Core type definitions for the TronRelic platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -119,7 +119,7 @@ export interface IUIComponents {
      * async-clipboard call, the non-secure-context fallback, the confirmation
      * timing, and `event.stopPropagation()` so it is safe inside a clickable
      * row. Provide `label` for a text+icon button; omit it for icon-only and
-     * set `ariaLabel` so the action is still announced.
+     * set `aria-label` so the action is still announced.
      */
     CopyButton: ComponentType<{
         /** String written to the clipboard on click. */
@@ -131,10 +131,12 @@ export interface IUIComponents {
         /** How long the confirmation state persists, in milliseconds. */
         resetMs?: number;
         /** Accessible label used when no visible `label` is shown. */
-        ariaLabel?: string;
+        'aria-label'?: string;
         variant?: 'primary' | 'secondary' | 'ghost' | 'danger' | 'warning';
         size?: 'xs' | 'sm' | 'md' | 'lg';
         disabled?: boolean;
+        /** Button `type`; set to `'button'` to avoid submitting an enclosing form. */
+        type?: 'button' | 'submit' | 'reset';
         className?: string;
     }>;
 

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -109,6 +109,36 @@ export interface IUIComponents {
     }>;
 
     /**
+     * CopyButton — one-click "copy to clipboard" affordance.
+     *
+     * Writes `value` to the system clipboard on click and briefly swaps to a
+     * confirmation state (`copiedLabel`) for `resetMs`. Wraps `Button`, so it
+     * takes the same `variant`/`size` and defaults to a quiet `ghost`/`sm`
+     * treatment. Use instead of hand-rolling `navigator.clipboard` in a plugin
+     * (copy a post's text, an address, a code block) — the primitive owns the
+     * async-clipboard call, the non-secure-context fallback, the confirmation
+     * timing, and `event.stopPropagation()` so it is safe inside a clickable
+     * row. Provide `label` for a text+icon button; omit it for icon-only and
+     * set `ariaLabel` so the action is still announced.
+     */
+    CopyButton: ComponentType<{
+        /** String written to the clipboard on click. */
+        value: string;
+        /** Visible label beside the icon; icon-only when omitted. */
+        label?: string;
+        /** Label shown during the post-copy confirmation window. */
+        copiedLabel?: string;
+        /** How long the confirmation state persists, in milliseconds. */
+        resetMs?: number;
+        /** Accessible label used when no visible `label` is shown. */
+        ariaLabel?: string;
+        variant?: 'primary' | 'secondary' | 'ghost' | 'danger' | 'warning';
+        size?: 'xs' | 'sm' | 'md' | 'lg';
+        disabled?: boolean;
+        className?: string;
+    }>;
+
+    /**
      * IconButton — borderless icon-only button for inline row actions.
      *
      * Use when a bordered `<Button>` with an icon would visually dominate
@@ -1061,7 +1091,7 @@ export interface IFrontendPluginContext {
     /** Plugin identifier used for namespacing events and API routes */
     pluginId: string;
 
-    /** UI component library (Card, Badge, Button, IconButton, Switch, Input, Select, Skeleton, ClientTime, Tooltip, IconPickerModal, Table family) */
+    /** UI component library (Card, Badge, Button, CopyButton, IconButton, Switch, Input, Select, Skeleton, ClientTime, Tooltip, IconPickerModal, Table family) */
     ui: IUIComponents;
 
     /** Layout component library (Page, PageHeader, Stack, Grid, Section, SubMenu) */

--- a/src/frontend/app/(core)/system/system/components/ClickHouseTableBrowser.tsx
+++ b/src/frontend/app/(core)/system/system/components/ClickHouseTableBrowser.tsx
@@ -242,7 +242,7 @@ export function ClickHouseTableBrowser() {
                                                                             <div onClick={(e) => e.stopPropagation()}>
                                                                                 <CopyButton
                                                                                     value={rowJson}
-                                                                                    ariaLabel="Copy row JSON"
+                                                                                    aria-label="Copy row JSON"
                                                                                 />
                                                                             </div>
                                                                         </Td>

--- a/src/frontend/app/(core)/system/system/components/CollectionBrowser.tsx
+++ b/src/frontend/app/(core)/system/system/components/CollectionBrowser.tsx
@@ -319,7 +319,7 @@ export function CollectionBrowser() {
                                                                             <div className={styles.row_actions} onClick={(e) => e.stopPropagation()}>
                                                                                 <CopyButton
                                                                                     value={JSON.stringify(doc, null, 2)}
-                                                                                    ariaLabel="Copy document JSON"
+                                                                                    aria-label="Copy document JSON"
                                                                                 />
                                                                                 <Button
                                                                                     variant="ghost"

--- a/src/frontend/components/ui/CopyButton/CopyButton.tsx
+++ b/src/frontend/components/ui/CopyButton/CopyButton.tsx
@@ -27,7 +27,7 @@ interface CopyButtonProps extends Omit<ButtonProps, 'icon' | 'onClick' | 'childr
      * Accessible label when no visible text is shown.
      * @default 'Copy to clipboard'
      */
-    ariaLabel?: string;
+    'aria-label'?: string;
 }
 
 /**
@@ -41,7 +41,7 @@ export function CopyButton({
     label,
     copiedLabel = 'Copied',
     resetMs = 1500,
-    ariaLabel = 'Copy to clipboard',
+    'aria-label': ariaLabel = 'Copy to clipboard',
     variant = 'ghost',
     size = 'sm',
     ...rest

--- a/src/frontend/lib/frontendPluginContext.tsx
+++ b/src/frontend/lib/frontendPluginContext.tsx
@@ -15,6 +15,7 @@ import { Card } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { Skeleton } from '../components/ui/Skeleton';
 import { Button } from '../components/ui/Button';
+import { CopyButton } from '../components/ui/CopyButton';
 import { IconButton } from '../components/ui/IconButton';
 import { Switch } from '../components/ui/Switch';
 import { Input } from '../components/ui/Input';
@@ -333,6 +334,7 @@ export function FrontendPluginContextProvider({ children }: { children: React.Re
             Badge,
             Skeleton,
             Button,
+            CopyButton,
             IconButton,
             Switch,
             // forwardRef gives Input a ForwardRefExoticComponent type whose static
@@ -441,6 +443,7 @@ export function createPluginContext(pluginId: string): IFrontendPluginContext {
         Badge,
         Skeleton,
         Button,
+        CopyButton,
         IconButton,
         Switch,
         // See FrontendPluginContextProvider above: forwardRef's static propTypes

--- a/src/frontend/modules/user/components/WalletManager/WalletManageList.tsx
+++ b/src/frontend/modules/user/components/WalletManager/WalletManageList.tsx
@@ -116,7 +116,7 @@ export function WalletManageList({
                                                     <CopyButton
                                                         value={wallet.address}
                                                         size="xs"
-                                                        ariaLabel="Copy wallet address"
+                                                        aria-label="Copy wallet address"
                                                     />
                                                 </span>
                                                 <span className={styles.meta}>


### PR DESCRIPTION
Adds `CopyButton` to the plugin frontend UI component library (`IUIComponents`) and wires it into both `FrontendPluginContextProvider` and `createPluginContext`.

Plugins can now use a one-click copy-to-clipboard affordance (post text, addresses, code blocks) instead of hand-rolling `navigator.clipboard`. The primitive owns the async-clipboard call, the non-secure-context fallback, confirmation timing, and `event.stopPropagation()` so it is safe inside clickable rows.

Bumps `@delphian/tronrelic-types` to 6.11.0.