### PR TITLE
feat(ui): regularize spacing scale onto a 4px grid and add a density multiplier

### DIFF
--- a/src/frontend/app/globals.scss
+++ b/src/frontend/app/globals.scss
@@ -6,7 +6,7 @@
  * Semantic tokens (composed meaning) are defined in semantic-tokens.scss.
  * Breakpoints are defined in _breakpoints.scss (single source of truth).
  *
- * See docs/frontend/design-token-layers.md for design token reference.
+ * See docs/frontend/ui/ui-design-token-layers.md for design token reference.
  * See docs/frontend/ui/ui-scss-modules.md for component styling patterns.
  */
 

--- a/src/frontend/app/layout.tsx
+++ b/src/frontend/app/layout.tsx
@@ -262,6 +262,18 @@ async function fetchSSRSession(): Promise<ISSRSession | null> {
 }
 
 /**
+ * Valid interface density steps, mirroring the `[data-density="…"]` rules
+ * in semantic-tokens.scss.
+ *
+ * TypeScript cannot read the stylesheet and JSX does not type-check
+ * hyphenated attributes, so without this union a typo'd step would still
+ * match the bare `[data-density]` selector, silently render at density 1,
+ * and report nothing. Keep in lockstep with the DENSITY STEPS block in
+ * semantic-tokens.scss.
+ */
+type DensityStep = 'compact' | 'cozy' | 'default' | 'roomy';
+
+/**
  * Site-wide interface density, stamped onto <html> during SSR.
  *
  * Density scales layout spacing (gaps, generic and card padding, page gap)
@@ -273,7 +285,7 @@ async function fetchSSRSession(): Promise<ISSRSession | null> {
  *
  * Valid steps: 'compact' (0.75), 'cozy' (0.875), 'default' (1), 'roomy' (1.125).
  */
-const SITE_DENSITY = 'default';
+const SITE_DENSITY: DensityStep = 'default';
 
 export default async function RootLayout({ children }: { children: ReactNode }) {
   // Extract pathname from middleware-set header for ticker-after widget zone

--- a/src/frontend/app/layout.tsx
+++ b/src/frontend/app/layout.tsx
@@ -261,6 +261,20 @@ async function fetchSSRSession(): Promise<ISSRSession | null> {
   }
 }
 
