### PR TITLE
feat(ai-tools): group registry tools into per-provider sections

### DIFF
--- a/src/frontend/app/(core)/system/ai-tools/components/RegistryToolRow.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/components/RegistryToolRow.tsx
@@ -24,17 +24,22 @@ import styles from '../page.module.scss';
 /**
  * A single tool's registry row.
  *
- * @param props.tool - The tool to render (enabled, capability, name, description, provider).
+ * @param props.tool - The tool to render (enabled, capability, name, description).
  * @param props.hasOverride - Whether the tool carries a saved policy override; drives the "override" badge.
  * @param props.busy - Whether an enable toggle for this tool is in flight, disabling the switch.
+ * @param props.indented - Indents the row's leading cell so it nests visually under its
+ *                         provider-section header. The registry lists tools grouped by
+ *                         provider, so the provider is named once on the section header
+ *                         rather than repeated per row.
  * @param props.onToggle - Enable/disable handler the parent owns (reloads and re-checks the trifecta).
  * @param props.onSelect - Opens the detail slide-over for this tool.
  * @returns The table row.
  */
-export function RegistryToolRow({ tool, hasOverride, busy, onToggle, onSelect }: {
+export function RegistryToolRow({ tool, hasOverride, busy, indented = false, onToggle, onSelect }: {
     tool: IAiToolInfo;
     hasOverride: boolean;
     busy: boolean;
+    indented?: boolean;
     onToggle: (name: string, enabled: boolean) => void;
     onSelect: (tool: IAiToolInfo) => void;
 }) {
@@ -50,7 +55,7 @@ export function RegistryToolRow({ tool, hasOverride, busy, onToggle, onSelect }:
 
     return (
         <Tr className={styles.tool_row} onClick={() => onSelect(tool)}>
-            <Td onClick={stopCellClick}>
+            <Td onClick={stopCellClick} className={indented ? styles.tool_indent : undefined}>
                 <Switch
                     on={tool.enabled}
                     onChange={(next) => onToggle(tool.name, next)}
@@ -72,7 +77,6 @@ export function RegistryToolRow({ tool, hasOverride, busy, onToggle, onSelect }:
                 </div>
             </Td>
             <Td><span className={styles.tool_teaser}>{tool.description}</span></Td>
-            <Td muted>{tool.provider}</Td>
         </Tr>
     );
 }

--- a/src/frontend/app/(core)/system/ai-tools/page.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/page.module.scss
@@ -319,6 +319,37 @@
     cursor: pointer;
 }
 
+/* Per-provider section header row: names the registering plugin/module once for
+ * the tools grouped beneath it, so the provider is not repeated per row. Left
+ * aligned; a muted fill sets it apart from the tool rows it heads. */
+.provider_group_row {
+    background: var(--color-surface-muted);
+}
+
+.provider_group_cell {
+    display: flex;
+    align-items: baseline;
+    gap: var(--gap-sm);
+}
+
+.provider_group_name {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text);
+}
+
+.provider_group_count {
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--letter-spacing-wide);
+    text-transform: uppercase;
+    color: var(--color-text-subtle);
+}
+
+/* Slight indent on a tool row's leading cell so its tools nest visually under the
+ * provider header above them. */
+.tool_indent {
+    padding-left: var(--gap-xl);
+}
+
 /* Tool name rendered as a bare button so it is keyboard-focusable and opens the
  * slide-over without an extra control competing on the row. */
 .tool_name_button {

--- a/src/frontend/app/(core)/system/ai-tools/page.module.scss
+++ b/src/frontend/app/(core)/system/ai-tools/page.module.scss
@@ -326,10 +326,21 @@
     background: var(--color-surface-muted);
 }
 
+/* Flex wrapper INSIDE the spanning header cell — never on the `<th>`/`<td>` itself:
+ * a table cell whose display computes to flex loses `table-cell`, which drops the
+ * colSpan and collapses the header into the first (shrink) column. The header cell
+ * is a `<th scope="rowgroup">` (screen-reader association for the tools grouped in
+ * the tbody), so neutralize the `.th` typography (xs / uppercase / wide / medium)
+ * it would otherwise impose on this content; the name reads at body size in normal
+ * case, while the count span keeps its own caption/uppercase treatment. */
 .provider_group_cell {
     display: flex;
     align-items: baseline;
     gap: var(--gap-sm);
+    font-size: var(--font-size-body);
+    font-weight: var(--font-weight-normal);
+    text-transform: none;
+    letter-spacing: normal;
 }
 
 .provider_group_name {

--- a/src/frontend/app/(core)/system/ai-tools/tabs/RegistryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/RegistryTab.tsx
@@ -18,7 +18,7 @@ import { AlertCircle } from 'lucide-react';
 import type { IAiToolInfo, IAiProviderInfo } from '@/types';
 import { cn } from '../../../../../lib/cn';
 import { Stack } from '../../../../../components/layout';
-import { Table, Thead, Tbody, Tr, Th } from '../../../../../components/ui/Table';
+import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
 import { Input } from '../../../../../components/ui/Input';
 import { Select } from '../../../../../components/ui/Select';
 import { SlideOver } from '../../../../../components/ui/SlideOver';
@@ -134,26 +134,44 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
     }
     const providerOptions = [...providerCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
 
-    // Apply the three filters, then sort: enabled tools first so the live set
-    // an operator acts on stays together at the top and disabled tools sink to
-    // the bottom; within each group, dangerous-first (then by name) so an audit
-    // sweep still meets the high-stakes tools at the top of the active list.
+    // Apply the four filters, then group by registering provider. Grouping is the
+    // layout, not a toggle: each provider is its own always-open section (a header
+    // naming the provider, then its tools), so the registry reads as "who
+    // contributed what." The provider dropdown narrows to a single section; the
+    // search, risk, and overrides filters thin the tools inside each. Within a
+    // section tools keep the triage order — enabled first, then dangerous-first,
+    // then by name — and the sections sort alphabetically to match the dropdown.
     const query = search.trim().toLowerCase();
-    const visibleTools = tools
+    const filteredTools = tools
         .filter(tool => !onlyOverrides || policy.overrides[tool.name] !== undefined)
         .filter(tool => providerFilter === '' || tool.provider === providerFilter)
         .filter(tool => riskFilter.size === 0 || riskFilter.has(riskClassOf(tool.capability)))
         .filter(tool => query === ''
             || tool.name.toLowerCase().includes(query)
             || tool.description.toLowerCase().includes(query)
-            || tool.provider.toLowerCase().includes(query))
-        .sort((a, b) => {
-            if (a.enabled !== b.enabled) {
-                return a.enabled ? -1 : 1;
-            }
-            const byRisk = riskRankOf(b.capability) - riskRankOf(a.capability);
-            return byRisk !== 0 ? byRisk : a.name.localeCompare(b.name);
-        });
+            || tool.provider.toLowerCase().includes(query));
+
+    const toolsByProvider = new Map<string, IAiToolInfo[]>();
+    for (const tool of filteredTools) {
+        const existing = toolsByProvider.get(tool.provider);
+        if (existing) {
+            existing.push(tool);
+        } else {
+            toolsByProvider.set(tool.provider, [tool]);
+        }
+    }
+    const providerGroups = [...toolsByProvider.entries()]
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([provider, groupTools]) => ({
+            provider,
+            tools: [...groupTools].sort((a, b) => {
+                if (a.enabled !== b.enabled) {
+                    return a.enabled ? -1 : 1;
+                }
+                const byRisk = riskRankOf(b.capability) - riskRankOf(a.capability);
+                return byRisk !== 0 ? byRisk : a.name.localeCompare(b.name);
+            })
+        }));
 
     // Derive the open tool from the live list so a reload (after toggle/policy
     // edit) flows fresh data into the panel rather than freezing a stale copy.
