### PR TITLE
feat(ai-tools): submenu-pattern tab row + provider dropdown; UI/UX fixes

### DIFF
--- a/src/backend/modules/ai-tools/AiToolsModule.ts
+++ b/src/backend/modules/ai-tools/AiToolsModule.ts
@@ -258,6 +258,28 @@ export interface IAiToolsModuleDependencies {
 }
 
 /**
+ * Dedicated menu namespace for the /system/ai-tools in-page tab row. Kept out of
+ * `main` so the tabs never leak into the global nav chrome — only the page's own
+ * `MenuNavClient` reads this namespace (menu module's Submenu Pattern).
+ */
+const SUBMENU_NAMESPACE = 'ai-tools';
+
+/**
+ * The in-page tab row, declared as menu nodes rather than a hand-rolled button
+ * array so the row inherits per-user gating, ordering, and live `menu:update`
+ * refresh from the menu service. Each `url` carries a `?tab=` the client reads
+ * to drive the active panel; the route is identical across tabs. The order
+ * matches the historical shell (Query default, then Registry, Activity,
+ * Approvals) so the deep links and default panel are unchanged.
+ */
+const SUBMENU_TABS: ReadonlyArray<{ label: string; tab: string; icon: string; order: number }> = [
+    { label: 'Query', tab: 'query', icon: 'MessageSquare', order: 0 },
+    { label: 'Registry', tab: 'registry', icon: 'Boxes', order: 1 },
+    { label: 'Activity', tab: 'activity', icon: 'Activity', order: 2 },
+    { label: 'Approvals', tab: 'approvals', icon: 'ShieldCheck', order: 3 }
+];
+
+/**
  * The AI tool governance module.
  */
 export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
@@ -859,6 +881,27 @@ export class AiToolsModule implements IModule<IAiToolsModuleDependencies> {
             parent: MAIN_SYSTEM_CONTAINER_ID,
             enabled: true
         });