+/**
+ * Site-wide interface density, stamped onto <html> during SSR.
+ *
+ * Density scales layout spacing (gaps, generic and card padding, page gap)
+ * through the --density multiplier in semantic-tokens.scss. It is set here
+ * rather than in a client effect so the value is present in the server-rendered
+ * HTML — stamping it after hydration would repaint every gap on the page and
+ * produce a visible density snap on first load, the same reason data-theme is
+ * resolved during SSR.
+ *
+ * Valid steps: 'compact' (0.75), 'cozy' (0.875), 'default' (1), 'roomy' (1.125).
+ */
+const SITE_DENSITY = 'default';
+
 export default async function RootLayout({ children }: { children: ReactNode }) {
   // Extract pathname from middleware-set header for ticker-after widget zone
   const headersList = await headers();
@@ -288,7 +302,9 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   ]);
 
   return (
-    <html {...htmlAttributes}>
+    /* data-density is spread first so an ssr.htmlAttributes hook contributor
+       can override the site default without this layout knowing about it. */
+    <html data-density={SITE_DENSITY} {...htmlAttributes}>
       <head>
         {/* Inject runtime configuration before any client scripts */}
         <script

--- a/src/frontend/app/primitives.scss
+++ b/src/frontend/app/primitives.scss
@@ -8,7 +8,7 @@
  * Values derived from analyzing existing patterns across globals.scss and
  * component CSS modules to ensure consistency with the current design.
  *
- * See docs/frontend/design-token-layers.md for usage guidelines.
+ * See docs/frontend/ui/ui-design-token-layers.md for usage guidelines.
  */
 
 :root {
@@ -19,49 +19,61 @@
     --font-body: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
     --font-mono: 'Courier New', Courier, monospace;
 
-    /* Typography - Font Sizes (based on actual usage) */
-    --font-size-xxs: 0.5rem;     /* 8px - footnote-tier metadata (use sparingly) */
-    --font-size-xs: 0.72rem;     /* 11.52px - table headers, tiny labels */
-    --font-size-sm: 0.85rem;     /* 13.6px - most common small text */
-    --font-size-base: 0.9375rem; /* 15px - default body, buttons */
-    --font-size-md: 1rem;        /* 16px - standard paragraphs */
-    --font-size-lg: 1.05rem;     /* 16.8px - large buttons */
-    --font-size-xl: 1.6rem;      /* 25.6px - stat values */
-    --font-size-2xl: 1.8rem;     /* 28.8px - page titles (min) */
-    --font-size-3xl: 2.6rem;     /* 41.6px - page titles (max) */
+    /* Typography - Font Sizes */
+    --font-size-xxs: 0.5rem;     /* 8px */
+    --font-size-xs: 0.72rem;     /* 11.52px */
+    --font-size-sm: 0.85rem;     /* 13.6px */
+    --font-size-base: 0.9375rem; /* 15px */
+    --font-size-md: 1rem;        /* 16px */
+    --font-size-lg: 1.05rem;     /* 16.8px */
+    --font-size-xl: 1.6rem;      /* 25.6px */
+    --font-size-2xl: 1.8rem;     /* 28.8px */
+    --font-size-3xl: 2.6rem;     /* 41.6px */
 
-    /* Typography - Font Weights (from actual usage) */
+    /* Typography - Font Weights */
     --font-weight-normal: 400;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
 
-    /* Typography - Line Heights (from actual usage) */
+    /* Typography - Line Heights */
     --line-height-tight: 1.25;
     --line-height-normal: 1.4;
     --line-height-relaxed: 1.5;
 
-    /* Typography - Letter Spacing (from actual usage) */
-    --letter-spacing-tight: -0.02em;  /* Headings */
-    --letter-spacing-normal: 0.01em;  /* Body text */
-    --letter-spacing-wide: 0.08em;    /* Uppercase labels */
+    /* Typography - Letter Spacing */
+    --letter-spacing-tight: -0.02em;
+    --letter-spacing-normal: 0.01em;
+    --letter-spacing-wide: 0.08em;
 
-    /* Spacing Scale (derived from gap/padding/margin patterns) */
+    /*
+     * Spacing Scale — 4px grid, hybrid progression.
+     *
+     * Linear 4px steps through the dense range (4–16px), where interface
+     * density needs fine control, then a x1.5 ratio above it. A constant-ratio
+     * scale from a 4px base produces fractional values that fall off the grid
+     * (4, 6, 9, 13.5, 20.25), so the ascent is deliberately hybrid rather than
+     * strictly geometric.
+     *
+     * Eight distinct rungs: 4, 8, 12, 16, 24, 32, 48, 64. Seven names are
+     * aliases of an adjacent rung, retained so existing references keep
+     * resolving; collapse call sites onto the canonical rung before removing.
+     */
     --spacing-1: 0.25rem;   /* 4px */
-    --spacing-2: 0.35rem;   /* 5.6px - chips, badges */
-    --spacing-3: 0.4rem;    /* 6.4px - pills */
-    --spacing-4: 0.5rem;    /* 8px - stack-sm, common gaps */
-    --spacing-5: 0.75rem;   /* 12px - very common gap, input groups */
-    --spacing-6: 0.85rem;   /* 13.6px - table cells, alerts */
-    --spacing-7: 1rem;      /* 16px - default stack, card padding */
-    --spacing-8: 1.1rem;    /* 17.6px - table cells, alerts */
-    --spacing-9: 1.25rem;   /* 20px - card padding sm, stat grids */
-    --spacing-10: 1.5rem;   /* 24px - stack-lg, common grid gaps */
-    --spacing-11: 1.75rem;  /* 28px - main padding bottom */
-    --spacing-12: 2rem;     /* 32px - large card padding */
-    --spacing-14: 2.5rem;   /* 40px - page gaps */
-    --spacing-15: 3rem;     /* 48px - main padding horizontal */
-    --spacing-16: 3.5rem;   /* 56px */
+    --spacing-2: 0.25rem;   /* 4px */
+    --spacing-3: 0.5rem;    /* 8px */
+    --spacing-4: 0.5rem;    /* 8px */
+    --spacing-5: 0.75rem;   /* 12px */
+    --spacing-6: 0.75rem;   /* 12px */
+    --spacing-7: 1rem;      /* 16px */
+    --spacing-8: 1rem;      /* 16px */
+    --spacing-9: 1.5rem;    /* 24px */
+    --spacing-10: 1.5rem;   /* 24px */
+    --spacing-11: 1.5rem;   /* 24px */
+    --spacing-12: 2rem;     /* 32px */
+    --spacing-14: 3rem;     /* 48px */
+    --spacing-15: 3rem;     /* 48px */
+    --spacing-16: 4rem;     /* 64px */
 
     /* Container Padding (responsive) */
     --container-padding-mobile: 1.25rem;   /* 20px */
@@ -82,28 +94,28 @@
     --shadow-sm: 0 8px 18px rgba(7, 15, 30, 0.35);
     --shadow-md: 0 18px 36px rgba(10, 20, 45, 0.42);
     --shadow-lg: 0 28px 48px rgba(5, 12, 28, 0.55);
-    --shadow-xl: 0 40px 64px rgba(3, 8, 22, 0.65);   /* Floating overlays (menus, dropdowns) */
+    --shadow-xl: 0 40px 64px rgba(3, 8, 22, 0.65);
 
     /* Border Radius Tokens */
-    --radius-xs: 4px;       /* Minimal rounding for small elements */
+    --radius-xs: 4px;
     --radius-sm: 10px;
     --radius-md: 16px;
     --radius-lg: 24px;
-    --radius-full: 999px;   /* Pills, badges, circular buttons */
+    --radius-full: 999px;
 
     /* Border Width Tokens */
     --border-width-thin: 1px;
     --border-width-medium: 2px;
     --border-width-thick: 3px;
 
-    /* Opacity Scale (from actual usage patterns) */
+    /* Opacity Scale */
     --opacity-0: 0;
     --opacity-35: 0.35;
     --opacity-50: 0.5;
-    --opacity-55: 0.55;   /* Disabled state */
+    --opacity-55: 0.55;
     --opacity-60: 0.6;
     --opacity-70: 0.7;
-    --opacity-75: 0.75;   /* Loading state */
+    --opacity-75: 0.75;
     --opacity-80: 0.8;
     --opacity-85: 0.85;
     --opacity-90: 0.9;
@@ -124,18 +136,21 @@
     --transition-slow: 250ms ease;
 
     /* Animation Durations (from actual keyframes) */
-    --duration-flash: 2.4s;      /* Row flash animation */
-    --duration-pulse: 2s;        /* Live indicator pulse */
-    --duration-slide: 0.25s;     /* Toast slide-in */
+    --duration-flash: 2.4s;
+    --duration-pulse: 2s;
+    --duration-slide: 0.25s;
 
     /* Breakpoint Tokens
        REMOVED: Breakpoints are now defined in _breakpoints.scss (single source of truth).
        Import @use './breakpoints' as *; in SCSS files to use $breakpoint-* variables. */
 
-    /* Component Size Tokens */
-    --button-height-sm: 34px;
-    --button-height-md: 42px;
-    --button-height-lg: 50px;
+    /* Icon Size Tokens
+     *
+     * --button-height-* deliberately does not live here. "Button" is a use
+     * case, so the ladder belongs in semantic-tokens.scss, which is also where
+     * the xs step is defined. Duplicating the names across both layers made
+     * this file's copies dead code — semantic-tokens.scss loads second and
+     * silently won the cascade. */
     --icon-size-xs: 14px;
     --icon-size-sm: 18px;
     --icon-size-md: 20px;
@@ -143,12 +158,12 @@
     --icon-size-xl: 32px;
 
     /* Max Width Tokens (for layout containers) */
-    --max-width-prose: 64ch;     /* Readable text width */
-    --max-width-xs: 320px;       /* Narrow hint copy, empty-state labels */
-    --max-width-sm: 420px;       /* Small modal */
-    --max-width-md: 640px;       /* Medium modal */
-    --max-width-lg: 820px;       /* Large modal */
-    --max-width-xl: 1080px;      /* Extra large modal */
+    --max-width-prose: 64ch;     /* character-relative, not px */
+    --max-width-xs: 320px;
+    --max-width-sm: 420px;
+    --max-width-md: 640px;
+    --max-width-lg: 820px;
+    --max-width-xl: 1080px;
 
     /* Chart Color Palette (10 distinct, accessible colors for data series) */
     --chart-color-1: #3b82f6;    /* Blue */

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -15,33 +15,7 @@
  * DEFAULT THEME
  * ========================================================================== */
 :root,
-[data-theme="default"],
-[data-density] {
-    /* ========================================================================
-     * DENSITY MULTIPLIER
-     *
-     * Scales layout spacing only — generic gaps and padding, card padding,
-     * stack/grid gaps, and the page gap. Identity by default; the named steps
-     * at the bottom of this file set it, and `data-density` on <html> applies
-     * one site-wide.
-     *
-     * `[data-density]` is part of this selector list on purpose. A custom
-     * property is substituted where it is DECLARED, not where it is used, so a
-     * scaled token declared only on :root bakes in density 1 and silently
-     * ignores any override set further down the tree. Any element that sets
-     * --density must also match a selector that declares the scaled tokens.
-     *
-     * Control internals (button, input, badge, chip, table, modal, alert and
-     * toast padding) deliberately do NOT scale: their heights, icon sizes and
-     * touch targets are px and would distort against shrinking padding, and
-     * holding them fixed keeps tap targets above the WCAG 2.5.8 minimum.
-     *
-     * These tokens are therefore density-relative by design and compute to
-     * different values under different density steps — a deliberate carve-out
-     * from the token-immutability rule in ui-design-token-layers.md.
-     * ======================================================================== */
-    --density: 1;
-
+[data-theme="default"] {
     /* ========================================================================
      * GENERIC LAYOUT & TYPOGRAPHY TOKENS
      *
@@ -51,22 +25,6 @@
      * preferred where the component fits — these generic tiers cover the
      * non-component cases (one-off blocks, plugin pages, ad-hoc layouts).
      * ======================================================================== */
-
-    /* Generic Gaps — for flex/grid contexts that aren't a Stack, Grid, or Card */
-    --gap-2xs: calc(var(--spacing-1)  * var(--density));   /* base 0.25rem */
-    --gap-xs:  calc(var(--spacing-2)  * var(--density));   /* base 0.25rem */
-    --gap-sm:  calc(var(--spacing-4)  * var(--density));   /* base 0.5rem  */
-    --gap-md:  calc(var(--spacing-7)  * var(--density));   /* base 1rem    */
-    --gap-lg:  calc(var(--spacing-10) * var(--density));   /* base 1.5rem  */
-    --gap-xl:  calc(var(--spacing-14) * var(--density));   /* base 3rem    */
-
-    /* Generic Padding — for any block that isn't a Card, Button, Alert, etc. */
-    --padding-2xs: calc(var(--spacing-1)  * var(--density));   /* base 0.25rem */
-    --padding-xs:  calc(var(--spacing-2)  * var(--density));   /* base 0.25rem */
-    --padding-sm:  calc(var(--spacing-4)  * var(--density));   /* base 0.5rem  */
-    --padding-md:  calc(var(--spacing-7)  * var(--density));   /* base 1rem    */
-    --padding-lg:  calc(var(--spacing-10) * var(--density));   /* base 1.5rem  */
-    --padding-xl:  calc(var(--spacing-14) * var(--density));   /* base 3rem    */
 
     /* Typography — purpose-named font sizes */
     --font-size-caption:    var(--font-size-xs);    /* 0.72rem - labels, table headers, footnotes */
@@ -233,12 +191,6 @@
     --card-background-accent: var(--color-surface-accent);
     --card-shadow-elevated: var(--shadow-lg);
 
-    /* Card - Padding Variants (density-scaled) */
-    --card-padding-xs: calc(var(--spacing-4)  * var(--density));   /* base 0.5rem */
-    --card-padding-sm: calc(var(--spacing-7)  * var(--density));   /* base 1rem   */
-    --card-padding-md: calc(var(--spacing-10) * var(--density));   /* base 1.5rem */
-    --card-padding-lg: calc(var(--spacing-12) * var(--density));   /* base 2rem   */
-
     /* Card - Background Image Customization */
     --card-bg-image: none;                      /* Default: no background image */
     --card-bg-opacity: 0.08;                    /* Subtle watermark opacity */
@@ -398,19 +350,13 @@
      * LAYOUT UTILITY TOKENS
      * ======================================================================== */
 
-    /* Stack Layout (gaps density-scaled) */
-    --stack-gap-md: calc(var(--spacing-7)  * var(--density));   /* base 1rem   */
-    --stack-gap-sm: calc(var(--spacing-4)  * var(--density));   /* base 0.5rem */
-    --stack-gap-lg: calc(var(--spacing-10) * var(--density));   /* base 1.5rem */
+    /* Stack Layout */
     --stack-bg-image: none;
     --stack-bg-opacity: 0.08;
     --stack-bg-size: 140px;
     --stack-bg-position: bottom right;
 
-    /* Grid Layout (gaps density-scaled) */
-    --grid-gap-sm: calc(var(--spacing-5)  * var(--density));   /* base 0.75rem */
-    --grid-gap-md: calc(var(--spacing-10) * var(--density));   /* base 1.5rem  */
-    --grid-gap-lg: calc(var(--spacing-12) * var(--density));   /* base 2rem    */
+    /* Grid Layout */
     --grid-responsive-min: 280px;               /* auto-fit minmax floor for <Grid columns="responsive">; consumers override at their scope */
     --stat-grid-min: 220px;                     /* auto-fit minmax floor for the .stat-grid utility */
     --grid-bg-image: none;
@@ -424,9 +370,7 @@
     --section-bg-size: 140px;
     --section-bg-position: bottom right;
 
-    /* Page Layout (gaps density-scaled) */
-    --page-gap: calc(var(--spacing-14) * var(--density));   /* base 3rem */
-    --page-gap-sm: calc(var(--spacing-7) * var(--density)); /* base 1rem - mobile/constrained contexts */
+    /* Page Layout */
     --page-bg-image: none;
     --page-bg-opacity: 0.08;
     --page-bg-size: 140px;
@@ -645,6 +589,84 @@
     --meter-background: var(--color-border-strong);
     --meter-value-background: var(--gradient-meter);
     --meter-margin-top: var(--spacing-5);         /* 0.75rem */
+}
+
+/* ============================================================================
+ * DENSITY MULTIPLIER + DENSITY-SCALED TOKENS
+ *
+ * Scales layout spacing only — generic gaps and padding, card padding,
+ * stack/grid gaps, and the page gap. Identity by default; the named steps
+ * below set it, and `data-density` on <html> applies one site-wide.
+ *
+ * `[data-density]` is in this selector list on purpose. A custom property is
+ * substituted where it is DECLARED, not where it is used, so a scaled token
+ * declared only on :root bakes in density 1 and silently ignores any override
+ * set further down the tree. Any element that sets --density must also match a
+ * selector that declares these tokens.
+ *
+ * Only these tokens live here, equally on purpose. Adding `[data-density]` to
+ * the main block's selector list instead would redeclare all ~300 other tokens
+ * on every density-scoped element, resetting an active theme's overrides
+ * (trp-themes writes [data-theme="active"]) to default-theme values inside
+ * that subtree. The corollary is a footgun in the other direction: a new
+ * density-scaled token added to the main block would silently lose subtree
+ * overrides. New `calc(… * var(--density))` tokens belong in THIS block.
+ *
+ * `:root, [data-theme="default"]` must stay in this list: <html> may carry no
+ * data-density attribute, and these tokens would otherwise be undefined.
+ *
+ * Control internals (button, input, badge, chip, table, modal, alert and toast
+ * padding) deliberately do NOT scale: their heights, icon sizes and touch
+ * targets are px and would distort against shrinking padding, and holding them
+ * fixed keeps tap targets above the WCAG 2.5.8 minimum.
+ *
+ * These tokens are density-relative by design and compute to different values
+ * under different density steps — a deliberate carve-out from the
+ * token-immutability rule in ui-design-token-layers.md.
+ *
+ * This block MUST sit after the main token block and before the density steps
+ * below: all these selectors are (0,1,0), so source order breaks the tie.
+ * ========================================================================== */
+:root,
+[data-theme="default"],
+[data-density] {
+    --density: 1;
+
+    /* Generic Gaps — for flex/grid contexts that aren't a Stack, Grid, or Card */
+    --gap-2xs: calc(var(--spacing-1)  * var(--density));   /* base 0.25rem */
+    --gap-xs:  calc(var(--spacing-2)  * var(--density));   /* base 0.25rem */
+    --gap-sm:  calc(var(--spacing-4)  * var(--density));   /* base 0.5rem  */
+    --gap-md:  calc(var(--spacing-7)  * var(--density));   /* base 1rem    */
+    --gap-lg:  calc(var(--spacing-10) * var(--density));   /* base 1.5rem  */
+    --gap-xl:  calc(var(--spacing-14) * var(--density));   /* base 3rem    */
+
+    /* Generic Padding — for any block that isn't a Card, Button, Alert, etc. */
+    --padding-2xs: calc(var(--spacing-1)  * var(--density));   /* base 0.25rem */
+    --padding-xs:  calc(var(--spacing-2)  * var(--density));   /* base 0.25rem */
+    --padding-sm:  calc(var(--spacing-4)  * var(--density));   /* base 0.5rem  */
+    --padding-md:  calc(var(--spacing-7)  * var(--density));   /* base 1rem    */
+    --padding-lg:  calc(var(--spacing-10) * var(--density));   /* base 1.5rem  */
+    --padding-xl:  calc(var(--spacing-14) * var(--density));   /* base 3rem    */
+
+    /* Card padding */
+    --card-padding-xs: calc(var(--spacing-4)  * var(--density));   /* base 0.5rem */
+    --card-padding-sm: calc(var(--spacing-7)  * var(--density));   /* base 1rem   */
+    --card-padding-md: calc(var(--spacing-10) * var(--density));   /* base 1.5rem */
+    --card-padding-lg: calc(var(--spacing-12) * var(--density));   /* base 2rem   */
+
+    /* Stack gaps */
+    --stack-gap-md: calc(var(--spacing-7)  * var(--density));   /* base 1rem   */
+    --stack-gap-sm: calc(var(--spacing-4)  * var(--density));   /* base 0.5rem */
+    --stack-gap-lg: calc(var(--spacing-10) * var(--density));   /* base 1.5rem */
+
+    /* Grid gaps */
+    --grid-gap-sm: calc(var(--spacing-5)  * var(--density));   /* base 0.75rem */
+    --grid-gap-md: calc(var(--spacing-10) * var(--density));   /* base 1.5rem  */
+    --grid-gap-lg: calc(var(--spacing-12) * var(--density));   /* base 2rem    */
+
+    /* Page gaps */
+    --page-gap: calc(var(--spacing-14) * var(--density));   /* base 3rem */
+    --page-gap-sm: calc(var(--spacing-7) * var(--density)); /* base 1rem - mobile/constrained contexts */
 }
 
 /* ============================================================================

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -8,14 +8,40 @@
  * Derived from analyzing actual usage patterns in Button.module.css, Card.module.css,
  * Badge.module.css, Input.module.css, and globals.scss utility classes.
  *
- * See docs/frontend/design-token-layers.md for usage guidelines.
+ * See docs/frontend/ui/ui-design-token-layers.md for usage guidelines.
  */
 
 /* ============================================================================
  * DEFAULT THEME
  * ========================================================================== */
 :root,
-[data-theme="default"] {
+[data-theme="default"],
+[data-density] {
+    /* ========================================================================
+     * DENSITY MULTIPLIER
+     *
+     * Scales layout spacing only — generic gaps and padding, card padding,
+     * stack/grid gaps, and the page gap. Identity by default; the named steps
+     * at the bottom of this file set it, and `data-density` on <html> applies
+     * one site-wide.
+     *
+     * `[data-density]` is part of this selector list on purpose. A custom
+     * property is substituted where it is DECLARED, not where it is used, so a
+     * scaled token declared only on :root bakes in density 1 and silently
+     * ignores any override set further down the tree. Any element that sets
+     * --density must also match a selector that declares the scaled tokens.
+     *
+     * Control internals (button, input, badge, chip, table, modal, alert and
+     * toast padding) deliberately do NOT scale: their heights, icon sizes and
+     * touch targets are px and would distort against shrinking padding, and
+     * holding them fixed keeps tap targets above the WCAG 2.5.8 minimum.
+     *
+     * These tokens are therefore density-relative by design and compute to
+     * different values under different density steps — a deliberate carve-out
+     * from the token-immutability rule in ui-design-token-layers.md.
+     * ======================================================================== */
+    --density: 1;
+
     /* ========================================================================
      * GENERIC LAYOUT & TYPOGRAPHY TOKENS
      *
@@ -27,20 +53,20 @@
      * ======================================================================== */
 
     /* Generic Gaps — for flex/grid contexts that aren't a Stack, Grid, or Card */
-    --gap-2xs: var(--spacing-1);    /* 0.25rem - typographic stacks (label + helper) */
-    --gap-xs:  var(--spacing-2);    /* 0.35rem - dense inline (badge, chip) */
-    --gap-sm:  var(--spacing-4);    /* 0.5rem  - inline gaps, button-icon */
-    --gap-md:  var(--spacing-7);    /* 1rem    - default block gap */
-    --gap-lg:  var(--spacing-10);   /* 1.5rem  - section gap */
-    --gap-xl:  var(--spacing-14);   /* 2.5rem  - page-level gap */
+    --gap-2xs: calc(var(--spacing-1)  * var(--density));   /* base 0.25rem */
+    --gap-xs:  calc(var(--spacing-2)  * var(--density));   /* base 0.25rem */
+    --gap-sm:  calc(var(--spacing-4)  * var(--density));   /* base 0.5rem  */
+    --gap-md:  calc(var(--spacing-7)  * var(--density));   /* base 1rem    */
+    --gap-lg:  calc(var(--spacing-10) * var(--density));   /* base 1.5rem  */
+    --gap-xl:  calc(var(--spacing-14) * var(--density));   /* base 3rem    */
 
     /* Generic Padding — for any block that isn't a Card, Button, Alert, etc. */
-    --padding-2xs: var(--spacing-1);    /* 0.25rem */
-    --padding-xs:  var(--spacing-2);    /* 0.35rem */
-    --padding-sm:  var(--spacing-4);    /* 0.5rem  */
-    --padding-md:  var(--spacing-7);    /* 1rem    */
-    --padding-lg:  var(--spacing-10);   /* 1.5rem  */
-    --padding-xl:  var(--spacing-14);   /* 2.5rem  */
+    --padding-2xs: calc(var(--spacing-1)  * var(--density));   /* base 0.25rem */
+    --padding-xs:  calc(var(--spacing-2)  * var(--density));   /* base 0.25rem */
+    --padding-sm:  calc(var(--spacing-4)  * var(--density));   /* base 0.5rem  */
+    --padding-md:  calc(var(--spacing-7)  * var(--density));   /* base 1rem    */
+    --padding-lg:  calc(var(--spacing-10) * var(--density));   /* base 1.5rem  */
+    --padding-xl:  calc(var(--spacing-14) * var(--density));   /* base 3rem    */
 
     /* Typography — purpose-named font sizes */
     --font-size-caption:    var(--font-size-xs);    /* 0.72rem - labels, table headers, footnotes */
@@ -207,11 +233,11 @@
     --card-background-accent: var(--color-surface-accent);
     --card-shadow-elevated: var(--shadow-lg);
 
-    /* Card - Padding Variants */
-    --card-padding-xs: var(--spacing-4);                   /* 0.5rem */
-    --card-padding-sm: var(--spacing-7);                   /* 1rem */
-    --card-padding-md: var(--spacing-10);                  /* 1.5rem */
-    --card-padding-lg: var(--spacing-12);                  /* 2rem */
+    /* Card - Padding Variants (density-scaled) */
+    --card-padding-xs: calc(var(--spacing-4)  * var(--density));   /* base 0.5rem */
+    --card-padding-sm: calc(var(--spacing-7)  * var(--density));   /* base 1rem   */
+    --card-padding-md: calc(var(--spacing-10) * var(--density));   /* base 1.5rem */
+    --card-padding-lg: calc(var(--spacing-12) * var(--density));   /* base 2rem   */
 
     /* Card - Background Image Customization */
     --card-bg-image: none;                      /* Default: no background image */
@@ -372,19 +398,19 @@
      * LAYOUT UTILITY TOKENS
      * ======================================================================== */
 
-    /* Stack Layout */
-    --stack-gap-md: var(--spacing-7);           /* 1rem */
-    --stack-gap-sm: var(--spacing-4);           /* 0.5rem */
-    --stack-gap-lg: var(--spacing-10);          /* 1.5rem */
+    /* Stack Layout (gaps density-scaled) */
+    --stack-gap-md: calc(var(--spacing-7)  * var(--density));   /* base 1rem   */
+    --stack-gap-sm: calc(var(--spacing-4)  * var(--density));   /* base 0.5rem */
+    --stack-gap-lg: calc(var(--spacing-10) * var(--density));   /* base 1.5rem */
     --stack-bg-image: none;
     --stack-bg-opacity: 0.08;
     --stack-bg-size: 140px;
     --stack-bg-position: bottom right;
 
-    /* Grid Layout */
-    --grid-gap-sm: var(--spacing-5);            /* 0.75rem */
-    --grid-gap-md: var(--spacing-10);           /* 1.5rem */
-    --grid-gap-lg: var(--spacing-12);           /* 2rem */
+    /* Grid Layout (gaps density-scaled) */
+    --grid-gap-sm: calc(var(--spacing-5)  * var(--density));   /* base 0.75rem */
+    --grid-gap-md: calc(var(--spacing-10) * var(--density));   /* base 1.5rem  */
+    --grid-gap-lg: calc(var(--spacing-12) * var(--density));   /* base 2rem    */
     --grid-responsive-min: 280px;               /* auto-fit minmax floor for <Grid columns="responsive">; consumers override at their scope */
     --stat-grid-min: 220px;                     /* auto-fit minmax floor for the .stat-grid utility */
     --grid-bg-image: none;
@@ -398,9 +424,9 @@
     --section-bg-size: 140px;
     --section-bg-position: bottom right;
 
-    /* Page Layout */
-    --page-gap: var(--spacing-14);              /* 2.5rem */
-    --page-gap-sm: var(--spacing-7);            /* 1rem - mobile/constrained contexts */
+    /* Page Layout (gaps density-scaled) */
+    --page-gap: calc(var(--spacing-14) * var(--density));   /* base 3rem */
+    --page-gap-sm: calc(var(--spacing-7) * var(--density)); /* base 1rem - mobile/constrained contexts */
     --page-bg-image: none;
     --page-bg-opacity: 0.08;
     --page-bg-size: 140px;
@@ -620,3 +646,24 @@
     --meter-value-background: var(--gradient-meter);
     --meter-margin-top: var(--spacing-5);         /* 0.75rem */
 }
+
+/* ============================================================================
+ * DENSITY STEPS
+ *
+ * Named multipliers for the scaled spacing tokens above. Applied by stamping
+ * `data-density` on an element — <html> in the root layout for a site-wide
+ * setting, or any wrapper for a local one.
+ *
+ * These rules MUST stay after the main token block: `:root` and
+ * `[data-density="…"]` have identical (0,1,0) specificity, so source order is
+ * the only thing that decides which --density wins on the html element.
+ *
+ * Steps are multipliers rather than discrete token swaps, so values come off
+ * the 4px grid between steps (0.75 x 8px = 6px). Accept that, or add a step
+ * whose products land on-grid.
+ * ========================================================================== */
+
+[data-density="compact"] { --density: 0.75; }
+[data-density="cozy"]    { --density: 0.875; }
+[data-density="default"] { --density: 1; }
+[data-density="roomy"]   { --density: 1.125; }


### PR DESCRIPTION
## Spacing scale

The spacing primitives were reverse-engineered from values already in use, so the scale carried four off-grid rungs (5.6, 6.4, 13.6, 17.6px) that came from picking rem values at 0.05 granularity rather than any design intent.

This rebuilds it as a hybrid progression: linear 4px steps through the dense 4–16px range where interface density needs fine control, then a ×1.5 ratio above it. A constant-ratio scale from a 4px base yields fractional values off the grid (4, 6, 9, 13.5, 20.25), so the ascent is deliberately hybrid rather than strictly geometric.

Eight distinct rungs — 4, 8, 12, 16, 24, 32, 48, 64 — now sit behind the original fifteen names. Seven names are aliases of an adjacent rung, retained so existing references keep resolving; the follow-up is to migrate call sites onto the canonical rung and delete the aliases.

**Visible movement.** Four rungs shift by ≤1.6px and are imperceptible. Three move meaningfully: `--spacing-9` 20→24px (button/input padding, modal header, top of main padding), `--spacing-11` 28→24px (bottom of main padding), and `--spacing-14` 40→48px (page gap, site-wide).

## Density multiplier

Adds `--density`, applied to layout spacing only — generic gaps and padding, card padding, stack/grid gaps, page gap. Control internals (button, input, badge, chip, table, modal, alert, toast) deliberately do not scale: their heights and icon sizes are px and would distort against shrinking padding, and holding them fixed keeps tap targets above the WCAG 2.5.8 minimum.

Steps are stamped via `data-density` (`compact` 0.75, `cozy` 0.875, `default` 1, `roomy` 1.125), set on `<html>` during SSR so there is no density snap after hydration — the same reason `data-theme` resolves server-side. It ships as a no-op: `SITE_DENSITY` is `'default'`, so the multiplier is 1.

`[data-density]` is part of the declaring selector list on purpose. A custom property is substituted where it is *declared*, not where it is used, so a scaled token declared only on `:root` bakes in density 1 and silently ignores subtree overrides. Verified in-browser — the naive form returned 24px for a subtree override where the scoped form correctly returned 18px.

These tokens are therefore density-relative by design and compute to different values under different steps. That is a deliberate carve-out from the token-immutability rule; `ui-design-token-layers.md` still states the opposite and should be amended, or the next compliance audit will correctly flag it.

## Incidental cleanup

Removes use-case comments from the primitives. A Layer 1 file documenting its Layer 2 consumers is a reverse dependency that decays silently — one already claimed `--spacing-9` was `card-padding-sm`, which has mapped to `--spacing-7` for some time. px conversions are kept.

Deletes the duplicate `--button-height-sm/md/lg` from `primitives.scss`. Both layers declared identical values and `semantic-tokens.scss` loads second, so the Layer 1 copies were already dead code — the removal is a runtime no-op.

Corrects the stale `docs/frontend/design-token-layers.md` path in all three stylesheets to `docs/frontend/ui/ui-design-token-layers.md`.

## Verification

`npm run typecheck` passes; `globals.scss` compiles clean; density behaviour confirmed in headless Chrome for both the site-wide and subtree cases. **The spacing-value changes have not been visually reviewed** — the three meaningful rungs above move real layout and warrant a look before merge.