### PR TITLE
feat(blockchain): forward transaction signatures to observers in rawValue

### DIFF
--- a/src/backend/modules/blockchain/blockchain.service.ts
+++ b/src/backend/modules/blockchain/blockchain.service.ts
@@ -1504,9 +1504,24 @@ export class BlockchainService implements IBlockchainService {
 
         // Include Permission_id in rawValue for observers that need to distinguish pool-controlled delegations
         // Permission_id >= 3 indicates the transaction was authorized by a custom permission (typically pool control)
+        //
+        // Also forward the wire signature(s) unconditionally: txID is
+        // sha256(raw_data) — the signing digest — so an observer can
+        // ecrecover the actual signing key (e.g. a rental market's
+        // controller wallet signing a pool participant's delegation) with
+        // no extra network calls. Permission_id alone cannot carry this:
+        // the default active permission (id 2) has a mutable key set, so
+        // only signer recovery distinguishes an owner signing with their
+        // own active key from a granted third-party key. The strings
+        // already exist on the parsed block (attaching is a reference
+        // copy), and rawValue is observer-facing — core persists only
+        // `payload` to the transactions collection.
         const rawValue: Record<string, unknown> = {
             ...value,
-            Permission_id: contract.Permission_id
+            Permission_id: contract.Permission_id,
+            ...(Array.isArray(transaction.signature)
+                ? { signature: transaction.signature }
+                : {})
         };
 
         const rawTransaction: ITransaction = { payload, snapshot, categories: emptyCategories, rawValue, info };

--- a/src/backend/modules/blockchain/tron-grid.client.ts
+++ b/src/backend/modules/blockchain/tron-grid.client.ts
@@ -115,6 +115,12 @@ export interface TronGridTransaction {
         fee_limit?: number;
     };
     raw_data_hex?: string;
+    /**
+     * ECDSA signature(s) over sha256(raw_data) — which equals the txID, so
+     * the signer is recoverable from `txID` + this field alone. Multi-signed
+     * transactions carry one entry per signer.
+     */
+    signature?: string[];
     ret?: Array<{ contractRet: string; fee: number }>;
 }
 


### PR DESCRIPTION
Attaches the wire `signature` array to the observer-facing `rawValue` so observers can ecrecover the actual signing key from `txID` (sha256 of `raw_data`) with no extra network calls. This distinguishes owner-signed transactions from granted third-party keys, which `Permission_id` alone cannot — the default active permission has a mutable key set.

Core persists only `payload` to the transactions collection, so nothing new is stored. Also documents the `signature` field on `TronGridTransaction`.

Consumed by trp-resource-markets signer recovery (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)