### PR TITLE
feat(traffic): admin-managed URL redirects via edge middleware feed

### DIFF
--- a/src/backend/modules/traffic/README.md
+++ b/src/backend/modules/traffic/README.md
@@ -8,12 +8,12 @@ Owns cookieless behavioral analytics: the ClickHouse `traffic_events` pipeline, 
 |---------|-------|
 | Module id | `traffic` |
 | Module class | `src/backend/modules/traffic/TrafficModule.ts` |
-| Admin page | `/system/traffic` (menu item `Traffic`, order 26, registered in `run()`) |
-| Mounted routes | `/api/admin/users/traffic/*`, `/api/admin/users/analytics/*`, `/api/user/bootstrap`, `/api/user/track` |
+| Admin page | `/system/traffic` (menu item `Traffic`, order 26; tab row is the Submenu Pattern under menu namespace `traffic`, both registered in `run()`) |
+| Mounted routes | `/api/admin/users/traffic/*`, `/api/admin/users/analytics/*`, `/api/user/bootstrap`, `/api/user/track`, `/api/redirects` (public), `/api/admin/redirects/*` |
 | Scheduled job | `gsc:fetch` (daily, `0 3 * * *`) |
 | ClickHouse table | `traffic_events` (migrations 010, 012, 013, 014, 015) |
 | Event types | `bootstrap` (cookieless first touch, incl. bots) · `page` (interactive navigation) |
-| Mongo collections | `module_user_gsc_queries` (GSC keyword cache — physical name preserved) · `module_user_gsc_daily_totals` (date-only GSC daily totals) · `module_user_gsc_page_totals` ([page, date] GSC totals, anonymization-immune) · `module_traffic_ignored_users` (operator ignore list) |
+| Mongo collections | `module_user_gsc_queries` (GSC keyword cache — physical name preserved) · `module_user_gsc_daily_totals` (date-only GSC daily totals) · `module_user_gsc_page_totals` ([page, date] GSC totals, anonymization-immune) · `module_traffic_ignored_users` (operator ignore list) · `module_traffic_redirects` (admin-managed URL redirect rules) |
 | Analytics key | cookieless `tronrelic_tid` (`candidate_uid`), independent of identity |
 | Bootstrap order | Inits/runs **before** `IdentityModule` so its `/api/admin/users/{traffic,analytics}` routers mount ahead of the accounts `/api/admin/users` catch-all |
 
@@ -31,6 +31,8 @@ Physical storage names are unchanged from when this code lived under the user mo
 | `services/traffic.service.ts` | ClickHouse `traffic_events` writes + admin aggregate reads; `buildTrafficEvent`, `ITrafficEvent`. Also owns the always-on ignore-list exclusion: `setIgnoredUserIds` resolves the whole-person tid set once per list change (one unwindowed `user_id` scan) and caches it; `rangeParams` (plus `getLiveVisitorCount`) then appends a literal, index-friendly `candidate_uid NOT IN (<cached tids>)` |
 | `services/ignored-users.service.ts` | `IgnoredUsersService` — Mongo-backed operator ignore list (`module_traffic_ignored_users`); persists id + denormalized email/name, exposes `list`/`getIds`/`add`/`remove`. Persistence only; the query-time filtering is TrafficService's |
 | `services/gsc.service.ts` | Google Search Console keyword fetch/store (`module_user_gsc_queries`) plus date-only daily totals (`module_user_gsc_daily_totals`) and [page, date] page totals (`module_user_gsc_page_totals`) — GSC drops anonymized queries from keyword rows, so chart totals and the top-pages panel come from query-less fetches that escape anonymization |
+| `services/redirect.service.ts` | Admin-managed legacy-URL redirect rules (`module_traffic_redirects`, one doc per rule, unique index on `pattern`). Validates same-site paths, refuses reserved prefixes (`/api`, `/_next`), rejects self- and prefix-loop redirects. `getActiveRules()` serves enabled rules most-specific-first to the edge middleware; migration 017 seeds the initial legacy set, thereafter admin-managed from the UI |
+| `api/redirects.{controller,routes}.ts` | Public `GET /api/redirects` (unauthenticated cached feed the Next.js edge middleware polls) and admin CRUD under `/api/admin/redirects` (`requireAdmin`). The middleware issues the actual 301/302; no rules are hardcoded in the frontend bundle |
 | `services/bot-classifier.ts` | Request → `BotClass` (powers `traffic_events.bot_class`). `classifyTrafficRequest` runs scanner heuristics first — probe paths (`/.env`, encoded traversal) and spoofed search-engine `Referer` with no `Sec-Fetch-Site` — then falls through to the UA-only `classifyUserAgent`; scanners fake browser UAs, so UA-only classification cannot catch them |
 | `services/geo.service.ts` | IP → country, referrer parsing, device derivation, `getClientIP`; defines `DeviceCategory` / `ScreenSizeCategory` |
 | `api/traffic.{controller,routes}.ts` | `/api/admin/users/traffic/*` raw-traffic reads **and** `/api/admin/users/analytics/*` dashboard aggregates (ClickHouse-backed), including the per-tid / per-user page-activity reads |
@@ -43,6 +45,7 @@ Physical storage names are unchanged from when this code lived under the user mo
 | `services/channel-classifier.ts` | `classifyChannel` — the single canonical acquisition-channel definition (direct/organic/paid/social/email/ai/referral), GA4-aligned: paid mediums + ad click-IDs first (gclid et al., names forwarded by the middleware, values never stored), then email/social mediums, then referrer-domain lists. Stored at write time on `traffic_events.channel`, bootstrap rows only |
 | `migrations/015_traffic_events_source_hash_columns.ts` | Adds `ip_hash` (per-client) + `subnet_hash` (/24 v4, /48 v6) so analytics can answer "same source?" without PII; run before deploying code that writes them |
 | `migrations/016_traffic_events_channel_column.ts` | Adds the `channel` column; run before deploying code that writes it. Pre-migration rows read as NULL and fall back to domain-only classification |
+| `migrations/017_seed_redirect_rules.ts` | MongoDB seed: back-fills `module_traffic_redirects` with the 17 legacy middleware redirects + 3 audit 404-fixes (prefix, 301). Idempotent (`$setOnInsert` by `pattern`), so re-runs are no-ops and operator edits are never clobbered |
 
 ## Metrics Contract
 
