### PR TITLE
feat(traffic): GSC keyword→page pairs section + standardize admin UI on shared components

### DIFF
--- a/src/backend/modules/traffic/api/traffic.controller.ts
+++ b/src/backend/modules/traffic/api/traffic.controller.ts
@@ -768,6 +768,28 @@ export class TrafficController {
     }
 
     /**
+     * GET /api/admin/users/analytics/gsc/keyword-pages?periodHours=168&limit=25
+     * Aggregated GSC keyword→page pairs for the window — which pages each
+     * keyword surfaced. Backed by the raw query cache (the only rows carrying
+     * query and page together), so it inherits GSC's low-volume-query
+     * anonymization exactly as the keyword panel does; its clicks will not
+     * fully reconcile with the anonymization-immune page totals. Returns an
+     * empty array until the `gsc:fetch` job has stored data; carries
+     * `windowStart`/`windowEnd` for a truthful period label.
+     */
+    async getGscKeywordPages(req: Request, res: Response): Promise<void> {
+        const periodHours = parsePositiveInt(req.query.periodHours, 168, MAX_SINCE_HOURS);
+        const limit = parsePositiveInt(req.query.limit, 25, MAX_LIMIT);
+        try {
+            const result = await this.gscService.getKeywordPagePairsForPeriod(periodHours, limit);
+            res.json({ periodHours, limit, ...result });
+        } catch (error) {
+            this.logger.error({ err: error }, 'Failed to fetch GSC keyword-page pairs');
+            res.status(500).json({ error: 'InternalError', message: 'Failed to fetch GSC keyword-page pairs' });
+        }
+    }
+
+    /**
      * GET /api/admin/users/analytics/gsc/keywords-by-day?days=14&topN=15
      * Daily GSC keyword buckets (clicks/impressions trend with per-day top
      * keywords). Already offset by the GSC ingestion delay in the service.

--- a/src/backend/modules/traffic/api/traffic.routes.ts
+++ b/src/backend/modules/traffic/api/traffic.routes.ts
@@ -71,6 +71,7 @@ export function createAdminAnalyticsRouter(controller: TrafficController): Route
     router.post('/gsc/refresh', controller.refreshGscData.bind(controller));
     router.get('/gsc/keywords', controller.getGscKeywords.bind(controller));
     router.get('/gsc/pages', controller.getGscPages.bind(controller));
+    router.get('/gsc/keyword-pages', controller.getGscKeywordPages.bind(controller));
     router.get('/gsc/keywords-by-day', controller.getGscKeywordsByDay.bind(controller));
 
     // AI tab — a filtered proxy onto the core 'ai-tools' registry, showing and

--- a/src/backend/modules/traffic/services/gsc.service.ts
+++ b/src/backend/modules/traffic/services/gsc.service.ts
@@ -174,6 +174,48 @@ export interface IGscPagesPeriodResult {
     pages: IGscPage[];
 }
 
+/**
+ * One aggregated keyword→page pair: how much a single query drove a single
+ * landing page over the window.
+ *
+ * The "Top keywords" and "Top pages" panels each collapse one of the two
+ * dimensions away, so neither can answer "which page did this keyword
+ * surface?". This pairing keeps both dimensions, aggregating the raw
+ * `module_user_gsc_queries` rows (which carry `query` and `page` together)
+ * by the `{query, page}` couple. Because it reads the query-dimensioned
+ * collection it inherits GSC's low-volume-query anonymization — the same
+ * coverage gap the keyword panel already has — so its clicks will not fully
+ * reconcile with the anonymization-immune page totals.
+ */
+export interface IGscKeywordPage {
+    /** Search query. */
+    keyword: string;
+    /** Landing page URL the query surfaced. */
+    page: string;
+    /** Total clicks for this keyword→page pair. */
+    clicks: number;
+    /** Total impressions for this keyword→page pair. */
+    impressions: number;
+    /** Average CTR across rows (0-1). */
+    ctr: number;
+    /** Impression-weighted average position across rows. */
+    position: number;
+}
+
+/**
+ * Aggregated keyword→page pairs for a period plus the delay-shifted window
+ * covered — the two-dimensional counterpart to {@link IGscKeywordsPeriodResult}
+ * and {@link IGscPagesPeriodResult}.
+ */
+export interface IGscKeywordPagesPeriodResult {
+    /** Inclusive window start (ISO-8601 UTC). */
+    windowStart: string;
+    /** Inclusive window end (ISO-8601 UTC) — always ~3 days behind now. */
+    windowEnd: string;
+    /** Aggregated pairs sorted by clicks descending. */
+    pairs: IGscKeywordPage[];
+}
+
 /** Key-value store keys for GSC configuration. */
 const KV_CREDENTIALS = 'gsc:credentials';
 const KV_SITE_URL = 'gsc:siteUrl';
@@ -916,6 +958,72 @@ export class GscService {
             windowStart: since.toISOString(),
             windowEnd: end.toISOString(),
             pages
+        };
+    }
+
+    /**
+     * Get aggregated keyword→page pairs for a given time period.
+     *
+     * Answers "which pages did each keyword surface?" — the join the separate
+     * keyword and page panels cannot express because each drops one dimension.
+     * Aggregates the raw `module_user_gsc_queries` rows (the only collection
+     * carrying `query` and `page` on the same document) by the `{query, page}`
+     * couple, summing clicks and impressions and impression-weighting position,
+     * sorted by clicks then impressions descending so impression-only pairs
+     * still surface.
+     *
+     * Reads the query-dimensioned collection, so it inherits GSC's low-volume
+     * query anonymization exactly as the keyword panel does: anonymized queries
+     * never produced a row here, so their clicks are absent and will not
+     * reconcile with the anonymization-immune page totals. The window is
+     * delay-shifted identically to the sibling reads and the true dates are
+     * returned for honest labelling.
+     *
+     * @param periodHours - Lookback period in hours.
+     * @param limit - Maximum pairs to return (default: 10).
+     * @returns The delay-shifted window and its aggregated keyword→page pairs.
+     */
+    async getKeywordPagePairsForPeriod(periodHours: number, limit: number = 10): Promise<IGscKeywordPagesPeriodResult> {
+        const delayMs = GSC_DATA_DELAY_DAYS * 24 * 60 * 60 * 1000;
+        const end = new Date(Date.now() - delayMs);
+        const since = new Date(end.getTime() - (periodHours * 60 * 60 * 1000));
+
+        const results = await this.collection.aggregate<{
+            _id: { query: string; page: string };
+            totalClicks: number;
+            totalImpressions: number;
+            weightedPosition: number;
+        }>([
+            { $match: { date: { $gte: since, $lte: end } } },
+            {
+                $group: {
+                    _id: { query: '$query', page: '$page' },
+                    totalClicks: { $sum: '$clicks' },
+                    totalImpressions: { $sum: '$impressions' },
+                    weightedPosition: { $sum: { $multiply: ['$position', '$impressions'] } }
+                }
+            },
+            { $sort: { totalClicks: -1, totalImpressions: -1 } },
+            { $limit: limit }
+        ]).toArray();
+
+        const pairs = results.map(r => ({
+            keyword: r._id.query,
+            page: r._id.page,
+            clicks: r.totalClicks,
+            impressions: r.totalImpressions,
+            ctr: r.totalImpressions > 0
+                ? Math.round((r.totalClicks / r.totalImpressions) * 10000) / 10000
+                : 0,
+            position: r.totalImpressions > 0
+                ? Math.round((r.weightedPosition / r.totalImpressions) * 10) / 10
+                : 0
+        }));
+
+        return {
+            windowStart: since.toISOString(),
+            windowEnd: end.toISOString(),
+            pairs
         };
     }
 }

--- a/src/frontend/components/ui/Table/Table.module.scss
+++ b/src/frontend/components/ui/Table/Table.module.scss
@@ -13,7 +13,7 @@
     background: var(--card-background);
     border-radius: var(--radius-md);
     border: var(--card-border);
-    overflow: hidden;
+    overflow-x: auto;
     container-type: inline-size;
     container-name: table;
 }
@@ -30,9 +30,9 @@
 }
 
 /*
- * Sticky-header variant. The base wrapper uses `overflow: hidden`, which makes
- * it a scroll box that captures `position: sticky` and never scrolls — so a
- * sticky header cannot work against it. This modifier turns the wrapper into a
+ * Sticky-header variant. The base wrapper uses `overflow-x: auto` with no height
+ * bound, so it scrolls horizontally but never vertically — a `position: sticky`
+ * header has nothing to stick against. This modifier turns the wrapper into a
  * bounded vertical scroll container; the header then sticks to its top while the
  * body scrolls. Height is tunable via `--table-sticky-max-height`.
  */

--- a/src/frontend/modules/traffic/api/client.ts
+++ b/src/frontend/modules/traffic/api/client.ts
@@ -992,6 +992,62 @@ export async function adminGetGscPages(options?: { periodHours?: number; limit?:
 }
 
 /**
+ * One aggregated GSC keyword→page pair — which page a query surfaced and how
+ * much traffic that couple drew over the window.
+ */
+export interface IGscKeywordPage {
+    /** Search query. */
+    keyword: string;
+    /** Landing page URL the query surfaced. */
+    page: string;
+    /** Total clicks for this keyword→page pair. */
+    clicks: number;
+    /** Total impressions for this keyword→page pair. */
+    impressions: number;
+    /** Average click-through rate (0-1). */
+    ctr: number;
+    /** Impression-weighted average position in search results. */
+    position: number;
+}
+
+/**
+ * Aggregated GSC keyword→page pairs plus the delay-shifted window covered — the
+ * two-dimensional counterpart to {@link IGscKeywordsResult} and
+ * {@link IGscPagesResult}, keeping both the query and the page it surfaced.
+ */
+export interface IGscKeywordPagesResult {
+    /** Inclusive window start (ISO-8601 UTC). */
+    windowStart: string;
+    /** Inclusive window end (ISO-8601 UTC). */
+    windowEnd: string;
+    /** Pairs sorted by clicks descending. */
+    pairs: IGscKeywordPage[];
+}
+
+/**
+ * Get aggregated GSC keyword→page pairs for a lookback window (admin endpoint).
+ *
+ * Backed by the raw query cache, the only rows carrying query and page
+ * together, so it inherits GSC's low-volume-query anonymization the same way
+ * the keyword panel does — its clicks will not fully reconcile with the
+ * anonymization-immune page totals.
+ * @param options - Window in hours (default 168 = 7d) and row limit
+ * @returns Pairs sorted by clicks descending plus the covered window
+ */
+export async function adminGetGscKeywordPages(options?: { periodHours?: number; limit?: number }
+): Promise<IGscKeywordPagesResult> {
+    const response = await apiClient.get('/admin/users/analytics/gsc/keyword-pages', {
+        params: options
+    });
+    const data = response.data as Partial<IGscKeywordPagesResult>;
+    return {
+        windowStart: data.windowStart ?? '',
+        windowEnd: data.windowEnd ?? '',
+        pairs: data.pairs ?? []
+    };
+}
+
+/**
  * Get daily GSC keyword buckets for trend charting (admin endpoint).
  * @param days - Number of daily buckets (default 14)
  * @param topN - Max keywords per bucket (default 15)

--- a/src/frontend/modules/traffic/api/index.ts
+++ b/src/frontend/modules/traffic/api/index.ts
@@ -44,6 +44,7 @@ export {
     adminRefreshGscData,
     adminGetGscKeywords,
     adminGetGscPages,
+    adminGetGscKeywordPages,
     adminGetGscKeywordsByDay,
     // Crawler analytics functions
     adminGetBotTrend,
@@ -86,6 +87,8 @@ export type {
     IGscKeywordsResult,
     IGscPage,
     IGscPagesResult,
+    IGscKeywordPage,
+    IGscKeywordPagesResult,
     IGscDailyKeywords,
     ITrafficBucket,
     IBotClassDailyPoint,

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.module.scss
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.module.scss
@@ -7,12 +7,6 @@
 
 @use '../../../../../app/breakpoints' as *;
 
-.dashboard {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-lg);
-}
-
 /* Period controls moved to the shared PeriodPicker component. */
 
 .section_title {
@@ -115,48 +109,19 @@
     overflow-x: auto;
 }
 
-.table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: var(--font-size-body-sm);
-}
-
-.table th {
-    text-align: left;
-    padding: var(--gap-sm) var(--input-group-gap);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-muted);
-    font-size: var(--font-size-caption);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-wide);
-    border-bottom: var(--border-width-thin) solid var(--color-border);
-}
-
-.table td {
-    padding: var(--gap-sm) var(--input-group-gap);
-    color: var(--color-text);
-    border-bottom: var(--border-width-thin) solid var(--color-border);
-    vertical-align: middle;
-}
-
-.table tr:last-child td {
-    border-bottom: none;
-}
-
 .table__number {
     text-align: right;
     font-variant-numeric: tabular-nums;
 }
 
 /*
- * Numeric headers must right-align over their right-aligned cells. The base
- * `.table th { text-align: left }` rule outranks a bare `.table__number`
- * (both single-class, but `.table th` also matches the element, giving it the
- * higher specificity), so without this the header sat left while the numbers
- * sat right — header and content visibly out of column. Re-qualify with the
- * table ancestor to win the cascade.
+ * Numeric headers must right-align over their right-aligned cells. The shared
+ * <Table>/<Th> component's own `.th { text-align: left }` rule is a single
+ * class selector — equal specificity to a bare `.table__number`, so the
+ * winner would depend on unpredictable CSS Module bundling order. Re-qualify
+ * with the `th` element to reliably outrank it regardless of source order.
  */
