### PR TITLE
fix(ui): scale --main-padding-* with --density

### DIFF
--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -383,11 +383,9 @@
     --page-header-bg-size: 140px;
     --page-header-bg-position: bottom right;
 
-    /* Main Content Area Padding (top / sides / bottom) */
-    --main-padding-lg: var(--spacing-9) var(--spacing-15) var(--spacing-11);    /* desktop:   20px / 48px / 28px */
-    --main-padding-md: var(--spacing-7) var(--spacing-10) var(--spacing-10);    /* tablet:    16px / 24px / 24px */
-    --main-padding-sm: var(--spacing-5) var(--spacing-9) var(--spacing-9);      /* mobile:    12px / 20px / 20px */
-    --main-padding-xs: var(--spacing-1) var(--spacing-4) var(--spacing-4);      /* mobile-sm:  4px /  8px /  8px */
+    /* Main Content Area Padding — declared in the density block below, since
+       the shell gutter scales with --density alongside the other layout
+       spacing. See --main-padding-lg/md/sm/xs there. */
 
     /* Site-wide Body Background Image */
     --body-bg-image: none;
@@ -595,8 +593,9 @@
  * DENSITY MULTIPLIER + DENSITY-SCALED TOKENS
  *
  * Scales layout spacing only — generic gaps and padding, card padding,
- * stack/grid gaps, and the page gap. Identity by default; the named steps
- * below set it, and `data-density` on <html> applies one site-wide.
+ * stack/grid gaps, the page gap, and the <main> shell padding. Identity by
+ * default; the named steps below set it, and `data-density` on <html> applies
+ * one site-wide.
  *
  * `[data-density]` is in this selector list on purpose. A custom property is
  * substituted where it is DECLARED, not where it is used, so a scaled token
@@ -667,6 +666,26 @@
     /* Page gaps */
     --page-gap: calc(var(--spacing-14) * var(--density));   /* base 3rem */
     --page-gap-sm: calc(var(--spacing-7) * var(--density)); /* base 1rem - mobile/constrained contexts */
+
+    /* Main Content Area Padding (top / sides / bottom)
+     *
+     * The <main> shell gutter, selected per breakpoint in globals.scss. Each
+     * side is multiplied individually because a three-value shorthand cannot
+     * be scaled as a unit. Base values at density 1 are, in order:
+     *   lg  desktop    24px / 48px / 24px
+     *   md  tablet     16px / 24px / 24px
+     *   sm  mobile     12px / 24px / 24px
+     *   xs  mobile-sm   4px /  8px /  8px
+     *
+     * Each declaration stays on ONE line on purpose: trp-themes builds its
+     * new-theme template by line-matching `--var: value;` out of this file's
+     * served copy, and a wrapped value would emit a valueless declaration.
+     * (That template is currently inert — no /semantic-tokens.css is served —
+     * but keep the constraint so restoring it doesn't silently break.) */
+    --main-padding-lg: calc(var(--spacing-9) * var(--density)) calc(var(--spacing-15) * var(--density)) calc(var(--spacing-11) * var(--density));
+    --main-padding-md: calc(var(--spacing-7) * var(--density)) calc(var(--spacing-10) * var(--density)) calc(var(--spacing-10) * var(--density));
+    --main-padding-sm: calc(var(--spacing-5) * var(--density)) calc(var(--spacing-9) * var(--density)) calc(var(--spacing-9) * var(--density));
+    --main-padding-xs: calc(var(--spacing-1) * var(--density)) calc(var(--spacing-4) * var(--density)) calc(var(--spacing-4) * var(--density));
 }
 
 /* ============================================================================


### PR DESCRIPTION
The `<main>` shell gutter held constant under every density step while all other layout spacing scaled — `--page-gap`, `--card-padding-*`, `--stack-gap-*` and friends all carry a `calc(… * var(--density))` factor, but `--main-padding-*` carried none. A compact density therefore tightened every inner gap while leaving a 48px side gutter untouched, which reads as inconsistent at exactly the density where you're trying to reclaim width.

Each side is now multiplied individually, since a three-value shorthand cannot be scaled as a unit, and the four declarations move from the main `:root` block into the `[data-density]` block. That move is required, not cosmetic: a custom property is substituted where it is *declared*, so a scaled token declared only on `:root` bakes in density 1 and silently ignores any `data-density` set further down the tree.

Two stale value comments are corrected along the way. `--main-padding-lg` computes 24/48/24 rather than the annotated 20/48/28, and `-sm` computes 12/24/24 rather than 12/20/20 — `--spacing-9` and `--spacing-11` are both 1.5rem, so the comments had drifted from the arithmetic.

The declarations deliberately stay on one line each. `trp-themes` builds its new-theme template by line-matching `--var: value;` out of this file's served copy, and a wrapped value would emit a valueless declaration. (That template is currently inert — no `/semantic-tokens.css` is served — but the constraint is documented so restoring it doesn't silently break.)

Verified with `sass` compilation plus headless Chrome reading computed styles: `lg` goes 24/48/24 default → 18/36/18 compact → 27/54/27 roomy, and `xs` 4/8/8 → 3/6/6 → 4.5/9/9. The `compact` and `roomy` steps produce off-grid values, which is the tradeoff the density-steps comment already documents.