### PR TITLE
refactor(ui): redraw the design token layer boundary as input-vs-endpoint

### DIFF
--- a/docs/frontend/frontend.md
+++ b/docs/frontend/frontend.md
@@ -38,7 +38,7 @@ Component responsiveness uses `container-type: inline-size` and `@container` que
 
 ### Design Tokens and SCSS Modules — No Hardcoded Values
 
-Component-specific styles live in colocated `Component.module.scss` files with scoped class names (use underscores for multi-word identifiers so TypeScript dot notation works: `styles.market_card`). Reference design tokens (`var(--color-primary)`, `var(--gap-md)`, `var(--card-padding-md)`, `var(--radius-md)`) — never hardcoded colors, spacing, fonts, or sizes. The token system has three layers: foundation primitives in `primitives.scss` (forbidden in component code — including the `--radius-1`…`--radius-6` scale), use-case-named semantics and curated t-shirt-sized primitives in `semantic-tokens.scss` (preferred), and design-constant primitives like `--shadow-sm` and `--border-width-thin` (acceptable fallback). Full tier rules in [ui-design-token-layers.md](./ui/ui-design-token-layers.md); SCSS workflow in [ui-scss-modules.md](./ui/ui-scss-modules.md).
+Component-specific styles live in colocated `Component.module.scss` files with scoped class names (use underscores for multi-word identifiers so TypeScript dot notation works: `styles.market_card`). Reference design tokens (`var(--color-primary)`, `var(--gap-md)`, `var(--card-padding-md)`, `var(--radius-md)`) — never hardcoded colors, spacing, fonts, or sizes. The rule is one line: **component code references Layer 2 (`semantic-tokens.scss`); Layer 1 (`primitives.scss`) is composition input.** Layer 1 holds only `--spacing-N`, `--radius-N`, and the raw font-size scale. Full detail in [ui-design-token-layers.md](./ui/ui-design-token-layers.md); SCSS workflow in [ui-scss-modules.md](./ui/ui-scss-modules.md).
 
 ### Modules Export Through `index.ts`
 