-.table th.table__number {
+th.table__number {
     text-align: right;
 }
 
@@ -184,48 +149,18 @@
     opacity: 0.7;
 }
 
-/* Category badges — use semantic color tokens with opacity via color-mix */
-.category_badge {
-    display: inline-block;
-    font-size: var(--font-size-caption);
-    padding: var(--gap-2xs) var(--padding-sm);
-    border-radius: var(--radius-full);
-    font-weight: var(--font-weight-medium);
-}
-
-.category_badge--direct {
-    background: color-mix(in srgb, var(--color-text-muted) 20%, transparent);
-    color: var(--color-text-muted);
-}
-
-.category_badge--organic {
-    background: color-mix(in srgb, var(--color-success) 15%, transparent);
-    color: var(--color-success);
-}
-
-.category_badge--social {
-    background: color-mix(in srgb, var(--color-primary) 15%, transparent);
-    color: var(--color-primary);
-}
-
-.category_badge--referral {
-    background: color-mix(in srgb, var(--color-warning) 15%, transparent);
-    color: var(--color-warning);
-}
-
-.category_badge--paid {
-    background: color-mix(in srgb, var(--color-danger) 15%, transparent);
-    color: var(--color-danger);
-}
-
-.category_badge--email {
+/* Category badges — the Badge component (tone prop) now supplies the
+   structural look (padding, radius, font-size, uppercase). Email and ai
+   have no matching Badge tone, so they render on the neutral tone with
+   just a color override layered on top via these classes. */
+.category_badge_email {
     background: color-mix(in srgb, var(--color-secondary) 15%, transparent);
     color: var(--color-secondary);
 }
 
 /* AI-assistant referrals — a blend of two theme tokens keeps the hue distinct
    from social (primary) and email (secondary) while remaining fully themable. */
-.category_badge--ai {
+.category_badge_ai {
     background: color-mix(in srgb, color-mix(in srgb, var(--color-primary) 50%, var(--color-success)) 18%, transparent);
     color: color-mix(in srgb, var(--color-primary) 50%, var(--color-success));
 }
@@ -389,19 +324,12 @@
     flex-shrink: 0;
 }
 
-/* Google Search Console keyword table */
+/* Google Search Console keyword table. The Badge component (tone="info")
+   now supplies the structural look; only positioning inside the heading
+   remains here. */
 .gsc_badge {
-    display: inline-block;
-    font-size: var(--font-size-caption);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-primary);
-    background: color-mix(in srgb, var(--color-primary) 12%, transparent);
-    padding: var(--gap-2xs) var(--padding-xs);
-    border-radius: var(--radius-sm);
     margin-left: var(--padding-xs);
     vertical-align: middle;
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-wide);
 }
 
 .gsc_table {

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
@@ -32,7 +32,9 @@ import {
 import { LineChart } from '../../../../../features/charts/components/LineChart';
 import type { ChartSeries } from '../../../../../features/charts/components/LineChart';
 import { Card } from '../../../../../components/ui/Card';
-import { Grid } from '../../../../../components/layout';
+import { Badge, type BadgeTone } from '../../../../../components/ui/Badge';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
+import { Grid, Stack } from '../../../../../components/layout';
 import { OverviewTrend } from '../OverviewTrend';
 import {
     adminGetTrafficSources,
@@ -92,24 +94,28 @@ function formatDuration(seconds: number): string {
 }
 
 /**
- * Get CSS class for a traffic source category badge.
+ * Resolve the Badge tone (and, for categories with no direct tone
+ * equivalent, a color-override class) for a traffic source category badge.
  *
  * Categories come from the backend's stored channel classification
  * (direct/organic/paid/social/email/ai/referral); unknown values fall
- * back to the referral style.
+ * back to the referral tone. Five categories map onto an existing Badge
+ * tone; email and ai have no matching tone, so they render on the neutral
+ * tone with a small color-override class layered on top.
  *
  * @param category - Acquisition channel string
- * @returns CSS module class name
+ * @returns Badge tone plus an optional className for categories without a
+ *   direct Badge tone equivalent
  */
-function getCategoryClass(category: string): string {
+function getCategoryBadgeProps(category: string): { tone: BadgeTone; className?: string } {
     switch (category) {
-        case 'direct': return styles['category_badge--direct'];
-        case 'organic': return styles['category_badge--organic'];
-        case 'social': return styles['category_badge--social'];
-        case 'paid': return styles['category_badge--paid'];
-        case 'email': return styles['category_badge--email'];
-        case 'ai': return styles['category_badge--ai'];
-        default: return styles['category_badge--referral'];
+        case 'direct': return { tone: 'neutral' };
+        case 'organic': return { tone: 'success' };
+        case 'social': return { tone: 'info' };
+        case 'paid': return { tone: 'danger' };
+        case 'email': return { tone: 'neutral', className: styles.category_badge_email };
+        case 'ai': return { tone: 'neutral', className: styles.category_badge_ai };
+        default: return { tone: 'warning' };
     }
 }
 
@@ -315,7 +321,7 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
         : 1;
 
     return (
-        <div className={styles.dashboard}>
+        <Stack gap="lg">
             {/* Overview headline — KPI strip + unified trend (owns its fetch) */}
             <OverviewTrend period={period} customRange={customRange} includeBots={includeBots} refreshSignal={refreshSignal} />
 
@@ -372,25 +378,25 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
                                     <div className={styles.empty_state}>No traffic data for this period</div>
                                 ) : (
                                     <div className={styles.table_wrapper}>
-                                        <table className={styles.table}>
-                                            <thead>
-                                                <tr>
-                                                    <th className={styles.table__expand_cell}></th>
-                                                    <th>Source</th>
-                                                    <th>Category</th>
-                                                    <th className={styles.table__number}>Visitors</th>
-                                                    <th className={styles.table__bar_cell}></th>
-                                                    <th className={styles.table__number}>%</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
+                                        <Table>
+                                            <Thead>
+                                                <Tr>
+                                                    <Th scope="col" className={styles.table__expand_cell}></Th>
+                                                    <Th scope="col">Source</Th>
+                                                    <Th scope="col">Category</Th>
+                                                    <Th scope="col" className={styles.table__number}>Visitors</Th>
+                                                    <Th scope="col" className={styles.table__bar_cell}></Th>
+                                                    <Th scope="col" className={styles.table__number}>%</Th>
+                                                </Tr>
+                                            </Thead>
+                                            <Tbody>
                                                 {trafficSources.map(s => {
                                                     const isExpanded = expandedSource === s.source;
                                                     const details = sourceDetails[s.source];
                                                     const isLoading = sourceDetailsLoading === s.source;
                                                     return (
                                                         <React.Fragment key={s.source}>
-                                                            <tr
+                                                            <Tr
                                                                 className={`${styles.table__row_clickable} ${isExpanded ? styles.table__row_expanded : ''}`}
                                                                 onClick={() => toggleSourceDetails(s.source)}
                                                                 role="button"
@@ -403,30 +409,30 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
                                                                 }}
                                                                 aria-expanded={isExpanded}
                                                             >
-                                                                <td className={styles.table__expand_cell}>
+                                                                <Td className={styles.table__expand_cell}>
                                                                     {isExpanded
                                                                         ? <ChevronDown size={14} />
                                                                         : <ChevronRight size={14} />
                                                                     }
-                                                                </td>
-                                                                <td>{s.source}</td>
-                                                                <td>
-                                                                    <span className={`${styles.category_badge} ${getCategoryClass(s.category)}`}>
+                                                                </Td>
+                                                                <Td>{s.source}</Td>
+                                                                <Td>
+                                                                    <Badge {...getCategoryBadgeProps(s.category)}>
                                                                         {s.category}
-                                                                    </span>
-                                                                </td>
-                                                                <td className={styles.table__number}>{s.visitors.toLocaleString()}</td>
-                                                                <td className={styles.table__bar_cell}>
+                                                                    </Badge>
+                                                                </Td>
+                                                                <Td className={styles.table__number}>{s.visitors.toLocaleString()}</Td>
+                                                                <Td className={styles.table__bar_cell}>
                                                                     <div
                                                                         className={styles.table__bar}
                                                                         style={{ width: `${(s.visitors / maxSourceCount) * 100}%` }}
                                                                     />
-                                                                </td>
-                                                                <td className={styles.table__number}>{s.percentage}%</td>
-                                                            </tr>
+                                                                </Td>
+                                                                <Td className={styles.table__number}>{s.percentage}%</Td>
+                                                            </Tr>
                                                             {isExpanded && (
-                                                                <tr className={styles.detail_row}>
-                                                                    <td colSpan={6} className={styles.detail_row__cell}>
+                                                                <Tr className={styles.detail_row}>
+                                                                    <Td colSpan={6} className={styles.detail_row__cell}>
                                                                         {isLoading ? (
                                                                             <div className={styles.detail_loading}>Loading details...</div>
                                                                         ) : details ? (
@@ -528,30 +534,30 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
                                                                                     <div className={styles.detail_section}>
                                                                                         <h4 className={styles.detail_section__title}>
                                                                                             Search Keywords
-                                                                                            <span className={styles.gsc_badge}>Search Console</span>
+                                                                                            <Badge tone="info" className={styles.gsc_badge}>Search Console</Badge>
                                                                                         </h4>
-                                                                                        <table className={styles.gsc_table}>
-                                                                                            <thead>
-                                                                                                <tr>
-                                                                                                    <th className={styles.gsc_table__keyword}>Keyword</th>
-                                                                                                    <th className={styles.gsc_table__metric}>Clicks</th>
-                                                                                                    <th className={styles.gsc_table__metric}>Impr.</th>
-                                                                                                    <th className={styles.gsc_table__metric}>CTR</th>
-                                                                                                    <th className={styles.gsc_table__metric}>Pos.</th>
-                                                                                                </tr>
-                                                                                            </thead>
-                                                                                            <tbody>
+                                                                                        <Table className={styles.gsc_table}>
+                                                                                            <Thead>
+                                                                                                <Tr>
+                                                                                                    <Th scope="col" className={styles.gsc_table__keyword}>Keyword</Th>
+                                                                                                    <Th scope="col" className={styles.gsc_table__metric}>Clicks</Th>
+                                                                                                    <Th scope="col" className={styles.gsc_table__metric}>Impr.</Th>
+                                                                                                    <Th scope="col" className={styles.gsc_table__metric}>CTR</Th>
+                                                                                                    <Th scope="col" className={styles.gsc_table__metric}>Pos.</Th>
+                                                                                                </Tr>
+                                                                                            </Thead>
+                                                                                            <Tbody>
                                                                                                 {details.gscKeywords.map(kw => (
-                                                                                                    <tr key={kw.keyword}>
-                                                                                                        <td className={styles.gsc_table__keyword}>{kw.keyword}</td>
-                                                                                                        <td className={styles.gsc_table__metric}>{kw.clicks.toLocaleString()}</td>
-                                                                                                        <td className={styles.gsc_table__metric}>{kw.impressions.toLocaleString()}</td>
-                                                                                                        <td className={styles.gsc_table__metric}>{(kw.ctr * 100).toFixed(1)}%</td>
-                                                                                                        <td className={styles.gsc_table__metric}>{kw.position.toFixed(1)}</td>
-                                                                                                    </tr>
+                                                                                                    <Tr key={kw.keyword}>
+                                                                                                        <Td className={styles.gsc_table__keyword}>{kw.keyword}</Td>
+                                                                                                        <Td className={styles.gsc_table__metric}>{kw.clicks.toLocaleString()}</Td>
+                                                                                                        <Td className={styles.gsc_table__metric}>{kw.impressions.toLocaleString()}</Td>
+                                                                                                        <Td className={styles.gsc_table__metric}>{(kw.ctr * 100).toFixed(1)}%</Td>
+                                                                                                        <Td className={styles.gsc_table__metric}>{kw.position.toFixed(1)}</Td>
+                                                                                                    </Tr>
                                                                                                 ))}
-                                                                                            </tbody>
-                                                                                        </table>
+                                                                                            </Tbody>
+                                                                                        </Table>
                                                                                     </div>
                                                                                 ) : details.searchKeywords.length > 0 ? (
                                                                                     <div className={styles.detail_section}>
@@ -588,14 +594,14 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
                                                                                 )}
                                                                             </div>
                                                                         ) : null}
-                                                                    </td>
-                                                                </tr>
+                                                                    </Td>
+                                                                </Tr>
                                                             )}
                                                         </React.Fragment>
                                                     );
                                                 })}
-                                            </tbody>
-                                        </table>
+                                            </Tbody>
+                                        </Table>
                                     </div>
                                 )}
                             </div>
