### PR TITLE
feat(plugin-context): expose Textarea and ConfirmDialog to plugin UI

### DIFF
--- a/docs/frontend/ui/ui-components.md
+++ b/docs/frontend/ui/ui-components.md
@@ -23,6 +23,7 @@ Source: [components/layout/](../../../src/frontend/components/layout/). Export b
 | `<Section>` | Content section with internal `gap` spacing | [Section](../../../src/frontend/components/layout/Section/) |
 | `<MainHeader>` | Site header: database-driven `MenuNav`, logo, wallet/theme controls (server component) | [MainHeader](../../../src/frontend/components/layout/MainHeader/) |
 | `MenuNavSSR` / `MenuNavClient` | SSR-first navigation fed by the backend Menu module; hydrates into a client menu with hamburger support. `MenuNavClient` (submenu mode) is also the **required** renderer for a core/module admin page's in-page tab row — see [Submenu Pattern](../../../src/backend/modules/menu/README.md#submenu-pattern-namespaced-tab-rows) | [MenuNav](../../../src/frontend/components/layout/MenuNav/) |
+| `<SubMenu>` | Plugin-facing wrapper over `MenuNavClient`: a menu-namespace-backed in-page tab strip. `onSelect` drives in-page tab state and suppresses navigation; omit it for ordinary nav links. Exposed to plugins as `context.layout.SubMenu` | [SubMenu](../../../src/frontend/components/layout/MenuNav/SubMenu.tsx) |
 | `<BlockTicker>` | Compact real-time block ticker; follows SSR + Live Updates with Redux hydration | [BlockTicker](../../../src/frontend/components/layout/BlockTicker/) |
 
 See [ui.md](./ui.md) and [frontend.md](../frontend.md#component-first-layout-architecture) for the decision hierarchy (layout components > utility classes > raw divs).
@@ -33,6 +34,7 @@ Source: [components/ui/](../../../src/frontend/components/ui/). Each folder expo
 
 | Component | Purpose | Key Props | Source |
 |-----------|---------|-----------|--------|
+| `<AccountPicker>` | Searchable Better Auth account selector (by name/email); self-contained — queries the admin account-search endpoint itself. Admin-gated, admin surfaces only | `value` (account id or null), `onChange`, `disabled`, `placeholder` | [AccountPicker](../../../src/frontend/components/ui/AccountPicker/) |
 | `<Badge>` | Inline status/label pill | `tone="neutral\|info\|success\|warning\|danger"`, `showLiveIndicator` | [Badge](../../../src/frontend/components/ui/Badge/) |
 | `<Button>` | Primary interactive button with text label | `variant="primary\|secondary\|ghost\|danger\|warning"`, `size="xs\|sm\|md\|lg"`, `icon`, `loading` | [Button](../../../src/frontend/components/ui/Button/) |
 | `<Card>` | Content surface with padding, elevation, and tone. Padding never shrinks by breakpoint — pick the step the surface needs | `padding="xs\|sm\|md\|lg"`, `elevated`, `tone`, `noBackgroundImage` | [Card](../../../src/frontend/components/ui/Card/) |

--- a/docs/plugins/plugins-frontend-context.md
+++ b/docs/plugins/plugins-frontend-context.md
@@ -12,7 +12,7 @@ Direct imports from `src/frontend/` break Next.js module resolution and couple p
 interface IFrontendPluginContext {
     pluginId: string;              // namespacing for events and API routes
     layout: ILayoutComponents;     // Page, PageHeader, Stack, Grid, Section, SubMenu
-    ui: IUIComponents;             // Card, Badge, Button, CopyButton, IconButton, Switch, Input, Skeleton, ClientTime, Tooltip, IconPickerModal, Table family
+    ui: IUIComponents;             // Card, Badge, Button, CopyButton, IconButton, Switch, Input, Select, Textarea, Skeleton, ClientTime, Tooltip, IconPickerModal, ConfirmDialog, AccountPicker, Table family
     charts: IChartComponents;      // LineChart, BarChart
     system: ISystemComponents;     // SchedulerMonitor (admin)
     api: IApiClient;               // get/post/put/patch/delete with runtime base URL

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delphian/tronrelic-types",
-  "version": "6.11.0",
+  "version": "6.12.0",
   "description": "Core type definitions for the TronRelic platform",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -237,6 +237,29 @@ export interface IUIComponents {
         'aria-label'?: string;
     }>;
 
+    /**
+     * Textarea — themed multiline field matching the Input/Select treatment
+     * (shared input tokens plus focus ring), wrapping a native `<textarea>`.
+     * Supports standard textarea attributes (`rows`, `placeholder`,
+     * `disabled`). Use instead of a bare `<textarea>` so plugin multiline
+     * fields match core admin surfaces.
+     */
+    Textarea: ComponentType<{
+        value?: string;
+        onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+        placeholder?: string;
+        disabled?: boolean;
+        required?: boolean;
+        variant?: 'default' | 'ghost';
+        /** Padding density; shares the Input ladder so adjacent controls match. */
+        size?: 'xs' | 'sm' | 'md' | 'lg';
+        rows?: number;
+        className?: string;
+        id?: string;
+        name?: string;
+        'aria-label'?: string;
+    }>;
+
     /** Client-side time rendering component (prevents SSR hydration mismatches) */
     ClientTime: ComponentType<{
         date: Date | string | null | undefined;
@@ -256,6 +279,23 @@ export interface IUIComponents {
         selectedIcon?: string;
         onSelect: (iconName: string) => void;
         onClose: () => void;
+    }>;
+
+    /**
+     * ConfirmDialog — destructive-action confirmation body mounted inside a
+     * `useModal()` modal. Pairs an alert icon with the message and a
+     * danger/ghost button pair, tracking its own async spinner across
+     * `onConfirm`. The dialog never closes itself — wire `onConfirm` /
+     * `onCancel` to `close(modalId)`. Use instead of hand-rolling a confirm
+     * modal body so plugin confirmations match core.
+     */
+    ConfirmDialog: ComponentType<{
+        label: string;
+        message?: React.ReactNode;
+        confirmLabel?: string;
+        cancelLabel?: string;
+        onConfirm: () => Promise<void> | void;
+        onCancel: () => void;
     }>;
 
     /**
@@ -1093,7 +1133,7 @@ export interface IFrontendPluginContext {
     /** Plugin identifier used for namespacing events and API routes */
     pluginId: string;
 
-    /** UI component library (Card, Badge, Button, CopyButton, IconButton, Switch, Input, Select, Skeleton, ClientTime, Tooltip, IconPickerModal, Table family) */
+    /** UI component library (Card, Badge, Button, CopyButton, IconButton, Switch, Input, Select, Textarea, Skeleton, ClientTime, Tooltip, IconPickerModal, ConfirmDialog, Table family) */
     ui: IUIComponents;
 
     /** Layout component library (Page, PageHeader, Stack, Grid, Section, SubMenu) */

--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -247,6 +247,8 @@ export interface IUIComponents {
     Textarea: ComponentType<{
         value?: string;
         onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+        /** Key handler so plugins can wire Ctrl/Cmd+Enter submit, matching Input. */
+        onKeyDown?: (e: React.KeyboardEvent) => void;
         placeholder?: string;
         disabled?: boolean;
         required?: boolean;

--- a/src/frontend/lib/frontendPluginContext.tsx
+++ b/src/frontend/lib/frontendPluginContext.tsx
@@ -20,6 +20,8 @@ import { IconButton } from '../components/ui/IconButton';
 import { Switch } from '../components/ui/Switch';
 import { Input } from '../components/ui/Input';
 import { Select } from '../components/ui/Select';
+import { Textarea } from '../components/ui/Textarea';
+import { ConfirmDialog } from '../components/ui/ConfirmDialog';
 import { ClientTime } from '../components/ui/ClientTime';
 import { Tooltip } from '../components/ui/Tooltip';
 import { LazyIconPickerModal as IconPickerModal } from '../components/ui/IconPickerModal';
@@ -345,9 +347,15 @@ export function FrontendPluginContextProvider({ children }: { children: React.Re
             // metadata quirk without widening the published plugin contract.
             Input: Input as IUIComponents['Input'],
             Select,
+            // forwardRef (like Input) gives Textarea a static `propTypes` field
+            // that trips the invariant check against the narrowed contract; the
+            // runtime component accepts every prop the contract advertises, so
+            // the cast is sound.
+            Textarea: Textarea as IUIComponents['Textarea'],
             ClientTime,
             Tooltip,
             IconPickerModal,
+            ConfirmDialog,
             AccountPicker,
             Table,
             Thead,
@@ -451,9 +459,13 @@ export function createPluginContext(pluginId: string): IFrontendPluginContext {
         // component is fully compatible, so the cast is sound.
         Input: Input as IUIComponents['Input'],
         Select,
+        // forwardRef (like Input) trips the invariant check against the narrowed
+        // contract; the runtime component is fully compatible, so the cast is sound.
+        Textarea: Textarea as IUIComponents['Textarea'],
         ClientTime,
         Tooltip,
         IconPickerModal,
+        ConfirmDialog,
         AccountPicker,
         Table,
         Thead,


### PR DESCRIPTION
Adds `Textarea` and `ConfirmDialog` to the plugin frontend UI contract (`IUIComponents`) and wires both into the two frontend plugin-context factories (`FrontendPluginContextProvider` and `createPluginContext`).

- `Textarea` — themed multiline field matching the Input/Select treatment; cast like `Input` to sidestep the forwardRef `propTypes` invariant.
- `ConfirmDialog` — destructive-action confirmation body for `useModal()` modals; never self-closes.
- Bumps `@delphian/tronrelic-types` to 6.12.0.
- Refreshes `docs/plugins/plugins-frontend-context.md` and `docs/frontend/ui/ui-components.md`.

Plugin multiline fields and confirmations now match core admin surfaces instead of hand-rolled markup.