+
+        // Register the in-page tab row as a namespaced menu (menu module's Submenu
+        // Pattern). The nodes are memory-only and live outside the System
+        // container, so the container's non-bypassable `requiresAdmin` force does
+        // not reach them — the module sets `requiresAdmin` per node itself. The
+        // page renders this namespace with MenuNavClient instead of hand-rolling
+        // a `<button>` tab strip, inheriting per-user gating, ordering, and live
+        // `menu:update` refresh.
+        for (const tab of SUBMENU_TABS) {
+            await this.menuService.create({
+                namespace: SUBMENU_NAMESPACE,
+                label: tab.label,
+                url: `/system/ai-tools?tab=${tab.tab}`,
+                icon: tab.icon,
+                order: tab.order,
+                parent: null,
+                enabled: true,
+                requiresAdmin: true
+            });
+        }
+        this.logger.info('AI tools submenu tab nodes registered');
 
         this.logger.info(
             { services: [AI_TOOLS_SERVICE, AI_TOOL_GOVERNOR_SERVICE, AI_PROVIDERS_SERVICE, PROMPT_VARIABLES_SERVICE] },

--- a/src/frontend/app/(core)/system/ai-tools/AiToolsAdminClient.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/AiToolsAdminClient.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+/**
+ * @fileoverview Client shell for /system/ai-tools — the AI tool governance dashboard.
+ *
+ * Holds the interactive surface: the in-page tab row and the four panels (Query —
+ * the default — Registry, Activity, Approvals). The tab row is the menu module's
+ * Submenu Pattern — a namespaced menu rendered with `MenuNavClient`, not a
+ * hand-rolled button array — so it inherits per-user gating, ordering, and live
+ * `menu:update` refresh. The server entry (`page.tsx`) fetches that namespace tree
+ * SSR-first and passes it in, mirroring how `MenuNavSSR` feeds `MenuNavClient`.
+ * Clicking a tab drives local state via `onItemSelect` rather than navigating;
+ * `activeUrl` highlights the active tab since the route is identical across them.
+ *
+ * When holds are already waiting on first load the shell opens on Approvals
+ * instead of Query, so the operator lands on the decision that needs them — unless
+ * a `?tab=` deep link already named a tab, in which case that choice wins. A menu
+ * node cannot carry a live count, so the pending-approval tally rides a summary
+ * badge above the tab row rather than on the Approvals node itself. Governed
+ * events arrive as WebSocket refetch signals — the count itself always comes from
+ * the gated REST feed, never a global broadcast.
+ */
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import type { MenuNodeSerialized } from '@/shared';
+import { Page, PageHeader } from '../../../../components/layout';
+import { Badge } from '../../../../components/ui/Badge';
+import { MenuNavClient } from '../../../../components/layout/MenuNav/MenuNavClient';
+import { getSocket } from '../../../../lib/socketClient';
+import { getApprovalsCount } from '../../../../modules/ai-tools';
+import { RegistryTab } from './tabs/RegistryTab';
+import { ActivityTab } from './tabs/ActivityTab';
+import { ApprovalsTab } from './tabs/ApprovalsTab';
+import { QueryTab } from './tabs/QueryTab';
+import styles from './page.module.scss';
+
+/** The dashboard tabs; the `?tab=` value carried by each submenu node. */
+type TabId = 'query' | 'registry' | 'activity' | 'approvals';
+
+/** The menu namespace the module registers the tab nodes under. */
+const SUBMENU_NAMESPACE = 'ai-tools';
+
+/**
+ * Narrow an arbitrary `?tab=` string to a known TabId, so the deep-link seeding
+ * and the click routing share one source of truth for valid tabs.
+ *
+ * @param tab - The raw `?tab=` value.
+ * @returns True when the value names a real tab.
+ */
+function isTabId(tab: string | undefined): tab is TabId {
+    return tab === 'query' || tab === 'registry' || tab === 'activity' || tab === 'approvals';
+}
+
+/**
+ * Resolve a submenu node's `?tab=` value to a known TabId, defaulting to `query`
+ * for an unrecognized or missing value so a malformed node can never leave the
+ * page on a blank panel.
+ *
+ * @param url - The clicked node's url (e.g. `/system/ai-tools?tab=registry`).
+ * @returns The matching tab id.
+ */
+function tabFromUrl(url: string | undefined): TabId {
+    const tab = url?.match(/[?&]tab=([^&]+)/)?.[1];
+    return isTabId(tab) ? tab : 'query';
+}
+
+/**
+ * Stable no-op for RegistryTab's required `onChanged`. The callback used to
+ * re-check the trifecta banner after a registry change; with that banner removed
+ * there is nothing left for the page to do, and a module-level constant keeps
+ * RegistryTab's memoized callbacks from re-creating each render.
+ */
+const noop = (): void => {};
+
+/**
+ * Props for the client shell.
+ */
+interface IAiToolsAdminClientProps {
+    /** SSR-fetched submenu nodes (the tab row), already gated for the admin. */
+    submenuTree: MenuNodeSerialized[];
+    /** Snapshot timestamp of the submenu tree, seeded onto the menu Redux slice. */
+    submenuGeneratedAt: string;
+    /**
+     * The `?tab=` value from the request URL, read SSR-first in `page.tsx` so a
+     * refreshed, bookmarked, or shared deep link opens on the right panel. An
+     * unknown or absent value resolves to `query` and lets the pending-approval
+     * auto-route decide the initial panel.
+     */
+    initialTab?: string;
+}
+
+/**
+ * AI tool governance admin client shell.
+ *
+ * @param props - SSR submenu tree, its timestamp, and the deep-linked initial tab.
+ * @returns The page.
+ */
+export function AiToolsAdminClient({ submenuTree, submenuGeneratedAt, initialTab }: IAiToolsAdminClientProps) {
+    const [activeTab, setActiveTab] = useState<TabId>(isTabId(initialTab) ? initialTab : 'query');
+    const [pending, setPending] = useState(0);
+    /** True once the initial pending fetch has auto-routed, so it fires at most once. */
+    const autoRoutedRef = useRef(false);
+    /**
+     * True once the operator drives a tab choice — or a `?tab=` deep link already
+     * named one — so the initial auto-route to Approvals never yanks them away.
+     */
+    const userPickedRef = useRef(isTabId(initialTab));
+
+    const refreshPending = useCallback(async (): Promise<number | null> => {
+        try {
+            const count = await getApprovalsCount();
+            setPending(count);
+            return count;
+        } catch {
+            return null;
+        }
+    }, []);
+
+    // On first load, if holds are already waiting, open on Approvals rather than
+    // the default Query — unless a deep link or the operator already chose a tab.
+    useEffect(() => {
+        void (async () => {
+            const count = await refreshPending();
+            if (count && count > 0 && !autoRoutedRef.current && !userPickedRef.current) {
+                autoRoutedRef.current = true;
+                setActiveTab('approvals');
+                window.history.replaceState(null, '', '/system/ai-tools?tab=approvals');
+            }
+        })();
+    }, [refreshPending]);
+
+    // Keep the pending-approvals badge live regardless of which tab is open.
+    useEffect(() => {
+        const socket = getSocket();
+        const onApprovals = () => { void refreshPending(); };
+        socket.on('ai-tools:approvals-changed', onApprovals);
+        return () => {
+            socket.off('ai-tools:approvals-changed', onApprovals);
+        };
+    }, [refreshPending]);
+
+    /**
+     * Activate the clicked tab and keep its URL a real deep link.
+     *
+     * `MenuNavClient` suppresses the <Link> navigation when `onItemSelect` is set,
+     * so this both drives `activeTab` and rewrites the address in place with
+     * `history.replaceState` (no server round-trip) so the registered `?tab=` URLs
+     * become true deep links; `page.tsx` reads that value SSR-first to seed the
+     * panel on next load. Recording the pick also locks out the pending-approval
+     * auto-route so it can never override the operator's choice.
+     *
+     * @param item - The clicked submenu node, carrying its `?tab=` url.
+     */
+    const handleTabSelect = useCallback((item: MenuNodeSerialized) => {
+        userPickedRef.current = true;
+        const tab = tabFromUrl(item.url);
+        setActiveTab(tab);
+        window.history.replaceState(null, '', `/system/ai-tools?tab=${tab}`);
+    }, []);
+
+    return (
+        <Page>
+            <PageHeader title="AI Tools" subtitle="Govern every tool an AI agent can invoke — registry, activity, approvals, and per-tool policy." />
+
+            {pending > 0 && (
+                <div className={styles.summary}>
+                    <Badge tone="warning">{pending} pending approval{pending === 1 ? '' : 's'}</Badge>
+                </div>
+            )}
+
+            <div className={styles.submenu}>
+                <MenuNavClient
+                    namespace={SUBMENU_NAMESPACE}
+                    items={submenuTree}
+                    generatedAt={submenuGeneratedAt}
+                    ariaLabel="AI tool governance sections"
+                    activeUrl={`/system/ai-tools?tab=${activeTab}`}
+                    onItemSelect={handleTabSelect}
+                />
+            </div>
+
+            <div className={styles.content}>
+                {activeTab === 'query' && <QueryTab />}
+                {activeTab === 'registry' && <RegistryTab onChanged={noop} />}
+                {activeTab === 'activity' && <ActivityTab />}
+                {activeTab === 'approvals' && <ApprovalsTab onChanged={refreshPending} />}
+            </div>
+        </Page>
+    );
+}

--- a/src/frontend/app/(core)/system/ai-tools/components/CollapsibleSection.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/CollapsibleSection.tsx
@@ -1,11 +1,15 @@
 'use client';
 
 /**
- * @fileoverview A titled, collapsible section for the Registry tab. Both the
- * Tools and Variables sections default collapsed and show a one-line summary in
- * the header, so the registry opens compact and an admin expands only the part
- * they came for. Client-only disclosure state — this is an admin surface, not a
- * public-facing component, so no SSR data hydration is involved.
+ * @fileoverview The single collapsible-disclosure primitive for the AI Tools
+ * dashboard. The Registry tab's Tools / Variables / System Prompts / Screen
+ * Settings sections and the Query tab's Saved Prompts panel all render through it,
+ * so one disclosure treatment (chevron, `aria-expanded`, section chrome) is shared
+ * instead of each surface re-hand-rolling the same toggle. Sections default
+ * collapsed and show a one-line summary in the header, so the registry opens
+ * compact and an admin expands only the part they came for. Client-only disclosure
+ * state — this is an admin surface, not a public-facing component, so no SSR data
+ * hydration is involved.
  */
 
 import { useState, type ReactNode } from 'react';
@@ -15,34 +19,67 @@ import styles from '../page.module.scss';
 /**
  * Collapsible disclosure section with a summary shown while collapsed.
  *
+ * Disclosure state is uncontrolled by default (the component owns its `useState`),
+ * which is all the Registry sections need. A caller whose logic depends on the
+ * open state — the Saved Prompts panel lazy-loads its list and polls schedules
+ * only while open — drives it in controlled mode by passing `open` + `onToggle`,
+ * keeping that state in the caller while still sharing this component's markup.
+ *
  * @param props.title - Section heading.
  * @param props.summary - Compact statistics shown in the header (always visible).
- * @param props.defaultOpen - Whether the section starts expanded (default false).
+ * @param props.icon - Optional leading glyph rendered after the chevron, before the title.
+ * @param props.defaultOpen - Initial open state in uncontrolled mode (default false).
+ * @param props.open - Controlled open state; when provided, `onToggle` owns changes.
+ * @param props.onToggle - Controlled toggle handler, called with the next open state.
  * @param props.children - The section body, rendered only while expanded.
  * @returns The section.
  */
 export function CollapsibleSection({
     title,
     summary,
+    icon,
     defaultOpen = false,
+    open: controlledOpen,
+    onToggle,
     children
 }: {
     title: string;
     summary?: ReactNode;
+    icon?: ReactNode;
     defaultOpen?: boolean;
+    open?: boolean;
+    onToggle?: (next: boolean) => void;
     children: ReactNode;
 }) {
-    const [open, setOpen] = useState(defaultOpen);
+    const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+    const isControlled = controlledOpen !== undefined;
+    const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+    /**
+     * Flip the disclosure, routing the change to the caller in controlled mode or
+     * to the internal state otherwise — the one branch that makes this component
+     * serve both the self-contained Registry sections and the state-owning Saved
+     * Prompts panel.
+     */
+    const toggle = (): void => {
+        const next = !open;
+        if (isControlled) {
+            onToggle?.(next);
+        } else {
+            setUncontrolledOpen(next);
+        }
+    };
 
     return (
         <div className={styles.section}>
             <button
                 type="button"
                 className={styles.section_header}
-                onClick={() => setOpen(current => !current)}
+                onClick={toggle}
                 aria-expanded={open}
             >
                 {open ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
+                {icon}
                 <span className={styles.section_title}>{title}</span>
                 {summary !== undefined && <span className={styles.section_summary}>{summary}</span>}
             </button>

--- a/src/frontend/app/(core)/system/ai-tools/components/RunTrifectaBadge.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/components/RunTrifectaBadge.module.scss
@@ -30,10 +30,14 @@
     gap: var(--gap-xs);
 }
 
+/* Fixed label column so the three trifecta legs align their names. The width is a
+ * component-local sizing token (no Layer 2 token fits a label-column width) so a
+ * theme can retune it without editing this rule. */
 .leg_label {
+    --trifecta-leg-label-min-width: 9rem;
     font-size: var(--font-size-caption);
     color: var(--color-text-muted);
-    min-width: 9rem;
+    min-width: var(--trifecta-leg-label-min-width);
 }
 
 .leg_names {

--- a/src/frontend/app/(core)/system/ai-tools/components/ToolAllowlistPicker.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/components/ToolAllowlistPicker.module.scss
@@ -57,13 +57,17 @@
 /* Bounded height so a long tool registry scrolls inside the picker instead of
  * pushing the modal's save button off-screen. */
 .list {
+    /* Cap the scroll list's height so a long tool set scrolls within the modal
+     * instead of pushing the save button off-screen. Component-local sizing token
+     * (no Layer 2 token fits a scroll-list cap) so a theme can retune it. */
+    --tool-allowlist-list-max-height: 14rem;
     display: flex;
     flex-direction: column;
     gap: var(--gap-2xs);
     list-style: none;
     margin: 0;
     padding: var(--padding-xs);
-    max-height: 14rem;
+    max-height: var(--tool-allowlist-list-max-height);
     overflow-y: auto;
     border: var(--border-width-thin) solid var(--color-border);
     border-radius: var(--radius-sm);

--- a/src/frontend/app/(core)/system/ai-tools/page.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/page.module.scss
@@ -6,55 +6,31 @@
 
 @use '../../../breakpoints' as *;
 
-.container {
+/* Summary strip above the tab row: carries the live pending-approval tally a
+ * menu node cannot. Mirrors the account-history summary row. */
+.summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--gap-sm);
+}
+
+/* The in-page tab row (menu module's Submenu Pattern, rendered by MenuNavClient). */
+.submenu {
+    margin-top: var(--gap-sm);
+}
+
+/* Active tab panel. Declares the `ai-tools-dashboard` container so the tables it
+ * hosts (Activity feed, invocation table) can reflow their columns to the panel's
+ * own width via `@container` — correct inside the slideout/modal contexts this
+ * dashboard renders in. */
+.content {
+    margin-top: var(--gap-md);
     display: flex;
     flex-direction: column;
-    gap: var(--gap-lg);
+    gap: var(--gap-md);
     container-type: inline-size;
     container-name: ai-tools-dashboard;
-}
-
-.header_row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--gap-md);
-    flex-wrap: wrap;
-}
-
-.tabs {
-    display: flex;
-    gap: var(--gap-sm);
-    border-bottom: var(--border-width-thin) solid var(--color-border);
-    flex-wrap: wrap;
-}
-
-.tab,
-.tab__active {
-    padding: var(--gap-sm) var(--gap-md);
-    background: none;
-    border: none;
-    border-bottom: var(--border-width-medium) solid transparent;
-    cursor: pointer;
-    font-size: var(--font-size-body-lg);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-text-muted);
-    transition: color var(--transition-base), border-color var(--transition-base);
-}
-
-.tab:hover {
-    color: var(--color-text);
-}
-
-.tab__active {
-    color: var(--color-primary);
-    border-bottom-color: var(--color-primary);
-}
-
-.content {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-md);
 }
 
 /* Tool name + description stack inside a table cell. */