@@ -621,29 +627,29 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
                                     <div className={styles.empty_state}>No landing page data for this period</div>
                                 ) : (
                                     <div className={styles.table_wrapper}>
-                                        <table className={styles.table}>
-                                            <thead>
-                                                <tr>
-                                                    <th>Page</th>
-                                                    <th className={styles.table__number}>Visitors</th>
-                                                    <th className={styles.table__bar_cell}></th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
+                                        <Table>
+                                            <Thead>
+                                                <Tr>
+                                                    <Th scope="col">Page</Th>
+                                                    <Th scope="col" className={styles.table__number}>Visitors</Th>
+                                                    <Th scope="col" className={styles.table__bar_cell}></Th>
+                                                </Tr>
+                                            </Thead>
+                                            <Tbody>
                                                 {landingPages.map(p => (
-                                                    <tr key={p.path}>
-                                                        <td className={styles.table__truncate} title={p.path}>{p.path}</td>
-                                                        <td className={styles.table__number}>{p.visitors.toLocaleString()}</td>
-                                                        <td className={styles.table__bar_cell}>
+                                                    <Tr key={p.path}>
+                                                        <Td className={styles.table__truncate} title={p.path}>{p.path}</Td>
+                                                        <Td className={styles.table__number}>{p.visitors.toLocaleString()}</Td>
+                                                        <Td className={styles.table__bar_cell}>
                                                             <div
                                                                 className={styles.table__bar}
                                                                 style={{ width: `${(p.visitors / maxPageVisitors) * 100}%` }}
                                                             />
-                                                        </td>
-                                                    </tr>
+                                                        </Td>
+                                                    </Tr>
                                                 ))}
-                                            </tbody>
-                                        </table>
+                                            </Tbody>
+                                        </Table>
                                     </div>
                                 )}
                             </div>
@@ -660,31 +666,31 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
                                     <div className={styles.empty_state}>No geographic data for this period</div>
                                 ) : (
                                     <div className={styles.table_wrapper}>
-                                        <table className={styles.table}>
-                                            <thead>
-                                                <tr>
-                                                    <th>Country</th>
-                                                    <th className={styles.table__number}>Visitors</th>
-                                                    <th className={styles.table__bar_cell}></th>
-                                                    <th className={styles.table__number}>%</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
+                                        <Table>
+                                            <Thead>
+                                                <Tr>
+                                                    <Th scope="col">Country</Th>
+                                                    <Th scope="col" className={styles.table__number}>Visitors</Th>
+                                                    <Th scope="col" className={styles.table__bar_cell}></Th>
+                                                    <Th scope="col" className={styles.table__number}>%</Th>
+                                                </Tr>
+                                            </Thead>
+                                            <Tbody>
                                                 {geoData.map(g => (
-                                                    <tr key={g.country}>
-                                                        <td>{g.country}</td>
-                                                        <td className={styles.table__number}>{g.count.toLocaleString()}</td>
-                                                        <td className={styles.table__bar_cell}>
+                                                    <Tr key={g.country}>
+                                                        <Td>{g.country}</Td>
+                                                        <Td className={styles.table__number}>{g.count.toLocaleString()}</Td>
+                                                        <Td className={styles.table__bar_cell}>
                                                             <div
                                                                 className={styles.table__bar}
                                                                 style={{ width: `${(g.count / maxGeoCount) * 100}%` }}
                                                             />
-                                                        </td>
-                                                        <td className={styles.table__number}>{g.percentage}%</td>
-                                                    </tr>
+                                                        </Td>
+                                                        <Td className={styles.table__number}>{g.percentage}%</Td>
+                                                    </Tr>
                                                 ))}
-                                            </tbody>
-                                        </table>
+                                            </Tbody>
+                                        </Table>
                                     </div>
                                 )}
                             </div>
@@ -730,40 +736,42 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
                             </h3>
                             <div>
                                 <div className={styles.table_wrapper}>
-                                    <table className={styles.table}>
-                                        <thead>
-                                            <tr>
-                                                <th>Source</th>
-                                                <th>Medium</th>
-                                                <th>Campaign</th>
-                                                <th className={styles.table__number}>Visitors</th>
-                                                <th
+                                    <Table>
+                                        <Thead>
+                                            <Tr>
+                                                <Th scope="col">Source</Th>
+                                                <Th scope="col">Medium</Th>
+                                                <Th scope="col">Campaign</Th>
+                                                <Th scope="col" className={styles.table__number}>Visitors</Th>
+                                                <Th
+                                                    scope="col"
                                                     className={styles.table__number}
                                                     title="Visitors logged in at any point during the window — includes returning account holders, not only new signups"
                                                 >
                                                     Logged In
-                                                </th>
-                                                <th
+                                                </Th>
+                                                <Th
+                                                    scope="col"
                                                     className={styles.table__number}
                                                     title="Logged-in visitors / visitors"
                                                 >
                                                     Login %
-                                                </th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
+                                                </Th>
+                                            </Tr>
+                                        </Thead>
+                                        <Tbody>
                                             {campaigns.map(c => (
-                                                <tr key={`${c.source}|${c.medium}|${c.campaign}`}>
-                                                    <td>{c.source}</td>
-                                                    <td>{c.medium}</td>
-                                                    <td>{c.campaign}</td>
-                                                    <td className={styles.table__number}>{c.visitors.toLocaleString()}</td>
-                                                    <td className={styles.table__number}>{c.conversions}</td>
-                                                    <td className={styles.table__number}>{c.conversionRate}%</td>
-                                                </tr>
+                                                <Tr key={`${c.source}|${c.medium}|${c.campaign}`}>
+                                                    <Td>{c.source}</Td>
+                                                    <Td>{c.medium}</Td>
+                                                    <Td>{c.campaign}</Td>
+                                                    <Td className={styles.table__number}>{c.visitors.toLocaleString()}</Td>
+                                                    <Td className={styles.table__number}>{c.conversions}</Td>
+                                                    <Td className={styles.table__number}>{c.conversionRate}%</Td>
+                                                </Tr>
                                             ))}
-                                        </tbody>
-                                    </table>
+                                        </Tbody>
+                                    </Table>
                                 </div>
                             </div>
                         </Card>
@@ -822,6 +830,6 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
                     )}
                 </>
             )}
-        </div>
+        </Stack>
     );
 }

--- a/src/frontend/modules/traffic/components/admin/CrawlerDashboard/CrawlerDashboard.module.scss
+++ b/src/frontend/modules/traffic/components/admin/CrawlerDashboard/CrawlerDashboard.module.scss
@@ -11,9 +11,6 @@
 .container {
     container-type: inline-size;
     container-name: crawler-dashboard;
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-lg);
 }
 
 .header {
@@ -40,24 +37,26 @@
 }
 
 .window_picker {
-    display: inline-flex;
-    background: var(--color-surface-muted);
-    border-radius: var(--radius-full);
-    padding: var(--padding-2xs);
+    display: flex;
+    gap: 0;
     border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
 }
 
 .window_button,
 .window_active {
+    padding: var(--padding-xs) var(--gap-md);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-medium);
     border: none;
-    background: transparent;
-    color: var(--color-text-muted);
-    font-size: var(--font-size-body-sm);
-    font-weight: var(--font-weight-semibold);
-    padding: var(--padding-2xs) var(--padding-sm);
-    border-radius: var(--radius-full);
     cursor: pointer;
-    transition: background-color var(--transition-base), color var(--transition-base);
+    transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.window_button {
+    color: var(--color-text-muted);
+    background: var(--color-surface);
 }
 
 .window_button:hover {
@@ -65,8 +64,8 @@
 }
 
 .window_active {
-    background: var(--gradient-primary);
     color: var(--color-text);
+    background: var(--gradient-primary);
 }
 
 .notice_card {
@@ -113,30 +112,6 @@
     font-size: var(--font-size-body-sm);
     color: var(--color-danger);
     margin: 0;
-}
-
-.table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: var(--font-size-body-sm);
-
-    th,
-    td {
-        text-align: left;
-        padding: var(--padding-sm) var(--padding-md);
-        border-bottom: var(--border-width-thin) solid var(--color-border);
-        vertical-align: middle;
-    }
-
-    th {
-        font-weight: var(--font-weight-semibold);
-        color: var(--color-text-muted);
-        background: var(--color-surface-muted);
-    }
-
-    tbody tr:last-child td {
-        border-bottom: none;
-    }
 }
 
 .numeric_col {

--- a/src/frontend/modules/traffic/components/admin/CrawlerDashboard/CrawlerDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/CrawlerDashboard/CrawlerDashboard.tsx
@@ -32,6 +32,8 @@ import { LineChart } from '../../../../../features/charts/components/LineChart';
 import type { ChartSeries } from '../../../../../features/charts/components/LineChart';
 import { Card } from '../../../../../components/ui/Card';
 import { Select } from '../../../../../components/ui/Select';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
+import { Stack } from '../../../../../components/layout';
 import { adminGetBotTrend, adminGetBotPaths } from '../../../api';
 import type { IBotClassDailyPoint, ITrafficBucket } from '../../../api';
 import styles from './CrawlerDashboard.module.scss';
@@ -221,7 +223,7 @@ export function CrawlerDashboard({ refreshSignal }: ICrawlerDashboardProps) {
     const numberFormatter = useMemo(() => new Intl.NumberFormat(), []);
 
     return (
-        <div className={styles.container}>
+        <Stack gap="lg" className={styles.container}>
             <header className={styles.header}>
                 <div>
                     <h2 className={styles.title}>Crawlers</h2>
@@ -300,24 +302,24 @@ export function CrawlerDashboard({ refreshSignal }: ICrawlerDashboardProps) {
                 ) : !paths || paths.length === 0 ? (
                     <p className={styles.panel_empty}>No events for this class in this window.</p>
                 ) : (
-                    <table className={styles.table}>
-                        <thead>
-                            <tr>
-                                <th scope="col">path</th>
-                                <th scope="col" className={styles.numeric_col}>events</th>
-                            </tr>
-                        </thead>
-                        <tbody>
+                    <Table>
+                        <Thead>
+                            <Tr>
+                                <Th scope="col">path</Th>
+                                <Th scope="col" className={styles.numeric_col}>events</Th>
+                            </Tr>
+                        </Thead>
+                        <Tbody>
                             {paths.map((b, i) => (
-                                <tr key={`${b.key ?? 'null'}_${i}`}>
-                                    <td><code className={styles.code}>{b.key ?? '(null)'}</code></td>
-                                    <td className={styles.numeric}>{numberFormatter.format(b.count)}</td>
-                                </tr>
+                                <Tr key={`${b.key ?? 'null'}_${i}`}>
+                                    <Td><code className={styles.code}>{b.key ?? '(null)'}</code></Td>
+                                    <Td className={styles.numeric}>{numberFormatter.format(b.count)}</Td>
+                                </Tr>
                             ))}
-                        </tbody>
-                    </table>
+                        </Tbody>
+                    </Table>
                 )}
             </Card>
-        </div>
+        </Stack>
     );
 }