@@ -82,6 +85,8 @@ The `/api/admin/users/analytics/*` router (also `requireAdmin`) serves the `/sys
 Per-page clickstream reads live on the same router: `tid-activity` and `user-activity` summarize `page` events by anonymous tid (`user_id IS NULL`) and registered account (`user_id IS NOT NULL`) respectively, and `page-hits?subject=tid|user&id=` returns one subject's ordered page hits — "every page they hit".
 
 The ignore list is managed on the same router: `GET/POST /ignored-users` and `DELETE /ignored-users/:userId` read and edit `module_traffic_ignored_users` (each mutation refreshes `TrafficService`'s cached id set so the always-on exclusion takes effect at once), and `account-search?q=` resolves accounts to add — an exact Better Auth id via the `'accounts'` service's `getAccount`, otherwise an email/name substring via `listAccounts`. See the "Ignored account" row in the Metrics Contract for the exclusion semantics.
+
+URL redirects are managed on their own admin router (`requireAdmin`): `GET /api/admin/redirects` lists every rule, `POST` creates one, `PATCH /:id` patches (e.g. toggle `enabled`, retarget), `DELETE /:id` removes. The public `GET /api/redirects` (no auth) returns only enabled rules in the minimal `{ pattern, isPrefix, destination, permanent }` shape, most-specific-first, with a 60s `Cache-Control` — it is the feed the Next.js edge middleware polls and caches to issue the actual 301/302. Redirect rules are DATA, never deployed code: an operator adds a rule from `/system/traffic` → Redirects and the middleware serves it within a minute, no rebuild.
 
 Two public ingestion endpoints (no auth) write rows; both resolve the tid from the unsigned `tronrelic_tid` cookie and attribute to the Better Auth account when one is present:
 

--- a/src/backend/modules/traffic/TrafficModule.ts
+++ b/src/backend/modules/traffic/TrafficModule.ts
@@ -24,11 +24,14 @@ import { MAIN_SYSTEM_CONTAINER_ID } from '../menu/index.js';
 import { GscService } from './services/gsc.service.js';
 import { TrafficService } from './services/traffic.service.js';
 import { IgnoredUsersService } from './services/ignored-users.service.js';
+import { RedirectService } from './services/redirect.service.js';
 import { initGeoIP } from './services/geo.service.js';
 import { TrafficController } from './api/traffic.controller.js';
 import { BootstrapController } from './api/bootstrap.controller.js';
+import { RedirectsController } from './api/redirects.controller.js';
 import { createAdminTrafficRouter, createAdminAnalyticsRouter } from './api/traffic.routes.js';
 import { createBootstrapRouter, createPageEventRouter } from './api/bootstrap.routes.js';
+import { createPublicRedirectsRouter, createAdminRedirectsRouter } from './api/redirects.routes.js';
 import { requireAdmin } from '../../api/middleware/admin-auth.js';
 
 /**
@@ -65,6 +68,27 @@ export interface ITrafficModuleDependencies {
 }
 
 /**
+ * Namespace for the `/system/traffic` in-page tab row. Rendered as a menu via
+ * the Submenu Pattern (`MenuNavClient`) rather than a hand-rolled button row, so
+ * the tabs inherit per-user gating, ordering, and live `menu:update` refresh and
+ * a plugin could contribute a tab.
+ */
+const TRAFFIC_SUBMENU_NAMESPACE = 'traffic';
+
+/**
+ * The `/system/traffic` tab row. `order` is left-to-right position; `tab` is the
+ * `?tab=` query key the page switches panels on. Icons are lucide names.
+ */
+const TRAFFIC_SUBMENU_TABS: ReadonlyArray<{ label: string; tab: string; icon: string; order: number }> = [
+    { label: 'Analytics', tab: 'analytics', icon: 'BarChart3', order: 0 },
+    { label: 'Visitors', tab: 'visitors', icon: 'Users', order: 1 },
+    { label: 'Crawlers', tab: 'crawlers', icon: 'Bot', order: 2 },
+    { label: 'SEO', tab: 'seo', icon: 'Search', order: 3 },
+    { label: 'Redirects', tab: 'redirects', icon: 'CornerUpRight', order: 4 },
+    { label: 'Settings', tab: 'settings', icon: 'Settings', order: 5 }
+];
+
+/**
  * Cookieless traffic analytics module.
  */
 export class TrafficModule implements IModule<ITrafficModuleDependencies> {
@@ -83,8 +107,10 @@ export class TrafficModule implements IModule<ITrafficModuleDependencies> {
     private gscService!: GscService;
     private trafficService!: TrafficService;
     private ignoredUsersService!: IgnoredUsersService;
+    private redirectService!: RedirectService;
     private trafficController!: TrafficController;
     private bootstrapController!: BootstrapController;
+    private redirectsController!: RedirectsController;
 
     private readonly logger = logger.child({ module: 'traffic' });
 
@@ -122,6 +148,14 @@ export class TrafficModule implements IModule<ITrafficModuleDependencies> {
         await this.ignoredUsersService.createIndexes();
         await this.trafficService.setIgnoredUserIds(await this.ignoredUsersService.getIds());
 
+        // RedirectService — admin-managed legacy-URL 301/302 map. Rules live in
+        // Mongo and are served to the edge middleware, so operators add
+        // redirects without a deploy. Migration 017 seeds the initial legacy
+        // set; operators add/edit the rest from the /system/traffic Redirects tab.
+        RedirectService.setDependencies(dependencies.database, this.logger);
+        this.redirectService = RedirectService.getInstance();
+        await this.redirectService.createIndexes();
+
         // Admin dashboard reads against traffic_events aggregates, plus the
         // analytics + GSC surface. Resolves account/wallet services from the
         // registry at request time.
@@ -135,6 +169,9 @@ export class TrafficModule implements IModule<ITrafficModuleDependencies> {
 
         // Slim first-touch analytics bootstrap (no identity, no Mongo).
         this.bootstrapController = new BootstrapController(this.trafficService, this.logger);
+
+        // Admin redirect management + the public feed the edge middleware polls.
+        this.redirectsController = new RedirectsController(this.redirectService, this.logger);
 
         this.logger.info('Traffic module initialized');
     }
@@ -163,6 +200,25 @@ export class TrafficModule implements IModule<ITrafficModuleDependencies> {
             });
 
             this.logger.info('Traffic menu item registered under the System container');
+
+            // In-page tab row as a namespaced menu (Submenu Pattern). Nodes are
+            // memory-only and live outside the System container, so the
+            // container's non-bypassable requiresAdmin force does not reach them
+            // — each node sets requiresAdmin itself. The page renders this
+            // namespace with MenuNavClient instead of hand-rolling the tabs.
+            for (const tab of TRAFFIC_SUBMENU_TABS) {
+                await this.menuService.create({
+                    namespace: TRAFFIC_SUBMENU_NAMESPACE,
+                    label: tab.label,
+                    url: `/system/traffic?tab=${tab.tab}`,
+                    icon: tab.icon,
+                    order: tab.order,
+                    parent: null,
+                    enabled: true,
+                    requiresAdmin: true
+                });
+            }
+            this.logger.info('Traffic submenu tab nodes registered');
         } catch (error) {
             this.logger.error({ error }, 'Failed to register traffic menu item');
             throw new Error(`Failed to register traffic menu item: ${error instanceof Error ? error.message : 'Unknown error'}`);
@@ -192,6 +248,19 @@ export class TrafficModule implements IModule<ITrafficModuleDependencies> {
         const pageEventRouter: Router = createPageEventRouter(this.bootstrapController);
         this.app.use('/api/user/track', pageEventRouter);
         this.logger.info('Page-event router mounted at /api/user/track');
+
+        // Public redirect feed — no auth. The Next.js edge middleware polls this
+        // server-to-server (before any auth context exists) to learn the active
+        // legacy-URL redirect map, just like the public bootstrap ingestion.
+        const publicRedirectsRouter: Router = createPublicRedirectsRouter(this.redirectsController);
+        this.app.use('/api/redirects', publicRedirectsRouter);
+        this.logger.info('Public redirect feed mounted at /api/redirects');
+
+        // Admin redirect management. Distinct prefix from the identity module's
+        // /api/admin/users catch-all, so ordering is not load-bearing here.
+        const adminRedirectsRouter: Router = createAdminRedirectsRouter(this.redirectsController);
+        this.app.use('/api/admin/redirects', requireAdmin, adminRedirectsRouter);
+        this.logger.info('Admin redirects router mounted at /api/admin/redirects');
 
         // Daily GSC fetch (3 AM). SchedulerService supports late registration.
         if (this.scheduler) {

--- a/src/backend/modules/traffic/__tests__/redirect.service.test.ts
+++ b/src/backend/modules/traffic/__tests__/redirect.service.test.ts
@@ -181,6 +181,14 @@ describe('RedirectService', () => {
                 .rejects.toBeInstanceOf(RedirectValidationError);
         });
 
+        it('rejects a protocol-relative destination that would resolve off-site', async () => {
+            const { service } = setup();
+            await expect(service.createRule({ pattern: '/old', destination: '//evil.example' }))
+                .rejects.toBeInstanceOf(RedirectValidationError);
+            await expect(service.createRule({ pattern: '/old2', destination: '/\\evil.example' }))
+                .rejects.toBeInstanceOf(RedirectValidationError);
+        });
+
         it('rejects a self-redirect', async () => {
             const { service } = setup();
             await expect(service.createRule({ pattern: '/same', destination: '/same' }))

--- a/src/backend/modules/traffic/__tests__/redirect.service.test.ts
+++ b/src/backend/modules/traffic/__tests__/redirect.service.test.ts
@@ -1,0 +1,274 @@
+/// <reference types="vitest" />
+
+/**
+ * RedirectService unit tests.
+ *
+ * The redirect map is admin-entered data that the edge middleware trusts to
+ * issue 301/302s, so the invariants that keep a bad rule out of that feed —
+ * same-site paths, reserved-prefix refusal, loop prevention, path
+ * normalization, enabled-only + most-specific-first serving — are exactly what
+ * these tests pin. Storage is an in-memory collection double so CRUD actually
+ * round-trips without a live Mongo.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ObjectId } from 'mongodb';
+import type { IDatabaseService, ISystemLogService } from '@/types';
+import {
+    RedirectService,
+    RedirectValidationError,
+    RedirectNotFoundError,
+    type IRedirectRuleDocument
+} from '../services/redirect.service.js';
+
+/**
+ * Minimal logger double — every level is a spy so the service's info/error
+ * logging never reaches pino during tests.
+ *
+ * @returns A logger whose methods are all `vi.fn`.
+ */
+function createMockLogger(): ISystemLogService {
+    const fns = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        fatal: vi.fn(),
+        trace: vi.fn(),
+        child: vi.fn(() => fns)
+    } as unknown as ISystemLogService;
+    return fns;
+}
+
+/**
+ * In-memory stand-in for the redirect Mongo collection. Stores documents in an
+ * array and implements the exact surface RedirectService touches, including a
+ * unique-`pattern` constraint that throws E11000 like the real index.
+ */
+interface IFakeCollection {
+    docs: IRedirectRuleDocument[];
+    createIndex: ReturnType<typeof vi.fn>;
+    insertOne(doc: IRedirectRuleDocument): Promise<unknown>;
+    findOne(filter: { _id: ObjectId }): Promise<IRedirectRuleDocument | null>;
+    find(filter: Partial<IRedirectRuleDocument>): {
+        sort(spec: Record<string, 1 | -1>): { toArray(): Promise<IRedirectRuleDocument[]> };
+        toArray(): Promise<IRedirectRuleDocument[]>;
+    };
+    updateOne(filter: { _id: ObjectId }, update: { $set: Partial<IRedirectRuleDocument> }): Promise<unknown>;
+    deleteOne(filter: { _id: ObjectId }): Promise<{ deletedCount: number }>;
+}
+
+/**
+ * Build the in-memory collection double.
+ *
+ * @returns A collection that stores docs and enforces unique `pattern`.
+ */
+function createFakeCollection(): IFakeCollection {
+    const fake: IFakeCollection = {
+        docs: [],
+        createIndex: vi.fn(async () => 'ok'),
+        async insertOne(doc) {
+            if (fake.docs.some(d => d.pattern === doc.pattern)) {
+                throw Object.assign(new Error('duplicate key'), { code: 11000 });
+            }
+            fake.docs.push(doc);
+            return { acknowledged: true };
+        },
+        async findOne(filter) {
+            return fake.docs.find(d => d._id.equals(filter._id)) ?? null;
+        },
+        find(filter) {
+            const matched = fake.docs.filter(d =>
+                filter.enabled === undefined ? true : d.enabled === filter.enabled
+            );
+            const cursor = {
+                sort(spec: Record<string, 1 | -1>) {
+                    const [key, dir] = Object.entries(spec)[0];
+                    matched.sort((a, b) => {
+                        const av = a[key as keyof IRedirectRuleDocument] as unknown as number;
+                        const bv = b[key as keyof IRedirectRuleDocument] as unknown as number;
+                        return av < bv ? -dir : av > bv ? dir : 0;
+                    });
+                    return { toArray: async () => matched };
+                },
+                toArray: async () => matched
+            };
+            return cursor;
+        },
+        async updateOne(filter, update) {
+            const doc = fake.docs.find(d => d._id.equals(filter._id));
+            if (doc) {
+                Object.assign(doc, update.$set);
+            }
+            return { matchedCount: doc ? 1 : 0 };
+        },
+        async deleteOne(filter) {
+            const before = fake.docs.length;
+            fake.docs = fake.docs.filter(d => !d._id.equals(filter._id));
+            return { deletedCount: before - fake.docs.length };
+        }
+    };
+    return fake;
+}
+
+/**
+ * Wire a fresh RedirectService over a fresh fake collection.
+ *
+ * @returns The service under test and its backing collection double.
+ */
+function setup(): { service: RedirectService; collection: IFakeCollection } {
+    const collection = createFakeCollection();
+    const database = {
+        getCollection: vi.fn(() => collection)
+    } as unknown as IDatabaseService;
+    RedirectService.resetInstance();
+    RedirectService.setDependencies(database, createMockLogger());
+    return { service: RedirectService.getInstance(), collection };
+}
+
+describe('RedirectService', () => {
+    beforeEach(() => {
+        RedirectService.resetInstance();
+    });
+
+    describe('createIndexes', () => {
+        it('creates a unique index on pattern', async () => {
+            const { service, collection } = setup();
+            await service.createIndexes();
+            expect(collection.createIndex).toHaveBeenCalledWith({ pattern: 1 }, { unique: true });
+        });
+    });
+
+    describe('createRule', () => {
+        it('defaults isPrefix/permanent/enabled to true and returns admin shape', async () => {
+            const { service } = setup();
+            const rule = await service.createRule({ pattern: '/tron-forum', destination: '/forum' });
+            expect(rule).toMatchObject({
+                pattern: '/tron-forum',
+                destination: '/forum',
+                isPrefix: true,
+                permanent: true,
+                enabled: true
+            });
+            expect(rule.id).toMatch(/^[a-f0-9]{24}$/);
+            expect(new Date(rule.createdAt).toISOString()).toBe(rule.createdAt);
+        });
+
+        it('strips a trailing slash from pattern and destination', async () => {
+            const { service } = setup();
+            const rule = await service.createRule({ pattern: '/tron-forum/', destination: '/forum/' });
+            expect(rule.pattern).toBe('/tron-forum');
+            expect(rule.destination).toBe('/forum');
+        });
+
+        it('collapses a blank note to undefined and trims a real one', async () => {
+            const { service } = setup();
+            const blank = await service.createRule({ pattern: '/a-old', destination: '/a', notes: '   ' });
+            expect(blank.notes).toBeUndefined();
+            const noted = await service.createRule({ pattern: '/b-old', destination: '/b', notes: '  legacy  ' });
+            expect(noted.notes).toBe('legacy');
+        });
+
+        it('rejects a pattern that is not root-relative', async () => {
+            const { service } = setup();
+            await expect(service.createRule({ pattern: 'tron-forum', destination: '/forum' }))
+                .rejects.toBeInstanceOf(RedirectValidationError);
+        });
+
+        it('rejects a reserved /api pattern', async () => {
+            const { service } = setup();
+            await expect(service.createRule({ pattern: '/api/thing', destination: '/forum' }))
+                .rejects.toBeInstanceOf(RedirectValidationError);
+        });
+
+        it('rejects a self-redirect', async () => {
+            const { service } = setup();
+            await expect(service.createRule({ pattern: '/same', destination: '/same' }))
+                .rejects.toBeInstanceOf(RedirectValidationError);
+        });
+
+        it('rejects a prefix rule whose destination falls under the pattern (loop)', async () => {
+            const { service } = setup();
+            await expect(service.createRule({ pattern: '/tools', destination: '/tools/new', isPrefix: true }))
+                .rejects.toBeInstanceOf(RedirectValidationError);
+        });
+
+        it('surfaces a duplicate pattern as an E11000 error', async () => {
+            const { service } = setup();
+            await service.createRule({ pattern: '/dup', destination: '/one' });
+            await expect(service.createRule({ pattern: '/dup', destination: '/two' }))
+                .rejects.toMatchObject({ code: 11000 });
+        });
+    });
+
+    describe('getActiveRules', () => {
+        it('returns only enabled rules in the minimal middleware shape, most specific first', async () => {
+            const { service } = setup();
+            await service.createRule({ pattern: '/tools', destination: '/t' });
+            await service.createRule({ pattern: '/tools/custom-address-generator', destination: '/tools-hub' });
+            await service.createRule({ pattern: '/disabled-old', destination: '/x', enabled: false });
+
+            const active = await service.getActiveRules();
+            expect(active).toHaveLength(2);
+            expect(active[0].pattern).toBe('/tools/custom-address-generator');
+            expect(active[1].pattern).toBe('/tools');
+            expect(Object.keys(active[0]).sort()).toEqual(['destination', 'isPrefix', 'pattern', 'permanent']);
+        });
+    });
+
+    describe('updateRule', () => {
+        it('patches a subset and leaves other fields intact', async () => {
+            const { service } = setup();
+            const created = await service.createRule({ pattern: '/old', destination: '/new' });
+            const updated = await service.updateRule(created.id, { enabled: false });
+            expect(updated.enabled).toBe(false);
+            expect(updated.pattern).toBe('/old');
+            expect(updated.destination).toBe('/new');
+        });
+
+        it('re-validates the merged rule and rejects a patch that introduces a loop', async () => {
+            const { service } = setup();
+            const created = await service.createRule({ pattern: '/tools', destination: '/hub' });
+            await expect(service.updateRule(created.id, { destination: '/tools/x' }))
+                .rejects.toBeInstanceOf(RedirectValidationError);
+        });
+
+        it('throws RedirectValidationError on a malformed id', async () => {
+            const { service } = setup();
+            await expect(service.updateRule('not-an-id', { enabled: false }))
+                .rejects.toBeInstanceOf(RedirectValidationError);
+        });
+
+        it('throws RedirectNotFoundError when no rule matches', async () => {
+            const { service } = setup();
+            await expect(service.updateRule(new ObjectId().toString(), { enabled: false }))
+                .rejects.toBeInstanceOf(RedirectNotFoundError);
+        });
+    });
+
+    describe('deleteRule', () => {
+        it('removes an existing rule', async () => {
+            const { service } = setup();
+            const created = await service.createRule({ pattern: '/old', destination: '/new' });
+            await service.deleteRule(created.id);
+            expect(await service.listRules()).toHaveLength(0);
+        });
+
+        it('throws RedirectNotFoundError when nothing was deleted', async () => {
+            const { service } = setup();
+            await expect(service.deleteRule(new ObjectId().toString()))
+                .rejects.toBeInstanceOf(RedirectNotFoundError);
+        });
+    });
+
+    describe('listRules', () => {
+        it('returns every rule (enabled and disabled) in admin shape', async () => {
+            const { service } = setup();
+            await service.createRule({ pattern: '/one-old', destination: '/one' });
+            await service.createRule({ pattern: '/two-old', destination: '/two', enabled: false });
+            const rules = await service.listRules();
+            expect(rules).toHaveLength(2);
+            expect(rules.every(r => typeof r.id === 'string' && typeof r.createdAt === 'string')).toBe(true);
+        });
+    });
+});

--- a/src/backend/modules/traffic/__tests__/seed-redirects-migration.test.ts
+++ b/src/backend/modules/traffic/__tests__/seed-redirects-migration.test.ts
@@ -1,0 +1,100 @@
+/// <reference types="vitest" />
+
+/**
+ * Migration 017 (seed redirect rules) unit tests.
+ *
+ * The migration back-fills the legacy redirect set into `module_traffic_redirects`
+ * on cutover, so the guarantees that matter are: it seeds every rule in the
+ * shape the service/middleware read, it is idempotent on re-run, and it never
+ * clobbers an operator's later edit to a seeded pattern. An in-memory collection
+ * double reproduces `$setOnInsert` upsert semantics so all three are exercised
+ * without a live Mongo.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { IDatabaseService, IMigrationContext } from '@/types';
+import { migration } from '../migrations/017_seed_redirect_rules.js';
+
+/** Total seed rows: 17 restored legacy redirects + 3 audit 404-fixes. */
+const EXPECTED_SEED_COUNT = 20;
+
+/**
+ * In-memory collection double reproducing the `updateOne` + `$setOnInsert` +
+ * `upsert` behavior the migration relies on: insert only when the `pattern` is
+ * absent, no-op (and no mutation) when it already exists.
+ *
+ * @returns A collection double with its backing `docs` array.
+ */
+function createFakeCollection() {
+    const docs: Array<Record<string, unknown>> = [];
+    return {
+        docs,
+        async updateOne(
+            filter: { pattern: string },
+            update: { $setOnInsert: Record<string, unknown> },
+            options?: { upsert?: boolean }
+        ) {
+            const existing = docs.find(d => d.pattern === filter.pattern);
+            if (existing) {
+                return { matchedCount: 1, modifiedCount: 0, upsertedCount: 0 };
+            }
+            if (options?.upsert) {
+                docs.push({ _id: `id-${docs.length}`, ...update.$setOnInsert });
+                return { matchedCount: 0, modifiedCount: 0, upsertedCount: 1 };
+            }
+            return { matchedCount: 0, modifiedCount: 0, upsertedCount: 0 };
+        }
+    };
+}
+
+/**
+ * Build a migration context whose database routes every `getCollection` to one
+ * shared collection double.
+ *
+ * @param collection - The collection double to serve.
+ * @returns A migration context plus the collection.
+ */
+function createContext(collection: ReturnType<typeof createFakeCollection>): IMigrationContext {
+    const database = { getCollection: () => collection } as unknown as IDatabaseService;
+    return { database } as unknown as IMigrationContext;
+}
+
+describe('migration: 017_seed_redirect_rules', () => {
+    it('has the id matching its filename', () => {
+        expect(migration.id).toBe('017_seed_redirect_rules');
+    });
+
+    it('seeds every rule as an enabled, permanent, prefix rule', async () => {
+        const collection = createFakeCollection();
+        await migration.up(createContext(collection));
+
+        expect(collection.docs).toHaveLength(EXPECTED_SEED_COUNT);
+        expect(collection.docs.every(d => d.isPrefix === true && d.permanent === true && d.enabled === true)).toBe(true);
+
+        const forum = collection.docs.find(d => d.pattern === '/tron-forum');
+        expect(forum?.destination).toBe('/forum');
+        const blockchain = collection.docs.find(d => d.pattern === '/blockchain');
+        expect(blockchain?.destination).toBe('/');
+    });
+
+    it('is idempotent — a second run inserts nothing', async () => {
+        const collection = createFakeCollection();
+        await migration.up(createContext(collection));
+        await migration.up(createContext(collection));
+
+        expect(collection.docs).toHaveLength(EXPECTED_SEED_COUNT);
+    });
+
+    it('never clobbers an operator edit to a seeded pattern', async () => {
+        const collection = createFakeCollection();
+        // Operator already retargeted /tron-forum before the migration runs.
+        collection.docs.push({ _id: 'admin', pattern: '/tron-forum', destination: '/community', isPrefix: true, permanent: true, enabled: true });
+
+        await migration.up(createContext(collection));
+
+        const forum = collection.docs.find(d => d.pattern === '/tron-forum');
+        expect(forum?.destination).toBe('/community');
+        // The remaining 19 rules still seed alongside the preserved edit.
+        expect(collection.docs).toHaveLength(EXPECTED_SEED_COUNT);
+    });
+});

--- a/src/backend/modules/traffic/api/redirects.controller.ts
+++ b/src/backend/modules/traffic/api/redirects.controller.ts
@@ -1,0 +1,159 @@
+/**
+ * HTTP controller for admin-managed URL redirects.
+ *
+ * Exposes one public read (`GET /api/redirects`) that the Next.js edge
+ * middleware polls to learn the active redirect map, plus the admin CRUD the
+ * `/system/traffic` management UI drives. The public read is deliberately
+ * unauthenticated: the middleware fetches it server-to-server before any auth
+ * context exists, exactly like the public bootstrap ingestion endpoint.
+ *
+ * Handlers mirror the traffic module's conventions — try/catch every handler,
+ * log failures via `this.logger.error({ err }, '...')`, and translate service
+ * errors into precise status codes (400 validation, 404 missing, 409 duplicate
+ * pattern, 500 unexpected).
+ */
+
+import type { Request, Response } from 'express';
+import type { ISystemLogService } from '@/types';
+import {
+    RedirectService,
+    RedirectValidationError,
+    RedirectNotFoundError
+} from '../services/redirect.service.js';
+
+/**
+ * Seconds any intermediary (CDN) may cache the public redirect feed. Matches
+ * the middleware's own refresh cadence, so a freshly-added rule goes live in at
+ * most this long regardless of caching layer.
+ */
+const PUBLIC_FEED_MAX_AGE_SECONDS = 60;
+
+/**
+ * Routes redirect reads/writes to `RedirectService`.
+ */
+export class RedirectsController {
+    /**
+     * @param redirectService - The redirect storage/validation service.
+     * @param logger - Scoped logger for handler-level failure diagnostics.
+     */
+    constructor(
+        private readonly redirectService: RedirectService,
+        private readonly logger: ISystemLogService
+    ) { }
+
+    /**
+     * Public read consumed by the edge middleware. Emits only enabled rules in
+     * the minimal four-field shape, with a short cache window so a CDN in front
+     * of the origin cannot pin a stale map longer than the middleware would.
+     *
+     * @param _req - Unused; the feed is identical for every caller.
+     * @param res - Express response carrying `{ rules }`.
+     */
+    async getPublicRedirects(_req: Request, res: Response): Promise<void> {
+        try {
+            const rules = await this.redirectService.getActiveRules();
+            res.set('Cache-Control', `public, max-age=${PUBLIC_FEED_MAX_AGE_SECONDS}`);
+            res.json({ rules });
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to serve public redirect feed');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to load redirects' });
+        }
+    }
+
+    /**
+     * Admin list of every rule (enabled and disabled) for the management table.
+     *
+     * @param _req - Unused.
+     * @param res - Express response carrying `{ rules }` in admin shape.
+     */
+    async listRedirects(_req: Request, res: Response): Promise<void> {
+        try {
+            const rules = await this.redirectService.listRules();
+            res.json({ rules });
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to list redirect rules');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to list redirects' });
+        }
+    }
+
+    /**
+     * Create a rule from the admin form. Requires string `pattern` and
+     * `destination`; the service applies the deeper same-site/loop validation.
+     *
+     * @param req - Express request; body carries the rule fields.
+     * @param res - Express response carrying the created rule (201).
+     */
+    async createRedirect(req: Request, res: Response): Promise<void> {
+        const { pattern, destination, isPrefix, permanent, enabled, notes } = req.body ?? {};
+        if (typeof pattern !== 'string' || typeof destination !== 'string') {
+            res.status(400).json({ error: 'ValidationError', message: 'pattern and destination are required strings' });
+            return;
+        }
+        try {
+            const rule = await this.redirectService.createRule({ pattern, destination, isPrefix, permanent, enabled, notes });
+            res.status(201).json(rule);
+        } catch (error) {
+            this.respondError(res, error, 'create');
+        }
+    }
+
+    /**
+     * Patch an existing rule. Only supplied fields change; the service
+     * re-validates the merged result.
+     *
+     * @param req - Express request; `params.id` selects the rule, body carries changes.
+     * @param res - Express response carrying the updated rule.
+     */
+    async updateRedirect(req: Request, res: Response): Promise<void> {
+        const { id } = req.params;
+        const { pattern, destination, isPrefix, permanent, enabled, notes } = req.body ?? {};
+        try {
+            const rule = await this.redirectService.updateRule(id, { pattern, destination, isPrefix, permanent, enabled, notes });
+            res.json(rule);
+        } catch (error) {
+            this.respondError(res, error, 'update');
+        }
+    }
+
+    /**
+     * Delete a rule.
+     *
+     * @param req - Express request; `params.id` selects the rule.
+     * @param res - Express response (204 on success).
+     */
+    async deleteRedirect(req: Request, res: Response): Promise<void> {
+        const { id } = req.params;
+        try {
+            await this.redirectService.deleteRule(id);
+            res.status(204).end();
+        } catch (error) {
+            this.respondError(res, error, 'delete');
+        }
+    }
+
+    /**
+     * Translate a thrown service error into the right status code. Validation
+     * problems are 400, a missing rule 404, a duplicate `pattern` (Mongo
+     * E11000) 409, and anything unexpected 500 with the failure logged.
+     *
+     * @param res - Express response to write.
+     * @param error - The thrown value from the service call.
+     * @param action - Verb for the log line (create/update/delete).
+     */
+    private respondError(res: Response, error: unknown, action: string): void {
+        if (error instanceof RedirectValidationError) {
+            res.status(400).json({ error: 'ValidationError', message: error.message });
+            return;
+        }
+        if (error instanceof RedirectNotFoundError) {
+            res.status(404).json({ error: 'NotFound', message: error.message });
+            return;
+        }
+        if (typeof error === 'object' && error !== null && (error as { code?: number }).code === 11000) {
+            res.status(409).json({ error: 'Conflict', message: 'A redirect for this pattern already exists' });
+            return;
+        }
+        this.logger.error({ err: error }, `Failed to ${action} redirect rule`);
+        res.status(500).json({ error: 'InternalError', message: `Failed to ${action} redirect` });
+    }
+}

--- a/src/backend/modules/traffic/api/redirects.routes.ts
+++ b/src/backend/modules/traffic/api/redirects.routes.ts
@@ -1,0 +1,44 @@
+/**
+ * Router factories for the admin-managed redirect feature.
+ *
+ * The public router exposes a single read the edge middleware polls; the admin
+ * router exposes CRUD. They are separate factories because the module mounts
+ * them at different prefixes with different auth: the public feed unauthenticated
+ * at `/api/redirects`, the admin CRUD behind `requireAdmin` at `/api/admin/redirects`.
+ */
+
+import { Router } from 'express';
+import type { RedirectsController } from './redirects.controller.js';
+
+/**
+ * Build the public redirect-feed router (the edge middleware's data source).
+ *
+ * @param controller - Redirects controller whose read handler is bound.
+ * @returns Router exposing `GET /` (mounted at `/api/redirects`).
+ */
+export function createPublicRedirectsRouter(controller: RedirectsController): Router {
+    const router = Router();
+
+    router.get('/', controller.getPublicRedirects.bind(controller));
+
+    return router;
+}
+
+/**
+ * Build the admin redirect-management router. Admin gating is applied by the
+ * module at the mount site (`requireAdmin`), matching the traffic/analytics
+ * routers, so no per-route auth middleware is declared here.
+ *
+ * @param controller - Redirects controller whose CRUD handlers are bound.
+ * @returns Router exposing list/create/update/delete (mounted at `/api/admin/redirects`).
+ */
+export function createAdminRedirectsRouter(controller: RedirectsController): Router {
+    const router = Router();
+
+    router.get('/', controller.listRedirects.bind(controller));
+    router.post('/', controller.createRedirect.bind(controller));
+    router.patch('/:id', controller.updateRedirect.bind(controller));
+    router.delete('/:id', controller.deleteRedirect.bind(controller));
+
+    return router;
+}

--- a/src/backend/modules/traffic/index.ts
+++ b/src/backend/modules/traffic/index.ts
@@ -30,6 +30,14 @@ export { GscService } from './services/gsc.service.js';
 export type { IGscStatus, IGscKeyword, IGscQueryDocument } from './services/gsc.service.js';
 export { IgnoredUsersService } from './services/ignored-users.service.js';
 export type { IIgnoredUserDocument } from './services/ignored-users.service.js';
+export { RedirectService, RedirectValidationError, RedirectNotFoundError } from './services/redirect.service.js';
+export type {
+    IRedirectRule,
+    IRedirectRuleAdmin,
+    IRedirectRuleDocument,
+    IRedirectRuleInput,
+    IRedirectRulePatch
+} from './services/redirect.service.js';
 export { classifyUserAgent } from './services/bot-classifier.js';
 export type { BotClass } from './services/bot-classifier.js';
 export {
@@ -44,5 +52,7 @@ export {
 
 export { TrafficController } from './api/traffic.controller.js';
 export { createAdminTrafficRouter, createAdminAnalyticsRouter } from './api/traffic.routes.js';
+export { RedirectsController } from './api/redirects.controller.js';
+export { createPublicRedirectsRouter, createAdminRedirectsRouter } from './api/redirects.routes.js';
 export { resolveAnalyticsRange } from './services/traffic.service.js';
 export type { IAnalyticsRangeQuery } from './services/traffic.service.js';

--- a/src/backend/modules/traffic/migrations/017_seed_redirect_rules.ts
+++ b/src/backend/modules/traffic/migrations/017_seed_redirect_rules.ts
@@ -1,0 +1,127 @@
+import type { IMigration, IMigrationContext } from '@/types';
+
+/**
+ * Seed the admin-managed redirect collection with the known legacy-URL set.
+ *
+ * **Why this migration exists**
+ *
+ * Redirect rules moved out of the hardcoded middleware bundle into
+ * `module_traffic_redirects`, where the edge middleware reads them and
+ * operators edit them without a deploy. That left the collection empty, so on
+ * cutover the previously-hardcoded redirects would go dead until re-entered by
+ * hand. This migration back-fills them — the 17 rules lifted verbatim from the
+ * former middleware `REDIRECT_RULES` array plus 3 fixes for dead 404s the SEO
+ * audit surfaced (`/tron-forum`, `/blockchain*`, `/a/*`).
+ *
+ * Seeding is a one-time data load, not a return to bundle-hardcoded redirects:
+ * every seeded rule is fully admin-editable/deletable afterward and the
+ * middleware still reads the live DB feed, so adding future redirects never
+ * needs a deploy.
+ *
+ * **Idempotent.** Each rule upserts by `pattern` with `$setOnInsert`, so a
+ * re-run inserts nothing and an operator's later edit to a seeded rule is never
+ * clobbered. New patterns an operator added by hand are untouched.
+ *
+ * All seeded rules are prefix matches issuing a 301, matching the former
+ * middleware behavior (a prefix rule also catches sub-paths, e.g. `/blockchain`
+ * absorbs `/blockchain/account?address=…`).
+ */
+
+/** Physical collection the redirect service reads/writes. */
+const COLLECTION_NAME = 'module_traffic_redirects';
+
+/**
+ * One seed rule. All seeds share `isPrefix: true`, `permanent: true`,
+ * `enabled: true`; only the paths and provenance note vary.
+ */
+interface ISeedRedirect {
+    /** Source path to match. */
+    pattern: string;
+    /** Destination path. */
+    destination: string;
+    /** Provenance note surfaced in the admin table. */
+    note: string;
+}
+
+/**
+ * The legacy redirect set. First block is restored verbatim from the middleware
+ * `REDIRECT_RULES` array; second block is the audit's dead-404 fixes.
+ */
+const SEED_RULES: ReadonlyArray<ISeedRedirect> = [
+    // Restored from the former hardcoded middleware REDIRECT_RULES array.
+    { pattern: '/rent-tron-energy', destination: '/resource-markets', note: 'Legacy resource-markets landing path' },
+    { pattern: '/lp/rm', destination: '/resource-markets', note: 'Legacy resource-markets landing path' },
+    { pattern: '/tron-trx-energy-fee-calculator', destination: '/tools', note: 'Legacy tool path' },
+    { pattern: '/tools/staking-calculator', destination: '/tools', note: 'Legacy tool path' },
+    { pattern: '/tools/tronmoji', destination: '/tools', note: 'Legacy tool path' },
+    { pattern: '/tools/tron-custom-address-generator', destination: '/tools', note: 'Legacy tool path' },
+    { pattern: '/tools/signature-verification', destination: '/tools', note: 'Legacy tool path' },
+    { pattern: '/tools/hex-to-base58check', destination: '/tools', note: 'Legacy tool path' },
+    { pattern: '/tools/base58check-to-hex', destination: '/tools', note: 'Legacy tool path' },
+    { pattern: '/tron-dex', destination: '/articles', note: 'Legacy article slug' },
+    { pattern: '/tron-latest-trc10-tokens', destination: '/articles', note: 'Legacy article slug' },
+    { pattern: '/tron-latest-trc10-exchanges', destination: '/articles', note: 'Legacy article slug' },
+    { pattern: '/tron-node-setup-guide', destination: '/articles', note: 'Legacy article slug' },
+    { pattern: '/tron-bandwidth-vs-energy', destination: '/articles', note: 'Legacy article slug' },
+    { pattern: '/tron-delegated-proof-of-stake', destination: '/articles', note: 'Legacy article slug' },
+    { pattern: '/tron-trc10-token', destination: '/articles', note: 'Legacy article slug' },
+    { pattern: '/tron-super-representatives', destination: '/articles', note: 'Legacy article slug' },
+
+    // Dead-404 fixes from the SEO audit. `/blockchain` (prefix) absorbs the old
+    // `/blockchain/account` explorer and its `?address=` variants; `/a` (prefix)
+    // absorbs the removed per-address `/a/{address}` pages.
+    { pattern: '/tron-forum', destination: '/forum', note: 'Renamed forum section' },
+    { pattern: '/blockchain', destination: '/', note: 'Removed blockchain/account explorer' },
+    { pattern: '/a', destination: '/', note: 'Removed per-address account pages' }
+];
+
+/**
+ * Idempotent seed of the legacy redirect rules.
+ */
+export const migration: IMigration = {
+    id: '017_seed_redirect_rules',
+    description:
+        'Seed module_traffic_redirects with the 17 legacy middleware redirects plus 3 audit 404-fixes ' +
+        '(prefix, 301), idempotently via $setOnInsert so admin edits are never clobbered.',
+    dependencies: [],
+
+    /**
+     * Upsert each seed rule by `pattern`. `$setOnInsert` inserts only when the
+     * pattern is absent, so re-runs are no-ops and any operator edit to a seeded
+     * rule survives.
+     *
+     * @param context - Migration context providing the database service.
+     */
+    async up(context: IMigrationContext): Promise<void> {
+        const collection = context.database.getCollection(COLLECTION_NAME);
+        const now = new Date();
+        let inserted = 0;
+
+        for (const rule of SEED_RULES) {
+            const result = await collection.updateOne(
+                { pattern: rule.pattern },
+                {
+                    $setOnInsert: {
+                        pattern: rule.pattern,
+                        destination: rule.destination,
+                        isPrefix: true,
+                        permanent: true,
+                        enabled: true,
+                        notes: rule.note,
+                        createdAt: now,
+                        updatedAt: now
+                    }
+                },
+                { upsert: true }
+            );
+            if (result.upsertedCount > 0) {
+                inserted++;
+            }
+        }
+
+        console.log(
+            `[Migration] Seeded ${inserted} redirect rule(s) into ${COLLECTION_NAME} ` +
+            `(${SEED_RULES.length - inserted} already present)`
+        );
+    }
+};