@@ -406,6 +382,14 @@
     white-space: nowrap;
     font-size: var(--font-size-body-sm);
     color: var(--color-text-muted);
+}
+
+/* Provider dropdown in the filter bar: the leading control that scopes the tool
+ * list to one registering plugin/module. Intrinsic width (sized to the selected
+ * option) suits the wrapping inline filter bar; it never grows to crowd the search
+ * field beside it. */
+.provider_select {
+    flex: 0 0 auto;
 }
 
 /* Search input in the filter bar: grow to fill, but keep a sane floor so it does

--- a/src/frontend/app/(core)/system/ai-tools/page.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/page.tsx
@@ -1,133 +1,69 @@
-'use client';
-
 /**
- * @fileoverview /system/ai-tools — the AI tool governance dashboard.
+ * @fileoverview /system/ai-tools server entry — the AI tool governance dashboard.
  *
- * Four tabs (Query — the default — then Registry, Activity, Approvals) plus a
- * live pending-approval count on the Approvals tab. When holds are already
- * waiting on first load the shell opens on Approvals instead of Query, so the
- * operator lands on the decision that needs them. Curation moved to its own
- * surface at /system/curation. Per-tool policy editing is not its own tab —
- * the Registry slide-over carries it — so this shell has no Policy tab.
- * Admin-gated by the /system layout; like the other system pages it is a client
- * component that fetches over the cookie-authenticated admin API. Governed events
- * arrive as WebSocket refetch signals — the data itself always comes from the
- * gated REST feed, never a global broadcast.
+ * Fetches the page's in-page tab row from the menu service SSR-first and hands it
+ * to the client shell. The tab row is a namespaced menu (menu module's Submenu
+ * Pattern), not a hand-rolled button array, so it inherits per-user gating,
+ * ordering, and live `menu:update` refresh. This server component fetches that
+ * namespace tree once — forwarding the admin's session cookie so the nodes'
+ * `requiresAdmin` gating resolves — exactly as `MenuNavSSR` feeds the global nav;
+ * the client shell then renders it with `MenuNavClient` and drives the active
+ * panel. Admin-gated by the /system layout.
  */
 