--- a/src/frontend/modules/traffic/components/admin/GscKeywords/GscKeywords.module.scss
+++ b/src/frontend/modules/traffic/components/admin/GscKeywords/GscKeywords.module.scss
@@ -2,8 +2,9 @@
  * GscKeywords styles.
  *
  * GSC keyword dashboard — clicks/impressions trend pair plus the
- * top-keywords table. Container query collapses the chart pair to a
- * single column at narrow widths.
+ * top-keywords table. The chart pair collapses to one column by its own
+ * width via the shared <Grid columns="responsive"> (auto-fit); the
+ * container context here backs the .header collapse.
  */
 
 @use '../../../../../app/breakpoints' as *;

--- a/src/frontend/modules/traffic/components/admin/GscKeywords/GscKeywords.module.scss
+++ b/src/frontend/modules/traffic/components/admin/GscKeywords/GscKeywords.module.scss
@@ -11,9 +11,6 @@
 .container {
     container-type: inline-size;
     container-name: gsc-keywords;
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-lg);
 }
 
 .header {
@@ -62,24 +59,26 @@
 }
 
 .window_picker {
-    display: inline-flex;
-    background: var(--color-surface-muted);
-    border-radius: var(--radius-full);
-    padding: var(--padding-2xs);
+    display: flex;
+    gap: 0;
     border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
 }
 
 .window_button,
 .window_active {
+    padding: var(--padding-xs) var(--gap-md);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-medium);
     border: none;
-    background: transparent;
-    color: var(--color-text-muted);
-    font-size: var(--font-size-body-sm);
-    font-weight: var(--font-weight-semibold);
-    padding: var(--padding-2xs) var(--padding-sm);
-    border-radius: var(--radius-full);
     cursor: pointer;
-    transition: background-color var(--transition-base), color var(--transition-base);
+    transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.window_button {
+    color: var(--color-text-muted);
+    background: var(--color-surface);
 }
 
 .window_button:hover {
@@ -87,14 +86,8 @@
 }
 
 .window_active {
-    background: var(--gradient-primary);
     color: var(--color-text);
-}
-
-.grid_two {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--grid-gap-md);
+    background: var(--gradient-primary);
 }
 
 .panel {
@@ -124,34 +117,17 @@
     margin: 0;
 }
 
+.panel_note {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+    margin: 0;
+    max-width: var(--max-width-prose);
+}
+
 .panel_error {
     font-size: var(--font-size-body-sm);
     color: var(--color-danger);
     margin: 0;
-}
-
-.table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: var(--font-size-body-sm);
-
-    th,
-    td {
-        text-align: left;
-        padding: var(--padding-sm) var(--padding-md);
-        border-bottom: var(--border-width-thin) solid var(--color-border);
-        vertical-align: middle;
-    }
-
-    th {
-        font-weight: var(--font-weight-semibold);
-        color: var(--color-text-muted);
-        background: var(--color-surface-muted);
-    }
-
-    tbody tr:last-child td {
-        border-bottom: none;
-    }
 }
 
 .numeric_col {
@@ -180,14 +156,5 @@
 
     .picker_stack {
         align-items: flex-start;
-    }
-
-    .grid_two {
-        grid-template-columns: 1fr;
-    }
-
-    .table th,
-    .table td {
-        padding: var(--padding-xs) var(--padding-sm);
     }
 }

--- a/src/frontend/modules/traffic/components/admin/GscKeywords/GscKeywords.tsx
+++ b/src/frontend/modules/traffic/components/admin/GscKeywords/GscKeywords.tsx
@@ -17,6 +17,10 @@
  *   `query` dimension it escapes GSC's query anonymization, so it accounts for
  *   clicks that no keyword row can (the anonymized low-volume queries), and
  *   including impressions surfaces pages Google showed even with zero clicks.
+ * - **Keyword → page pairs table** — the join the two tables above cannot
+ *   express: which page each keyword surfaced. Aggregates the raw query cache
+ *   by the `{query, page}` couple, so it inherits the same query anonymization
+ *   as the keyword table and will not fully reconcile with the top-pages totals.
  *
  * Chart totals come from the backend's date-only GSC totals (immune to
  * query anonymization); the keyword table is limited to non-anonymized
@@ -30,13 +34,15 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { AlertTriangle, FileText, Search, TrendingUp } from 'lucide-react';
+import { AlertTriangle, FileText, Link2, Search, TrendingUp } from 'lucide-react';
 import { LineChart } from '../../../../../features/charts/components/LineChart';
 import type { ChartSeries } from '../../../../../features/charts/components/LineChart';
+import { Stack, Grid } from '../../../../../components/layout';
 import { Card } from '../../../../../components/ui/Card';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
-import { adminGetGscKeywords, adminGetGscPages, adminGetGscKeywordsByDay, adminGetGscStatus } from '../../../api';
-import type { IGscKeyword, IGscPage, IGscDailyKeywords, IGscStatus } from '../../../api';
+import { adminGetGscKeywords, adminGetGscPages, adminGetGscKeywordPages, adminGetGscKeywordsByDay, adminGetGscStatus } from '../../../api';
+import type { IGscKeyword, IGscPage, IGscKeywordPage, IGscDailyKeywords, IGscStatus } from '../../../api';
 import styles from './GscKeywords.module.scss';
 
 /** Keyword-table lookback windows. 30d is the backend's hard ceiling. */
@@ -78,6 +84,10 @@ export function GscKeywords() {
     const [pagesError, setPagesError] = useState<string | null>(null);
     const [pagesLoading, setPagesLoading] = useState(true);
 
+    const [pairs, setPairs] = useState<IGscKeywordPage[] | null>(null);
+    const [pairsError, setPairsError] = useState<string | null>(null);
+    const [pairsLoading, setPairsLoading] = useState(true);
+
     const [daily, setDaily] = useState<IGscDailyKeywords[] | null>(null);
     const [dailyError, setDailyError] = useState<string | null>(null);
     const [dailyLoading, setDailyLoading] = useState(true);
@@ -117,6 +127,22 @@ export function GscKeywords() {
             .then(data => { if (active) setPages(data.pages); })
             .catch(err => { if (active) setPagesError(err instanceof Error ? err.message : 'Failed to load'); })
             .finally(() => { if (active) setPagesLoading(false); });
+
+        return () => { active = false; };
+    }, [periodHours]);
+
+    // Keyword→page pairs fetch — re-runs when the window changes, keyed to the
+    // same picker as the tables above. Reads the raw query cache, so it carries
+    // GSC's query anonymization exactly as the keyword table does.
+    useEffect(() => {
+        let active = true;
+        setPairsLoading(true);
+        setPairsError(null);
+
+        adminGetGscKeywordPages({ periodHours, limit: 50 })
+            .then(data => { if (active) setPairs(data.pairs); })
+            .catch(err => { if (active) setPairsError(err instanceof Error ? err.message : 'Failed to load'); })
+            .finally(() => { if (active) setPairsLoading(false); });
 
         return () => { active = false; };
     }, [periodHours]);
@@ -175,7 +201,7 @@ export function GscKeywords() {
     const numberFormatter = useMemo(() => new Intl.NumberFormat(), []);
 
     return (
-        <div className={styles.container}>
+        <Stack gap="lg" className={styles.container}>
             <header className={styles.header}>
                 <div>
                     <h2 className={styles.title}>Search keywords</h2>
@@ -229,7 +255,7 @@ export function GscKeywords() {
                 </div>
             </header>
 
-            <div className={styles.grid_two}>
+            <Grid columns={2} gap="md">
                 <Card padding="md" className={styles.panel}>
                     <div className={styles.panel_header}>
                         <TrendingUp size={18} aria-hidden="true" />
@@ -267,7 +293,7 @@ export function GscKeywords() {
                         />
                     )}
                 </Card>
-            </div>
+            </Grid>
 
             <Card padding="md" className={styles.panel}>
                 <div className={styles.panel_header}>
@@ -286,28 +312,28 @@ export function GscKeywords() {
                         status above and the Settings tab.
                     </p>
                 ) : (
-                    <table className={styles.table}>
-                        <thead>
-                            <tr>
-                                <th scope="col">keyword</th>
-                                <th scope="col" className={styles.numeric_col}>clicks</th>
-                                <th scope="col" className={styles.numeric_col}>impressions</th>
-                                <th scope="col" className={styles.numeric_col}>CTR</th>
-                                <th scope="col" className={styles.numeric_col}>position</th>
-                            </tr>
-                        </thead>
-                        <tbody>
+                    <Table>
+                        <Thead>
+                            <Tr>
+                                <Th scope="col">keyword</Th>
+                                <Th scope="col" className={styles.numeric_col}>clicks</Th>
+                                <Th scope="col" className={styles.numeric_col}>impressions</Th>
+                                <Th scope="col" className={styles.numeric_col}>CTR</Th>
+                                <Th scope="col" className={styles.numeric_col}>position</Th>
+                            </Tr>
+                        </Thead>
+                        <Tbody>
                             {keywords.map(kw => (
-                                <tr key={kw.keyword}>
-                                    <td className={styles.keyword_cell}>{kw.keyword}</td>
-                                    <td className={styles.numeric}>{numberFormatter.format(kw.clicks)}</td>
-                                    <td className={styles.numeric}>{numberFormatter.format(kw.impressions)}</td>
-                                    <td className={styles.numeric}>{(kw.ctr * 100).toFixed(1)}%</td>
-                                    <td className={styles.numeric}>{kw.position.toFixed(1)}</td>
-                                </tr>
+                                <Tr key={kw.keyword}>
+                                    <Td className={styles.keyword_cell}>{kw.keyword}</Td>
+                                    <Td className={styles.numeric}>{numberFormatter.format(kw.clicks)}</Td>
+                                    <Td className={styles.numeric}>{numberFormatter.format(kw.impressions)}</Td>
+                                    <Td className={styles.numeric}>{(kw.ctr * 100).toFixed(1)}%</Td>
+                                    <Td className={styles.numeric}>{kw.position.toFixed(1)}</Td>
+                                </Tr>
                             ))}
-                        </tbody>
-                    </table>
+                        </Tbody>
+                    </Table>
                 )}
             </Card>
 
@@ -328,30 +354,81 @@ export function GscKeywords() {
                         the current window immediately.
                     </p>
                 ) : (
-                    <table className={styles.table}>
-                        <thead>
-                            <tr>
-                                <th scope="col">page</th>
-                                <th scope="col" className={styles.numeric_col}>clicks</th>
-                                <th scope="col" className={styles.numeric_col}>impressions</th>
-                                <th scope="col" className={styles.numeric_col}>CTR</th>
-                                <th scope="col" className={styles.numeric_col}>position</th>
-                            </tr>
-                        </thead>
-                        <tbody>
+                    <Table>
+                        <Thead>
+                            <Tr>
+                                <Th scope="col">page</Th>
+                                <Th scope="col" className={styles.numeric_col}>clicks</Th>
+                                <Th scope="col" className={styles.numeric_col}>impressions</Th>
+                                <Th scope="col" className={styles.numeric_col}>CTR</Th>
+                                <Th scope="col" className={styles.numeric_col}>position</Th>
+                            </Tr>
+                        </Thead>
+                        <Tbody>
                             {pages.map(pg => (
-                                <tr key={pg.page}>
-                                    <td className={styles.keyword_cell}>{pg.page}</td>
-                                    <td className={styles.numeric}>{numberFormatter.format(pg.clicks)}</td>
-                                    <td className={styles.numeric}>{numberFormatter.format(pg.impressions)}</td>
-                                    <td className={styles.numeric}>{(pg.ctr * 100).toFixed(1)}%</td>
-                                    <td className={styles.numeric}>{pg.position.toFixed(1)}</td>
-                                </tr>
+                                <Tr key={pg.page}>
+                                    <Td className={styles.keyword_cell}>{pg.page}</Td>
+                                    <Td className={styles.numeric}>{numberFormatter.format(pg.clicks)}</Td>
+                                    <Td className={styles.numeric}>{numberFormatter.format(pg.impressions)}</Td>
+                                    <Td className={styles.numeric}>{(pg.ctr * 100).toFixed(1)}%</Td>
+                                    <Td className={styles.numeric}>{pg.position.toFixed(1)}</Td>
+                                </Tr>
                             ))}
-                        </tbody>
-                    </table>
+                        </Tbody>
+                    </Table>
                 )}
             </Card>