--- a/src/backend/modules/traffic/services/redirect.service.ts
+++ b/src/backend/modules/traffic/services/redirect.service.ts
@@ -1,0 +1,438 @@
+/**
+ * Admin-managed URL redirect service.
+ *
+ * Stores operator-curated legacy-URL redirect rules (old path → new path)
+ * in MongoDB and serves them to the Next.js edge middleware, which issues the
+ * actual 301/302 at request time. The rules are DATA, never deployed code:
+ * an operator adds a rule from the `/system/traffic` admin surface and the
+ * middleware picks it up on its next cache refresh — no rebuild, no deploy.
+ *
+ * ## Why This Service Exists
+ *
+ * A URL restructure leaves the old paths indexed by Google but dead (404),
+ * evaporating the link equity and crawl familiarity those URLs held. The fix
+ * is a 301 from each legacy path to its live equivalent. Hardcoding those in
+ * the middleware bundle means a deploy per redirect — unacceptable when the
+ * whole point is that operators add them as Search Console surfaces new 404s.
+ * This service moves the redirect list into admin-editable storage.
+ *
+ * ## Design Decisions
+ *
+ * - **Singleton pattern** matching `GscService` for consistent DI.
+ * - **One document per rule** (not a settings singleton) — rules are an
+ *   unbounded, independently-editable list, like the GSC query cache.
+ * - **Unique index on `pattern`** — a source path resolves to one rule.
+ * - **Same-site only** — `pattern` and `destination` are both root-relative
+ *   paths; off-site redirects are out of scope and rejected by validation.
+ * - **Loop-guarded** — a rule whose destination re-matches its own pattern is
+ *   rejected at write time so the middleware can never bounce a request.
+ * - **Most-specific-first ordering** — active rules are served longest-pattern
+ *   first so `/tools/x` wins over `/tools` under the middleware's first-match.
+ */
+
+import type { Collection } from 'mongodb';
+import { ObjectId } from 'mongodb';
+import type { IDatabaseService, ISystemLogService } from '@/types';
+
+/**
+ * Collection name following the `module_{module-id}_{collection}` convention.
+ */
+const COLLECTION_NAME = 'module_traffic_redirects';
+
+/**
+ * Path prefixes a redirect may never target or shadow. Redirecting these would
+ * break the application itself (API calls, Next internals) rather than a stale
+ * marketing URL, so they are refused at validation time.
+ */
+const RESERVED_PREFIXES: ReadonlyArray<string> = ['/api', '/_next'];
+
+/**
+ * Thrown when caller-supplied rule fields are malformed, reserved, or would
+ * create a redirect loop. The controller maps it to HTTP 400 so the operator
+ * sees exactly which invariant they violated.
+ */
+export class RedirectValidationError extends Error {
+    /**
+     * @param message - Operator-readable description of the violated invariant.
+     */
+    constructor(message: string) {
+        super(message);
+        this.name = 'RedirectValidationError';
+    }
+}
+
+/**
+ * Thrown when an update/delete targets a rule id that no longer exists. The
+ * controller maps it to HTTP 404.
+ */
+export class RedirectNotFoundError extends Error {
+    /**
+     * @param message - Description of the missing resource.
+     */
+    constructor(message: string = 'Redirect rule not found') {
+        super(message);
+        this.name = 'RedirectNotFoundError';
+    }
+}
+
+/**
+ * A redirect rule as persisted in MongoDB. One document per source path.
+ */
+export interface IRedirectRuleDocument {
+    /** Mongo id; the admin API exposes its hex string as the rule id. */
+    _id: ObjectId;
+    /** Source path to match, root-relative (e.g. `/tron-forum`). */
+    pattern: string;
+    /** True matches `pattern` and any `pattern/...` sub-path; false is exact. */
+    isPrefix: boolean;
+    /** Destination path, root-relative (e.g. `/forum`). */
+    destination: string;
+    /** True issues a 301 (permanent); false a 302 (temporary). */
+    permanent: boolean;
+    /** Disabled rules are retained but never served to the middleware. */
+    enabled: boolean;
+    /** Optional operator annotation recording why the redirect exists. */
+    notes?: string;
+    /** Creation timestamp. */
+    createdAt: Date;
+    /** Last-update timestamp. */
+    updatedAt: Date;
+}
+
+/**
+ * The minimal rule shape the edge middleware consumes. Only enabled rules are
+ * ever emitted, and only the four fields the middleware needs to match + issue
+ * a redirect — no ids, timestamps, or operator notes cross that boundary.
+ */
+export interface IRedirectRule {
+    /** Source path to match. */
+    pattern: string;
+    /** Prefix vs exact match. */
+    isPrefix: boolean;
+    /** Destination path. */
+    destination: string;
+    /** 301 when true, 302 when false. */
+    permanent: boolean;
+}
+
+/**
+ * The admin-facing rule shape. Extends the middleware shape with the id,
+ * enabled flag, notes, and ISO timestamps the management UI renders.
+ */
+export interface IRedirectRuleAdmin extends IRedirectRule {
+    /** Hex string of the Mongo `_id`; the handle admin edits/deletes address. */
+    id: string;
+    /** Whether the rule is currently served to the middleware. */
+    enabled: boolean;
+    /** Optional operator annotation. */
+    notes?: string;
+    /** ISO-8601 creation timestamp. */
+    createdAt: string;
+    /** ISO-8601 last-update timestamp. */
+    updatedAt: string;
+}
+
+/**
+ * Caller-supplied fields when creating a rule. Booleans default to the common
+ * case (prefix match, permanent, enabled) so an operator entering a simple
+ * legacy→new mapping supplies only `pattern` and `destination`.
+ */
+export interface IRedirectRuleInput {
+    /** Source path to match. */
+    pattern: string;
+    /** Destination path. */
+    destination: string;
+    /** Prefix vs exact match; defaults to true (prefix). */
+    isPrefix?: boolean;
+    /** 301 vs 302; defaults to true (permanent). */
+    permanent?: boolean;
+    /** Whether the rule is active; defaults to true. */
+    enabled?: boolean;
+    /** Optional operator annotation. */
+    notes?: string;
+}
+
+/**
+ * Editable subset when patching an existing rule. Every field optional; only
+ * those present are applied.
+ */
+export type IRedirectRulePatch = Partial<IRedirectRuleInput>;
+
+/**
+ * Manages the admin-curated redirect collection and serves the active rules to
+ * the edge middleware.
+ */
+export class RedirectService {
+    /** The single process-wide instance. */
+    private static instance: RedirectService;
+
+    /** Typed handle to the redirect collection, grabbed once in the constructor. */
+    private readonly collection: Collection<IRedirectRuleDocument>;
+
+    /**
+     * @param database - Injected database service; the redirect collection is
+     *   resolved from it so the service stays mockable in tests.
+     * @param logger - Scoped logger for write/validation diagnostics.
+     */
+    private constructor(
+        private readonly database: IDatabaseService,
+        private readonly logger: ISystemLogService
+    ) {
+        this.collection = database.getCollection<IRedirectRuleDocument>(COLLECTION_NAME);
+    }
+
+    /**
+     * Wire the singleton's dependencies. Idempotent — the first call constructs
+     * the instance, later calls are no-ops so re-entrant bootstrap is safe.
+     *
+     * @param database - Database service for the redirect collection.
+     * @param logger - Scoped logger.
+     */
+    public static setDependencies(database: IDatabaseService, logger: ISystemLogService): void {
+        if (!RedirectService.instance) {
+            RedirectService.instance = new RedirectService(database, logger);
+        }
+    }
+
+    /**
+     * Retrieve the configured singleton.
+     *
+     * @returns The shared instance.
+     * @throws If accessed before `setDependencies()` has run.
+     */
+    public static getInstance(): RedirectService {
+        if (!RedirectService.instance) {
+            throw new Error('RedirectService.setDependencies() must be called before getInstance()');
+        }
+        return RedirectService.instance;
+    }
+
+    /**
+     * Clear the singleton so tests can re-wire it with fresh mocks.
+     */
+    public static resetInstance(): void {
+        RedirectService.instance = undefined as unknown as RedirectService;
+    }
+
+    /**
+     * Ensure the unique `pattern` index exists. Called once from module
+     * `init()`; the uniqueness constraint is what makes a duplicate-pattern
+     * create fail loudly (E11000) instead of silently shadowing.
+     */
+    async createIndexes(): Promise<void> {
+        await this.collection.createIndex({ pattern: 1 }, { unique: true });
+        this.logger.info('Redirect collection indexes ensured');
+    }
+
+    /**
+     * The active rules the edge middleware consumes, most-specific first.
+     *
+     * Ordering by descending pattern length lets the middleware keep its simple
+     * first-match loop while still preferring `/tools/x` over `/tools`. Disabled
+     * rules are excluded so toggling `enabled` is the operator's kill switch.
+     *
+     * @returns Enabled rules as the minimal four-field middleware shape.
+     */
+    async getActiveRules(): Promise<IRedirectRule[]> {
+        const docs = await this.collection.find({ enabled: true }).toArray();
+        const rules = docs
+            .sort((a, b) => b.pattern.length - a.pattern.length)
+            .map(doc => ({
+                pattern: doc.pattern,
+                isPrefix: doc.isPrefix,
+                destination: doc.destination,
+                permanent: doc.permanent
+            }));
+        return rules;
+    }
+
+    /**
+     * All rules, newest first, for the admin management table.
+     *
+     * @returns Every rule in the admin shape (enabled and disabled).
+     */
+    async listRules(): Promise<IRedirectRuleAdmin[]> {
+        const docs = await this.collection.find({}).sort({ createdAt: -1 }).toArray();
+        const rules = docs.map(doc => this.toAdmin(doc));
+        return rules;
+    }
+
+    /**
+     * Create a rule after validating it. Validation throws on bad input; a
+     * duplicate `pattern` surfaces as a Mongo E11000 the controller maps to 409.
+     *
+     * @param input - Caller fields; booleans default to prefix/permanent/enabled.
+     * @returns The created rule in admin shape.
+     */
+    async createRule(input: IRedirectRuleInput): Promise<IRedirectRuleAdmin> {
+        const pattern = this.normalizePath(input.pattern);
+        const destination = this.normalizePath(input.destination);
+        const isPrefix = input.isPrefix ?? true;
+        this.assertValidRule(pattern, destination, isPrefix);
+
+        const now = new Date();
+        const doc: IRedirectRuleDocument = {
+            _id: new ObjectId(),
+            pattern,
+            destination,
+            isPrefix,
+            permanent: input.permanent ?? true,
+            enabled: input.enabled ?? true,
+            notes: this.normalizeNotes(input.notes),
+            createdAt: now,
+            updatedAt: now
+        };
+
+        await this.collection.insertOne(doc);
+        this.logger.info({ pattern, destination }, 'Redirect rule created');
+        return this.toAdmin(doc);
+    }
+
+    /**
+     * Patch an existing rule. Only supplied fields change; the merged result is
+     * re-validated so a patch cannot produce an invalid or looping rule.
+     *
+     * @param id - Hex string of the rule's `_id`.
+     * @param patch - Fields to change.
+     * @returns The updated rule in admin shape.
+     * @throws If the id is malformed or no rule matches.
+     */
+    async updateRule(id: string, patch: IRedirectRulePatch): Promise<IRedirectRuleAdmin> {
+        const _id = this.toObjectId(id);
+        const existing = await this.collection.findOne({ _id });
+        if (!existing) {
+            throw new RedirectNotFoundError();
+        }
+
+        const pattern = patch.pattern !== undefined ? this.normalizePath(patch.pattern) : existing.pattern;
+        const destination = patch.destination !== undefined ? this.normalizePath(patch.destination) : existing.destination;
+        const isPrefix = patch.isPrefix ?? existing.isPrefix;
+        this.assertValidRule(pattern, destination, isPrefix);
+
+        const update: Partial<IRedirectRuleDocument> = {
+            pattern,
+            destination,
+            isPrefix,
+            permanent: patch.permanent ?? existing.permanent,
+            enabled: patch.enabled ?? existing.enabled,
+            notes: patch.notes !== undefined ? this.normalizeNotes(patch.notes) : existing.notes,
+            updatedAt: new Date()
+        };
+
+        await this.collection.updateOne({ _id }, { $set: update });
+        this.logger.info({ id, pattern, destination }, 'Redirect rule updated');
+        const merged: IRedirectRuleDocument = { ...existing, ...update };
+        return this.toAdmin(merged);
+    }
+
+    /**
+     * Delete a rule.
+     *
+     * @param id - Hex string of the rule's `_id`.
+     * @throws If the id is malformed or no rule matched.
+     */
+    async deleteRule(id: string): Promise<void> {
+        const _id = this.toObjectId(id);
+        const result = await this.collection.deleteOne({ _id });
+        if (result.deletedCount === 0) {
+            throw new RedirectNotFoundError();
+        }
+        this.logger.info({ id }, 'Redirect rule deleted');
+    }
+
+    /**
+     * Project a stored document into the admin API shape (id + ISO timestamps).
+     *
+     * @param doc - The stored rule.
+     * @returns The admin-facing rule.
+     */
+    private toAdmin(doc: IRedirectRuleDocument): IRedirectRuleAdmin {
+        const admin: IRedirectRuleAdmin = {
+            id: doc._id.toString(),
+            pattern: doc.pattern,
+            isPrefix: doc.isPrefix,
+            destination: doc.destination,
+            permanent: doc.permanent,
+            enabled: doc.enabled,
+            notes: doc.notes,
+            createdAt: doc.createdAt.toISOString(),
+            updatedAt: doc.updatedAt.toISOString()
+        };
+        return admin;
+    }
+
+    /**
+     * Trim a path and strip a single trailing slash (except the root) so
+     * `/forum/` and `/forum` are stored identically and match consistently.
+     *
+     * @param value - Raw caller-supplied path.
+     * @returns The normalized path (unchanged shape validated separately).
+     */
+    private normalizePath(value: string): string {
+        const trimmed = typeof value === 'string' ? value.trim() : '';
+        const normalized = trimmed.length > 1 && trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+        return normalized;
+    }
+
+    /**
+     * Collapse an empty/blank note to `undefined` so the field is absent rather
+     * than an empty string in storage.
+     *
+     * @param value - Raw note or undefined.
+     * @returns Trimmed note, or undefined when blank.
+     */
+    private normalizeNotes(value: string | undefined): string | undefined {
+        const trimmed = typeof value === 'string' ? value.trim() : '';
+        const notes = trimmed.length > 0 ? trimmed : undefined;
+        return notes;
+    }
+
+    /**
+     * Parse a hex id into an ObjectId, converting a malformed id into a clear
+     * error the controller returns as a 400 rather than a 500.
+     *
+     * @param id - Candidate hex string.
+     * @returns The parsed ObjectId.
+     * @throws If `id` is not a valid ObjectId.
+     */
+    private toObjectId(id: string): ObjectId {
+        if (!ObjectId.isValid(id)) {
+            throw new RedirectValidationError('Invalid redirect rule id');
+        }
+        return new ObjectId(id);
+    }
+
+    /**
+     * Enforce the same-site, non-reserved, non-looping invariants a rule must
+     * satisfy. Throws with an operator-readable message on the first violation.
+     *
+     * @param pattern - Normalized source path.
+     * @param destination - Normalized destination path.
+     * @param isPrefix - Whether the rule matches by prefix.
+     * @throws If the rule is malformed, reserved, or would loop.
+     */
+    private assertValidRule(pattern: string, destination: string, isPrefix: boolean): void {
+        if (!pattern.startsWith('/') || pattern.length < 2) {
+            throw new RedirectValidationError('pattern must be a root-relative path (e.g. /old-page)');
+        }
+        if (!destination.startsWith('/') || destination.length < 1) {
+            throw new RedirectValidationError('destination must be a root-relative path (e.g. /new-page)');
+        }
+        if (/\s/.test(pattern) || /\s/.test(destination)) {
+            throw new RedirectValidationError('pattern and destination must not contain whitespace');
+        }
+        for (const reserved of RESERVED_PREFIXES) {
+            if (pattern === reserved || pattern.startsWith(reserved + '/')) {
+                throw new RedirectValidationError(`pattern must not target the reserved prefix ${reserved}`);
+            }
+        }
+        if (pattern === destination) {
+            throw new RedirectValidationError('pattern and destination must differ (self-redirect loop)');
+        }
+        // A prefix rule whose destination sits under the same prefix re-matches
+        // itself on the redirected request, bouncing forever.
+        if (isPrefix && (destination === pattern || destination.startsWith(pattern + '/'))) {
+            throw new RedirectValidationError('destination must not fall under a prefix pattern (redirect loop)');
+        }
+    }
+}

