### PR TITLE
feat(ui): canonical TronAddress chip exposed via context.ui

### DIFF
--- a/packages/types/src/plugin/IFrontendPluginContext.ts
+++ b/packages/types/src/plugin/IFrontendPluginContext.ts
@@ -276,6 +276,36 @@ export interface IUIComponents {
         placement?: 'top' | 'bottom';
     }>;
 
+    /**
+     * TronAddress — the canonical way to render a TRON wallet/contract address.
+     *
+     * Shows the address as a compact monospace chip (`first 4 … last 4`, full
+     * value in a tooltip) with three slim affordances: copy-to-clipboard, a
+     * "forward to a public tool" dropdown, and an external Tronscan link. Use
+     * this instead of hand-truncating an address and hand-building a Tronscan
+     * anchor so every surface — core and plugin — stays visually and
+     * behaviourally identical and only has to be fixed in one place.
+     *
+     * Renders synchronously from `address`, so it is SSR-safe: pass the address
+     * straight from your SSR data. The chip does not resolve labels itself —
+     * pass a pre-resolved `label` (from an SSR fetcher) to display a name in
+     * place of the truncation. Trim affordances off with `copy`/`tools`/
+     * `explorer` for dense read-only contexts.
+     */
+    TronAddress: ComponentType<{
+        /** Full base58check TRON address (`T…`); the value copied and linked. */
+        address: string;
+        /** Pre-resolved human label shown in place of the truncated address. */
+        label?: string;
+        /** Show the copy-to-clipboard affordance. @default true */
+        copy?: boolean;
+        /** Show the "forward to a tool" dropdown. @default true */
+        tools?: boolean;
+        /** Show the external Tronscan link. @default true */
+        explorer?: boolean;
+        className?: string;
+    }>;
+
     /** Icon picker modal component for visual icon selection */
     IconPickerModal: ComponentType<{
         selectedIcon?: string;
@@ -1135,7 +1165,7 @@ export interface IFrontendPluginContext {
     /** Plugin identifier used for namespacing events and API routes */
     pluginId: string;
 
-    /** UI component library (Card, Badge, Button, CopyButton, IconButton, Switch, Input, Select, Textarea, Skeleton, ClientTime, Tooltip, IconPickerModal, ConfirmDialog, Table family) */
+    /** UI component library (Card, Badge, Button, CopyButton, IconButton, Switch, Input, Select, Textarea, Skeleton, ClientTime, Tooltip, TronAddress, IconPickerModal, ConfirmDialog, Table family) */
     ui: IUIComponents;
 
     /** Layout component library (Page, PageHeader, Stack, Grid, Section, SubMenu) */

--- a/src/frontend/app/(core)/tools/address-converter/page.tsx
+++ b/src/frontend/app/(core)/tools/address-converter/page.tsx
@@ -5,6 +5,7 @@
  * No SSR data — the tool is a user-driven interactive form.
  */
 
+import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { buildMetadata } from '../../../../lib/seo';
 import { getServerConfig } from '../../../../lib/serverConfig';
@@ -34,6 +35,15 @@ export async function generateMetadata(): Promise<Metadata> {
     });
 }
 
+/**
+ * Wraps AddressConverter in Suspense because it reads `useSearchParams()`
+ * (to pre-fill a forwarded `?address=`), which Next.js App Router requires be
+ * inside a Suspense boundary when the page has no generateStaticParams.
+ */
 export default function AddressConverterPage() {
-    return <AddressConverter />;
+    return (
+        <Suspense>
+            <AddressConverter />
+        </Suspense>
+    );
 }

--- a/src/frontend/app/(core)/tools/address-origins/page.tsx
+++ b/src/frontend/app/(core)/tools/address-origins/page.tsx
@@ -5,6 +5,7 @@
  * No SSR data — results stream in over SSE after the user acts.
  */
 
+import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { buildMetadata } from '../../../../lib/seo';
 import { getServerConfig } from '../../../../lib/serverConfig';
@@ -34,6 +35,16 @@ export async function generateMetadata(): Promise<Metadata> {
     });
 }
 
+/**
+ * Wraps AddressOrigins in Suspense because it reads `useSearchParams()` (to
+ * pre-fill a forwarded `?address=` into the first wallet row), which Next.js
+ * App Router requires be inside a Suspense boundary when the page has no
+ * generateStaticParams.
+ */
 export default function AddressOriginsPage() {
-    return <AddressOrigins />;
+    return (
+        <Suspense>
+            <AddressOrigins />
+        </Suspense>
+    );
 }