-import { useEffect, useState, useCallback, useRef } from 'react';
-import { Page, PageHeader } from '../../../../components/layout';
-import { Badge } from '../../../../components/ui/Badge';
-import { getSocket } from '../../../../lib/socketClient';
-import { getApprovalsCount } from '../../../../modules/ai-tools';
-import { RegistryTab } from './tabs/RegistryTab';
-import { ActivityTab } from './tabs/ActivityTab';
-import { ApprovalsTab } from './tabs/ApprovalsTab';
-import { QueryTab } from './tabs/QueryTab';
-import styles from './page.module.scss';
+import { cookies } from 'next/headers';
+import type { MenuNodeSerialized } from '@/shared';
+import { getServerSideApiUrl } from '../../../../lib/api-url';
+import { AiToolsAdminClient } from './AiToolsAdminClient';
 
-/** The dashboard tabs. */
-type TabId = 'registry' | 'query' | 'activity' | 'approvals';
-
-const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
-    { id: 'query', label: 'Query' },
-    { id: 'registry', label: 'Registry' },
-    { id: 'activity', label: 'Activity' },
-    { id: 'approvals', label: 'Approvals' }
-];
+/** Namespace holding the page's tab nodes; registered by AiToolsModule. */
+const SUBMENU_NAMESPACE = 'ai-tools';
 
 /**
- * Stable no-op for RegistryTab's required `onChanged`. The callback used to
- * re-check the trifecta banner after a registry change; with that banner
- * removed there is nothing left for the page to do, and a module-level constant
- * keeps RegistryTab's memoized callbacks from re-creating each render.
- */
-const noop = (): void => {};
-
-/**
- * AI tool governance dashboard page.
+ * Fetch the submenu namespace tree from the menu API, forwarding the visitor's
+ * cookies so the backend's per-user `requiresAdmin` gating resolves for the
+ * admin. On any failure it returns an empty tree, mirroring `MenuNavSSR`'s
+ * graceful degradation — the page still renders, just without the tab row until
+ * a live `menu:update` refetch repopulates it.
  *
- * @returns The page.
+ * @returns The namespace root nodes and the tree snapshot timestamp.
  */