-        </div>
+
+            <Card padding="md" className={styles.panel}>
+                <div className={styles.panel_header}>
+                    <Link2 size={18} aria-hidden="true" />
+                    <h3 className={styles.panel_title}>Keyword → page pairs</h3>
+                </div>
+                <p className={styles.panel_note}>
+                    Which page each keyword surfaced — the join the two tables
+                    above can&apos;t show. Drawn from the raw query cache, so it
+                    carries the same low-volume-query anonymization as the top
+                    keywords table; clicks here won&apos;t fully reconcile with
+                    the anonymization-immune top pages totals.
+                </p>
+                {pairsError ? (
+                    <p className={styles.panel_error}>{pairsError}</p>
+                ) : pairsLoading ? (
+                    <p className={styles.panel_loading}>Loading…</p>
+                ) : !pairs || pairs.length === 0 ? (
+                    <p className={styles.panel_empty}>
+                        No keyword→page pairs in this window — Google omits
+                        anonymized low-volume queries from the underlying rows,
+                        so quiet windows can be empty even when the top pages
+                        table shows clicks. Check the fetch status above.
+                    </p>
+                ) : (
+                    <Table>
+                        <Thead>
+                            <Tr>
+                                <Th scope="col">keyword</Th>
+                                <Th scope="col">page</Th>
+                                <Th scope="col" className={styles.numeric_col}>clicks</Th>
+                                <Th scope="col" className={styles.numeric_col}>impressions</Th>
+                                <Th scope="col" className={styles.numeric_col}>CTR</Th>
+                                <Th scope="col" className={styles.numeric_col}>position</Th>
+                            </Tr>
+                        </Thead>
+                        <Tbody>
+                            {pairs.map(pair => (
+                                <Tr key={`${pair.keyword} ${pair.page}`}>
+                                    <Td className={styles.keyword_cell}>{pair.keyword}</Td>
+                                    <Td className={styles.keyword_cell}>{pair.page}</Td>
+                                    <Td className={styles.numeric}>{numberFormatter.format(pair.clicks)}</Td>
+                                    <Td className={styles.numeric}>{numberFormatter.format(pair.impressions)}</Td>
+                                    <Td className={styles.numeric}>{(pair.ctr * 100).toFixed(1)}%</Td>
+                                    <Td className={styles.numeric}>{pair.position.toFixed(1)}</Td>
+                                </Tr>
+                            ))}
+                        </Tbody>
+                    </Table>
+                )}
+            </Card>
+        </Stack>
     );
 }

--- a/src/frontend/modules/traffic/components/admin/GscKeywords/GscKeywords.tsx
+++ b/src/frontend/modules/traffic/components/admin/GscKeywords/GscKeywords.tsx
@@ -255,7 +255,7 @@ export function GscKeywords() {
                 </div>
             </header>
 
-            <Grid columns={2} gap="md">
+            <Grid columns="responsive" gap="md">
                 <Card padding="md" className={styles.panel}>
                     <div className={styles.panel_header}>
                         <TrendingUp size={18} aria-hidden="true" />

--- a/src/frontend/modules/traffic/components/admin/GscSettings/GscSettings.module.scss
+++ b/src/frontend/modules/traffic/components/admin/GscSettings/GscSettings.module.scss
@@ -8,9 +8,6 @@
 @use '../../../../../app/breakpoints' as *;
 
 .container {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-lg);
     container-type: inline-size;
     container-name: gsc-settings;
 }

--- a/src/frontend/modules/traffic/components/admin/GscSettings/GscSettings.tsx
+++ b/src/frontend/modules/traffic/components/admin/GscSettings/GscSettings.tsx
@@ -148,7 +148,7 @@ export function GscSettings() {
     }
 
     return (
-        <div className={styles.container}>
+        <Stack gap="lg" className={styles.container}>
             <Card padding="lg">
                 <Stack gap="md">
                     <h3>Google Search Console</h3>
@@ -294,6 +294,6 @@ export function GscSettings() {
                     )}
                 </Stack>
             </Card>
-        </div>
+        </Stack>
     );
 }

--- a/src/frontend/modules/traffic/components/admin/IgnoredUsers/IgnoredUsers.tsx
+++ b/src/frontend/modules/traffic/components/admin/IgnoredUsers/IgnoredUsers.tsx
@@ -17,7 +17,7 @@
  * auth, so the initial load state here is the permitted admin case.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useId } from 'react';
 import { isAxiosError } from 'axios';
 import { Search, UserX, X } from 'lucide-react';
 import { Button } from '../../../../../components/ui/Button';