--- a/src/frontend/app/(core)/tools/approval-checker/page.tsx
+++ b/src/frontend/app/(core)/tools/approval-checker/page.tsx
@@ -5,6 +5,7 @@
  * No SSR data — the tool is a user-driven interactive form.
  */
 
+import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { buildMetadata } from '../../../../lib/seo';
 import { getServerConfig } from '../../../../lib/serverConfig';
@@ -34,6 +35,15 @@ export async function generateMetadata(): Promise<Metadata> {
     });
 }
 
+/**
+ * Wraps ApprovalChecker in Suspense because it reads `useSearchParams()` (to
+ * pre-fill a forwarded `?address=`), which Next.js App Router requires be
+ * inside a Suspense boundary when the page has no generateStaticParams.
+ */
 export default function ApprovalCheckerPage() {
-    return <ApprovalChecker />;
+    return (
+        <Suspense>
+            <ApprovalChecker />
+        </Suspense>
+    );
 }

--- a/src/frontend/components/ui/TronAddress/TronAddress.module.scss
+++ b/src/frontend/components/ui/TronAddress/TronAddress.module.scss
@@ -1,0 +1,103 @@
+/*
+ * TronAddress chip styling.
+ *
+ * Layout and affordance treatment for the canonical address chip. Structure is
+ * a single inline row (address + slim icon actions); the tools popover is an
+ * absolutely-positioned menu anchored to its trigger. All values reference
+ * semantic (Layer 2) tokens so the chip themes with the rest of the app — the
+ * address uses the shared monospace face (`--font-mono`), and affordance icons
+ * follow the muted -> primary hover convention used by the bare IconButton.
+ */
+
+.root {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-2xs);
+    max-width: 100%;
+}
+
+/* Truncated address: monospace so leading/trailing chars align across rows. */
+.address {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text);
+    white-space: nowrap;
+    cursor: default;
+}
+
+/* Label-first display: a resolved human name reads as prose, not code. */
+.label {
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text);
+    white-space: nowrap;
+    cursor: default;
+}
+
+/* Trim the wrapped CopyButton/IconButton so the icons sit slim in the row. */
+.action {
+    flex: 0 0 auto;
+}
+
+/* Anchor establishes the positioning context for the tools popover. */
+.menu_anchor {
+    position: relative;
+    display: inline-flex;
+}
+
+/* Explorer out-link: styled to match the slim icon actions (muted -> primary). */
+.action_link {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--padding-2xs);
+    color: var(--color-text-muted);
+    border-radius: var(--radius-xs);
+    transition: color var(--transition-fast);
+
+    &:hover {
+        color: var(--color-primary);
+    }
+
+    &:focus-visible {
+        outline: var(--border-width-medium) solid var(--color-primary);
+        outline-offset: 2px;
+    }
+}
+
+/* Popover surface floating below the tools trigger. */
+.menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: var(--z-index-dropdown);
+    margin-top: var(--gap-2xs);
+    display: flex;
+    flex-direction: column;
+    padding: var(--padding-2xs);
+    background: var(--color-surface);
+    border: var(--border-width-thin) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-md);
+}
+
+/* Individual forward target link. */
+.menu_item {
+    display: block;
+    padding: var(--padding-xs) var(--padding-sm);
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text);
+    border-radius: var(--radius-xs);
+    white-space: nowrap;
+    text-align: left;
+    transition: background var(--transition-fast);
+
+    &:hover {
+        background: var(--color-surface-muted);
+    }
+
+    &:focus-visible {
+        outline: var(--border-width-medium) solid var(--color-primary);
+        outline-offset: -2px;
+    }
+}

--- a/src/frontend/components/ui/TronAddress/TronAddress.module.scss
+++ b/src/frontend/components/ui/TronAddress/TronAddress.module.scss
@@ -81,6 +81,18 @@
     box-shadow: var(--shadow-md);
 }
 