@@ -214,7 +232,7 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
                                     Only overrides
                                 </label>
                             </div>
-                            {visibleTools.length === 0
+                            {filteredTools.length === 0
                                 ? <div className={styles.placeholder}>No tools match the current filters.</div>
                                 : (
                                     <div className="table-scroll">
@@ -225,21 +243,31 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
                                                     <Th width="shrink">Risk</Th>
                                                     <Th>Tool</Th>
                                                     <Th width="expand">Description</Th>
-                                                    <Th width="shrink">Provider</Th>
                                                 </Tr>
                                             </Thead>
-                                            <Tbody>
-                                                {visibleTools.map(tool => (
-                                                    <RegistryToolRow
-                                                        key={tool.name}
-                                                        tool={tool}
-                                                        hasOverride={policy.overrides[tool.name] !== undefined}
-                                                        busy={busyName === tool.name}
-                                                        onToggle={handleToggle}
-                                                        onSelect={(selected) => setSelectedName(selected.name)}
-                                                    />
-                                                ))}
-                                            </Tbody>
+                                            {providerGroups.map(group => (
+                                                <Tbody key={group.provider}>
+                                                    <Tr className={styles.provider_group_row}>
+                                                        <Td colSpan={4} className={styles.provider_group_cell}>
+                                                            <span className={styles.provider_group_name}>{group.provider}</span>
+                                                            <span className={styles.provider_group_count}>
+                                                                {group.tools.length} tool{group.tools.length === 1 ? '' : 's'}
+                                                            </span>
+                                                        </Td>
+                                                    </Tr>
+                                                    {group.tools.map(tool => (
+                                                        <RegistryToolRow
+                                                            key={tool.name}
+                                                            tool={tool}
+                                                            indented
+                                                            hasOverride={policy.overrides[tool.name] !== undefined}
+                                                            busy={busyName === tool.name}
+                                                            onToggle={handleToggle}
+                                                            onSelect={(selected) => setSelectedName(selected.name)}
+                                                        />
+                                                    ))}
+                                                </Tbody>
+                                            ))}
                                         </Table>
                                     </div>
                                 )}

--- a/src/frontend/app/(core)/system/ai-tools/tabs/RegistryTab.tsx
+++ b/src/frontend/app/(core)/system/ai-tools/tabs/RegistryTab.tsx
@@ -18,7 +18,7 @@ import { AlertCircle } from 'lucide-react';
 import type { IAiToolInfo, IAiProviderInfo } from '@/types';
 import { cn } from '../../../../../lib/cn';
 import { Stack } from '../../../../../components/layout';
-import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
+import { Table, Thead, Tbody, Tr, Th } from '../../../../../components/ui/Table';
 import { Input } from '../../../../../components/ui/Input';
 import { Select } from '../../../../../components/ui/Select';
 import { SlideOver } from '../../../../../components/ui/SlideOver';
@@ -248,12 +248,14 @@ export function RegistryTab({ onChanged }: { onChanged: () => void }) {
                                             {providerGroups.map(group => (
                                                 <Tbody key={group.provider}>
                                                     <Tr className={styles.provider_group_row}>
-                                                        <Td colSpan={4} className={styles.provider_group_cell}>
-                                                            <span className={styles.provider_group_name}>{group.provider}</span>
-                                                            <span className={styles.provider_group_count}>
-                                                                {group.tools.length} tool{group.tools.length === 1 ? '' : 's'}
-                                                            </span>
-                                                        </Td>
+                                                        <Th scope="rowgroup" colSpan={4}>
+                                                            <div className={styles.provider_group_cell}>
+                                                                <span className={styles.provider_group_name}>{group.provider}</span>
+                                                                <span className={styles.provider_group_count}>
+                                                                    {group.tools.length} tool{group.tools.length === 1 ? '' : 's'}
+                                                                </span>
+                                                            </div>
+                                                        </Th>
                                                     </Tr>
                                                     {group.tools.map(tool => (
                                                         <RegistryToolRow


### PR DESCRIPTION
Groups the Registry tab's Tools list by the registering plugin/module instead of a single flat table.

## What changed
Each provider is now an **always-open section**: a left-aligned header naming the provider (with an "N tools" count), followed by its tools rendered slightly indented beneath it. Providers sort alphabetically; within a section tools keep the existing triage order (enabled first, then dangerous-first, then by name).

- The redundant per-row **Provider column is dropped** — the provider is named once on the section header.
- `RegistryToolRow` gains an `indented` prop (adds left padding to its leading cell) and no longer renders a provider cell.
- The **provider dropdown filter is retained** and now reads as jump-to-section: selecting a provider renders only that section; "All providers" shows every section. Search, risk-class, and overrides filters still thin the tools inside each section.
- New styles (`.provider_group_row/_cell/_name/_count`, `.tool_indent`) are all design-token-based.

Follow-up to the AI Tools dashboard work in #459 (Submenu Pattern tab row + provider dropdown).

`npm run typecheck` passes.