-export default function AiToolsAdminPage() {
-    const [activeTab, setActiveTab] = useState<TabId>('query');
-    const [pending, setPending] = useState(0);
-    /** True once the initial pending fetch has auto-routed, so it fires at most once. */
-    const autoRoutedRef = useRef(false);
-    /** True once the operator picks a tab, so auto-routing never yanks them away. */
-    const userPickedRef = useRef(false);
-
-    const refreshPending = useCallback(async (): Promise<number | null> => {
-        try {
-            const count = await getApprovalsCount();
-            setPending(count);
-            return count;
-        } catch {
-            return null;
+async function fetchSubmenu(): Promise<{ roots: MenuNodeSerialized[]; generatedAt: string }> {
+    const fallback = { roots: [] as MenuNodeSerialized[], generatedAt: new Date().toISOString() };
+    try {
+        const cookieHeader = (await cookies()).toString();
+        const response = await fetch(`${getServerSideApiUrl()}/api/menu?namespace=${SUBMENU_NAMESPACE}`, {
+            cache: 'no-store',
+            headers: cookieHeader ? { Cookie: cookieHeader } : undefined
+        });
+        if (!response.ok) {
+            return fallback;
         }
-    }, []);
-
-    // On first load, if holds are already waiting, open on Approvals rather than
-    // the default Query — unless the operator has already chosen a tab.
-    useEffect(() => {
-        void (async () => {
-            const count = await refreshPending();
-            if (count && count > 0 && !autoRoutedRef.current && !userPickedRef.current) {
-                autoRoutedRef.current = true;
-                setActiveTab('approvals');
-            }
-        })();
-    }, [refreshPending]);
-
-    // Keep the pending-approvals badge live regardless of which tab is open.
-    useEffect(() => {
-        const socket = getSocket();
-        const onApprovals = () => { void refreshPending(); };
-        socket.on('ai-tools:approvals-changed', onApprovals);
-        return () => {
-            socket.off('ai-tools:approvals-changed', onApprovals);
+        const data = await response.json() as { tree?: { roots?: MenuNodeSerialized[]; generatedAt?: string } };
+        return {
+            roots: data.tree?.roots ?? [],
+            generatedAt: data.tree?.generatedAt ?? fallback.generatedAt
         };
-    }, [refreshPending]);
+    } catch {
+        return fallback;
+    }
+}
 
-    /**
-     * Select a tab and record that the operator drove the choice, so the initial
-     * auto-route to Approvals cannot later override their pick.
-     *
-     * @param id - The tab to open.
-     */
-    const pickTab = useCallback((id: TabId) => {
-        userPickedRef.current = true;
-        setActiveTab(id);
-    }, []);
-
-    return (
-        <Page>
-            <PageHeader title="AI Tools" subtitle="Govern every tool an AI agent can invoke — registry, activity, approvals, and per-tool policy." />
-            <div className={styles.container}>
-                <div className={styles.tabs} role="tablist" aria-label="AI tool governance sections">
-                    {TABS.map(tab => (
-                        <button
-                            key={tab.id}
-                            role="tab"
-                            aria-selected={activeTab === tab.id}
-                            className={activeTab === tab.id ? styles.tab__active : styles.tab}
-                            onClick={() => pickTab(tab.id)}
-                        >
-                            {tab.label}
-                            {tab.id === 'approvals' && pending > 0 && (
-                                <> <Badge tone="warning">{pending}</Badge></>
-                            )}
-                        </button>
-                    ))}
-                </div>
-
-                <div className={styles.content}>
-                    {activeTab === 'registry' && <RegistryTab onChanged={noop} />}
-                    {activeTab === 'query' && <QueryTab />}
-                    {activeTab === 'activity' && <ActivityTab />}
-                    {activeTab === 'approvals' && <ApprovalsTab onChanged={refreshPending} />}
-                </div>
-            </div>
-        </Page>
-    );
+/**
+ * AI tool governance dashboard page (server entry).
+ *
+ * @param props - Next.js route props.
+ * @param props.searchParams - The `?tab=` deep link (a Promise in Next.js 15+),
+ *   read SSR-first to seed the initially active panel so a refreshed, bookmarked,
+ *   or shared link opens on the selected tab instead of falling back to Query.
+ * @returns The client shell seeded with the SSR-fetched submenu tree.
+ */
+export default async function AiToolsAdminPage({
+    searchParams
+}: {
+    searchParams: Promise<{ tab?: string }>;
+}) {
+    const { roots, generatedAt } = await fetchSubmenu();
+    const { tab } = await searchParams;
+    return <AiToolsAdminClient submenuTree={roots} submenuGeneratedAt={generatedAt} initialTab={tab} />;
 }

--- a/src/frontend/app/(core)/system/ai-tools/tabs/RegistryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/RegistryTab.tsx
@@ -20,6 +20,7 @@ import { cn } from '../../../../../lib/cn';
 import { Stack } from '../../../../../components/layout';
 import { Table, Thead, Tbody, Tr, Th } from '../../../../../components/ui/Table';
 import { Input } from '../../../../../components/ui/Input';
+import { Select } from '../../../../../components/ui/Select';
 import { SlideOver } from '../../../../../components/ui/SlideOver';
 import { useToast } from '../../../../../components/ui/ToastProvider';
 import { listTools, listProviders, setToolEnabled, getPolicy, type IPolicyResponse } from '../../../../../modules/ai-tools';
@@ -55,6 +56,7 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
     const [error, setError] = useState<string | null>(null);
     const [busyName, setBusyName] = useState<string | null>(null);
     const [onlyOverrides, setOnlyOverrides] = useState(false);
+    const [providerFilter, setProviderFilter] = useState('');
     const [search, setSearch] = useState('');
     const [riskFilter, setRiskFilter] = useState<Set<RiskClass>>(new Set());
     const [selectedName, setSelectedName] = useState<string | null>(null);
@@ -122,6 +124,16 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
     const disabledCount = tools.filter(tool => !tool.enabled).length;
     const toolsSummary = `${tools.length} tools · ${disabledCount} disabled · ${overrideCount} overrides`;
 
+    // Tally tools per registering plugin/module so the provider dropdown can label
+    // each option with its count and stays sorted alphabetically. Counts span the
+    // full registry (not the other active filters) so the dropdown reads as a
+    // stable table of contents rather than shifting as the search narrows.
+    const providerCounts = new Map<string, number>();
+    for (const tool of tools) {
+        providerCounts.set(tool.provider, (providerCounts.get(tool.provider) ?? 0) + 1);
+    }
+    const providerOptions = [...providerCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+
     // Apply the three filters, then sort: enabled tools first so the live set
     // an operator acts on stays together at the top and disabled tools sink to
     // the bottom; within each group, dangerous-first (then by name) so an audit
@@ -129,6 +141,7 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
     const query = search.trim().toLowerCase();
     const visibleTools = tools
         .filter(tool => !onlyOverrides || policy.overrides[tool.name] !== undefined)
+        .filter(tool => providerFilter === '' || tool.provider === providerFilter)
         .filter(tool => riskFilter.size === 0 || riskFilter.has(riskClassOf(tool.capability)))
         .filter(tool => query === ''
             || tool.name.toLowerCase().includes(query)
@@ -160,6 +173,17 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
                     : (
                         <Stack gap="sm">
                             <div className={styles.filters}>
+                                <Select
+                                    className={styles.provider_select}
+                                    aria-label="Filter by provider"
+                                    value={providerFilter}
+                                    onChange={(e) => setProviderFilter(e.target.value)}
+                                >
+                                    <option value="">All providers ({tools.length})</option>
+                                    {providerOptions.map(([id, count]) => (
+                                        <option key={id} value={id}>{id} ({count})</option>
+                                    ))}
+                                </Select>
                                 <Input
                                     className={styles.search_input}
                                     type="search"

--- a/src/frontend/app/(core)/system/ai-tools/tabs/SavedPromptsPanel.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/SavedPromptsPanel.module.scss
@@ -13,39 +13,18 @@
 
 /*
  * ===========================================================================
- * COLLAPSIBLE PANEL — header toggle + body (save row + prompt list).
+ * SAVED-PROMPTS PANEL — the shared CollapsibleSection carries the disclosure
+ * (header toggle, chevron, `aria-expanded`, section chrome, and the body wrapper);
+ * only the header's leading icon and count badge remain panel-specific.
  * ===========================================================================
  */
-.panel_card {
-    container-type: inline-size;
-    container-name: saved-prompts;
-    padding: 0;
-    overflow: hidden;
-}
 
-.panel_toggle {
-    display: flex;
-    align-items: center;
-    gap: var(--gap-xs);
-    width: 100%;
-    padding: var(--padding-sm) var(--card-padding-sm);
-    background: var(--color-surface-muted);
-    border: none;
-    color: var(--color-text);
-    font-size: var(--font-size-body-sm);
-    font-weight: var(--font-weight-medium);
-    cursor: pointer;
-
-    &:focus-visible {
-        outline: var(--focus-outline-width) solid var(--focus-outline-color);
-        outline-offset: calc(-1 * var(--focus-outline-width));
-    }
-}
-
+/* Bookmark glyph passed as the section's leading `icon`. */
 .panel_icon {
     color: var(--color-primary);
 }
 
+/* Saved-prompt tally passed as the section's `summary`. */
 .panel_count {
     display: inline-flex;
     align-items: center;
@@ -57,19 +36,6 @@
     color: var(--color-primary);
     font-size: var(--font-size-caption);
     font-weight: var(--font-weight-semibold);
-}
-
-.panel_chevron {
-    margin-left: auto;
-    color: var(--color-text-muted);
-}
-
-.panel_body {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-sm);
-    padding: var(--card-padding-sm);
-    border-top: var(--border-width-thin) solid var(--color-border);
 }
 
 /* Inline save row: name input + Save button to capture the composer text. */
@@ -272,9 +238,12 @@
 }
 
 /* Layout-only extras on top of the shared <Textarea> primitive: a taller resting
- * height and relaxed line spacing for prompt-body editing. */
+ * height and relaxed line spacing for prompt-body editing. The resting height is a
+ * component-local sizing token (no Layer 2 token fits a prompt-editor min-height),
+ * so a theme can retune it without reaching into this rule. */
 .textarea {
-    min-height: 8rem;
+    --saved-prompt-textarea-min-height: 8rem;
+    min-height: var(--saved-prompt-textarea-min-height);
     line-height: var(--line-height-relaxed);
 }
 

--- a/src/frontend/app/(core)/system/ai-tools/tabs/SavedPromptsPanel.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/SavedPromptsPanel.tsx
@@ -19,8 +19,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import {
     Bookmark,
-    ChevronDown,
-    ChevronRight,
     RefreshCw,
     Play,
     Pencil,
@@ -30,11 +28,12 @@ import {
     AlertTriangle
 } from 'lucide-react';
 import type { ISavedPrompt, ISavedPromptTrigger } from '@/types';
-import { Card } from '../../../../../components/ui/Card';
+import { Stack } from '../../../../../components/layout';
 import { Button } from '../../../../../components/ui/Button';
 import { Input } from '../../../../../components/ui/Input';
 import { IconButton } from '../../../../../components/ui/IconButton';
 import { useModal } from '../../../../../components/ui/ModalProvider';
+import { CollapsibleSection } from '../components/CollapsibleSection';
 import { listSavedPrompts, saveSavedPrompt, deleteSavedPrompt } from '../../../../../modules/ai-tools';
 import { describeCron, formatRelativeTime, getMsUntilNextCron, formatTimeUntil } from './savedPromptCron';
 import { PromptEditModal } from './PromptEditModal';
@@ -460,52 +459,41 @@ export function SavedPromptsPanel({
     }
 
     return (
-        <Card className={styles.panel_card}>
-            <button
-                type="button"
-                className={styles.panel_toggle}
-                onClick={() => setOpen(!open)}
-                aria-expanded={open}
-                aria-label="Toggle saved prompts panel"
-            >
-                <Bookmark size={16} className={styles.panel_icon} />
-                <span>Saved Prompts</span>
-                {prompts.length > 0 && <span className={styles.panel_count}>{prompts.length}</span>}
-                {open
-                    ? <ChevronDown size={14} className={styles.panel_chevron} />
-                    : <ChevronRight size={14} className={styles.panel_chevron} />}
-            </button>
-
-            {open && (
-                <div className={styles.panel_body}>
-                    <div className={styles.save_row}>
-                        <Input
-                            type="text"
-                            value={saveName}
-                            onChange={(e) => setSaveName(e.target.value)}
-                            placeholder="Prompt name…"
-                            className={styles.name_input}
-                            aria-label="Prompt name"
-                            onKeyDown={(e) => {
-                                if (e.key === 'Enter') {
-                                    e.preventDefault();
-                                    void handleSave();
-                                }
-                            }}
-                        />
-                        <Button
-                            variant="primary"
-                            size="xs"
-                            onClick={() => { void handleSave(); }}
-                            disabled={!saveName.trim() || !currentPromptText.trim()}
-                            aria-label="Save current prompt"
-                        >
-                            Save
-                        </Button>
-                    </div>
-                    {renderBody()}
+        <CollapsibleSection
+            title="Saved Prompts"
+            icon={<Bookmark size={16} className={styles.panel_icon} />}
+            summary={prompts.length > 0 ? <span className={styles.panel_count}>{prompts.length}</span> : undefined}
+            open={open}
+            onToggle={setOpen}
+        >
+            <Stack gap="sm">
+                <div className={styles.save_row}>
+                    <Input
+                        type="text"
+                        value={saveName}
+                        onChange={(e) => setSaveName(e.target.value)}
+                        placeholder="Prompt name…"
+                        className={styles.name_input}
+                        aria-label="Prompt name"
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                                e.preventDefault();
+                                void handleSave();
+                            }
+                        }}
+                    />
+                    <Button
+                        variant="primary"
+                        size="xs"
+                        onClick={() => { void handleSave(); }}
+                        disabled={!saveName.trim() || !currentPromptText.trim()}
+                        aria-label="Save current prompt"
+                    >
+                        Save
+                    </Button>
                 </div>
-            )}
-        </Card>
+                {renderBody()}
+            </Stack>
+        </CollapsibleSection>
     );
 }


### PR DESCRIPTION
Brings the `/system/ai-tools` admin dashboard into line with the documented UI/UX standards and adds provider-scoped filtering to the registry.

## Tab row → Submenu Pattern
The page-level tab row was a hand-rolled `<button>` strip, which `frontend.md` forbids for core admin pages — the menu module's Submenu Pattern is the only authorized approach. Adopted it, mirroring `/system/account-history`:
- `AiToolsModule.run()` registers an `ai-tools` menu namespace with the four tab nodes (per-node `requiresAdmin`, kept out of `main`).
- `page.tsx` is now a server component that SSR-fetches the namespace tree + `?tab=` deep link; new `AiToolsAdminClient` renders `MenuNavClient` (submenu mode) and drives `activeTab`.
- Tabs are real deep links and inherit per-user gating, ordering, and live `menu:update` refresh — and a plugin can now contribute a tab. Pending-approval auto-route and live count are preserved (count rides a summary badge above the row, since a menu node can't carry a live count).

## Registry provider dropdown
The Tools section gains a Provider `<Select>` — **All providers (N)** plus one option per registering plugin/module with a live tool count — that scopes the triage table by `tool.provider`, composing with the existing search, risk-class, and overrides filters.

## DRY
`CollapsibleSection` is now the single disclosure primitive for the dashboard (optional leading `icon` + controlled mode). `SavedPromptsPanel` renders through it, keeping its load-bearing `open` state via controlled props and dropping its parallel `Card`/toggle plus ~55 lines of duplicated styles. It now wears the shared `.section` chrome like its four sibling collapsibles (Bookmark icon and count pill retained).

## Token compliance
Replaced three bare `rem` literals (SavedPromptsPanel textarea min-height, RunTrifectaBadge leg-label width, ToolAllowlistPicker list max-height) with documented component-local sizing tokens, matching the `QueryTab` precedent.

`npm run typecheck` passes.