--- a/docs/frontend/react/component-icon-picker-modal.md
+++ b/docs/frontend/react/component-icon-picker-modal.md
@@ -75,7 +75,7 @@ export function IconField() {
 
 CSS Modules (`IconPickerModal.module.css`) scoped to the component, container queries on `container-name: icon-picker` to adapt grid columns to modal width (not viewport).
 
-The component's existing SCSS predates the project's 4-tier token rule and references foundation primitives (`--spacing-N`, `--font-size-xs/sm/md`). When adding new component CSS in this codebase, prefer the use-case semantics and curated t-shirt primitives — see [ui-design-token-layers.md](../ui/ui-design-token-layers.md) for the tier rules and [ui-scss-modules.md](../ui/ui-scss-modules.md) for the component-styling workflow.
+The component's existing SCSS predates the Layer 1 / Layer 2 boundary and references foundation scales (`--spacing-N`, `--font-size-xs/sm/md`) directly. New component CSS must reference Layer 2 only — see [ui-design-token-layers.md](../ui/ui-design-token-layers.md) for the rule and [ui-scss-modules.md](../ui/ui-scss-modules.md) for the styling workflow.
 
 ## Pre-Use Checklist
 
@@ -89,6 +89,6 @@ The component's existing SCSS predates the project's 4-tier token rule and refer
 
 - [react.md](./react.md) — Provider composition, where `ModalProvider` lives
 - [ui-scss-modules.md](../ui/ui-scss-modules.md) — Component styling workflow
-- [ui-design-token-layers.md](../ui/ui-design-token-layers.md) — Token tier rules
+- [ui-design-token-layers.md](../ui/ui-design-token-layers.md) — Token layer boundary and consumption rule
 - [ui-accessibility.md](../ui/ui-accessibility.md) — ARIA, focus, keyboard navigation rules
 - [ui-theme.md](../ui/ui-theme.md) — Theme system using IconPickerModal in admin

--- a/docs/frontend/ui/ui-design-token-layers.md
+++ b/docs/frontend/ui/ui-design-token-layers.md
@@ -1,37 +1,36 @@
 # Design Tokens
 
-TronRelic's design tokens are CSS variables that name design decisions (colors, spacing, typography, radii, shadows). The system follows the three-layer pattern used by W3C-DTCG, Material Design, Adobe Spectrum, and Shopify Polaris — primitives at the bottom, semantic aliases in the middle, component code on top.
+TronRelic's design tokens are CSS variables that name design decisions (colors, spacing, typography, radii, shadows). The system follows the three-layer pattern used by W3C-DTCG, Material Design, Adobe Spectrum, and Shopify Polaris — foundation scales at the bottom, the consumable surface in the middle, component code on top.
 
 ## Why This Matters
 
-Hardcoded values fragment the UI and make theming impossible. Three layers give a single source of truth at each level: change one semantic token and every component that aliases it updates; theme switching is a remap, not a rewrite. The price of breaking the layering is exactly what it sounds like — token names that lie, themes that don't propagate, mobile breakpoints that redefine "medium" until the word means nothing.
+Hardcoded values fragment the UI and make theming impossible. Layering gives a single source of truth at each level: change one Layer 2 token and every component using it updates; theme switching is a remap, not a rewrite. The price of breaking the layering is exactly what it sounds like — token names that lie, themes that don't propagate, mobile breakpoints that redefine "medium" until the word means nothing.
+
+## The Rule
+
+**Component code references Layer 2. Layer 1 is composition input.**
+
+That is the whole consumption rule. There is no ranking to memorize and no second numbering scheme — if a token is declared in `semantic-tokens.scss`, component CSS may use it; if it is declared in `primitives.scss`, component CSS may not.
 
 ## The Three Layers
 
-### Layer 1 — Foundation Primitives (`primitives.scss`)
+### Layer 1 — Foundation Scales (`primitives.scss`)
 
-Raw values with no use-case meaning. Color palette (`--color-blue-500`), spacing scale (`--spacing-1` through `--spacing-20`), raw t-shirt font sizes (`--font-size-xs/sm/md/lg/xl/2xl/3xl`), font weights, line heights, radii, shadows.
+Three scales and nothing else: `--spacing-1…16`, `--radius-1…6`, `--font-size-xxs…3xl`. Each exists solely to be composed into a Layer 2 token. Component code never picks a rung off these ladders.
 
-### Layer 2 — Semantic Tokens (`semantic-tokens.scss`)
+### Layer 2 — Consumable Surface (`semantic-tokens.scss`)
 
-Use-case names that alias primitives: `--color-text`, `--color-danger`, `--card-padding-md`, `--button-padding-md`, `--button-border-radius`, `--card-shadow`, `--card-border-radius`, `--font-size-heading-md`, `--font-size-body`, `--max-width-prose`. These are the chokepoint themes remap to switch dark/light/brand variants.
+Everything component code may reference. Naming here is **deliberately mixed**: `--color-primary` and `--card-padding-md` describe use cases, `--gap-md` and `--shadow-sm` describe values, and all four belong because all four are endpoints.
 
-`semantic-tokens.scss` also hosts curated t-shirt-sized scales — `--gap-2xs/xs/sm/md/lg/xl`, `--padding-2xs/xs/sm/md/lg/xl`, `--avatar-size-sm/md/lg`. **By industry convention these are still primitives** (the names describe values, not use cases — Spectrum, Tailwind v4, Carbon, Atlassian classify their equivalents the same way). They live in this file because it is the curated chokepoint of *tokens component code may reference*, not a strict semantic-only collection.
+The boundary between Layer 1 and Layer 2 is **input versus endpoint**, not primitive-name versus semantic-name. `--shadow-sm` reads like a primitive but nothing composes from it, so it is Layer 2. `--spacing-7` is an input to `--gap-md`, so it is Layer 1. This is the same line Material draws between `md.ref.*` and `md.sys.*`, where the consumable layer likewise mixes `md.sys.color.primary` with `md.sys.shape.corner.large`.
+
+Prefer the use-case name when one fits — `--card-padding-md` inside a card rather than `--gap-md` — because it carries intent and gives a theme a narrower handle. **This is guidance, not a rule.** The value-named scales exist precisely for what use-case names do not cover, and reaching for one is not a violation.
 
 ### Layer 3 — Component Code (`.module.scss`, `globals.scss` utilities)
 
-Where tokens meet markup. Component CSS Modules consume tokens; `globals.scss` defines the small set of global utility classes (`.text-muted`, `.chip`, `.alert`, etc.).
+Where tokens meet markup. Component CSS Modules consume Layer 2; `globals.scss` defines the small set of global utility classes (`.text-muted`, `.chip`, `.alert`, etc.).
 
-## The Four-Tier Rule for Component Code
-
-Component CSS reaches for tokens in this order:
-
-1. **Use-case-named semantic tokens** when one exists — `--color-text`, `--color-danger`, `--card-padding-md`, `--button-gap`, `--stack-gap-md`, `--font-size-heading-md`, `--font-size-body`, `--max-width-prose`. **Always preferred.**
-2. **Curated t-shirt primitives in `semantic-tokens.scss`** — `--gap-*`, `--padding-*`, `--radius-xs/sm/md/lg/xl/full`, `--avatar-size-*`. Acceptable when no use-case-named semantic fits.
-3. **Design-constant primitives in `primitives.scss`** — `--border-width-thin/medium/thick`, `--shadow-sm/md/lg`, `--font-weight-*`, `--line-height-*`, `--letter-spacing-*`, `--max-width-*`. These don't shift between themes; aliasing them through Layer 2 adds ceremony without value, so reach for them directly. Radius is **not** in this tier: the t-shirt scale carries the `--density` factor, so consuming a foundation radius silently opts that corner out of density scaling.
-4. **Forbidden in component code** — the foundation scales: `--spacing-1`...`--spacing-20`, `--radius-1`...`--radius-6`, raw color palette (`--color-blue-500`), raw t-shirt font sizes (`--font-size-xs/sm/md/lg/xl/2xl/3xl`).
-
-If no token in tiers 1–3 fits, **flag the gap so a use-case-named semantic can be added**. Don't silently drop to a forbidden foundation primitive.
+If no Layer 2 token fits, **add one** — don't reach into Layer 1.
 
 ## Layer 2 Composition Rules
 
@@ -41,7 +40,7 @@ Layer 2 tokens must derive from theme-controlled tokens. Literal values short-ci
 
 **No half-derived tokens.** A token that mixes `var(--color-primary)` with a literal stop (e.g., `linear-gradient(135deg, var(--color-primary), #6da3ff)`) themes the derived half and freezes the literal half. The result is a visible color shear when the theme remaps primary. Derive every stop from theme-controlled values; use `color-mix(in srgb, var(--color-primary) 70%, white)` for a lighter variant.
 
-**No duplicate token names across layers.** Defining the same token in both `primitives.scss` and `semantic-tokens.scss` creates dead code — the later file wins the cascade silently. Semantic-named tokens belong in Layer 2; raw scales in Layer 1. A token name may appear only once in the source tree.
+**No duplicate token names across layers.** Defining the same token in both `primitives.scss` and `semantic-tokens.scss` creates dead code — the later file wins the cascade silently. Endpoints belong in Layer 2; composition inputs in Layer 1. A token name may appear only once in the source tree.
 
 ### Alpha Ladder
 
@@ -175,7 +174,13 @@ Themes override semantic tokens via custom CSS attached to a `[data-theme="UUID"
 Drift accumulates quietly. A periodic grep catches most of it:
 
 ```bash
-# Layer 3/4 — color literals in component and plugin code
+# Component code reaching into Layer 1 — the boundary violation
+grep -rnE 'var\(--(spacing-[0-9]+|radius-[1-6]|font-size-(xxs|xs|sm|base|md|lg|xl|2xl|3xl))\)' \
+    src/frontend src/plugins --include="*.scss" --include="*.css" \
+    --exclude-dir=.next --exclude-dir=dist --exclude-dir=node_modules \
+    | grep -v 'app/semantic-tokens.scss'
+
+# Color literals in component and plugin code
 grep -rnE 'rgba?\(|#[0-9a-fA-F]{6}' \
     src/frontend/components src/frontend/modules src/frontend/features src/plugins \
     --include="*.scss" 2>/dev/null \
@@ -185,6 +190,8 @@ grep -rnE 'rgba?\(|#[0-9a-fA-F]{6}' \
 grep -nE 'rgba?\(([0-9]+,\s*){2}(2[0-9]{2}|1[5-9][0-9])' \
     src/frontend/app/semantic-tokens.scss
 ```
+
+The first grep currently reports a known backlog (~1,270 sites across 78 files, all `--spacing-*` and raw `--font-size-*`); radius is clean. Treat new hits as regressions, not as part of that backlog.
 
 Hits are either real violations (replace with semantic tokens, the alpha ladder, or `color-mix()`) or intentional literals from the exception carveout above. The latter should already carry an explaining comment; if they don't, add one and consider whether a plugin-local variable would be cleaner.
 

--- a/docs/frontend/ui/ui-design-token-layers.md
+++ b/docs/frontend/ui/ui-design-token-layers.md
@@ -175,7 +175,7 @@ Drift accumulates quietly. A periodic grep catches most of it:
 
 ```bash
 # Component code reaching into Layer 1 — the boundary violation
-grep -rnE 'var\(--(spacing-[0-9]+|radius-[1-6]|font-size-(xxs|xs|sm|base|md|lg|xl|2xl|3xl))\)' \
+grep -rnE 'var\(\s*--(spacing-[0-9]+|radius-[1-6]|font-size-(xxs|xs|sm|base|md|lg|xl|2xl|3xl))\s*\)' \
     src/frontend src/plugins --include="*.scss" --include="*.css" \
     --exclude-dir=.next --exclude-dir=dist --exclude-dir=node_modules \
     | grep -v 'app/semantic-tokens.scss'
@@ -191,7 +191,7 @@ grep -nE 'rgba?\(([0-9]+,\s*){2}(2[0-9]{2}|1[5-9][0-9])' \
     src/frontend/app/semantic-tokens.scss
 ```
 
-The first grep currently reports a known backlog (~1,270 sites across 78 files, all `--spacing-*` and raw `--font-size-*`); radius is clean. Treat new hits as regressions, not as part of that backlog.
+The first grep currently reports a known backlog (~1,170 sites across 78 files, all `--spacing-*` and raw `--font-size-*`); radius is clean. Treat new hits as regressions, not as part of that backlog.
 
 Hits are either real violations (replace with semantic tokens, the alpha ladder, or `color-mix()`) or intentional literals from the exception carveout above. The latter should already carry an explaining comment; if they don't, add one and consider whether a plugin-local variable would be cleaner.
 

--- a/docs/frontend/ui/ui-scss-modules.md
+++ b/docs/frontend/ui/ui-scss-modules.md
@@ -120,7 +120,7 @@ Reach for tokens in `semantic-tokens.scss` first. Tokens are immutable — selec
 }
 ```
 
-**Token tiering** (full rules in [ui-design-token-layers.md](./ui-design-token-layers.md#the-four-tier-rule-for-component-code)): prefer use-case-named semantics (`--card-padding-md`, `--button-gap`); fall back to curated t-shirt primitives (`--gap-*`, `--padding-*`, `--radius-*`) and design constants (`--shadow-*`, `--font-weight-*`); never touch foundation scales (`--spacing-*`, `--radius-1`…`--radius-6`, raw color palette, raw `--font-size-xs/sm/md/lg/xl/2xl/3xl`). If nothing fits, add a new use-case-named semantic — don't drop to a forbidden scale. Never hardcode values, never redefine tokens across breakpoints.
+**Token layering** (full rules in [ui-design-token-layers.md](./ui-design-token-layers.md#the-rule)): component code references Layer 2 (`semantic-tokens.scss`) and never Layer 1 (`primitives.scss`, which holds only `--spacing-N`, `--radius-N`, and the raw font-size scale as composition inputs). Within Layer 2, prefer the use-case name when one fits (`--card-padding-md` over `--gap-md` inside a card) — guidance, not a rule. If nothing fits, add a Layer 2 token rather than reaching into Layer 1. Never hardcode values, never redefine tokens across breakpoints.
 
 ## Complete Example
 

--- a/docs/frontend/ui/ui-theme.md
+++ b/docs/frontend/ui/ui-theme.md
@@ -65,9 +65,9 @@ Override only what you need — defaults apply for everything else.
 
 ### What Tokens Can a Theme Override?
 
-Any CSS custom property in the design system. The complete catalog is the source — browse [primitives.scss](../../../src/frontend/app/primitives.scss) (foundation values) and [semantic-tokens.scss](../../../src/frontend/app/semantic-tokens.scss) (use-case-named aliases). The admin's auto-generated template contains them all. For the conceptual hierarchy, see [ui-design-token-layers.md](./ui-design-token-layers.md).
+Any CSS custom property in the design system. The complete catalog is the source — browse [primitives.scss](../../../src/frontend/app/primitives.scss) (the three foundation scales) and [semantic-tokens.scss](../../../src/frontend/app/semantic-tokens.scss) (everything else). The admin's auto-generated template contains them all. For the conceptual hierarchy, see [ui-design-token-layers.md](./ui-design-token-layers.md).
 
-**Note on tier rules:** Component CSS forbids reaching into foundation primitives like `--spacing-*` or raw `--font-size-xs/sm/md/lg/xl/2xl/3xl`. Themes are different — they *are* the remap layer, so overriding primitives is legitimate when a theme needs to shift the foundation scale. The component-code restriction does not apply inside `[data-theme="..."]` blocks.
+**Note on the layer rule:** Component CSS may reference Layer 2 only, never the Layer 1 foundation scales (`--spacing-N`, `--radius-N`, raw `--font-size-*`). Themes are different — they *are* the remap layer, so overriding a foundation scale is legitimate when a theme needs to shift it wholesale. The component-code restriction does not apply inside `[data-theme="..."]` blocks.
 
 ## Background Image System
 
@@ -129,13 +129,13 @@ Before creating a theme, gather:
 ## Further Reading
 
 **Detail docs:**
-- [ui-design-token-layers.md](./ui-design-token-layers.md) — Token hierarchy, the 4-tier rule, breakpoints
+- [ui-design-token-layers.md](./ui-design-token-layers.md) — Layer boundary, the consumption rule, breakpoints
 - [ui-components.md](./ui-components.md) — Components that consume design tokens
 - [ui-scss-modules.md](./ui-scss-modules.md) — How component CSS Modules reference tokens
 
 **Source files:**
-- [primitives.scss](../../../src/frontend/app/primitives.scss) — Foundation primitives
-- [semantic-tokens.scss](../../../src/frontend/app/semantic-tokens.scss) — Semantic + curated tokens
+- [primitives.scss](../../../src/frontend/app/primitives.scss) — Layer 1: spacing, radius, font-size scales
+- [semantic-tokens.scss](../../../src/frontend/app/semantic-tokens.scss) — Layer 2: the consumable surface
 - [components/ui/](../../../src/frontend/components/ui/) — UI primitives
 - [components/layout/](../../../src/frontend/components/layout/) — Layout primitives
 

--- a/docs/frontend/ui/ui.md
+++ b/docs/frontend/ui/ui.md
@@ -32,7 +32,7 @@ Hardcoded values prevent theming. Global classes collide. Viewport media queries
 
 ### Common Design Tokens
 
-Component code (`.module.scss`) reaches for use-case-named semantics first (`--card-padding-md`, `--button-gap`), falls back to curated t-shirt primitives (`--gap-md`, `--padding-md`, `--radius-md`) and design-constant primitives (`--shadow-sm`, `--border-width-thin`), and never touches foundation scales (`--spacing-7`, `--radius-3`, `--color-blue-500`, raw `--font-size-xs/sm/md/lg/xl/2xl/3xl`). Tier definitions and full token reference live in [ui-design-token-layers.md](./ui-design-token-layers.md).
+Component code (`.module.scss`) references Layer 2 (`semantic-tokens.scss`) and never Layer 1 (`primitives.scss`). Layer 1 holds only composition inputs — `--spacing-N`, `--radius-N`, and the raw font-size scale. Within Layer 2, prefer the use-case name when one fits (`--card-padding-md`, `--button-gap`) over the value-named scales (`--gap-md`, `--radius-md`); that is guidance, not a rule. Full detail in [ui-design-token-layers.md](./ui-design-token-layers.md).
 
 | Category | Tokens component code may reference |
 |----------|--------------------------------------|

--- a/docs/plugins/plugins-frontend-context-styling.md
+++ b/docs/plugins/plugins-frontend-context-styling.md
@@ -45,7 +45,7 @@ export function MyPluginPage({ context }: { context: IFrontendPluginContext }) {
 }
 ```
 
-Multi-word identifiers use underscores (`styles.market_card`) so dot-notation works. See [ui-scss-modules.md](../frontend/ui/ui-scss-modules.md) for token tiers and naming.
+Multi-word identifiers use underscores (`styles.market_card`) so dot-notation works. See [ui-scss-modules.md](../frontend/ui/ui-scss-modules.md) for the token layer rule and naming.
 
 ## Status Colors and Brand-Tinted Overlays
 
@@ -158,5 +158,5 @@ If a legacy plugin imports from `apps/frontend` or `src/frontend/`:
 
 - [plugins-frontend-context.md](./plugins-frontend-context.md) — index
 - [plugins-seo-and-ssr.md](./plugins-seo-and-ssr.md) — `serverDataFetcher` contract and SEO fields
-- [ui-scss-modules.md](../frontend/ui/ui-scss-modules.md) — token tiers, naming, container queries
+- [ui-scss-modules.md](../frontend/ui/ui-scss-modules.md) — token layer rule, naming, container queries
 - [react.md](../frontend/react/react.md) — SSR + Live Updates pattern in depth

--- a/src/frontend/app/primitives.scss
+++ b/src/frontend/app/primitives.scss
@@ -1,25 +1,30 @@
 /**
- * TronRelic Foundation Tokens (Layer 1 - Primitives)
+ * TronRelic Foundation Scales (Layer 1)
  *
- * Context-free, reusable primitive values implemented as CSS custom properties.
- * These are raw values with no semantic meaning (e.g., --spacing-4, --blue-600).
- * Never reference these directly in components - use semantic tokens instead.
+ * Composition inputs. Every token here exists to be composed into a Layer 2
+ * token — never to be referenced by component code.
  *
- * Values derived from analyzing existing patterns across globals.scss and
- * component CSS modules to ensure consistency with the current design.
+ * The test for belonging here is not whether a name describes a value: it is
+ * whether the token is an INPUT to another token or an ENDPOINT for component
+ * code. `--shadow-sm` reads like a primitive but is an endpoint, so it lives in
+ * semantic-tokens.scss. `--spacing-7` is an input to `--gap-md`, so it lives
+ * here. This mirrors Material's md.ref.* -> md.sys.* boundary, where the
+ * consumable layer deliberately mixes semantic and t-shirt naming.
  *
- * See docs/frontend/ui/ui-design-token-layers.md for usage guidelines.
+ * Three scales. Nothing else belongs in this file.
+ *
+ * See docs/frontend/ui/ui-design-token-layers.md for the consumption rule.
  */
 
 :root {
     /* Color Scheme */
     color-scheme: dark;
 
-    /* Typography - Font Family (system fonts for zero-latency rendering) */
-    --font-body: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
-    --font-mono: 'Courier New', Courier, monospace;
-
-    /* Typography - Font Sizes */
+    /*
+     * Typography Scale — raw sizes composed into --font-size-body-* and
+     * --font-size-heading-* in semantic-tokens.scss. Component code picks a
+     * purpose (body / caption / heading), never a rung off this ladder.
+     */
     --font-size-xxs: 0.5rem;     /* 8px */
     --font-size-xs: 0.72rem;     /* 11.52px */
     --font-size-sm: 0.85rem;     /* 13.6px */
@@ -30,24 +35,9 @@
     --font-size-2xl: 1.8rem;     /* 28.8px */
     --font-size-3xl: 2.6rem;     /* 41.6px */
 
-    /* Typography - Font Weights */
-    --font-weight-normal: 400;
-    --font-weight-medium: 500;
-    --font-weight-semibold: 600;
-    --font-weight-bold: 700;
-
-    /* Typography - Line Heights */
-    --line-height-tight: 1.25;
-    --line-height-normal: 1.4;
-    --line-height-relaxed: 1.5;
-
-    /* Typography - Letter Spacing */
-    --letter-spacing-tight: -0.02em;
-    --letter-spacing-normal: 0.01em;
-    --letter-spacing-wide: 0.08em;
-
     /*
-     * Spacing Scale — 4px grid, hybrid progression.
+     * Spacing Scale — 4px grid, hybrid progression. Composed into --gap-*,
+     * --padding-*, --card-padding-* and the rest of the density-scaled block.
      *
      * Linear 4px steps through the dense range (4–16px), where interface
      * density needs fine control, then a x1.5 ratio above it. A constant-ratio
@@ -75,56 +65,19 @@
     --spacing-15: 3rem;     /* 48px */
     --spacing-16: 4rem;     /* 64px */
 
-    /* Container Padding (responsive) */
-    --container-padding-mobile: 1.25rem;   /* 20px */
-    --container-padding-tablet: 1.5rem;    /* 24px */
-    --container-padding-desktop: 3rem;     /* 48px */
-
-    /* Color Tokens - Background */
-    --color-background: #03060f;
-
-    /* Color Tokens - Brand & Semantic */
-    --color-primary: #4b8cff;
-    --color-primary-strong: #246bff;
-    --color-success: #57d48c;
-    --color-warning: #ffc857;
-    --color-danger: #ff6f7d;
-
-    /* Shadow Tokens */
-    --shadow-sm: 0 8px 18px rgba(7, 15, 30, 0.35);
-    --shadow-md: 0 18px 36px rgba(10, 20, 45, 0.42);
-    --shadow-lg: 0 28px 48px rgba(5, 12, 28, 0.55);
-    --shadow-xl: 0 40px 64px rgba(3, 8, 22, 0.65);
-
     /*
-     * Border Radius Tokens — FOUNDATION ONLY
+     * Radius Scale — composed into --radius-xs/sm/md/lg/xl/full, which carry
+     * the --density factor. Ordinal names mirror --spacing-N: the number is a
+     * position, not a multiple. Do not read --radius-2 as "2x something" — the
+     * values are 4/10/16/24/32 and 10 is not 2x4.
      *
-     * Do not reference these in component code. They are the unscaled base the
-     * role semantics in semantic-tokens.scss compose from:
-     *
-     *   --radius-1 -> --radius-xs     hairline text highlight
-     *   --radius-2 -> --radius-sm     input, switch, segmented control
-     *   --radius-3 -> --radius-md     table, alert, toast, panel
-     *   --radius-4 -> --radius-lg     card, modal
-     *   --radius-5 -> --radius-xl     sheet edge meeting the viewport
-     *   --radius-6 -> --radius-full   button, badge, chip, meter
-     *
-     * Ordinal names, mirroring --spacing-N: the number is a position on the
-     * scale, not a multiple of a base unit. Do not read --radius-2 as "2x
-     * something" — the values are 4/10/16/24/32 and 10 is not 2x4.
-     *
-     * The t-shirt tier carries the --density factor; consuming a foundation
-     * value directly silently opts that corner out of density scaling. This
-     * mirrors --spacing-N -> --gap-*, where the foundation scale is likewise
-     * off-limits and the consumable tier is t-shirt-named.
-     *
-     * Values are px on purpose. Control geometry here (--button-height-*,
+     * Values are px on purpose. Control geometry (--button-height-*,
      * --icon-size-*, --avatar-size-*) is px, so a rem radius would scale with
      * root font size while the box it rounds did not, distorting the corner.
      *
-     * The uneven numeric gaps carry no meaning — the steps are chosen per role
+     * The uneven gaps carry no meaning — the steps are chosen per role
      * (highlight / control / surface / card / sheet / pill), not sampled off a
-     * ramp. Pick the step whose role matches rather than interpolating.
+     * ramp.
      */
     --radius-1: 4px;
     --radius-2: 10px;
@@ -133,78 +86,7 @@
     --radius-5: 32px;
     --radius-6: 999px;
 
-    /* Border Width Tokens */
-    --border-width-thin: 1px;
-    --border-width-medium: 2px;
-    --border-width-thick: 3px;
-
-    /* Opacity Scale */
-    --opacity-0: 0;
-    --opacity-35: 0.35;
-    --opacity-50: 0.5;
-    --opacity-55: 0.55;
-    --opacity-60: 0.6;
-    --opacity-70: 0.7;
-    --opacity-75: 0.75;
-    --opacity-80: 0.8;
-    --opacity-85: 0.85;
-    --opacity-90: 0.9;
-    --opacity-100: 1;
-
-    /* Z-Index Scale (from actual usage) */
-    --z-index-base: 0;
-    --z-index-dropdown: 10;
-    --z-index-sticky: 100;
-    --z-index-fixed: 1000;
-    --z-index-modal-backdrop: 1100;
-    --z-index-modal: 1110;
-    --z-index-toast: 1200;
-
-    /* Transition Tokens */
-    --transition-base: 160ms ease;
-    --transition-fast: 100ms ease;
-    --transition-slow: 250ms ease;
-
-    /* Animation Durations (from actual keyframes) */
-    --duration-flash: 2.4s;
-    --duration-pulse: 2s;
-    --duration-slide: 0.25s;
-
     /* Breakpoint Tokens
        REMOVED: Breakpoints are now defined in _breakpoints.scss (single source of truth).
        Import @use './breakpoints' as *; in SCSS files to use $breakpoint-* variables. */
-
-    /* Icon Size Tokens
-     *
-     * --button-height-* deliberately does not live here. "Button" is a use
-     * case, so the ladder belongs in semantic-tokens.scss, which is also where
-     * the xs step is defined. Duplicating the names across both layers made
-     * this file's copies dead code — semantic-tokens.scss loads second and
-     * silently won the cascade. */
-    --icon-size-xs: 14px;
-    --icon-size-sm: 18px;
-    --icon-size-md: 20px;
-    --icon-size-lg: 24px;
-    --icon-size-xl: 32px;
-
-    /* Max Width Tokens (for layout containers) */
-    --max-width-prose: 64ch;     /* character-relative, not px */
-    --max-width-xs: 320px;
-    --max-width-sm: 420px;
-    --max-width-md: 640px;
-    --max-width-lg: 820px;
-    --max-width-xl: 1080px;
-
-    /* Chart Color Palette (10 distinct, accessible colors for data series) */
-    --chart-color-1: #3b82f6;    /* Blue */
-    --chart-color-2: #22c55e;    /* Green */
-    --chart-color-3: #f59e0b;    /* Amber */
-    --chart-color-4: #ef4444;    /* Red */
-    --chart-color-5: #8b5cf6;    /* Violet */
-    --chart-color-6: #06b6d4;    /* Cyan */
-    --chart-color-7: #ec4899;    /* Pink */
-    --chart-color-8: #f97316;    /* Orange */
-    --chart-color-9: #14b8a6;    /* Teal */
-    --chart-color-10: #6366f1;   /* Indigo */
-    --chart-color-total: #7C9BFF; /* Total/aggregate line */
 }

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -141,7 +141,7 @@
     --chart-color-8: #f97316;    /* Orange */
     --chart-color-9: #14b8a6;    /* Teal */
     --chart-color-10: #6366f1;   /* Indigo */
-    --chart-color-total: #7C9BFF; /* Total/aggregate line */
+    --chart-color-total: #7c9bff; /* Total/aggregate line */
 
     /* ========================================================================
      * GENERIC LAYOUT & TYPOGRAPHY TOKENS

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -1,14 +1,21 @@
 /**
- * TronRelic Semantic Tokens (Layer 2)
+ * TronRelic Consumable Tokens (Layer 2)
  *
- * Semantic tokens composed from primitives.scss foundation values.
- * These tokens add meaning to primitive values (e.g., --color-primary instead of --blue-600).
- * They provide consistent theming and can be changed globally to affect all components.
+ * The complete surface component code may reference. If a token is not declared
+ * here (or in the density block below), component code must not use it.
  *
- * Derived from analyzing actual usage patterns in Button.module.css, Card.module.css,
- * Badge.module.css, Input.module.css, and globals.scss utility classes.
+ * Naming is deliberately mixed. `--color-primary` describes a use case,
+ * `--gap-md` describes a value, and both belong here because both are endpoints
+ * for component code. The Layer 1 / Layer 2 boundary is input-vs-endpoint, not
+ * primitive-vs-semantic — the same boundary Material draws between md.ref.* and
+ * md.sys.*, where the consumable layer also mixes the two naming styles.
  *
- * See docs/frontend/ui/ui-design-token-layers.md for usage guidelines.
+ * Prefer the use-case name when one fits (`--card-padding-md` over `--gap-md`
+ * inside a card); it carries intent and gives themes a narrower handle. This is
+ * guidance, not a rule — the value-named scales exist precisely for everything
+ * a use-case name does not cover, and reaching for one is not a violation.
+ *
+ * See docs/frontend/ui/ui-design-token-layers.md for the consumption rule.
  */
 
 /* ============================================================================
@@ -16,6 +23,126 @@
  * ========================================================================== */
 :root,
 [data-theme="default"] {
+    /* ========================================================================
+     * DESIGN CONSTANTS
+     *
+     * Endpoints with no composition step — the token IS the value. They live
+     * here rather than in primitives.scss because component code consumes them
+     * directly; a name like --shadow-sm reading "primitive" is irrelevant to
+     * where it belongs.
+     * ======================================================================== */
+
+    /* Typography - Font Family (system fonts for zero-latency rendering) */
+    --font-body: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    --font-mono: 'Courier New', Courier, monospace;
+
+    /* Typography - Font Weights */
+    --font-weight-normal: 400;
+    --font-weight-medium: 500;
+    --font-weight-semibold: 600;
+    --font-weight-bold: 700;
+
+    /* Typography - Line Heights */
+    --line-height-tight: 1.25;
+    --line-height-normal: 1.4;
+    --line-height-relaxed: 1.5;
+
+    /* Typography - Letter Spacing */
+    --letter-spacing-tight: -0.02em;
+    --letter-spacing-normal: 0.01em;
+    --letter-spacing-wide: 0.08em;
+
+    /* Brand & Status Colors — the source of truth a theme remaps */
+    --color-background: #03060f;
+    --color-primary: #4b8cff;
+    --color-primary-strong: #246bff;
+    --color-success: #57d48c;
+    --color-warning: #ffc857;
+    --color-danger: #ff6f7d;
+
+    /* Shadows */
+    --shadow-sm: 0 8px 18px rgba(7, 15, 30, 0.35);
+    --shadow-md: 0 18px 36px rgba(10, 20, 45, 0.42);
+    --shadow-lg: 0 28px 48px rgba(5, 12, 28, 0.55);
+    --shadow-xl: 0 40px 64px rgba(3, 8, 22, 0.65);
+
+    /* Border Widths */
+    --border-width-thin: 1px;
+    --border-width-medium: 2px;
+    --border-width-thick: 3px;
+
+    /* Opacity Scale */
+    --opacity-0: 0;
+    --opacity-35: 0.35;
+    --opacity-50: 0.5;
+    --opacity-55: 0.55;
+    --opacity-60: 0.6;
+    --opacity-70: 0.7;
+    --opacity-75: 0.75;
+    --opacity-80: 0.8;
+    --opacity-85: 0.85;
+    --opacity-90: 0.9;
+    --opacity-100: 1;
+
+    /* Z-Index Scale */
+    --z-index-base: 0;
+    --z-index-dropdown: 10;
+    --z-index-sticky: 100;
+    --z-index-fixed: 1000;
+    --z-index-modal-backdrop: 1100;
+    --z-index-modal: 1110;
+    --z-index-toast: 1200;
+
+    /* Transitions */
+    --transition-base: 160ms ease;
+    --transition-fast: 100ms ease;
+    --transition-slow: 250ms ease;
+
+    /* Animation Durations (from actual keyframes) */
+    --duration-flash: 2.4s;
+    --duration-pulse: 2s;
+    --duration-slide: 0.25s;
+
+    /* Icon Sizes
+     *
+     * --button-height-* deliberately does not sit alongside these: "button" is
+     * a component, so that ladder lives with the button tokens below. */
+    --icon-size-xs: 14px;
+    --icon-size-sm: 18px;
+    --icon-size-md: 20px;
+    --icon-size-lg: 24px;
+    --icon-size-xl: 32px;
+
+    /* Max Widths (layout containers) */
+    --max-width-prose: 64ch;     /* character-relative, not px */
+    --max-width-xs: 320px;
+    --max-width-sm: 420px;
+    --max-width-md: 640px;
+    --max-width-lg: 820px;
+    --max-width-xl: 1080px;
+
+    /* Container Padding (responsive) */
+    --container-padding-mobile: 1.25rem;   /* 20px */
+    --container-padding-tablet: 1.5rem;    /* 24px */
+    --container-padding-desktop: 3rem;     /* 48px */
+
+    /* Chart Color Palette (10 distinct, accessible colors for data series)
+     *
+     * A palette rather than a scale: chart components consume these directly
+     * because a series colour encodes data identity, not brand. Inventing ten
+     * use-case aliases would be ceremony without a caller. */
+    --chart-color-1: #3b82f6;    /* Blue */
+    --chart-color-2: #22c55e;    /* Green */
+    --chart-color-3: #f59e0b;    /* Amber */
+    --chart-color-4: #ef4444;    /* Red */
+    --chart-color-5: #8b5cf6;    /* Violet */
+    --chart-color-6: #06b6d4;    /* Cyan */
+    --chart-color-7: #ec4899;    /* Pink */
+    --chart-color-8: #f97316;    /* Orange */
+    --chart-color-9: #14b8a6;    /* Teal */
+    --chart-color-10: #6366f1;   /* Indigo */
+    --chart-color-total: #7C9BFF; /* Total/aggregate line */
+
     /* ========================================================================
      * GENERIC LAYOUT & TYPOGRAPHY TOKENS
      *


### PR DESCRIPTION
Layer 1 previously mixed composition inputs with tokens component code had to consume directly (`--shadow-sm`, `--z-index-modal`, `--icon-size-md`), so the "never reference primitives" rule was unfollowable and quietly ignored.

`primitives.scss` now holds only the three scales that feed other tokens — typography sizes, spacing, radius. Everything component code consumes moves to `semantic-tokens.scss` under a DESIGN CONSTANTS block, including the chart palette. Values are unchanged; only their file changes, and `semantic-tokens.scss` already loaded second so the cascade is unaffected.

Docs restate the rule as: component code references Layer 2, Layer 1 is composition input, and the mixed naming in Layer 2 (`--color-primary` alongside `--gap-md`) is intentional — the boundary is input-vs-endpoint, not primitive-vs-semantic.