--- a/src/backend/modules/traffic/services/redirect.service.ts
+++ b/src/backend/modules/traffic/services/redirect.service.ts
@@ -24,8 +24,12 @@
  * - **Unique index on `pattern`** — a source path resolves to one rule.
  * - **Same-site only** — `pattern` and `destination` are both root-relative
  *   paths; off-site redirects are out of scope and rejected by validation.
- * - **Loop-guarded** — a rule whose destination re-matches its own pattern is
- *   rejected at write time so the middleware can never bounce a request.
+ * - **Single-rule loop-guarded** — a rule whose destination re-matches its own
+ *   pattern is rejected at write time. This guards only *self*-loops; a cycle
+ *   spanning multiple rules (`/a → /b` plus `/b → /a`) is not detected here.
+ *   The blast radius is bounded: writes are admin-only and the middleware
+ *   issues at most one redirect per request, so a cross-rule cycle surfaces as
+ *   a browser-capped `ERR_TOO_MANY_REDIRECTS`, never a server-side loop.
  * - **Most-specific-first ordering** — active rules are served longest-pattern
  *   first so `/tools/x` wins over `/tools` under the middleware's first-match.
  */
@@ -417,6 +421,15 @@ export class RedirectService {
         }
         if (!destination.startsWith('/') || destination.length < 1) {
             throw new RedirectValidationError('destination must be a root-relative path (e.g. /new-page)');
+        }
+        // A destination whose second character is `/` or `\` is scheme-relative:
+        // the edge middleware resolves it with `new URL(destination, request.url)`,
+        // which keeps the request scheme but takes the authority from the
+        // destination, so `//evil.example` (and the `/\` backslash variant) become
+        // `https://evil.example/` — an off-site open redirect that breaks the
+        // documented same-site-only contract. Reject both leading forms.
+        if (destination.length > 1 && (destination[1] === '/' || destination[1] === '\\')) {
+            throw new RedirectValidationError('destination must not begin with // or /\\ (resolves to an external origin)');
         }
         if (/\s/.test(pattern) || /\s/.test(destination)) {
             throw new RedirectValidationError('pattern and destination must not contain whitespace');

--- a/src/frontend/app/(core)/system/traffic/TrafficDashboardClient.tsx
+++ b/src/frontend/app/(core)/system/traffic/TrafficDashboardClient.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+/**
+ * @fileoverview Client shell for /system/traffic.
+ *
+ * Holds the interactive dashboard surface: the in-page tab row, the global
+ * period + bot-filter controls, the live "visitors now" counter, and the six
+ * tab panels (analytics, visitors, crawlers, SEO, redirects, settings). The tab
+ * row is the menu module's Submenu Pattern — a namespaced menu rendered with
+ * `MenuNavClient`, not a hand-rolled button array — so it inherits per-user
+ * gating, ordering, and live `menu:update` refresh, and a plugin could
+ * contribute a tab. The server entry (`page.tsx`) fetches that namespace tree
+ * SSR-first and passes it in; clicking a tab drives local state via
+ * `onItemSelect` rather than navigating, and `activeUrl` highlights the active
+ * tab since the route is identical across them.
+ *
+ * One global period picker governs the Analytics and Visitors tabs so an admin
+ * never unknowingly compares different windows. The bot filter reaches Analytics
+ * and the Visitors tab's New-visitors view only. Crawlers keeps its own
+ * `sinceHours` windows and SEO its delay-shifted GSC windows. The Redirects tab
+ * manages admin-curated legacy-URL 301/302 rules and is ungoverned by the period
+ * controls.
+ */
+
+import { useEffect, useMemo, useState, useCallback } from 'react';
+import { Radio } from 'lucide-react';
+import type { MenuNodeSerialized } from '@/shared';
+import { MenuNavClient } from '../../../../components/layout/MenuNav/MenuNavClient';
+import {
+    AnalyticsDashboard,
+    VisitorsExplorer,
+    CrawlerDashboard,
+    TrafficDashboard,
+    GscKeywords,
+    GscSettings,
+    IgnoredUsers,
+    RedirectsManager,
+    PeriodPicker,
+    toDateInputValue,
+    useAutoRefresh
+} from '../../../../modules/traffic';
+import type { VisitorsView } from '../../../../modules/traffic';
+import { adminGetLiveVisitors } from '../../../../modules/traffic/api';
+import type { AnalyticsPeriod, ICustomDateRange } from '../../../../modules/traffic/api';
+import styles from './page.module.scss';
+
+/** Tab identifiers for the traffic admin page. */
+type TrafficTab = 'analytics' | 'visitors' | 'crawlers' | 'seo' | 'redirects' | 'settings';
+
+/** The menu namespace TrafficModule registers the tab nodes under. */
+const SUBMENU_NAMESPACE = 'traffic';
+
+/** Tabs governed by the global period picker. */
+const GOVERNED_TABS: ReadonlySet<TrafficTab> = new Set(['analytics', 'visitors']);
+
+/** Subject views selectable within the Visitors tab, in display order. */
+const VISITOR_VIEWS: ReadonlyArray<{ id: VisitorsView; label: string; title: string }> = [
+    { id: 'new', label: 'New visitors', title: 'New visitors first seen in this window — first-touch acquisition (referrer, landing page, UTM). Bot filter applies here.' },
+    { id: 'anonymous', label: 'Anonymous', title: 'Per-page activity for cookied anonymous visitors, keyed on the traffic id. Expand a row for their full clickstream.' },
+    { id: 'registered', label: 'Registered', title: 'Per-page activity for signed-in accounts, keyed on the Better Auth user id. Expand a row for their full clickstream.' }
+];
+
+/** Polling interval for the live-visitor counter (ms). */
+const LIVE_POLL_MS = 30_000;
+
+/**
+ * Auto-refresh cadence for the aggregate dashboards (ms). Slower than the live
+ * counter: these are heavier ClickHouse aggregations and their numbers move on
+ * a coarser timescale, so a minute keeps them current without adding query
+ * pressure. The Visitors explorer, SEO, and Redirects tabs are intentionally
+ * excluded — the first holds pagination/drill-down state a refresh would
+ * disrupt, SEO serves daily multi-day-lagged data, and Redirects is static
+ * config edited on demand.
+ */
+const DASHBOARD_REFRESH_MS = 60_000;
+
+/**
+ * Narrow an arbitrary `?tab=` string to a known TrafficTab, so deep-link seeding
+ * and click routing share one source of truth for valid tabs.
+ *
+ * @param tab - The raw `?tab=` value.
+ * @returns True when the value names a real tab.
+ */
+function isTrafficTab(tab: string | undefined): tab is TrafficTab {
+    return tab === 'analytics' || tab === 'visitors' || tab === 'crawlers'
+        || tab === 'seo' || tab === 'redirects' || tab === 'settings';
+}
+
+/**
+ * Resolve a submenu node's `?tab=` value to a known TrafficTab, defaulting to
+ * `analytics` for an unrecognized or missing value so a malformed node can never
+ * leave the page on a blank panel.
+ *
+ * @param url - The clicked node's url (e.g. `/system/traffic?tab=redirects`).
+ * @returns The matching tab id.
+ */
+function tabFromUrl(url: string | undefined): TrafficTab {
+    const tab = url?.match(/[?&]tab=([^&]+)/)?.[1];
+    return isTrafficTab(tab) ? tab : 'analytics';
+}
+
+/**
+ * Props for the traffic dashboard client shell.
+ */
+interface ITrafficDashboardClientProps {
+    /** SSR-fetched submenu nodes (the tab row), already gated for the admin. */
+    submenuTree: MenuNodeSerialized[];
+    /** Snapshot timestamp of the submenu tree, seeded onto the menu Redux slice. */
+    submenuGeneratedAt: string;
+    /**
+     * The `?tab=` value from the request URL, read SSR-first in `page.tsx` so a
+     * refreshed, bookmarked, or shared deep link opens on the right panel. An
+     * unknown or absent value resolves to `analytics`.
+     */
+    initialTab?: string;
+}
+
+/**
+ * System traffic administration dashboard (client shell).
+ *
+ * @param props - SSR submenu tree, its timestamp, and the deep-linked initial tab.
+ * @returns The tabbed dashboard.
+ */
+export function TrafficDashboardClient({ submenuTree, submenuGeneratedAt, initialTab }: ITrafficDashboardClientProps) {
+    const [activeTab, setActiveTab] = useState<TrafficTab>(isTrafficTab(initialTab) ? initialTab : 'analytics');
+    // The subject view within the Visitors tab. Defaults to New visitors —
+    // the acquisition view that matches the old Visitors tab's landing state.
+    const [visitorsView, setVisitorsView] = useState<VisitorsView>('new');
+
+    // Global window + bot filter for the governed tabs. Defaults to the last
+    // 24 hours — the most-actionable recent window — which also makes the
+    // overview trend bucket hourly (≤ 48h) rather than daily.
+    const [period, setPeriod] = useState<AnalyticsPeriod>('24h');
+    const [customStart, setCustomStart] = useState(() => {
+        const d = new Date();
+        d.setDate(d.getDate() - 7);
+        return toDateInputValue(d);
+    });
+    const [customEnd, setCustomEnd] = useState(() => toDateInputValue(new Date()));
+    const [includeBots, setIncludeBots] = useState(false);
+
+    // Live visitors (last 5 minutes), polled while the page is open.
+    const [liveVisitors, setLiveVisitors] = useState<number | null>(null);
+
+    // Shared refresh clock for the aggregate dashboards. Ticking here (once, at
+    // the page level) and threading the signal down as a prop keeps a single
+    // timer driving every aggregate surface instead of each panel owning its
+    // own; it pauses while the tab is hidden.
+    const dashboardRefresh = useAutoRefresh(
+        DASHBOARD_REFRESH_MS,
+        activeTab === 'analytics' || activeTab === 'crawlers'
+    );
+
+    /**
+     * Memoized custom date range built from the date input values.
+     * Aligns to localized midnight: start at 00:00:00 of start date,
+     * end at 23:59:59.999 of end date. Dates are constructed with the
+     * multi-argument constructor (offset-less string parsing is
+     * engine-dependent) and inverted ranges return undefined — the
+     * backend would otherwise silently serve its default window while
+     * the UI displays the custom dates. Undefined unless period is
+     * 'custom' with two valid, ordered dates.
+     */
+    const customRange = useMemo<ICustomDateRange | undefined>(() => {
+        if (period !== 'custom' || !customStart || !customEnd) return undefined;
+        const [startY, startM, startD] = customStart.split('-').map(Number);
+        const [endY, endM, endD] = customEnd.split('-').map(Number);
+        const start = new Date(startY, startM - 1, startD, 0, 0, 0, 0);
+        const end = new Date(endY, endM - 1, endD, 23, 59, 59, 999);
+        if (isNaN(start.getTime()) || isNaN(end.getTime()) || start.getTime() > end.getTime()) return undefined;
+        return { startDate: start.toISOString(), endDate: end.toISOString() };
+    }, [period, customStart, customEnd]);
+
+    /**
+     * Activate the clicked tab and keep its URL a real deep link.
+     *
+     * `MenuNavClient` suppresses the <Link> navigation when `onItemSelect` is set
+     * (it preventDefaults the click), so this rewrites the address in place with
+     * `history.replaceState` — no server round-trip — so the registered `?tab=`
+     * URLs become true deep links that `page.tsx` reads SSR-first on next load.
+     *
+     * @param item - The clicked submenu node, carrying its `?tab=` url.
+     */
+    const handleTabSelect = useCallback((item: MenuNodeSerialized) => {
+        const tab = tabFromUrl(item.url);
+        setActiveTab(tab);
+        window.history.replaceState(null, '', `/system/traffic?tab=${tab}`);
+    }, []);
+
+    useEffect(() => {
+        let active = true;
+        /**
+         * Refresh the live counter, dropping the result after unmount.
+         */
+        const poll = async (): Promise<void> => {
+            try {
+                const { visitors } = await adminGetLiveVisitors(!includeBots);
+                if (active) setLiveVisitors(visitors);
+            } catch {
+                if (active) setLiveVisitors(null);
+            }
+        };
+        poll();
+        const timer = setInterval(poll, LIVE_POLL_MS);
+        return () => { active = false; clearInterval(timer); };
+    }, [includeBots]);
+
+    const showGlobalControls = GOVERNED_TABS.has(activeTab);
+    // The bot filter is meaningful for aggregate analytics and for the
+    // Visitors tab's New-visitors (first-touch) view — first touches include
+    // cookieless bots. The activity views read only `page` events, which
+    // non-JS crawlers never emit, so the toggle would be inert; hide it there.
+    const showBotToggle = activeTab === 'analytics'
+        || (activeTab === 'visitors' && visitorsView === 'new');
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.tab_row}>
+                <div className={styles.submenu}>
+                    <MenuNavClient
+                        namespace={SUBMENU_NAMESPACE}
+                        items={submenuTree}
+                        generatedAt={submenuGeneratedAt}
+                        ariaLabel="Traffic sections"
+                        activeUrl={`/system/traffic?tab=${activeTab}`}
+                        onItemSelect={handleTabSelect}
+                    />
+                </div>
+                {liveVisitors !== null && (
+                    <span className={styles.live} title="Distinct visitors in the last 5 minutes">
+                        <Radio size={14} aria-hidden="true" />
+                        {liveVisitors.toLocaleString()} online now
+                    </span>
+                )}
+            </div>
+
+            {showGlobalControls && (
+                <div className={styles.global_controls}>
+                    <div className={styles.control_group}>
+                        <PeriodPicker
+                            period={period}
+                            onPeriodChange={setPeriod}
+                            customStart={customStart}
+                            customEnd={customEnd}
+                            onCustomStartChange={setCustomStart}
+                            onCustomEndChange={setCustomEnd}
+                        />
+                        {activeTab === 'visitors' && (
+                            <div className={styles.subject_toggle} role="group" aria-label="Visitor view">
+                                {VISITOR_VIEWS.map(v => (
+                                    <button
+                                        key={v.id}
+                                        type="button"
+                                        className={visitorsView === v.id ? styles.subject_btn__active : styles.subject_btn}
+                                        onClick={() => setVisitorsView(v.id)}
+                                        aria-pressed={visitorsView === v.id}
+                                        title={v.title}
+                                    >
+                                        {v.label}
+                                    </button>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                    {showBotToggle && (
+                        <div className={styles.bot_toggle} role="group" aria-label="Bot traffic filter">
+                            <button
+                                type="button"
+                                className={!includeBots ? styles.bot_btn__active : styles.bot_btn}
+                                onClick={() => setIncludeBots(false)}
+                                aria-pressed={!includeBots}
+                                title="Counts only visitors that loaded a page (ran JavaScript) and were not classified as bots. Cookieless bots that never run JS are already excluded from every visitor number; unclassified rows are kept, so JS-running bots that spoof a browser may remain."
+                            >
+                                Exclude known bots
+                            </button>
+                            <button
+                                type="button"
+                                className={includeBots ? styles.bot_btn__active : styles.bot_btn}
+                                onClick={() => setIncludeBots(true)}
+                                aria-pressed={includeBots}
+                                title="Also counts JavaScript-running bots the classifier caught (headless scrapers). Cookieless bots that never run JS stay excluded regardless — a visitor must have loaded a page."
+                            >
+                                Include bots
+                            </button>
+                        </div>
+                    )}
+                </div>
+            )}
+
+            <div className={styles.content}>
+                {activeTab === 'analytics' && (
+                    <AnalyticsDashboard period={period} customRange={customRange} includeBots={includeBots} refreshSignal={dashboardRefresh} />
+                )}
+                {activeTab === 'visitors' && (
+                    <VisitorsExplorer
+                        view={visitorsView}
+                        period={period}
+                        customRange={customRange}
+                        includeBots={includeBots}
+                    />
+                )}
+                {activeTab === 'crawlers' && (
+                    <div className={styles.crawler_stack}>
+                        <CrawlerDashboard refreshSignal={dashboardRefresh} />
+                        <TrafficDashboard refreshSignal={dashboardRefresh} />
+                    </div>
+                )}
+                {activeTab === 'seo' && <GscKeywords />}
+                {activeTab === 'redirects' && <RedirectsManager />}
+                {activeTab === 'settings' && (
+                    <div className={styles.settings_stack}>
+                        <IgnoredUsers />
+                        <GscSettings />
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/frontend/app/(core)/system/traffic/page.module.scss
+++ b/src/frontend/app/(core)/system/traffic/page.module.scss
@@ -14,39 +14,21 @@
     container-name: traffic-admin;
 }
 
-.tabs {
+/* Tab row: the Submenu-Pattern menu (MenuNavClient) on the left, with the live
+   counter pushed to the right edge. Replaces the former hand-rolled button row
+   so the tabs inherit per-user gating, ordering, and live menu:update refresh. */
+.tab_row {
     display: flex;
-    gap: var(--gap-sm);
-    border-bottom: var(--border-width-thin) solid var(--color-border);
+    align-items: center;
+    gap: var(--gap-md);
     flex-wrap: wrap;
+    border-bottom: var(--border-width-thin) solid var(--color-border);
 }
 
-.tab,
-.tab__active {
-    padding: var(--gap-sm) var(--gap-md);
-    background: none;
-    border: none;
-    border-bottom: var(--border-width-medium) solid transparent;
-    cursor: pointer;
-    font-size: var(--font-size-body-lg);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-text-muted);
-    transition: color var(--transition-base), border-color var(--transition-base);
-}
-
-.tab:hover {
-    color: var(--color-text);
-}
-
-.tab:focus-visible,
-.tab__active:focus-visible {
-    outline: var(--focus-outline-width) solid var(--color-focus);
-    outline-offset: var(--focus-outline-offset);
-}
-
-.tab__active {
-    color: var(--color-primary);
-    border-bottom-color: var(--color-primary);
+/* Wrapper around MenuNavClient; lets it take its natural width so the live
+   counter's margin-left:auto can claim the remaining row width. */
+.submenu {
+    min-width: 0;
 }
 
 /* Live "online now" counter, pushed to the right edge of the tab row. */

--- a/src/frontend/app/(core)/system/traffic/page.tsx
+++ b/src/frontend/app/(core)/system/traffic/page.tsx
@@ -1,282 +1,69 @@
-'use client';
+/**
+ * @fileoverview /system/traffic server entry.
+ *
+ * Fetches the page's in-page tab row from the menu service SSR-first and hands
+ * it to the client shell. The tab row is a namespaced menu (menu module's
+ * Submenu Pattern), not a hand-rolled button array, so it inherits per-user
+ * gating, ordering, and live `menu:update` refresh. This server component
+ * fetches that namespace tree once — forwarding the admin's session cookie so
+ * the nodes' `requiresAdmin` gating resolves — exactly as `MenuNavSSR` feeds the
+ * global nav; the client shell then renders it with `MenuNavClient` and drives
+ * the active panel. Admin-gated by the /system layout.
+ */
 
-import { useEffect, useMemo, useState } from 'react';
-import { Radio } from 'lucide-react';
-import {
-    AnalyticsDashboard,
-    VisitorsExplorer,
-    CrawlerDashboard,
-    TrafficDashboard,
-    GscKeywords,
-    GscSettings,
-    IgnoredUsers,
-    PeriodPicker,
-    toDateInputValue,
-    useAutoRefresh
-} from '../../../../modules/traffic';
-import type { VisitorsView } from '../../../../modules/traffic';
-import { adminGetLiveVisitors } from '../../../../modules/traffic/api';
-import type { AnalyticsPeriod, ICustomDateRange } from '../../../../modules/traffic/api';
-import styles from './page.module.scss';
+import { cookies } from 'next/headers';
+import type { MenuNodeSerialized } from '@/shared';
+import { getServerSideApiUrl } from '../../../../lib/api-url';
+import { TrafficDashboardClient } from './TrafficDashboardClient';
 
-/** Tab identifiers for the traffic admin page. */
-type TrafficTab = 'analytics' | 'visitors' | 'crawlers' | 'seo' | 'settings';
-
-/** Tabs governed by the global period picker. */
-const GOVERNED_TABS: ReadonlySet<TrafficTab> = new Set(['analytics', 'visitors']);
-
-/** Subject views selectable within the Visitors tab, in display order. */
-const VISITOR_VIEWS: ReadonlyArray<{ id: VisitorsView; label: string; title: string }> = [
-    { id: 'new', label: 'New visitors', title: 'New visitors first seen in this window — first-touch acquisition (referrer, landing page, UTM). Bot filter applies here.' },
-    { id: 'anonymous', label: 'Anonymous', title: 'Per-page activity for cookied anonymous visitors, keyed on the traffic id. Expand a row for their full clickstream.' },
-    { id: 'registered', label: 'Registered', title: 'Per-page activity for signed-in accounts, keyed on the Better Auth user id. Expand a row for their full clickstream.' }
-];
-
-/** Polling interval for the live-visitor counter (ms). */
-const LIVE_POLL_MS = 30_000;
+/** Namespace holding the page's tab nodes; registered by TrafficModule. */
+const SUBMENU_NAMESPACE = 'traffic';
 
 /**
- * Auto-refresh cadence for the aggregate dashboards (ms). Slower than the live
- * counter: these are heavier ClickHouse aggregations and their numbers move on
- * a coarser timescale, so a minute keeps them current without adding query
- * pressure. The Visitors explorer and SEO tabs are intentionally excluded —
- * the former holds pagination/drill-down state a refresh would disrupt, the
- * latter serves daily, multi-day-lagged data that cannot change within a tick.
+ * Fetch the submenu namespace tree from the menu API, forwarding the visitor's
+ * cookies so the backend's per-user `requiresAdmin` gating resolves for the
+ * admin. On any failure it returns an empty tree, mirroring `MenuNavSSR`'s
+ * graceful degradation — the page still renders, just without the tab row until
+ * a live `menu:update` refetch repopulates it.
+ *
+ * @returns The namespace root nodes and the tree snapshot timestamp.
  */
-const DASHBOARD_REFRESH_MS = 60_000;
-
-/**
- * System traffic administration page with tabbed interface.
- *
- * Hosts the traffic module's analytics dashboards, carved out of
- * /system/users to mirror the backend identity/traffic split:
- * - Analytics: aggregate reporting — KPI strip + unified trend, sources,
- *   engagement, funnel, geo/device breakdowns
- * - Visitors: the individual-entity explorer — a subject selector switches
- *   between New visitors (first touches, bot-filterable), Anonymous (tid)
- *   page activity, and Registered (user_id) page activity
- * - Crawlers: Bot-class trend, per-bot-class paths, and the bot/geo/path
- *   breakdowns with the bot_other classifier-gap feedback loop
- * - SEO: Google Search Console keywords (clicks/impressions/CTR/position)
- * - Settings: GSC credential configuration
- *
- * Visitors and Pages were formerly two tabs; both rendered row-per-subject
- * tables with a drill-down, so they were merged into one explorer behind a
- * subject selector — aggregate reporting (Analytics) stays a separate mode
- * from row-level exploration (Visitors), the GA4 Reports-vs-Explore divide.
- *
- * One global period picker governs the Analytics and Visitors tabs so an
- * admin never unknowingly compares different windows. The bot filter reaches
- * Analytics and the Visitors tab's New-visitors view only — the activity
- * views read `page` events that non-JS crawlers never emit, so it is inert
- * there and hidden. Crawlers keeps its own `sinceHours` windows (capped at
- * 30d server-side) and SEO its delay-shifted GSC windows. A live "visitors
- * now" counter (last 5 minutes, polled every 30s) sits beside the tabs.
- *
- * Follows the simpler button-tab pattern from /system/pages (no ARIA
- * tablist/tab/tabpanel roles to avoid incomplete implementation).
- */
-export default function SystemTrafficPage() {
-    const [activeTab, setActiveTab] = useState<TrafficTab>('analytics');
-    // The subject view within the Visitors tab. Defaults to New visitors —
-    // the acquisition view that matches the old Visitors tab's landing state.
-    const [visitorsView, setVisitorsView] = useState<VisitorsView>('new');
-
-    // Global window + bot filter for the governed tabs. Defaults to the last
-    // 24 hours — the most-actionable recent window — which also makes the
-    // overview trend bucket hourly (≤ 48h) rather than daily.
-    const [period, setPeriod] = useState<AnalyticsPeriod>('24h');
-    const [customStart, setCustomStart] = useState(() => {
-        const d = new Date();
-        d.setDate(d.getDate() - 7);
-        return toDateInputValue(d);
-    });
-    const [customEnd, setCustomEnd] = useState(() => toDateInputValue(new Date()));
-    const [includeBots, setIncludeBots] = useState(false);
-
-    // Live visitors (last 5 minutes), polled while the page is open.
-    const [liveVisitors, setLiveVisitors] = useState<number | null>(null);
-
-    // Shared refresh clock for the aggregate dashboards. Ticking here (once, at
-    // the page level) and threading the signal down as a prop keeps a single
-    // timer driving every aggregate surface instead of each panel owning its
-    // own; it pauses while the tab is hidden.
-    const dashboardRefresh = useAutoRefresh(
-        DASHBOARD_REFRESH_MS,
-        activeTab === 'analytics' || activeTab === 'crawlers'
-    );
-
-    /**
-     * Memoized custom date range built from the date input values.
-     * Aligns to localized midnight: start at 00:00:00 of start date,
-     * end at 23:59:59.999 of end date. Dates are constructed with the
-     * multi-argument constructor (offset-less string parsing is
-     * engine-dependent) and inverted ranges return undefined — the
-     * backend would otherwise silently serve its default window while
-     * the UI displays the custom dates. Undefined unless period is
-     * 'custom' with two valid, ordered dates.
-     */
-    const customRange = useMemo<ICustomDateRange | undefined>(() => {
-        if (period !== 'custom' || !customStart || !customEnd) return undefined;
-        const [startY, startM, startD] = customStart.split('-').map(Number);
-        const [endY, endM, endD] = customEnd.split('-').map(Number);
-        const start = new Date(startY, startM - 1, startD, 0, 0, 0, 0);
-        const end = new Date(endY, endM - 1, endD, 23, 59, 59, 999);
-        if (isNaN(start.getTime()) || isNaN(end.getTime()) || start.getTime() > end.getTime()) return undefined;
-        return { startDate: start.toISOString(), endDate: end.toISOString() };
-    }, [period, customStart, customEnd]);
-
-    useEffect(() => {
-        let active = true;
-        /**
-         * Refresh the live counter, dropping the result after unmount.
-         */
-        const poll = async (): Promise<void> => {
-            try {
-                const { visitors } = await adminGetLiveVisitors(!includeBots);
-                if (active) setLiveVisitors(visitors);
-            } catch {
-                if (active) setLiveVisitors(null);
-            }
+async function fetchSubmenu(): Promise<{ roots: MenuNodeSerialized[]; generatedAt: string }> {
+    const fallback = { roots: [] as MenuNodeSerialized[], generatedAt: new Date().toISOString() };
+    try {
+        const cookieHeader = (await cookies()).toString();
+        const response = await fetch(`${getServerSideApiUrl()}/api/menu?namespace=${SUBMENU_NAMESPACE}`, {
+            cache: 'no-store',
+            headers: cookieHeader ? { Cookie: cookieHeader } : undefined
+        });
+        if (!response.ok) {
+            return fallback;
+        }
+        const data = await response.json() as { tree?: { roots?: MenuNodeSerialized[]; generatedAt?: string } };
+        return {
+            roots: data.tree?.roots ?? [],
+            generatedAt: data.tree?.generatedAt ?? fallback.generatedAt
         };
-        poll();
-        const timer = setInterval(poll, LIVE_POLL_MS);
-        return () => { active = false; clearInterval(timer); };
-    }, [includeBots]);
+    } catch {
+        return fallback;
+    }
+}
 
-    const showGlobalControls = GOVERNED_TABS.has(activeTab);
-    // The bot filter is meaningful for aggregate analytics and for the
-    // Visitors tab's New-visitors (first-touch) view — first touches include
-    // cookieless bots. The activity views read only `page` events, which
-    // non-JS crawlers never emit, so the toggle would be inert; hide it there.
-    const showBotToggle = activeTab === 'analytics'
-        || (activeTab === 'visitors' && visitorsView === 'new');
-
-    return (
-        <div className={styles.container}>
-            <div className={styles.tabs}>
-                <button
-                    type="button"
-                    className={activeTab === 'analytics' ? styles.tab__active : styles.tab}
-                    onClick={() => setActiveTab('analytics')}
-                >
-                    Analytics
-                </button>
-                <button
-                    type="button"
-                    className={activeTab === 'visitors' ? styles.tab__active : styles.tab}
-                    onClick={() => setActiveTab('visitors')}
-                >
-                    Visitors
-                </button>
-                <button
-                    type="button"
-                    className={activeTab === 'crawlers' ? styles.tab__active : styles.tab}
-                    onClick={() => setActiveTab('crawlers')}
-                >
-                    Crawlers
-                </button>
-                <button
-                    type="button"
-                    className={activeTab === 'seo' ? styles.tab__active : styles.tab}
-                    onClick={() => setActiveTab('seo')}
-                >
-                    SEO
-                </button>
-                <button
-                    type="button"
-                    className={activeTab === 'settings' ? styles.tab__active : styles.tab}
-                    onClick={() => setActiveTab('settings')}
-                >
-                    Settings
-                </button>
-                {liveVisitors !== null && (
-                    <span className={styles.live} title="Distinct visitors in the last 5 minutes">
-                        <Radio size={14} aria-hidden="true" />
-                        {liveVisitors.toLocaleString()} online now
-                    </span>
-                )}
-            </div>
-
-            {showGlobalControls && (
-                <div className={styles.global_controls}>
-                    <div className={styles.control_group}>
-                        <PeriodPicker
-                            period={period}
-                            onPeriodChange={setPeriod}
-                            customStart={customStart}
-                            customEnd={customEnd}
-                            onCustomStartChange={setCustomStart}
-                            onCustomEndChange={setCustomEnd}
-                        />
-                        {activeTab === 'visitors' && (
-                            <div className={styles.subject_toggle} role="group" aria-label="Visitor view">
-                                {VISITOR_VIEWS.map(v => (
-                                    <button
-                                        key={v.id}
-                                        type="button"
-                                        className={visitorsView === v.id ? styles.subject_btn__active : styles.subject_btn}
-                                        onClick={() => setVisitorsView(v.id)}
-                                        aria-pressed={visitorsView === v.id}
-                                        title={v.title}
-                                    >
-                                        {v.label}
-                                    </button>
-                                ))}
-                            </div>
-                        )}
-                    </div>
-                    {showBotToggle && (
-                        <div className={styles.bot_toggle} role="group" aria-label="Bot traffic filter">
-                            <button
-                                type="button"
-                                className={!includeBots ? styles.bot_btn__active : styles.bot_btn}
-                                onClick={() => setIncludeBots(false)}
-                                aria-pressed={!includeBots}
-                                title="Counts only visitors that loaded a page (ran JavaScript) and were not classified as bots. Cookieless bots that never run JS are already excluded from every visitor number; unclassified rows are kept, so JS-running bots that spoof a browser may remain."
-                            >
-                                Exclude known bots
-                            </button>
-                            <button
-                                type="button"
-                                className={includeBots ? styles.bot_btn__active : styles.bot_btn}
-                                onClick={() => setIncludeBots(true)}
-                                aria-pressed={includeBots}
-                                title="Also counts JavaScript-running bots the classifier caught (headless scrapers). Cookieless bots that never run JS stay excluded regardless — a visitor must have loaded a page."
-                            >
-                                Include bots
-                            </button>
-                        </div>
-                    )}
-                </div>
-            )}
-
-            <div className={styles.content}>
-                {activeTab === 'analytics' && (
-                    <AnalyticsDashboard period={period} customRange={customRange} includeBots={includeBots} refreshSignal={dashboardRefresh} />
-                )}
-                {activeTab === 'visitors' && (
-                    <VisitorsExplorer
-                        view={visitorsView}
-                        period={period}
-                        customRange={customRange}
-                        includeBots={includeBots}
-                    />
-                )}
-                {activeTab === 'crawlers' && (
-                    <div className={styles.crawler_stack}>
-                        <CrawlerDashboard refreshSignal={dashboardRefresh} />
-                        <TrafficDashboard refreshSignal={dashboardRefresh} />
-                    </div>
-                )}
-                {activeTab === 'seo' && <GscKeywords />}
-                {activeTab === 'settings' && (
-                    <div className={styles.settings_stack}>
-                        <IgnoredUsers />
-                        <GscSettings />
-                    </div>
-                )}
-            </div>
-        </div>
-    );
+/**
+ * System traffic admin page (server entry).
+ *
+ * @param props - Next.js route props.
+ * @param props.searchParams - The `?tab=` deep link (a Promise in Next.js 15+),
+ *   read SSR-first to seed the initially active panel so a refreshed, bookmarked,
+ *   or shared link opens on the selected tab instead of falling back to Analytics.
+ * @returns The client shell seeded with the SSR-fetched submenu tree.
+ */
+export default async function SystemTrafficPage({
+    searchParams
+}: {
+    searchParams: Promise<{ tab?: string }>;
+}) {
+    const { roots, generatedAt } = await fetchSubmenu();
+    const { tab } = await searchParams;
+    return <TrafficDashboardClient submenuTree={roots} submenuGeneratedAt={generatedAt} initialTab={tab} />;
 }

--- a/src/frontend/middleware.ts
+++ b/src/frontend/middleware.ts
@@ -250,32 +250,87 @@ interface RedirectRule {
 }
 
 /**
- * Legacy redirect rules migrated from next.config.mjs.
+ * How long (ms) a fetched redirect map is served before a background refresh.
+ * Matches the backend feed's Cache-Control, so an admin-added rule goes live in
+ * at most this long.
  */
-const REDIRECT_RULES: RedirectRule[] = [
-    // Resource markets legacy paths
-    { pattern: '/rent-tron-energy', isPrefix: true, destination: '/resource-markets', permanent: true },
-    { pattern: '/lp/rm', isPrefix: true, destination: '/resource-markets', permanent: true },
+const REDIRECT_CACHE_TTL_MS = 60_000;
 
-    // Legacy tool paths
-    { pattern: '/tron-trx-energy-fee-calculator', isPrefix: true, destination: '/tools', permanent: true },
-    { pattern: '/tools/staking-calculator', isPrefix: true, destination: '/tools', permanent: true },
-    { pattern: '/tools/tronmoji', isPrefix: true, destination: '/tools', permanent: true },
-    { pattern: '/tools/tron-custom-address-generator', isPrefix: true, destination: '/tools', permanent: true },
-    { pattern: '/tools/signature-verification', isPrefix: true, destination: '/tools', permanent: true },
-    { pattern: '/tools/hex-to-base58check', isPrefix: true, destination: '/tools', permanent: true },
-    { pattern: '/tools/base58check-to-hex', isPrefix: true, destination: '/tools', permanent: true },
+/**
+ * Timeout (ms) for the server-to-server redirect-map fetch. The map load sits on
+ * the request critical path, so a slow backend must not stall navigation — on
+ * timeout the last-known (or empty) map is used and the request proceeds.
+ */
+const REDIRECT_FETCH_TIMEOUT_MS = 3000;
 
-    // Legacy article slugs
-    { pattern: '/tron-dex', isPrefix: true, destination: '/articles', permanent: true },
-    { pattern: '/tron-latest-trc10-tokens', isPrefix: true, destination: '/articles', permanent: true },
-    { pattern: '/tron-latest-trc10-exchanges', isPrefix: true, destination: '/articles', permanent: true },
-    { pattern: '/tron-node-setup-guide', isPrefix: true, destination: '/articles', permanent: true },
-    { pattern: '/tron-bandwidth-vs-energy', isPrefix: true, destination: '/articles', permanent: true },
-    { pattern: '/tron-delegated-proof-of-stake', isPrefix: true, destination: '/articles', permanent: true },
-    { pattern: '/tron-trc10-token', isPrefix: true, destination: '/articles', permanent: true },
-    { pattern: '/tron-super-representatives', isPrefix: true, destination: '/articles', permanent: true },
-];
+/**
+ * Module-scope cache of the admin-managed redirect map. Redirect rules are no
+ * longer hardcoded here — they live in Mongo (`module_traffic_redirects`) and
+ * are edited from `/system/traffic`. This middleware runs on the Edge runtime
+ * and cannot reach Mongo directly, so it pulls the map from the backend's public
+ * `/api/redirects` feed and caches it in module scope. In the standalone Node
+ * server this cache persists across requests in one instance, so the steady
+ * state is ~one backend call per TTL window, not per request.
+ */
+let cachedRedirectRules: RedirectRule[] = [];
+
+/** Epoch ms after which the cached map is stale; 0 means never fetched (cold). */
+let redirectCacheExpiry = 0;
+
+/** Dedupes concurrent background refreshes so only one fetch runs at a time. */
+let redirectRefreshInFlight: Promise<void> | null = null;
+
+/**
+ * Fetch the active redirect map from the backend and replace the cache. A
+ * non-OK response leaves the last-known map in place rather than clearing it, so
+ * a transient backend hiccup never drops live redirects.
+ */
+async function refreshRedirectRules(): Promise<void> {
+    const response = await fetch(`${getServerSideApiUrl()}/api/redirects`, {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(REDIRECT_FETCH_TIMEOUT_MS)
+    });
+    if (!response.ok) {
+        return;
+    }
+    const data = await response.json() as { rules?: RedirectRule[] };
+    cachedRedirectRules = Array.isArray(data.rules) ? data.rules : [];
+    redirectCacheExpiry = Date.now() + REDIRECT_CACHE_TTL_MS;
+}
+
+/**
+ * Return the current redirect map, refreshing as needed. On a cold cache it
+ * blocks on the first fetch so a redirect fires on the very first request; once
+ * warm it serves the cached map immediately and refreshes stale data in the
+ * background (deduped), so no request pays fetch latency after warmup. Every
+ * failure path degrades to the last-known (or empty) map and lets the request
+ * fall through — a redirect lookup must never 500 or stall navigation.
+ *
+ * @returns The active redirect rules.
+ */
+async function getRedirectRules(): Promise<RedirectRule[]> {
+    const now = Date.now();
+    if (redirectCacheExpiry === 0) {
+        // Cold: block once so the very first request can still redirect. Arm the
+        // expiry either way so subsequent requests take the non-blocking warm
+        // path instead of blocking on every hit while a backend is unreachable.
+        try {
+            await refreshRedirectRules();
+        } catch {
+            /* leave the map empty; the background path will retry after the TTL */
+        }
+        if (redirectCacheExpiry === 0) {
+            redirectCacheExpiry = now + REDIRECT_CACHE_TTL_MS;
+        }
+        return cachedRedirectRules;
+    }
+    if (now >= redirectCacheExpiry && !redirectRefreshInFlight) {
+        redirectRefreshInFlight = refreshRedirectRules()
+            .catch(() => { /* keep last-known map on failure */ })
+            .finally(() => { redirectRefreshInFlight = null; });
+    }
+    return cachedRedirectRules;
+}
 
 /**
  * Check if a referrer URL is from an external domain.
@@ -293,9 +348,14 @@ function isExternalReferrer(referer: string, requestHost: string): boolean {
 
 /**
  * Find a matching redirect rule for the given path.
+ *
+ * @param pathname - The request path to match.
+ * @param rules - The active redirect map (served most-specific-first by the
+ *   backend, so the first match under this simple loop is the best one).
+ * @returns The matching rule, or undefined when none applies.
  */
-function findRedirectRule(pathname: string): RedirectRule | undefined {
-    for (const rule of REDIRECT_RULES) {
+function findRedirectRule(pathname: string, rules: RedirectRule[]): RedirectRule | undefined {
+    for (const rule of rules) {
         if (rule.isPrefix) {
             if (pathname === rule.pattern || pathname.startsWith(rule.pattern + '/')) {
                 return rule;
@@ -315,8 +375,10 @@ function findRedirectRule(pathname: string): RedirectRule | undefined {
 export async function middleware(request: NextRequest) {
     const pathname = request.nextUrl.pathname;
 
-    // Check for matching redirect rule
-    const rule = findRedirectRule(pathname);
+    // Check for a matching admin-managed redirect rule. The map is fetched from
+    // the backend and cached in module scope (see getRedirectRules) — no rules
+    // are hardcoded in this bundle.
+    const rule = findRedirectRule(pathname, await getRedirectRules());
 
     if (rule) {
         const referer = request.headers.get('referer');

--- a/src/frontend/middleware.ts
+++ b/src/frontend/middleware.ts
@@ -257,6 +257,16 @@ interface RedirectRule {
 const REDIRECT_CACHE_TTL_MS = 60_000;
 
 /**
+ * Backoff (ms) applied after a failed warm refresh (non-OK response or a thrown
+ * fetch). Shorter than the healthy TTL so recovery is detected quickly, yet far
+ * longer than a single request — it caps the frontend to one feed retry per
+ * window during a backend incident instead of one fetch per page view. Without
+ * it the warm path leaves the already-expired cache in place and re-fetches on
+ * every request, amplifying load against an already-unhealthy backend.
+ */
+const REDIRECT_RETRY_BACKOFF_MS = 10_000;
+
+/**
  * Timeout (ms) for the server-to-server redirect-map fetch. The map load sits on
  * the request critical path, so a slow backend must not stall navigation — on
  * timeout the last-known (or empty) map is used and the request proceeds.
@@ -325,9 +335,23 @@ async function getRedirectRules(): Promise<RedirectRule[]> {
         return cachedRedirectRules;
     }
     if (now >= redirectCacheExpiry && !redirectRefreshInFlight) {
+        // Snapshot the stale (already-expired) deadline so the settlement
+        // handler can distinguish a successful refresh — which pushes the
+        // expiry a full TTL into the future — from a failed one. Both failure
+        // modes (a non-OK response, which returns without advancing the
+        // expiry, and a thrown fetch caught below) leave the expiry equal to
+        // this snapshot. On failure, arm a short backoff so an unhealthy feed
+        // is retried once per backoff window instead of re-fetched on every
+        // request during a backend incident; the last-known map is retained.
+        const staleExpiry = redirectCacheExpiry;
         redirectRefreshInFlight = refreshRedirectRules()
             .catch(() => { /* keep last-known map on failure */ })
-            .finally(() => { redirectRefreshInFlight = null; });
+            .finally(() => {
+                if (redirectCacheExpiry === staleExpiry) {
+                    redirectCacheExpiry = Date.now() + REDIRECT_RETRY_BACKOFF_MS;
+                }
+                redirectRefreshInFlight = null;
+            });
     }
     return cachedRedirectRules;
 }

--- a/src/frontend/modules/traffic/api/client.ts
+++ b/src/frontend/modules/traffic/api/client.ts
@@ -1057,3 +1057,95 @@ export async function adminGetBotPaths(botClass: string,
     });
     return response.data as { buckets: ITrafficBucket[]; clickhouseEnabled: boolean };
 }
+
+// ============================================================================
+// Redirect Management API Functions
+// ============================================================================
+
+/**
+ * An admin-managed URL redirect rule. Mirrors the backend `IRedirectRuleAdmin`
+ * shape returned by the redirect management endpoints (the four match/issue
+ * fields plus id, enabled flag, notes, and ISO timestamps for the table).
+ */
+export interface IRedirectRuleAdmin {
+    /** Rule id (hex string); the handle edits/deletes address. */
+    id: string;
+    /** Source path to match, root-relative. */
+    pattern: string;
+    /** True matches `pattern` and any sub-path; false is exact. */
+    isPrefix: boolean;
+    /** Destination path, root-relative. */
+    destination: string;
+    /** True issues a 301 (permanent); false a 302 (temporary). */
+    permanent: boolean;
+    /** Whether the rule is currently served to the edge middleware. */
+    enabled: boolean;
+    /** Optional operator annotation recording why the redirect exists. */
+    notes?: string;
+    /** ISO-8601 creation timestamp. */
+    createdAt: string;
+    /** ISO-8601 last-update timestamp. */
+    updatedAt: string;
+}
+
+/**
+ * Editable fields when creating or patching a redirect rule. Booleans are
+ * optional so the backend can default a simple legacy→new mapping to
+ * prefix/permanent/enabled.
+ */
+export interface IRedirectRuleInput {
+    /** Source path to match. */
+    pattern: string;
+    /** Destination path. */
+    destination: string;
+    /** Prefix vs exact match; backend defaults to true. */
+    isPrefix?: boolean;
+    /** 301 vs 302; backend defaults to true. */
+    permanent?: boolean;
+    /** Active flag; backend defaults to true. */
+    enabled?: boolean;
+    /** Optional operator annotation. */
+    notes?: string;
+}
+
+/**
+ * List every redirect rule (enabled and disabled) for the management table.
+ *
+ * @returns All rules, newest first.
+ */
+export async function adminListRedirects(): Promise<IRedirectRuleAdmin[]> {
+    const response = await apiClient.get('/admin/redirects');
+    return (response.data as { rules: IRedirectRuleAdmin[] }).rules ?? [];
+}
+
+/**
+ * Create a redirect rule.
+ *
+ * @param input - The rule fields; omitted booleans default server-side.
+ * @returns The created rule.
+ */
+export async function adminCreateRedirect(input: IRedirectRuleInput): Promise<IRedirectRuleAdmin> {
+    const response = await apiClient.post('/admin/redirects', input);
+    return response.data as IRedirectRuleAdmin;
+}
+
+/**
+ * Patch a redirect rule (e.g. toggle `enabled`, retarget `destination`).
+ *
+ * @param id - The rule id.
+ * @param patch - Fields to change.
+ * @returns The updated rule.
+ */
+export async function adminUpdateRedirect(id: string, patch: Partial<IRedirectRuleInput>): Promise<IRedirectRuleAdmin> {
+    const response = await apiClient.patch(`/admin/redirects/${id}`, patch);
+    return response.data as IRedirectRuleAdmin;
+}
+
+/**
+ * Delete a redirect rule.
+ *
+ * @param id - The rule id.
+ */
+export async function adminDeleteRedirect(id: string): Promise<void> {
+    await apiClient.delete(`/admin/redirects/${id}`);
+}

--- a/src/frontend/modules/traffic/api/index.ts
+++ b/src/frontend/modules/traffic/api/index.ts
@@ -31,6 +31,11 @@ export {
     adminAddIgnoredUser,
     adminRemoveIgnoredUser,
     adminSearchAccounts,
+    // Redirect management functions
+    adminListRedirects,
+    adminCreateRedirect,
+    adminUpdateRedirect,
+    adminDeleteRedirect,
     // Google Search Console functions
     adminGetGscStatus,
     adminSaveGscCredentials,
@@ -82,5 +87,7 @@ export type {
     IGscPagesResult,
     IGscDailyKeywords,
     ITrafficBucket,
-    IBotClassDailyPoint
+    IBotClassDailyPoint,
+    IRedirectRuleAdmin,
+    IRedirectRuleInput
 } from './client';

--- a/src/frontend/modules/traffic/components/admin/RedirectsManager/RedirectsManager.module.scss
+++ b/src/frontend/modules/traffic/components/admin/RedirectsManager/RedirectsManager.module.scss
@@ -1,0 +1,147 @@
+@use '../../../../../app/breakpoints' as *;
+
+.container {
+    container-type: inline-size;
+    container-name: redirects-manager;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-lg);
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+
+    svg {
+        color: var(--color-primary);
+    }
+}
+
+/* Add-rule form: two-up source/destination row, then note, then options. */
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+    padding: var(--card-padding-sm);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-muted);
+}
+
+.form_row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--gap-md);
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+}
+
+.label {
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-muted);
+    letter-spacing: var(--letter-spacing-wide);
+    text-transform: uppercase;
+}
+
+.options {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-md);
+    flex-wrap: wrap;
+}
+
+.checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text);
+    cursor: pointer;
+}
+
+.error {
+    font-size: var(--font-size-body-sm);
+    color: var(--color-danger-text);
+    background: var(--color-danger-alpha-18);
+    border: var(--border-width-thin) solid var(--color-danger-alpha-50);
+    border-radius: var(--radius-sm);
+    padding: var(--padding-sm) var(--padding-md);
+}
+
+/* Source/destination paths render monospace so trailing slashes and casing
+   read unambiguously. */
+.path {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text);
+    word-break: break-all;
+}
+
+.note {
+    display: block;
+    margin-top: var(--gap-2xs);
+    font-size: var(--font-size-caption);
+    color: var(--color-text-subtle);
+}
+
+.dest {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    svg {
+        color: var(--color-text-subtle);
+        flex-shrink: 0;
+    }
+}
+
+.row_disabled {
+    opacity: var(--opacity-55);
+}
+
+.actions_col {
+    text-align: right;
+}
+
+.actions {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--gap-sm);
+}
+
+/* Borderless inline row actions; icon tone flips to the semantic action color
+   on hover, per the bare icon-button pattern. */
+.icon_btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--icon-button-bare-padding-md);
+    border: none;
+    border-radius: var(--icon-button-bare-border-radius);
+    background: transparent;
+    color: var(--icon-button-bare-color);
+    cursor: pointer;
+    transition: color var(--transition-base), background var(--transition-base);
+}
+
+.icon_btn:hover {
+    color: var(--icon-button-bare-color-primary-hover);
+    background: var(--color-surface-elevated);
+}
+
+.icon_btn__danger:hover {
+    color: var(--icon-button-bare-color-danger-hover);
+}
+
+@container redirects-manager (max-width: #{$breakpoint-mobile-md}) {
+    .form_row {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/frontend/modules/traffic/components/admin/RedirectsManager/RedirectsManager.tsx
+++ b/src/frontend/modules/traffic/components/admin/RedirectsManager/RedirectsManager.tsx
@@ -1,0 +1,316 @@
+'use client';
+
+/**
+ * Admin-managed URL redirect panel.
+ *
+ * Lets an operator add, toggle, and delete legacy-URL 301/302 rules that the
+ * Next.js edge middleware serves at request time. Redirects are the fix for the
+ * dead 404s Search Console surfaces on the sibling SEO tab, so this panel lives
+ * one tab over: see a 404 there, add the redirect here — no deploy, the
+ * middleware picks up new rules on its next cache refresh.
+ *
+ * Like the other `/system/traffic` admin panels (GscSettings, IgnoredUsers) this
+ * is an admin-only surface that fetches client-side after auth rather than
+ * SSR-first — the SSR + Live Updates rule targets public-facing components.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { isAxiosError } from 'axios';
+import { CornerUpRight, ArrowRight, Trash2, Power, PowerOff, Plus } from 'lucide-react';
+import { Button } from '../../../../../components/ui/Button';
+import { Input } from '../../../../../components/ui/Input';
+import { Card } from '../../../../../components/ui/Card';
+import { Badge } from '../../../../../components/ui/Badge';
+import { ClientTime } from '../../../../../components/ui/ClientTime';
+import { Stack } from '../../../../../components/layout';
+import {
+    adminListRedirects,
+    adminCreateRedirect,
+    adminUpdateRedirect,
+    adminDeleteRedirect
+} from '../../../api/client';
+import type { IRedirectRuleAdmin } from '../../../api/client';
+import styles from './RedirectsManager.module.scss';
+
+/**
+ * Pull an operator-readable message off a failed request, preferring the
+ * backend's `{ message | error }` body (which carries the 400 validation reason
+ * or the 409 duplicate-pattern message) over a bare axios string.
+ *
+ * @param err - The thrown value from an API call.
+ * @param fallback - Message to use when nothing better can be extracted.
+ * @returns The best available message.
+ */
+function extractError(err: unknown, fallback: string): string {
+    let message = fallback;
+    if (isAxiosError<{ message?: string; error?: string }>(err)) {
+        message = err.response?.data?.message || err.response?.data?.error || fallback;
+    } else if (err instanceof Error) {
+        message = err.message;
+    }
+    return message;
+}
+
+/**
+ * Redirect management panel for the `/system/traffic` Redirects tab.
+ *
+ * @returns The panel: an add-rule form above a table of existing rules.
+ */
+export function RedirectsManager() {
+    const [rules, setRules] = useState<IRedirectRuleAdmin[] | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [loadError, setLoadError] = useState<string | null>(null);
+
+    const [pattern, setPattern] = useState('');
+    const [destination, setDestination] = useState('');
+    const [isPrefix, setIsPrefix] = useState(true);
+    const [permanent, setPermanent] = useState(true);
+    const [notes, setNotes] = useState('');
+
+    const [creating, setCreating] = useState(false);
+    const [formError, setFormError] = useState<string | null>(null);
+    const [actionError, setActionError] = useState<string | null>(null);
+
+    /**
+     * Load all rules from the admin endpoint. Failure leaves the table empty
+     * with an inline message rather than throwing.
+     */
+    const fetchRules = useCallback(async () => {
+        setLoadError(null);
+        try {
+            setRules(await adminListRedirects());
+        } catch {
+            setLoadError('Failed to load redirects');
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void fetchRules();
+    }, [fetchRules]);
+
+    /**
+     * Create a rule from the form. Client-side it only checks both paths are
+     * present; the backend enforces the same-site, reserved-prefix, and
+     * loop-prevention invariants and returns a 400/409 message shown inline.
+     */
+    const handleCreate = useCallback(async () => {
+        if (!pattern.trim() || !destination.trim()) {
+            setFormError('Source and destination are required');
+            return;
+        }
+        setFormError(null);
+        setCreating(true);
+        try {
+            const rule = await adminCreateRedirect({
+                pattern: pattern.trim(),
+                destination: destination.trim(),
+                isPrefix,
+                permanent,
+                notes: notes.trim() || undefined
+            });
+            setRules(prev => [rule, ...(prev ?? [])]);
+            setPattern('');
+            setDestination('');
+            setNotes('');
+            setIsPrefix(true);
+            setPermanent(true);
+        } catch (err) {
+            setFormError(extractError(err, 'Failed to create redirect'));
+        } finally {
+            setCreating(false);
+        }
+    }, [pattern, destination, isPrefix, permanent, notes]);
+
+    /**
+     * Flip a rule's enabled flag — the operator's kill switch that keeps the
+     * rule but stops the middleware serving it.
+     *
+     * @param rule - The rule to toggle.
+     */
+    const handleToggle = useCallback(async (rule: IRedirectRuleAdmin) => {
+        setActionError(null);
+        try {
+            const updated = await adminUpdateRedirect(rule.id, { enabled: !rule.enabled });
+            setRules(prev => (prev ?? []).map(r => (r.id === updated.id ? updated : r)));
+        } catch (err) {
+            setActionError(extractError(err, 'Failed to update redirect'));
+        }
+    }, []);
+
+    /**
+     * Delete a rule after an explicit confirmation, since a removed redirect
+     * re-opens the 404 it was covering.
+     *
+     * @param rule - The rule to delete.
+     */
+    const handleDelete = useCallback(async (rule: IRedirectRuleAdmin) => {
+        if (!window.confirm(`Delete redirect ${rule.pattern} → ${rule.destination}?`)) {
+            return;
+        }
+        setActionError(null);
+        try {
+            await adminDeleteRedirect(rule.id);
+            setRules(prev => (prev ?? []).filter(r => r.id !== rule.id));
+        } catch (err) {
+            setActionError(extractError(err, 'Failed to delete redirect'));
+        }
+    }, []);
+
+    if (loading) {
+        return (
+            <Card padding="lg">
+                <p className="text-muted">Loading redirects...</p>
+            </Card>
+        );
+    }
+
+    return (
+        <div className={styles.container}>
+            <Card padding="lg">
+                <Stack gap="md">
+                    <div className={styles.header}>
+                        <CornerUpRight size={16} aria-hidden="true" />
+                        <h3>URL Redirects</h3>
+                    </div>
+                    <p className="text-muted">
+                        301/302 redirects for legacy URLs. When a page moves, add a rule so the
+                        old path forwards to the new one instead of 404ing &mdash; this recovers the
+                        crawl equity Google holds for the old URL. Rules are served to the edge
+                        middleware and go live within a minute of saving; no deploy needed.
+                        A <strong>prefix</strong> rule also matches sub-paths (e.g. <code>/old</code>{' '}
+                        catches <code>/old/anything</code>); an <strong>exact</strong> rule matches only
+                        the path itself.
+                    </p>
+
+                    <div className={styles.form}>
+                        <div className={styles.form_row}>
+                            <div className={styles.field}>
+                                <label className={styles.label} htmlFor="redirect-source">Source path</label>
+                                <Input
+                                    id="redirect-source"
+                                    type="text"
+                                    value={pattern}
+                                    onChange={e => setPattern(e.target.value)}
+                                    placeholder="/tron-forum"
+                                />
+                            </div>
+                            <div className={styles.field}>
+                                <label className={styles.label} htmlFor="redirect-destination">Destination path</label>
+                                <Input
+                                    id="redirect-destination"
+                                    type="text"
+                                    value={destination}
+                                    onChange={e => setDestination(e.target.value)}
+                                    placeholder="/forum"
+                                />
+                            </div>
+                        </div>
+                        <div className={styles.field}>
+                            <label className={styles.label} htmlFor="redirect-notes">Note (optional)</label>
+                            <Input
+                                id="redirect-notes"
+                                type="text"
+                                value={notes}
+                                onChange={e => setNotes(e.target.value)}
+                                placeholder="Why this redirect exists"
+                            />
+                        </div>
+                        <div className={styles.options}>
+                            <label className={styles.checkbox}>
+                                <input type="checkbox" checked={isPrefix} onChange={e => setIsPrefix(e.target.checked)} />
+                                Prefix match
+                            </label>
+                            <label className={styles.checkbox}>
+                                <input type="checkbox" checked={permanent} onChange={e => setPermanent(e.target.checked)} />
+                                Permanent (301)
+                            </label>
+                            <Button type="button" size="sm" onClick={handleCreate} loading={creating}>
+                                <Plus size={16} aria-hidden="true" /> Add redirect
+                            </Button>
+                        </div>
+                        {formError && <div className={styles.error}>{formError}</div>}
+                    </div>
+
+                    {actionError && <div className={styles.error}>{actionError}</div>}
+                    {loadError && <div className={styles.error}>{loadError}</div>}
+
+                    {rules && rules.length > 0 ? (
+                        <div className="table-scroll">
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Source</th>
+                                        <th scope="col">Destination</th>
+                                        <th scope="col">Match</th>
+                                        <th scope="col">Code</th>
+                                        <th scope="col">Status</th>
+                                        <th scope="col">Updated</th>
+                                        <th scope="col" className={styles.actions_col}>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {rules.map(rule => (
+                                        <tr key={rule.id} className={rule.enabled ? undefined : styles.row_disabled}>
+                                            <td>
+                                                <code className={styles.path}>{rule.pattern}</code>
+                                                {rule.notes && <span className={styles.note}>{rule.notes}</span>}
+                                            </td>
+                                            <td>
+                                                <span className={styles.dest}>
+                                                    <ArrowRight size={14} aria-hidden="true" />
+                                                    <code className={styles.path}>{rule.destination}</code>
+                                                </span>
+                                            </td>
+                                            <td>
+                                                <Badge tone="neutral">{rule.isPrefix ? 'prefix' : 'exact'}</Badge>
+                                            </td>
+                                            <td>
+                                                <Badge tone={rule.permanent ? 'info' : 'neutral'}>
+                                                    {rule.permanent ? '301' : '302'}
+                                                </Badge>
+                                            </td>
+                                            <td>
+                                                <Badge tone={rule.enabled ? 'success' : 'neutral'}>
+                                                    {rule.enabled ? 'active' : 'disabled'}
+                                                </Badge>
+                                            </td>
+                                            <td>
+                                                <ClientTime date={rule.updatedAt} format="date" />
+                                            </td>
+                                            <td>
+                                                <div className={styles.actions}>
+                                                    <button
+                                                        type="button"
+                                                        className={styles.icon_btn}
+                                                        onClick={() => handleToggle(rule)}
+                                                        aria-label={rule.enabled ? 'Disable redirect' : 'Enable redirect'}
+                                                        title={rule.enabled ? 'Disable' : 'Enable'}
+                                                    >
+                                                        {rule.enabled ? <Power size={16} /> : <PowerOff size={16} />}
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        className={`${styles.icon_btn} ${styles.icon_btn__danger}`}
+                                                        onClick={() => handleDelete(rule)}
+                                                        aria-label="Delete redirect"
+                                                        title="Delete"
+                                                    >
+                                                        <Trash2 size={16} />
+                                                    </button>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    ) : (
+                        !loadError && <p className="text-muted">No redirects yet. Add one above.</p>
+                    )}
+                </Stack>
+            </Card>
+        </div>
+    );
+}

--- a/src/frontend/modules/traffic/components/admin/RedirectsManager/index.ts
+++ b/src/frontend/modules/traffic/components/admin/RedirectsManager/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Barrel for the RedirectsManager admin panel (the `/system/traffic` Redirects tab).
+ */
+
+export { RedirectsManager } from './RedirectsManager';

--- a/src/frontend/modules/traffic/components/admin/index.ts
+++ b/src/frontend/modules/traffic/components/admin/index.ts
@@ -14,6 +14,7 @@ export { AnalyticsDashboard } from './AnalyticsDashboard';
 export { GscSettings } from './GscSettings';
 export { IgnoredUsers } from './IgnoredUsers';
 export { GscKeywords } from './GscKeywords';
+export { RedirectsManager } from './RedirectsManager';
 export { TrafficDashboard } from './TrafficDashboard';
 export { CrawlerDashboard } from './CrawlerDashboard';
 export { OverviewTrend } from './OverviewTrend';

--- a/src/frontend/modules/traffic/components/index.ts
+++ b/src/frontend/modules/traffic/components/index.ts
@@ -12,6 +12,7 @@ export {
     GscSettings,
     IgnoredUsers,
     GscKeywords,
+    RedirectsManager,
     TrafficDashboard,
     CrawlerDashboard,
     OverviewTrend,

--- a/src/frontend/modules/traffic/index.ts
+++ b/src/frontend/modules/traffic/index.ts
@@ -31,6 +31,7 @@ export { AnalyticsDashboard } from './components';
 export { GscSettings } from './components';
 export { IgnoredUsers } from './components';
 export { GscKeywords } from './components';
+export { RedirectsManager } from './components';
 export { TrafficDashboard } from './components';
 export { CrawlerDashboard } from './components';
 export { OverviewTrend } from './components';


### PR DESCRIPTION
Moves URL redirects out of the hardcoded Next.js middleware bundle into an admin-editable service, so operators fix SEO 404s from `/system/traffic` without a deploy.

## What changed

Redirect rules now live in `module_traffic_redirects` (one doc per rule, unique index on `pattern`). `RedirectService` validates each rule as a same-site root-relative path, refuses reserved prefixes (`/api`, `/_next`), and rejects self- and prefix-loop redirects so the middleware can never bounce a request. `getActiveRules()` serves enabled rules most-specific-first.

A public `GET /api/redirects` (no auth, 60s `Cache-Control`) returns the minimal `{ pattern, isPrefix, destination, permanent }` feed. The Next.js edge middleware polls and caches it and issues the actual 301/302 — no redirect logic hardcoded in the frontend bundle. Admin CRUD lives under `/api/admin/redirects` (`requireAdmin`): list, create, patch (toggle/retarget), delete.

Migration 017 seeds `module_traffic_redirects` with the 17 rules lifted verbatim from the former middleware `REDIRECT_RULES` array plus 3 fixes for dead 404s the SEO audit surfaced. It is idempotent (`$setOnInsert` by `pattern`), so re-runs insert nothing and never clobber operator edits.

Frontend adds the `RedirectsManager` admin UI on `/system/traffic` and converts the dashboard tab row to the menu Submenu Pattern. Tests cover the service validation/loop guards and the seed migration idempotency.