+/*
+ * Flip variant: open the menu above the trigger instead of below. Applied when
+ * the trigger sits near the bottom of the viewport so the menu opens into
+ * visible space rather than a scroll container's clipped overflow.
+ */
+.menu_top {
+    top: auto;
+    bottom: 100%;
+    margin-top: 0;
+    margin-bottom: var(--gap-2xs);
+}
+
 /* Individual forward target link. */
 .menu_item {
     display: block;

--- a/src/frontend/components/ui/TronAddress/TronAddress.tsx
+++ b/src/frontend/components/ui/TronAddress/TronAddress.tsx
@@ -16,7 +16,7 @@
  */
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { ExternalLink, Wrench } from 'lucide-react';
 import { CopyButton } from '../CopyButton';
 import { IconButton } from '../IconButton';
@@ -40,6 +40,15 @@ const TRONSCAN_ADDRESS_URL = 'https://tronscan.org/#/address/';
  */
 const HEAD_CHARS = 4;
 const TAIL_CHARS = 4;
+
+/**
+ * Minimum gap (px) to keep between the open tools menu and the viewport edge
+ * when deciding which way it opens. The menu flips above its trigger only when
+ * the space below cannot fit the menu plus this breathing room, so a menu near
+ * the bottom of a scroll-clipped container (the shared `Table` wrapper sets
+ * `overflow: auto`) opens upward into visible space instead of being clipped.
+ */
+const MENU_VIEWPORT_GAP_PX = 8;
 
 /**
  * Props for {@link TronAddress}.
@@ -100,7 +109,9 @@ export function TronAddress({
     className
 }: ITronAddressProps) {
     const [menuOpen, setMenuOpen] = useState(false);
+    const [menuPlacement, setMenuPlacement] = useState<'bottom' | 'top'>('bottom');
     const menuRef = useRef<HTMLDivElement | null>(null);
+    const menuListRef = useRef<HTMLDivElement | null>(null);
 
     /**
      * Close the tools popover on any click outside it and on Escape, why: an
@@ -136,6 +147,40 @@ export function TronAddress({
         setMenuOpen(prev => !prev);
     }, []);
 
+    /**
+     * Choose whether the open menu drops below its trigger or flips above it,
+     * why: the menu is absolutely positioned and cannot escape an ancestor's
+     * overflow box (a portal would, but that is heavier machinery than this
+     * primitive warrants — see the flip precedent in the sibling Tooltip). When
+     * the trigger sits near the bottom of the viewport (the common clipped case
+     * inside a scrolling table), opening downward would render the menu into
+     * clipped space; flipping it upward keeps it visible. Runs in a layout
+     * effect so the corrected side is set before paint (no downward flash), and
+     * re-measures on resize so a menu left open through a viewport change stays
+     * placed. Measuring needs the menu in the DOM, so this depends on menuOpen.
+     */
+    useLayoutEffect(() => {
+        if (!menuOpen) {
+            setMenuPlacement('bottom');
+            return undefined;
+        }
+        function updatePlacement(): void {
+            const anchor = menuRef.current;
+            const menu = menuListRef.current;
+            if (!anchor || !menu) return;
+            const anchorRect = anchor.getBoundingClientRect();
+            const menuHeight = menu.getBoundingClientRect().height;
+            const viewportHeight = document.documentElement.clientHeight;
+            const spaceBelow = viewportHeight - anchorRect.bottom;
+            const spaceAbove = anchorRect.top;
+            const fitsBelow = spaceBelow >= menuHeight + MENU_VIEWPORT_GAP_PX;
+            setMenuPlacement(!fitsBelow && spaceAbove > spaceBelow ? 'top' : 'bottom');
+        }
+        updatePlacement();
+        window.addEventListener('resize', updatePlacement);
+        return () => window.removeEventListener('resize', updatePlacement);
+    }, [menuOpen]);
+
     const display = label ?? truncateAddress(address);
 
     return (
@@ -159,7 +204,17 @@ export function TronAddress({
             )}
 
             {tools && (
-                <div className={styles.menu_anchor} ref={menuRef}>
+                // Stop tool clicks (the wrench toggle and the menu-item links,
+                // both descendants of this wrapper) from bubbling to an enclosing
+                // clickable row (`<Tr onClick>`), which would navigate or unmount
+                // the chip before the menu is usable. Mirrors CopyButton, which
+                // stops propagation for the same reason. preventDefault is not
+                // called, so the tool links still navigate.
+                <div
+                    className={styles.menu_anchor}
+                    ref={menuRef}
+                    onClick={event => event.stopPropagation()}
+                >
                     <IconButton
                         variant="primary"
                         size="xs"
@@ -172,7 +227,13 @@ export function TronAddress({
                         <Wrench size={14} />
                     </IconButton>
                     {menuOpen && (
-                        <div className={styles.menu} role="menu">
+                        <div
+                            ref={menuListRef}
+                            className={[styles.menu, menuPlacement === 'top' ? styles.menu_top : '']
+                                .filter(Boolean)
+                                .join(' ')}
+                            role="menu"
+                        >
                             {FORWARDABLE_TOOLS.map(tool => (
                                 <a
                                     key={tool.slug}

--- a/src/frontend/components/ui/TronAddress/TronAddress.tsx
+++ b/src/frontend/components/ui/TronAddress/TronAddress.tsx
@@ -1,0 +1,205 @@
+/**
+ * @fileoverview Canonical TRON address chip.
+ *
+ * Every surface that shows a wallet/contract address — core pages, admin
+ * tables, plugin UIs injected through `context.ui.TronAddress` — should render
+ * it through this one component so truncation, copy, explorer linking, and
+ * tool-forwarding stay identical everywhere and only have to be fixed in one
+ * place. Before this existed each caller hand-rolled its own slice/tronscan
+ * link, drifting in format and affordances.
+ *
+ * The chip renders synchronously from its `address` prop (no async, no data
+ * fetch), so it is SSR-first by construction: the truncated text is in the
+ * server HTML and only the copy button and tools popover are user-triggered
+ * after hydration. It is a `'use client'` component purely because those
+ * affordances need event handlers and a click-outside listener.
+ */
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ExternalLink, Wrench } from 'lucide-react';
+import { CopyButton } from '../CopyButton';
+import { IconButton } from '../IconButton';
+import { Tooltip } from '../Tooltip';
+import { FORWARDABLE_TOOLS, buildToolForwardUrl } from './forwardableTools';
+import styles from './TronAddress.module.scss';
+
+/**
+ * Base58 explorer deep-link root. Tronscan is hardcoded because the codebase
+ * has no configurable explorer provider today; every existing address link
+ * points here. Centralizing it means a future switch to a configurable
+ * provider changes one line rather than every caller.
+ */
+const TRONSCAN_ADDRESS_URL = 'https://tronscan.org/#/address/';
+
+/**
+ * Characters kept from each end when truncating. Four leading characters keep
+ * the `T` prefix plus enough entropy to disambiguate at a glance; four
+ * trailing characters mirror it. Addresses shorter than the combined length
+ * render whole (nothing to hide).
+ */
+const HEAD_CHARS = 4;
+const TAIL_CHARS = 4;
+
+/**
+ * Props for {@link TronAddress}.
+ */
+export interface ITronAddressProps {
+    /** Full base58check TRON address (`T…`). The value copied and linked. */
+    address: string;
+    /**
+     * Pre-resolved human label. When supplied it displays in place of the
+     * truncated address (the full address still shows in the tooltip), matching
+     * the label-first convention. The component does not look labels up itself —
+     * callers pass one already resolved (e.g. from an SSR data fetcher).
+     */
+    label?: string;
+    /** Show the copy-to-clipboard affordance. @default true */
+    copy?: boolean;
+    /** Show the "forward to a tool" dropdown. @default true */
+    tools?: boolean;
+    /** Show the external Tronscan link. @default true */
+    explorer?: boolean;
+    /** Extra class on the root wrapper for spacing in a host layout. */
+    className?: string;
+}
+
+/**
+ * Shorten a full address to `head…tail`, why: a full 34-char base58 address
+ * dominates dense tables and buries the surrounding data. Short inputs pass
+ * through untouched so we never render a `…` that hides nothing.
+ *
+ * @param address - Full address to shorten; supplied by the caller's data row.
+ * @returns The truncated display string, or the input unchanged when it is
+ *          already at or below the combined head+tail length.
+ */
+function truncateAddress(address: string): string {
+    let result = address;
+    if (address.length > HEAD_CHARS + TAIL_CHARS + 1) {
+        result = `${address.slice(0, HEAD_CHARS)}…${address.slice(-TAIL_CHARS)}`;
+    }
+    return result;
+}
+
+/**
+ * Render a TRON address as a compact, monospace chip with copy, tool-forward,
+ * and explorer affordances. See the file overview for why this is the single
+ * canonical address renderer.
+ *
+ * @param props - {@link ITronAddressProps}; `address` is required, the three
+ *        affordance booleans default on so the common case needs only the
+ *        address, and callers trim affordances off for read-only contexts.
+ * @returns The address chip element.
+ */
+export function TronAddress({
+    address,
+    label,
+    copy = true,
+    tools = true,
+    explorer = true,
+    className
+}: ITronAddressProps) {
+    const [menuOpen, setMenuOpen] = useState(false);
+    const menuRef = useRef<HTMLDivElement | null>(null);
+
+    /**
+     * Close the tools popover on any click outside it and on Escape, why: an
+     * anchored menu that only dismisses via its own toggle is a well-known
+     * usability trap. The listeners attach only while the menu is open, so
+     * they are a no-op in the common closed state. Mirrors the Tooltip
+     * primitive's outside-pointer handling.
+     */
+    useEffect(() => {
+        if (!menuOpen) return undefined;
+        function handlePointerDown(event: globalThis.PointerEvent): void {
+            const menu = menuRef.current;
+            if (menu && !menu.contains(event.target as Node)) {
+                setMenuOpen(false);
+            }
+        }
+        function handleKeyDown(event: globalThis.KeyboardEvent): void {
+            if (event.key === 'Escape') setMenuOpen(false);
+        }
+        document.addEventListener('pointerdown', handlePointerDown);
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('pointerdown', handlePointerDown);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [menuOpen]);
+
+    /**
+     * Toggle the tools popover. Extracted so the toggle and the outside-click
+     * effect share one piece of state and the button stays a pure view.
+     */
+    const toggleMenu = useCallback((): void => {
+        setMenuOpen(prev => !prev);
+    }, []);
+
+    const display = label ?? truncateAddress(address);
+
+    return (
+        <span className={[styles.root, className].filter(Boolean).join(' ')}>
+            <Tooltip content={address}>
+                <span
+                    className={label ? styles.label : styles.address}
+                    data-testid="tron-address-display"
+                >
+                    {display}
+                </span>
+            </Tooltip>
+
+            {copy && (
+                <CopyButton
+                    value={address}
+                    size="xs"
+                    aria-label="Copy address"
+                    className={styles.action}
+                />
+            )}
+
+            {tools && (
+                <div className={styles.menu_anchor} ref={menuRef}>
+                    <IconButton
+                        variant="primary"
+                        size="xs"
+                        aria-label="Forward address to a tool"
+                        aria-haspopup="menu"
+                        aria-expanded={menuOpen}
+                        onClick={toggleMenu}
+                        className={styles.action}
+                    >
+                        <Wrench size={14} />
+                    </IconButton>
+                    {menuOpen && (
+                        <div className={styles.menu} role="menu">
+                            {FORWARDABLE_TOOLS.map(tool => (
+                                <a
+                                    key={tool.slug}
+                                    role="menuitem"
+                                    className={styles.menu_item}
+                                    href={buildToolForwardUrl(tool.slug, address)}
+                                    onClick={() => setMenuOpen(false)}
+                                >
+                                    {tool.label}
+                                </a>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {explorer && (
+                <a
+                    className={styles.action_link}
+                    href={`${TRONSCAN_ADDRESS_URL}${address}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="View address on Tronscan"
+                >
+                    <ExternalLink size={14} />
+                </a>
+            )}
+        </span>
+    );
+}

--- a/src/frontend/components/ui/TronAddress/forwardableTools.ts
+++ b/src/frontend/components/ui/TronAddress/forwardableTools.ts
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview Forward targets for the TronAddress tools dropdown.
+ *
+ * The address chip lets a user hand an address off to a public tool page that
+ * can act on it. Only tools that actually consume a single address belong here
+ * (converting it, checking its approvals, tracing its origin, verifying a
+ * signature by it) — calculators and the timestamp converter take no address
+ * and are deliberately excluded, so the menu never offers a dead end.
+ *
+ * The list is co-located with the component rather than pulled from the tools
+ * module because a `components/ui/` primitive must not depend upward on a
+ * domain module, and there is no iterable tool registry to read (the tools'
+ * `IToolDescriptor` is unused dead code). These routes are stable platform
+ * paths; adding a new address-consuming tool means adding one row here plus the
+ * `?address=` pre-fill on that tool's page.
+ */
+
+/**
+ * The query parameter every forwardable tool reads to pre-fill an incoming
+ * address. Standardized here so the chip and the receiving pages share one
+ * contract; a receiver that reads a different name (signature-verifier's
+ * historical `?wallet=`) accepts this as an alias.
+ */
+export const TOOL_ADDRESS_PARAM = 'address';
+
+/**
+ * One selectable forward target.
+ */
+export interface IForwardableTool {
+    /** URL slug under `/tools/`. */
+    slug: string;
+    /** Menu label shown to the user. */
+    label: string;
+}
+
+/**
+ * Address-consuming public tool pages, in menu order. Kept small and explicit
+ * on purpose — see the file overview for why calculators are excluded.
+ */
+export const FORWARDABLE_TOOLS: readonly IForwardableTool[] = [
+    { slug: 'address-converter', label: 'Address Converter' },
+    { slug: 'address-origins', label: 'Address Origins' },
+    { slug: 'approval-checker', label: 'Approval Checker' },
+    { slug: 'signature-verifier', label: 'Signature Verifier' }
+] as const;
+
+/**
+ * Build the deep link that opens a tool page with the address pre-filled, why:
+ * the chip should not know how each tool spells its route — it only knows the
+ * shared `?address=` contract. Encoding guards against any unexpected
+ * characters in the value.
+ *
+ * @param slug - Target tool slug from {@link FORWARDABLE_TOOLS}.
+ * @param address - Full address to forward; becomes the `?address=` value.
+ * @returns The relative URL (`/tools/<slug>?address=<encoded>`).
+ */
+export function buildToolForwardUrl(slug: string, address: string): string {
+    return `/tools/${slug}?${TOOL_ADDRESS_PARAM}=${encodeURIComponent(address)}`;
+}

--- a/src/frontend/components/ui/TronAddress/index.ts
+++ b/src/frontend/components/ui/TronAddress/index.ts
@@ -1,0 +1,2 @@
+export { TronAddress, type ITronAddressProps } from './TronAddress';
+export { FORWARDABLE_TOOLS, buildToolForwardUrl, TOOL_ADDRESS_PARAM, type IForwardableTool } from './forwardableTools';

--- a/src/frontend/lib/frontendPluginContext.tsx
+++ b/src/frontend/lib/frontendPluginContext.tsx
@@ -24,6 +24,7 @@ import { Textarea } from '../components/ui/Textarea';
 import { ConfirmDialog } from '../components/ui/ConfirmDialog';
 import { ClientTime } from '../components/ui/ClientTime';
 import { Tooltip } from '../components/ui/Tooltip';
+import { TronAddress } from '../components/ui/TronAddress';
 import { LazyIconPickerModal as IconPickerModal } from '../components/ui/IconPickerModal';
 import { AccountPicker } from '../components/ui/AccountPicker';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../components/ui/Table';
@@ -354,6 +355,7 @@ export function FrontendPluginContextProvider({ children }: { children: React.Re
             Textarea: Textarea as IUIComponents['Textarea'],
             ClientTime,
             Tooltip,
+            TronAddress,
             IconPickerModal,
             ConfirmDialog,
             AccountPicker,
@@ -464,6 +466,7 @@ export function createPluginContext(pluginId: string): IFrontendPluginContext {
         Textarea: Textarea as IUIComponents['Textarea'],
         ClientTime,
         Tooltip,
+        TronAddress,
         IconPickerModal,
         ConfirmDialog,
         AccountPicker,

--- a/src/frontend/modules/tools/components/AddressConverter/AddressConverter.tsx
+++ b/src/frontend/modules/tools/components/AddressConverter/AddressConverter.tsx
@@ -7,7 +7,8 @@
  */
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { ArrowLeftRight } from 'lucide-react';
 import { Page, PageHeader, Stack } from '../../../../components/layout';
 import { Card } from '../../../../components/ui/Card';
@@ -24,10 +25,23 @@ import styles from './AddressConverter.module.scss';
  * receive both representations. No SSR data needed — purely interactive.
  */
 export function AddressConverter() {
+    const searchParams = useSearchParams();
     const [input, setInput] = useState('');
     const [result, setResult] = useState<IAddressConversionResult | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
+
+    /**
+     * Pre-fill from a forwarded `?address=` param on mount, why: the shared
+     * TronAddress chip forwards a full address here via that param (its
+     * canonical forward contract), so the field should arrive populated. Mount
+     * only so it never fights the user's own typing after the first paint.
+     */
+    useEffect(() => {
+        const forwarded = searchParams.get('address');
+        if (forwarded) setInput(forwarded);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     /** Determine format and submit to the API. */
     const handleConvert = async () => {

--- a/src/frontend/modules/tools/components/AddressOrigins/AddressOrigins.tsx
+++ b/src/frontend/modules/tools/components/AddressOrigins/AddressOrigins.tsx
@@ -14,6 +14,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { GitBranch, Plus, X, CornerRightUp, Loader2, Flag, AlertTriangle, Users, ExternalLink, Lock } from 'lucide-react';
 // Direct import (not the modules/user barrel) keeps that component's CSS out of the bundle.
 import { useAuthSession } from '../../../user/components/SessionProvider';
@@ -53,6 +54,7 @@ function truncateAddress(address: string): string {
  */
 export function AddressOrigins() {
     const { isLoggedIn } = useAuthSession();
+    const searchParams = useSearchParams();
     const [addresses, setAddresses] = useState<string[]>(['']);
     const [ladders, setLadders] = useState<Record<number, IOriginLadder>>({});
     const [streaming, setStreaming] = useState(false);
@@ -70,6 +72,18 @@ export function AddressOrigins() {
 
     // Tear the stream down if the component unmounts mid-climb.
     useEffect(() => stopStream, []);
+
+    /**
+     * Seed the first wallet row from a forwarded `?address=` param on mount,
+     * why: the shared TronAddress chip forwards a full address here via that
+     * param. Only the first row is seeded (anonymous users get a single row
+     * anyway); mount-only so it never clobbers rows the user edits afterward.
+     */
+    useEffect(() => {
+        const forwarded = searchParams.get('address');
+        if (forwarded) setAddresses([forwarded]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     /**
      * Map each activator address to the set of input wallets whose ladder passed

--- a/src/frontend/modules/tools/components/AddressOrigins/AddressOrigins.tsx
+++ b/src/frontend/modules/tools/components/AddressOrigins/AddressOrigins.tsx
@@ -22,6 +22,7 @@ import { Page, PageHeader, Stack } from '../../../../components/layout';
 import { Card } from '../../../../components/ui/Card';
 import { Input } from '../../../../components/ui/Input';
 import { Button } from '../../../../components/ui/Button';
+import { TronAddress } from '../../../../components/ui/TronAddress';
 import { createAddressOriginsStream } from '../../api/client';
 import type { IOriginHop, IOriginLadder } from '../../types';
 import styles from './AddressOrigins.module.scss';
@@ -32,18 +33,7 @@ const MAX_ADDRESSES = 10;
 /** Strict TRON base58check address, used only to enable the submit button. */
 const TRON_ADDRESS_PATTERN = /^T[1-9A-HJ-NP-Za-km-z]{33}$/;
 
-const TRONSCAN_ADDRESS_URL = 'https://tronscan.org/#/address/';
 const TRONSCAN_TX_URL = 'https://tronscan.org/#/transaction/';
-
-/**
- * Shorten an address to `Tabcd…wxyz` so ladders stay compact.
- *
- * @param address - Full base58 address.
- * @returns The shortened label.
- */
-function truncateAddress(address: string): string {
-    return address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
-}
 
 /**
  * Address Origins tool.
@@ -290,9 +280,7 @@ export function AddressOrigins() {
                                 <ol className={styles.ladder}>
                                     <li className={styles.node}>
                                         <span className={styles.tag}>wallet</span>
-                                        <a className={styles.addr} href={`${TRONSCAN_ADDRESS_URL}${ladder.address}`} target="_blank" rel="noopener noreferrer" title={ladder.address}>
-                                            {truncateAddress(ladder.address)}
-                                        </a>
+                                        <TronAddress address={ladder.address} tools={false} />
                                     </li>
 
                                     {ladder.hops.map((hop, index) => {
@@ -300,9 +288,7 @@ export function AddressOrigins() {
                                         return (
                                             <li key={`${hop.txId}-${index}`} className={`${styles.node} ${isShared ? styles.node_shared : ''}`}>
                                                 <CornerRightUp size={14} className={styles.node_arrow} aria-hidden="true" />
-                                                <a className={styles.addr} href={`${TRONSCAN_ADDRESS_URL}${hop.activatorAddress}`} target="_blank" rel="noopener noreferrer" title={hop.activatorAddress}>
-                                                    {truncateAddress(hop.activatorAddress)}
-                                                </a>
+                                                <TronAddress address={hop.activatorAddress} tools={false} />
                                                 {isShared && (
                                                     <span className={styles.shared_badge} title="Shared across wallets">
                                                         <Users size={14} /> shared

--- a/src/frontend/modules/tools/components/ApprovalChecker/ApprovalChecker.tsx
+++ b/src/frontend/modules/tools/components/ApprovalChecker/ApprovalChecker.tsx
@@ -18,6 +18,7 @@ import { Card } from '../../../../components/ui/Card';
 import { Input } from '../../../../components/ui/Input';
 import { Button } from '../../../../components/ui/Button';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../components/ui/Table';
+import { TronAddress } from '../../../../components/ui/TronAddress';
 import { checkApprovals } from '../../api/client';
 import type { IApprovalCheckResult } from '../../types';
 import styles from './ApprovalChecker.module.scss';
@@ -146,9 +147,7 @@ export function ApprovalChecker() {
                                                 </span>
                                             </Td>
                                             <Td>
-                                                <code className={styles.address_cell}>
-                                                    {approval.spenderAddress}
-                                                </code>
+                                                <TronAddress address={approval.spenderAddress} />
                                             </Td>
                                             <Td>{approval.allowanceFormatted}</Td>
                                             <Td>

--- a/src/frontend/modules/tools/components/ApprovalChecker/ApprovalChecker.tsx
+++ b/src/frontend/modules/tools/components/ApprovalChecker/ApprovalChecker.tsx
@@ -8,7 +8,8 @@
  */
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Shield, ShieldAlert } from 'lucide-react';
 // Direct import (not the modules/user barrel) keeps component CSS out of the bundle.
 import { useAuthSession } from '../../../user/components/SessionProvider';
@@ -30,10 +31,23 @@ import styles from './ApprovalChecker.module.scss';
  */
 export function ApprovalChecker() {
     const { isLoggedIn } = useAuthSession();
+    const searchParams = useSearchParams();
     const [address, setAddress] = useState('');
     const [result, setResult] = useState<IApprovalCheckResult | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
+
+    /**
+     * Pre-fill from a forwarded `?address=` param on mount, why: the shared
+     * TronAddress chip forwards a full address here via that param. Pre-filling
+     * still runs when the visitor is signed out, so the field is ready the
+     * moment they authenticate. Mount only so it never overrides later typing.
+     */
+    useEffect(() => {
+        const forwarded = searchParams.get('address');
+        if (forwarded) setAddress(forwarded);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     /** Submit the address for approval scanning. */
     const handleCheck = async () => {

--- a/src/frontend/modules/tools/components/SignatureVerifier/SignatureVerifier.tsx
+++ b/src/frontend/modules/tools/components/SignatureVerifier/SignatureVerifier.tsx
@@ -37,7 +37,9 @@ export function SignatureVerifier() {
 
     /** Pre-fill from URL parameters and auto-verify if all present. */
     useEffect(() => {
-        const w = searchParams.get('wallet') ?? '';
+        // Accept `?address=` as an alias for `?wallet=` so the shared
+        // TronAddress chip's canonical forward param lands in the wallet field.
+        const w = searchParams.get('wallet') ?? searchParams.get('address') ?? '';
         const m = searchParams.get('message') ?? '';
         const s = searchParams.get('signature') ?? '';
 

--- a/src/frontend/modules/tools/components/SignatureVerifier/SignatureVerifier.tsx
+++ b/src/frontend/modules/tools/components/SignatureVerifier/SignatureVerifier.tsx
@@ -14,6 +14,7 @@ import { Page, PageHeader, Stack } from '../../../../components/layout';
 import { Card } from '../../../../components/ui/Card';
 import { Input } from '../../../../components/ui/Input';
 import { Button } from '../../../../components/ui/Button';
+import { TronAddress } from '../../../../components/ui/TronAddress';
 import { verifySignature } from '../../api/client';
 import styles from './SignatureVerifier.module.scss';
 
@@ -138,7 +139,7 @@ export function SignatureVerifier() {
                                     {verified ? 'Signature Valid' : 'Signature Invalid'}
                                 </span>
                                 {normalizedWallet && (
-                                    <code className={styles.result__wallet}>{normalizedWallet}</code>
+                                    <TronAddress address={normalizedWallet} className={styles.result__wallet} />
                                 )}
                             </div>
                         </div>


### PR DESCRIPTION
Introduces a single canonical TRON address renderer at `src/frontend/components/ui/TronAddress` and exposes it to plugins through `IFrontendPluginContext.ui.TronAddress`.

The chip renders `first4…last4` with a copy button, a tools-forward menu, and a Tronscan link, replacing hand-rolled address truncation and linking. It is adopted across the address-converter, address-origins, and approval-checker tools and the signature verifier.

## Changes
- New `TronAddress` component, styles, `forwardableTools` helper, and barrel export.
- `IFrontendPluginContext.ui` gains the `TronAddress` surface; wired in `frontendPluginContext.tsx`.
- Tools pages and components adopt the shared chip.