@@ -69,6 +69,9 @@ export function IgnoredUsers() {
     const [results, setResults] = useState<IAccountMatch[]>([]);
     const [searching, setSearching] = useState(false);
     const [adding, setAdding] = useState(false);
+    // Stable id tying the search input to its results listbox for the ARIA
+    // combobox contract (aria-controls ↔ the <ul id>). Matches AccountPicker.
+    const listId = useId();
     useEffect(() => {
         let active = true;
         adminGetIgnoredUsers()
@@ -171,19 +174,23 @@ export function IgnoredUsers() {
                             <Search size={16} aria-hidden="true" className={styles.search_icon} />
                             <Input
                                 type="text"
+                                role="combobox"
                                 className={styles.search_field}
                                 value={query}
                                 onChange={e => setQuery(e.target.value)}
                                 placeholder="Search accounts by email, name, or paste a user id"
                                 aria-label="Search accounts to ignore"
+                                aria-controls={listId}
+                                aria-expanded={results.length > 0 || searching || !!rawIdOffer}
+                                aria-autocomplete="list"
                             />
                         </div>
 
                         {(results.length > 0 || searching || rawIdOffer) && (
-                            <ul className={styles.results} role="listbox" aria-label="Account search results">
+                            <ul className={styles.results} id={listId} role="listbox" aria-label="Account search results">
                                 {searching && <li className={styles.results_note}>Searching…</li>}
                                 {!searching && results.map(a => (
-                                    <li key={a.id}>
+                                    <li key={a.id} role="option" aria-selected={false}>
                                         <button
                                             type="button"
                                             className={styles.result}
@@ -199,7 +206,7 @@ export function IgnoredUsers() {
                                     </li>
                                 ))}
                                 {!searching && rawIdOffer && (
-                                    <li>
+                                    <li role="option" aria-selected={false}>
                                         <button
                                             type="button"
                                             className={styles.result}

--- a/src/frontend/modules/traffic/components/admin/PageActivity/PageActivity.module.scss
+++ b/src/frontend/modules/traffic/components/admin/PageActivity/PageActivity.module.scss
@@ -11,19 +11,12 @@
 .container {
     container-type: inline-size;
     container-name: page-activity;
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-lg);
 }
 
 .section {
     display: flex;
     flex-direction: column;
     gap: var(--gap-md);
-    background: var(--color-surface-muted);
-    border: var(--border-width-thin) solid var(--color-border);
-    border-radius: var(--radius-md);
-    padding: var(--card-padding-sm);
 }
 
 .section_header {
@@ -43,35 +36,6 @@
 
 .table_wrapper {
     overflow-x: auto;
-}
-
-.table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: var(--font-size-body-sm);
-}
-
-.table th {
-    text-align: left;
-    padding: var(--padding-xs) var(--input-group-gap);
-    font-size: var(--font-size-caption);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-muted);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-wide);
-    border-bottom: var(--border-width-thin) solid var(--color-border);
-    white-space: nowrap;
-}
-
-.table td {
-    padding: var(--padding-xs) var(--input-group-gap);
-    color: var(--color-text);
-    border-bottom: var(--border-width-thin) solid var(--color-border);
-    vertical-align: middle;
-}
-
-.table tr:hover td {
-    background: var(--color-surface-elevated);
 }
 
 .id_cell {

--- a/src/frontend/modules/traffic/components/admin/PageActivity/PageActivity.tsx
+++ b/src/frontend/modules/traffic/components/admin/PageActivity/PageActivity.tsx
@@ -25,6 +25,9 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { Button } from '../../../../../components/ui/Button';
+import { Card } from '../../../../../components/ui/Card';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
+import { Stack } from '../../../../../components/layout';
 import { adminGetPageActivity, adminGetPageHits } from '../../../api';
 import type { AnalyticsPeriod, ICustomDateRange, IPageActivityRow, IPageHit, PageActivitySubject, VisitorPeriod } from '../../../api';
 import { getDeviceIcon } from '../../../lib/deviceIcon';
@@ -93,8 +96,8 @@ function PageHitsRow({ subject, id, window }: IPageHitsRowProps) {
     }, [subject, id, window]);
 
     return (
-        <tr className={styles.detail_row}>
-            <td colSpan={8}>
+        <Tr className={styles.detail_row}>
+            <Td colSpan={8}>
                 {loading ? (
                     <div className={styles.loading}>Loading pages…</div>
                 ) : hits.length === 0 ? (
@@ -123,8 +126,8 @@ function PageHitsRow({ subject, id, window }: IPageHitsRowProps) {
                         )}
                     </>
                 )}
-            </td>
-        </tr>
+            </Td>
+        </Tr>
     );
 }
 
@@ -209,7 +212,7 @@ export function PageActivityTable({ subject, title, description, subjectHeading,
     }, []);
 
     return (
-        <div className={styles.section}>
+        <Card tone="muted" padding="sm" className={styles.section}>
             <div className={styles.section_header}>
                 <h2 className={styles.section_title}>{title}</h2>
             </div>
@@ -222,33 +225,33 @@ export function PageActivityTable({ subject, title, description, subjectHeading,
             ) : (
                 <>
                     <div className={styles.table_wrapper}>
-                        <table className={styles.table}>
-                            <thead>
-                                <tr>
-                                    <th>{subjectHeading}</th>
-                                    <th>First Seen</th>
-                                    <th>Last Seen</th>
-                                    <th>Page Views</th>
-                                    <th>Distinct Pages</th>
-                                    <th>Last Path</th>
-                                    <th>Device</th>
-                                    <th><span className="text-muted">Pages</span></th>
-                                </tr>
-                            </thead>
-                            <tbody>
+                        <Table>
+                            <Thead>
+                                <Tr>
+                                    <Th scope="col">{subjectHeading}</Th>
+                                    <Th scope="col">First Seen</Th>
+                                    <Th scope="col">Last Seen</Th>
+                                    <Th scope="col">Page Views</Th>
+                                    <Th scope="col">Distinct Pages</Th>
+                                    <Th scope="col">Last Path</Th>
+                                    <Th scope="col">Device</Th>
+                                    <Th scope="col"><span className="text-muted">Pages</span></Th>
+                                </Tr>
+                            </Thead>
+                            <Tbody>
                                 {rows.map(row => (
                                     <React.Fragment key={row.id}>
-                                        <tr>
-                                            <td className={styles.id_cell} title={row.id}>{row.id}</td>
-                                            <td><ClientTime date={row.firstSeen} format="relative" /></td>
-                                            <td><ClientTime date={row.lastSeen} format="relative" /></td>
-                                            <td>{row.pageViews.toLocaleString()}</td>
-                                            <td>{row.distinctPaths.toLocaleString()}</td>
-                                            <td className={styles.path_cell} title={row.lastPath ?? undefined}>
+                                        <Tr>
+                                            <Td className={styles.id_cell} title={row.id}>{row.id}</Td>
+                                            <Td><ClientTime date={row.firstSeen} format="relative" /></Td>
+                                            <Td><ClientTime date={row.lastSeen} format="relative" /></Td>
+                                            <Td>{row.pageViews.toLocaleString()}</Td>
+                                            <Td>{row.distinctPaths.toLocaleString()}</Td>
+                                            <Td className={styles.path_cell} title={row.lastPath ?? undefined}>
                                                 {row.lastPath || <span className={styles.muted}>—</span>}
-                                            </td>
-                                            <td className={styles.device_cell}>{getDeviceIcon(row.device)}</td>
-                                            <td>
+                                            </Td>
+                                            <Td className={styles.device_cell}>{getDeviceIcon(row.device)}</Td>
+                                            <Td>
                                                 <Button
                                                     size="xs"
                                                     variant="ghost"
@@ -258,15 +261,15 @@ export function PageActivityTable({ subject, title, description, subjectHeading,
                                                 >
                                                     {expandedId === row.id ? 'Hide' : 'View'}
                                                 </Button>
-                                            </td>
-                                        </tr>
+                                            </Td>
+                                        </Tr>
                                         {expandedId === row.id && (
                                             <PageHitsRow subject={subject} id={row.id} window={window} />
                                         )}
                                     </React.Fragment>
                                 ))}
-                            </tbody>
-                        </table>
+                            </Tbody>
+                        </Table>
                     </div>
 
                     <div className={styles.pagination}>
@@ -292,7 +295,7 @@ export function PageActivityTable({ subject, title, description, subjectHeading,
                     </div>
                 </>
             )}
-        </div>
+        </Card>
     );
 }
 
@@ -322,7 +325,7 @@ export function PageActivity({ period, customRange }: IPageActivityProps) {
     ), [period, customRange]);
 
     return (
-        <div className={styles.container}>
+        <Stack gap="lg" className={styles.container}>
             <PageActivityTable
                 subject="tid"
                 title="Anonymous Visitor Activity"
@@ -337,6 +340,6 @@ export function PageActivity({ period, customRange }: IPageActivityProps) {
                 description="Per-page navigation for signed-in accounts, keyed on the Better Auth user id. Expand a row to see every page they hit."
                 window={window}
             />
-        </div>
+        </Stack>
     );
 }

--- a/src/frontend/modules/traffic/components/admin/PeriodPicker/PeriodPicker.module.scss
+++ b/src/frontend/modules/traffic/components/admin/PeriodPicker/PeriodPicker.module.scss
@@ -29,18 +29,9 @@
     color: var(--color-text-muted);
 }
 
+/* Force the native date-picker's calendar UI (browser chrome, not stylable
+ * by tokens) to dark rendering — the only styling the shared <Input> does
+ * not provide, preserved when the raw input was replaced by <Input>. */
 .date_input {
-    font-size: var(--font-size-body-sm);
-    font-family: inherit;
-    padding: var(--padding-xs) var(--padding-sm);
-    border: var(--border-width-thin) solid var(--color-border);
-    border-radius: var(--radius-md);
-    background: var(--color-surface);
-    color: var(--color-text);
     color-scheme: dark;
-}
-
-.date_input:focus-visible {
-    outline: var(--border-width-medium) solid var(--color-primary);
-    outline-offset: calc(-1 * var(--border-width-medium));
 }

--- a/src/frontend/modules/traffic/components/admin/PeriodPicker/PeriodPicker.tsx
+++ b/src/frontend/modules/traffic/components/admin/PeriodPicker/PeriodPicker.tsx
@@ -16,6 +16,7 @@
 import React from 'react';
 import { Calendar } from 'lucide-react';
 import { Button } from '../../../../../components/ui/Button';
+import { Input } from '../../../../../components/ui/Input';
 import type { AnalyticsPeriod } from '../../../api';
 import styles from './PeriodPicker.module.scss';
 
@@ -93,8 +94,9 @@ export function PeriodPicker({
             </Button>
             {period === 'custom' && (
                 <div className={styles.date_range}>
-                    <input
+                    <Input
                         type="date"
+                        size="sm"
                         className={styles.date_input}
                         value={customStart}
                         max={customEnd}
@@ -105,8 +107,9 @@ export function PeriodPicker({
                         aria-label="Start date"
                     />
                     <span className={styles.date_range__separator}>to</span>
-                    <input
+                    <Input
                         type="date"
+                        size="sm"
                         className={styles.date_input}
                         value={customEnd}
                         min={customStart}

--- a/src/frontend/modules/traffic/components/admin/RedirectAnalytics/RedirectAnalytics.module.scss
+++ b/src/frontend/modules/traffic/components/admin/RedirectAnalytics/RedirectAnalytics.module.scss
@@ -12,9 +12,6 @@
 .container {
     container-type: inline-size;
     container-name: redirect-analytics;
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-lg);
 }
 
 .header {
@@ -50,26 +47,29 @@
 
 .window_picker,
 .bot_toggle {
-    display: inline-flex;
-    background: var(--color-surface-muted);
-    border-radius: var(--radius-full);
-    padding: var(--padding-2xs);
+    display: flex;
+    gap: 0;
     border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
 }
 
 .window_button,
 .window_active,
 .bot_button,
 .bot_active {
+    padding: var(--padding-xs) var(--gap-md);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-medium);
     border: none;
-    background: transparent;
-    color: var(--color-text-muted);
-    font-size: var(--font-size-body-sm);
-    font-weight: var(--font-weight-semibold);
-    padding: var(--padding-2xs) var(--padding-sm);
-    border-radius: var(--radius-full);
     cursor: pointer;
-    transition: background-color var(--transition-base), color var(--transition-base);
+    transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.window_button,
+.bot_button {
+    color: var(--color-text-muted);
+    background: var(--color-surface);
 }
 
 .window_button:hover,
@@ -79,8 +79,8 @@
 
 .window_active,
 .bot_active {
-    background: var(--gradient-primary);
     color: var(--color-text);
+    background: var(--gradient-primary);
 }
 
 .panel {
@@ -133,30 +133,6 @@
 .summary_split {
     font-size: var(--font-size-body-sm);
     color: var(--color-text-muted);
-}
-
-.table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: var(--font-size-body-sm);
-
-    th,
-    td {
-        text-align: left;
-        padding: var(--padding-sm) var(--padding-md);
-        border-bottom: var(--border-width-thin) solid var(--color-border);
-        vertical-align: middle;
-    }
-
-    th {
-        font-weight: var(--font-weight-semibold);
-        color: var(--color-text-muted);
-        background: var(--color-surface-muted);
-    }
-
-    tbody tr:last-child td {
-        border-bottom: none;
-    }
 }
 
 .numeric_col {

--- a/src/frontend/modules/traffic/components/admin/RedirectAnalytics/RedirectAnalytics.tsx
+++ b/src/frontend/modules/traffic/components/admin/RedirectAnalytics/RedirectAnalytics.tsx
@@ -23,6 +23,8 @@ import { CornerUpRight, ListOrdered } from 'lucide-react';
 import { LineChart } from '../../../../../features/charts/components/LineChart';
 import type { ChartSeries } from '../../../../../features/charts/components/LineChart';
 import { Card } from '../../../../../components/ui/Card';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
+import { Stack } from '../../../../../components/layout';
 import { adminGetRedirectAnalytics } from '../../../api';
 import type { AnalyticsPeriod, IRedirectAnalytics } from '../../../api';
 import styles from './RedirectAnalytics.module.scss';
@@ -126,7 +128,7 @@ export function RedirectAnalytics() {
     const hasHits = data !== null && data.total > 0;
 
     return (
-        <div className={styles.container}>
+        <Stack gap="lg" className={styles.container}>
             <header className={styles.header}>
                 <div>
                     <h2 className={styles.title}>Redirect analytics</h2>
@@ -215,28 +217,28 @@ export function RedirectAnalytics() {
                 ) : !hasHits || !data || data.byPattern.length === 0 ? (
                     <p className={styles.panel_empty}>No redirects served in this window.</p>
                 ) : (
-                    <table className={styles.table}>
-                        <thead>
-                            <tr>
-                                <th scope="col">Source</th>
-                                <th scope="col">Destination</th>
-                                <th scope="col" className={styles.center_col}>Code</th>
-                                <th scope="col" className={styles.numeric_col}>Hits</th>
-                            </tr>
-                        </thead>
-                        <tbody>
+                    <Table>
+                        <Thead>
+                            <Tr>
+                                <Th scope="col">Source</Th>
+                                <Th scope="col">Destination</Th>
+                                <Th scope="col" className={styles.center_col}>Code</Th>
+                                <Th scope="col" className={styles.numeric_col}>Hits</Th>
+                            </Tr>
+                        </Thead>
+                        <Tbody>
                             {data.byPattern.map(row => (
-                                <tr key={row.pattern}>
-                                    <td><code className={styles.code}>{row.pattern}</code></td>
-                                    <td><code className={styles.code}>{row.destination}</code></td>
-                                    <td className={styles.center}>{row.permanent ? '301' : '302'}</td>
-                                    <td className={styles.numeric}>{numberFormatter.format(row.hits)}</td>
-                                </tr>
+                                <Tr key={row.pattern}>
+                                    <Td><code className={styles.code}>{row.pattern}</code></Td>
+                                    <Td><code className={styles.code}>{row.destination}</code></Td>
+                                    <Td className={styles.center}>{row.permanent ? '301' : '302'}</Td>
+                                    <Td className={styles.numeric}>{numberFormatter.format(row.hits)}</Td>
+                                </Tr>
                             ))}
-                        </tbody>
-                    </table>
+                        </Tbody>
+                    </Table>
                 )}
             </Card>
-        </div>
+        </Stack>
     );
 }

--- a/src/frontend/modules/traffic/components/admin/RedirectsManager/RedirectsManager.module.scss
+++ b/src/frontend/modules/traffic/components/admin/RedirectsManager/RedirectsManager.module.scss
@@ -3,9 +3,6 @@
 .container {
     container-type: inline-size;
     container-name: redirects-manager;
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-lg);
 }
 
 .header {

--- a/src/frontend/modules/traffic/components/admin/RedirectsManager/RedirectsManager.tsx
+++ b/src/frontend/modules/traffic/components/admin/RedirectsManager/RedirectsManager.tsx
@@ -22,6 +22,7 @@ import { Input } from '../../../../../components/ui/Input';
 import { Card } from '../../../../../components/ui/Card';
 import { Badge } from '../../../../../components/ui/Badge';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
 import { Stack } from '../../../../../components/layout';
 import {
     adminListRedirects,
@@ -241,7 +242,7 @@ export function RedirectsManager() {
     }
 
     return (
-        <div className={styles.container}>
+        <Stack gap="lg" className={styles.container}>
             <Card padding="lg">
                 <Stack gap="md">
                     <div className={styles.header}>
@@ -312,26 +313,26 @@ export function RedirectsManager() {
 
                     {rules && rules.length > 0 ? (
                         <div className="table-scroll">
-                            <table className="table">
-                                <thead>
-                                    <tr>
-                                        <th scope="col">Source</th>
-                                        <th scope="col">Destination</th>
-                                        <th scope="col">Match</th>
-                                        <th scope="col">Code</th>
-                                        <th scope="col">Status</th>
-                                        <th scope="col">Updated</th>
-                                        <th scope="col" className={styles.actions_col}>Actions</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
+                            <Table>
+                                <Thead>
+                                    <Tr>
+                                        <Th scope="col">Source</Th>
+                                        <Th scope="col">Destination</Th>
+                                        <Th scope="col">Match</Th>
+                                        <Th scope="col">Code</Th>
+                                        <Th scope="col">Status</Th>
+                                        <Th scope="col">Updated</Th>
+                                        <Th scope="col" className={styles.actions_col}>Actions</Th>
+                                    </Tr>
+                                </Thead>
+                                <Tbody>
                                     {rules.map(rule => {
                                         const rowDraft = editingId === rule.id ? draft : null;
                                         return (
-                                            <tr key={rule.id} className={rule.enabled ? undefined : styles.row_disabled}>
+                                            <Tr key={rule.id} className={rule.enabled ? undefined : styles.row_disabled}>
                                                 {rowDraft ? (
                                                     <>
-                                                        <td>
+                                                        <Td>
                                                             <div className={styles.edit_stack}>
                                                                 <Input
                                                                     type="text"
@@ -352,8 +353,8 @@ export function RedirectsManager() {
                                                                     disabled={savingEdit}
                                                                 />
                                                             </div>
-                                                        </td>
-                                                        <td>
+                                                        </Td>
+                                                        <Td>
                                                             <Input
                                                                 type="text"
                                                                 size="sm"
@@ -363,8 +364,8 @@ export function RedirectsManager() {
                                                                 aria-label="Destination path"
                                                                 disabled={savingEdit}
                                                             />
-                                                        </td>
-                                                        <td>
+                                                        </Td>
+                                                        <Td>
                                                             <label className={styles.checkbox}>
                                                                 <input
                                                                     type="checkbox"
@@ -374,8 +375,8 @@ export function RedirectsManager() {
                                                                 />
                                                                 prefix
                                                             </label>
-                                                        </td>
-                                                        <td>
+                                                        </Td>
+                                                        <Td>
                                                             <label className={styles.checkbox}>
                                                                 <input
                                                                     type="checkbox"
@@ -385,16 +386,16 @@ export function RedirectsManager() {
                                                                 />
                                                                 301
                                                             </label>
-                                                        </td>
-                                                        <td>
+                                                        </Td>
+                                                        <Td>
                                                             <Badge tone={rule.enabled ? 'success' : 'neutral'}>
                                                                 {rule.enabled ? 'active' : 'disabled'}
                                                             </Badge>
-                                                        </td>
-                                                        <td>
+                                                        </Td>
+                                                        <Td>
                                                             <ClientTime date={rule.updatedAt} format="date" />
-                                                        </td>
-                                                        <td>
+                                                        </Td>
+                                                        <Td>
                                                             <div className={styles.actions}>
                                                                 <button
                                                                     type="button"
@@ -417,37 +418,37 @@ export function RedirectsManager() {
                                                                     <X size={16} />
                                                                 </button>
                                                             </div>
-                                                        </td>
+                                                        </Td>
                                                     </>
                                                 ) : (
                                                     <>
-                                                        <td>
+                                                        <Td>
                                                             <code className={styles.path}>{rule.pattern}</code>
                                                             {rule.notes && <span className={styles.note}>{rule.notes}</span>}
-                                                        </td>
-                                                        <td>
+                                                        </Td>
+                                                        <Td>
                                                             <span className={styles.dest}>
                                                                 <ArrowRight size={14} aria-hidden="true" />
                                                                 <code className={styles.path}>{rule.destination}</code>
                                                             </span>
-                                                        </td>
-                                                        <td>
+                                                        </Td>
+                                                        <Td>
                                                             <Badge tone="neutral">{rule.isPrefix ? 'prefix' : 'exact'}</Badge>
-                                                        </td>
-                                                        <td>
+                                                        </Td>
+                                                        <Td>
                                                             <Badge tone={rule.permanent ? 'info' : 'neutral'}>
                                                                 {rule.permanent ? '301' : '302'}
                                                             </Badge>
-                                                        </td>
-                                                        <td>
+                                                        </Td>
+                                                        <Td>
                                                             <Badge tone={rule.enabled ? 'success' : 'neutral'}>
                                                                 {rule.enabled ? 'active' : 'disabled'}
                                                             </Badge>
-                                                        </td>
-                                                        <td>
+                                                        </Td>
+                                                        <Td>
                                                             <ClientTime date={rule.updatedAt} format="date" />
-                                                        </td>
-                                                        <td>
+                                                        </Td>
+                                                        <Td>
                                                             <div className={styles.actions}>
                                                                 <button
                                                                     type="button"
@@ -480,20 +481,20 @@ export function RedirectsManager() {
                                                                     <Trash2 size={16} />
                                                                 </button>
                                                             </div>
-                                                        </td>
+                                                        </Td>
                                                     </>
                                                 )}
-                                            </tr>
+                                            </Tr>
                                         );
                                     })}
-                                </tbody>
-                            </table>
+                                </Tbody>
+                            </Table>
                         </div>
                     ) : (
                         !loadError && <p className="text-muted">No redirects yet. Add one above.</p>
                     )}
                 </Stack>
             </Card>
-        </div>
+        </Stack>
     );
 }

--- a/src/frontend/modules/traffic/components/admin/TrafficDashboard/TrafficDashboard.module.scss
+++ b/src/frontend/modules/traffic/components/admin/TrafficDashboard/TrafficDashboard.module.scss
@@ -12,10 +12,6 @@
 .container {
     container-type: inline-size;
     container-name: traffic-dashboard;
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-lg);
-    padding: var(--card-padding-md);
 }
 
 .header {
@@ -49,24 +45,26 @@
 }
 
 .window_picker {
-    display: inline-flex;
-    background: var(--color-surface-muted);
-    border-radius: var(--radius-full);
-    padding: var(--padding-2xs);
+    display: flex;
+    gap: 0;
     border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
 }
 
 .window_button,
 .window_active {
+    padding: var(--padding-xs) var(--gap-md);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-medium);
     border: none;
-    background: transparent;
-    color: var(--color-text-muted);
-    font-size: var(--font-size-body-sm);
-    font-weight: var(--font-weight-semibold);
-    padding: var(--padding-2xs) var(--padding-sm);
-    border-radius: var(--radius-full);
     cursor: pointer;
-    transition: background-color var(--transition-base), color var(--transition-base);
+    transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.window_button {
+    color: var(--color-text-muted);
+    background: var(--color-surface);
 }
 
 .window_button:hover {
@@ -74,8 +72,8 @@
 }
 
 .window_active {
-    background: var(--gradient-primary);
     color: var(--color-text);
+    background: var(--gradient-primary);
 }
 
 .notice_card {
@@ -129,30 +127,6 @@
     margin: 0;
 }
 
-.table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: var(--font-size-body-sm);
-
-    th,
-    td {
-        text-align: left;
-        padding: var(--padding-sm) var(--padding-md);
-        border-bottom: var(--border-width-thin) solid var(--color-border);
-        vertical-align: middle;
-    }
-
-    th {
-        font-weight: var(--font-weight-semibold);
-        color: var(--color-text-muted);
-        background: var(--color-surface-muted);
-    }
-
-    tbody tr:last-child td {
-        border-bottom: none;
-    }
-}
-
 .numeric_col {
     width: 1%;
     white-space: nowrap;
@@ -177,25 +151,10 @@
     max-width: 32rem;
 }
 
-.grid_two {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--grid-gap-md);
-}
-
 @container traffic-dashboard (max-width: #{$breakpoint-mobile-lg}) {
     .header {
         flex-direction: column;
         align-items: stretch;
-    }
-
-    .grid_two {
-        grid-template-columns: 1fr;
-    }
-
-    .table th,
-    .table td {
-        padding: var(--padding-xs) var(--padding-sm);
     }
 
     .ua_cell {

--- a/src/frontend/modules/traffic/components/admin/TrafficDashboard/TrafficDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/TrafficDashboard/TrafficDashboard.tsx
@@ -32,6 +32,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Bot, Globe, MapPin, RefreshCw } from 'lucide-react';
 import { Button } from '../../../../../components/ui/Button';
 import { Card } from '../../../../../components/ui/Card';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
+import { Stack, Grid } from '../../../../../components/layout';
 import styles from './TrafficDashboard.module.scss';
 
 interface AggregateBucket {
@@ -224,7 +226,7 @@ export function TrafficDashboard({ refreshSignal }: ITrafficDashboardProps) {
     const clickhouseDisabledNotice = summary && !summary.clickhouseEnabled;
 
     return (
-        <div className={styles.container}>
+        <Stack gap="lg" className={styles.container}>
             <header className={styles.header}>
                 <div>
                     <h1 className={styles.title}>Traffic</h1>
@@ -282,29 +284,29 @@ export function TrafficDashboard({ refreshSignal }: ITrafficDashboardProps) {
                 </div>
                 <PanelBody loading={summaryLoading} error={summaryError} empty={summary?.buckets.length === 0}>
                     {summary && (
-                        <table className={styles.table}>
-                            <thead>
-                                <tr>
-                                    <th scope="col">bot_class</th>
-                                    <th scope="col" className={styles.numeric_col}>events</th>
-                                    <th scope="col" className={styles.numeric_col}>share</th>
-                                </tr>
-                            </thead>
-                            <tbody>
+                        <Table>
+                            <Thead>
+                                <Tr>
+                                    <Th scope="col">bot_class</Th>
+                                    <Th scope="col" className={styles.numeric_col}>events</Th>
+                                    <Th scope="col" className={styles.numeric_col}>share</Th>
+                                </Tr>
+                            </Thead>
+                            <Tbody>
                                 {summary.buckets.map(b => {
                                     const share = summary.total > 0
                                         ? ((b.count / summary.total) * 100).toFixed(1)
                                         : '0.0';
                                     return (
-                                        <tr key={b.key ?? '__null__'}>
-                                            <td><code className={styles.code}>{renderKey(b.key)}</code></td>
-                                            <td className={styles.numeric}>{formatNumber(b.count)}</td>
-                                            <td className={styles.numeric}>{share}%</td>
-                                        </tr>
+                                        <Tr key={b.key ?? '__null__'}>
+                                            <Td><code className={styles.code}>{renderKey(b.key)}</code></Td>
+                                            <Td className={styles.numeric}>{formatNumber(b.count)}</Td>
+                                            <Td className={styles.numeric}>{share}%</Td>
+                                        </Tr>
                                     );
                                 })}
-                            </tbody>
-                        </table>
+                            </Tbody>
+                        </Table>
                     )}
                 </PanelBody>
             </Card>
@@ -321,29 +323,29 @@ export function TrafficDashboard({ refreshSignal }: ITrafficDashboardProps) {
                 </p>
                 <PanelBody loading={botOtherLoading} error={botOtherError} empty={botOther?.buckets.length === 0}>
                     {botOther && (
-                        <table className={styles.table}>
-                            <thead>
-                                <tr>
-                                    <th scope="col">user_agent</th>
-                                    <th scope="col" className={styles.numeric_col}>events</th>
-                                </tr>
-                            </thead>
-                            <tbody>
+                        <Table>
+                            <Thead>
+                                <Tr>
+                                    <Th scope="col">user_agent</Th>
+                                    <Th scope="col" className={styles.numeric_col}>events</Th>
+                                </Tr>
+                            </Thead>
+                            <Tbody>
                                 {botOther.buckets.map((b, i) => (
-                                    <tr key={`${b.key ?? 'null'}_${i}`}>
-                                        <td className={styles.ua_cell}>
+                                    <Tr key={`${b.key ?? 'null'}_${i}`}>
+                                        <Td className={styles.ua_cell}>
                                             <code className={styles.code}>{renderKey(b.key)}</code>
-                                        </td>
-                                        <td className={styles.numeric}>{formatNumber(b.count)}</td>
-                                    </tr>
+                                        </Td>
+                                        <Td className={styles.numeric}>{formatNumber(b.count)}</Td>
+                                    </Tr>
                                 ))}
-                            </tbody>
-                        </table>
+                            </Tbody>
+                        </Table>
                     )}
                 </PanelBody>
             </Card>
 
-            <div className={styles.grid_two}>
+            <Grid columns={2} gap="md">
                 <Card padding="md" className={styles.panel}>
                     <div className={styles.panel_header}>
                         <MapPin size={18} aria-hidden="true" />
@@ -351,22 +353,22 @@ export function TrafficDashboard({ refreshSignal }: ITrafficDashboardProps) {
                     </div>
                     <PanelBody loading={topPathsLoading} error={topPathsError} empty={topPaths?.buckets.length === 0}>
                         {topPaths && (
-                            <table className={styles.table}>
-                                <thead>
-                                    <tr>
-                                        <th scope="col">path</th>
-                                        <th scope="col" className={styles.numeric_col}>events</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
+                            <Table>
+                                <Thead>
+                                    <Tr>
+                                        <Th scope="col">path</Th>
+                                        <Th scope="col" className={styles.numeric_col}>events</Th>
+                                    </Tr>
+                                </Thead>
+                                <Tbody>
                                     {topPaths.buckets.map((b, i) => (
-                                        <tr key={`${b.key ?? 'null'}_${i}`}>
-                                            <td><code className={styles.code}>{renderKey(b.key)}</code></td>
-                                            <td className={styles.numeric}>{formatNumber(b.count)}</td>
-                                        </tr>
+                                        <Tr key={`${b.key ?? 'null'}_${i}`}>
+                                            <Td><code className={styles.code}>{renderKey(b.key)}</code></Td>
+                                            <Td className={styles.numeric}>{formatNumber(b.count)}</Td>
+                                        </Tr>
                                     ))}
-                                </tbody>
-                            </table>
+                                </Tbody>
+                            </Table>
                         )}
                     </PanelBody>
                 </Card>
@@ -378,27 +380,27 @@ export function TrafficDashboard({ refreshSignal }: ITrafficDashboardProps) {
                     </div>
                     <PanelBody loading={topCountriesLoading} error={topCountriesError} empty={topCountries?.buckets.length === 0}>
                         {topCountries && (
-                            <table className={styles.table}>
-                                <thead>
-                                    <tr>
-                                        <th scope="col">country</th>
-                                        <th scope="col" className={styles.numeric_col}>events</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
+                            <Table>
+                                <Thead>
+                                    <Tr>
+                                        <Th scope="col">country</Th>
+                                        <Th scope="col" className={styles.numeric_col}>events</Th>
+                                    </Tr>
+                                </Thead>
+                                <Tbody>
                                     {topCountries.buckets.map((b, i) => (
-                                        <tr key={`${b.key ?? 'null'}_${i}`}>
-                                            <td><code className={styles.code}>{renderKey(b.key)}</code></td>
-                                            <td className={styles.numeric}>{formatNumber(b.count)}</td>
-                                        </tr>
+                                        <Tr key={`${b.key ?? 'null'}_${i}`}>
+                                            <Td><code className={styles.code}>{renderKey(b.key)}</code></Td>
+                                            <Td className={styles.numeric}>{formatNumber(b.count)}</Td>
+                                        </Tr>
                                     ))}
-                                </tbody>
-                            </table>
+                                </Tbody>
+                            </Table>
                         )}
                     </PanelBody>
                 </Card>
-            </div>
-        </div>
+            </Grid>
+        </Stack>
     );
 }
 

--- a/src/frontend/modules/traffic/components/admin/VisitorAnalytics/VisitorAnalytics.module.scss
+++ b/src/frontend/modules/traffic/components/admin/VisitorAnalytics/VisitorAnalytics.module.scss
@@ -11,19 +11,12 @@
 .container {
     container-type: inline-size;
     container-name: visitor-analytics;
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-lg);
 }
 
 .section {
     display: flex;
     flex-direction: column;
     gap: var(--gap-md);
-    background: var(--color-surface-muted);
-    border: var(--border-width-thin) solid var(--color-border);
-    border-radius: var(--radius-md);
-    padding: var(--card-padding-sm);
 }
 
 .section_header {
@@ -44,39 +37,6 @@
 /* Traffic origins table */
 .table_wrapper {
     overflow-x: auto;
-}
-
-.table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: var(--font-size-body-sm);
-}
-
-.table th {
-    text-align: left;
-    padding: var(--padding-xs) var(--input-group-gap);
-    font-size: var(--font-size-caption);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-muted);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-wide);
-    border-bottom: var(--border-width-thin) solid var(--color-border);
-    white-space: nowrap;
-}
-
-.table td {
-    padding: var(--padding-xs) var(--input-group-gap);
-    color: var(--color-text);
-    border-bottom: var(--border-width-thin) solid var(--color-border);
-    vertical-align: middle;
-}
-
-.table tr:last-child td {
-    border-bottom: none;
-}
-
-.table tr:hover td {
-    background: var(--color-surface-elevated);
 }
 
 .country_cell {

--- a/src/frontend/modules/traffic/components/admin/VisitorAnalytics/VisitorAnalytics.tsx
+++ b/src/frontend/modules/traffic/components/admin/VisitorAnalytics/VisitorAnalytics.tsx
@@ -22,6 +22,9 @@ import React, { useEffect, useState } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import { ClientTime } from '../../../../../components/ui/ClientTime';
 import { Button } from '../../../../../components/ui/Button';
+import { Card } from '../../../../../components/ui/Card';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
+import { Stack } from '../../../../../components/layout';
 import { adminGetAnonymousFirstTouches, adminGetFlaggedSubnets } from '../../../api';
 import type { AnalyticsPeriod, ICustomDateRange, IVisitorOrigin, VisitorPeriod } from '../../../api';
 import { getDeviceIcon } from '../../../lib/deviceIcon';
@@ -139,8 +142,8 @@ export function VisitorAnalytics({ period, customRange, includeBots }: IVisitorA
     const totalFirstTouchesPages = firstTouchesTotal > 0 ? Math.ceil(firstTouchesTotal / PAGE_LIMIT) : 1;
 
     return (
-        <div className={styles.container}>
-            <div className={styles.section}>
+        <Stack gap="lg" className={styles.container}>
+            <Card tone="muted" padding="sm" className={styles.section}>
                 <div className={styles.section_header}>
                     <h2 className={styles.section_title}>New Visitors</h2>
                 </div>
@@ -173,39 +176,39 @@ export function VisitorAnalytics({ period, customRange, includeBots }: IVisitorA
                 ) : (
                     <>
                         <div className={styles.table_wrapper}>
-                            <table className={styles.table}>
-                                <thead>
-                                    <tr>
-                                        <th>First Seen</th>
-                                        <th>Country</th>
-                                        <th>Original Referrer</th>
-                                        <th>Landing Page</th>
-                                        <th>Source</th>
-                                        <th>UTM</th>
-                                        <th>Device</th>
-                                        <th title="Client-side page views (page events only — server-recorded first touches are not views)">Total Views</th>
-                                        <th title="Derived sessions within the selected window (30-minute inactivity rule over page events)">Sessions</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
+                            <Table>
+                                <Thead>
+                                    <Tr>
+                                        <Th scope="col">First Seen</Th>
+                                        <Th scope="col">Country</Th>
+                                        <Th scope="col">Original Referrer</Th>
+                                        <Th scope="col">Landing Page</Th>
+                                        <Th scope="col">Source</Th>
+                                        <Th scope="col">UTM</Th>
+                                        <Th scope="col">Device</Th>
+                                        <Th scope="col" title="Client-side page views (page events only — server-recorded first touches are not views)">Total Views</Th>
+                                        <Th scope="col" title="Derived sessions within the selected window (30-minute inactivity rule over page events)">Sessions</Th>
+                                    </Tr>
+                                </Thead>
+                                <Tbody>
                                     {firstTouches.map(touch => {
                                         const utmDisplay = formatUtm(touch.utm);
 
                                         return (
-                                            <tr key={touch.userId}>
-                                                <td>
+                                            <Tr key={touch.userId}>
+                                                <Td>
                                                     <ClientTime date={touch.firstSeen} format="relative" />
-                                                </td>
-                                                <td className={styles.country_cell}>
+                                                </Td>
+                                                <Td className={styles.country_cell}>
                                                     {touch.country || <span className={styles.muted}>—</span>}
-                                                </td>
-                                                <td className={styles.referrer_cell} title={touch.referrerDomain ?? undefined}>
+                                                </Td>
+                                                <Td className={styles.referrer_cell} title={touch.referrerDomain ?? undefined}>
                                                     {touch.referrerDomain || <span className={styles.muted}>direct</span>}
-                                                </td>
-                                                <td className={styles.landing_cell} title={touch.landingPage ?? undefined}>
+                                                </Td>
+                                                <Td className={styles.landing_cell} title={touch.landingPage ?? undefined}>
                                                     {touch.landingPage || <span className={styles.muted}>—</span>}
-                                                </td>
-                                                <td
+                                                </Td>
+                                                <Td
                                                     className={styles.source_cell}
                                                     title={touch.subnetHash
                                                         ? `${touch.subnetHash && flaggedSubnets.has(touch.subnetHash) ? 'High-volume network (possible automated traffic) — ' : ''}Salted subnet hash ${touch.subnetHash} — rows sharing this value came from the same /24 (IPv4) or /48 (IPv6) network`
@@ -225,20 +228,20 @@ export function VisitorAnalytics({ period, customRange, includeBots }: IVisitorA
                                                             </span>
                                                         )
                                                         : <span className={styles.muted}>—</span>}
-                                                </td>
-                                                <td className={styles.utm_cell} title={utmDisplay ?? undefined}>
+                                                </Td>
+                                                <Td className={styles.utm_cell} title={utmDisplay ?? undefined}>
                                                     {utmDisplay || <span className={styles.muted}>—</span>}
-                                                </td>
-                                                <td className={styles.device_cell}>
+                                                </Td>
+                                                <Td className={styles.device_cell}>
                                                     {getDeviceIcon(touch.device)}
-                                                </td>
-                                                <td>{touch.pageViews.toLocaleString()}</td>
-                                                <td>{touch.sessionsCount.toLocaleString()}</td>
-                                            </tr>
+                                                </Td>
+                                                <Td>{touch.pageViews.toLocaleString()}</Td>
+                                                <Td>{touch.sessionsCount.toLocaleString()}</Td>
+                                            </Tr>
                                         );
                                     })}
-                                </tbody>
-                            </table>
+                                </Tbody>
+                            </Table>
                         </div>
 
                         <div className={styles.pagination}>
@@ -264,7 +267,7 @@ export function VisitorAnalytics({ period, customRange, includeBots }: IVisitorA
                         </div>
                     </>
                 )}
-            </div>
-        </div>
+            </Card>
+        </Stack>
     );
 }


### PR DESCRIPTION
## Summary

Two changes to the traffic module.

**1. SEO — Keyword → page pairs.** A new section on the SEO tab answering which pages each search query surfaced — the join the separate Top Keywords and Top Pages tables cannot express. Backed by a new `getKeywordPagePairsForPeriod` aggregation over `module_user_gsc_queries` (the only rows carrying `query` and `page` together), a `GET /gsc/keyword-pages` endpoint, and the client + UI section. No new GSC fetch or schema change. Because it reads the query-dimensioned cache it inherits GSC's low-volume-query anonymization; the UI states its clicks will not fully reconcile with the anonymization-immune Top Pages totals.

**2. Admin UI standardized on shared components.** A conformance sweep of the traffic admin surface:

- All 17 hand-rolled tables migrated to the shared `Table`/`Thead`/`Tbody`/`Tr`/`Th`/`Td` component, with `scope="col"` on every header — closing a real accessibility gap in AnalyticsDashboard, VisitorAnalytics, and PageActivity (41 headers previously unscoped), and giving every table the component's horizontal-scroll wrapper.
- IgnoredUsers' account-search dropdown now honors the ARIA combobox/listbox contract (`role="combobox"`/`aria-controls`/`aria-expanded` on the input, `role="option"` on the results), mirroring `AccountPicker`.
- Hand-rolled containers/cards/grids/badges/date-inputs replaced with `Stack`, `Card`, `Grid`, `Badge`, and `Input` — which also corrects a muted-card corner-radius drift and unifies the date field with the rest of the app.
- The four segmented lookback controls rewritten to match the sibling `page.module.scss` implementation so they render identically.

## Notes

- `PeriodPicker` keeps `color-scheme: dark` via a one-line class (the only styling `<Input>` doesn't provide).
- `.grid_two` → `<Grid>` moves two chart-pair collapses from container-query to viewport-based (fine for these full-width admin tabs).
- A couple of narrow-width `@container` gap/padding overrides on now-`<Stack>`/`<Card>` elements depend on cascade order — cosmetic, worth an eyeball at mobile width.

Backend and frontend type checks pass.