### PR TITLE
feat(address): surface address tags on the TronAddress chip

### DIFF
--- a/src/backend/modules/address-tags/README.md
+++ b/src/backend/modules/address-tags/README.md
@@ -13,7 +13,9 @@ Central CRUD authority for free-text tags on TRON wallet addresses. Every surfac
 | User API | `/api/address-tags/*` — `requireLogin` |
 | Admin API | `/api/admin/system/address-tags/*` — `requireAdmin` |
 | Admin UI | `/system/address-tags` |
-| Frontend client | `src/frontend/modules/address-tags/api/client.ts` |
+| Frontend client | `src/frontend/modules/address-tags/api/client.ts` (both surfaces) |
+| Frontend read cache | `useAddressTags(address)` — batches every chip's lookup into one `by-address` call, invalidate with `invalidateAddressTags(address)` |
+| Frontend editor | `AddressTagsEditor` — freeform comma-separated field, opened from the `TronAddress` chip's wrench menu ("Edit tags", admin only) |
 
 ## Why MongoDB
 
@@ -57,6 +59,19 @@ Admin surface (`createAdminRateLimiter` + `requireAdmin`; admin-group session or
 | `POST /tags/delete` | `{ tags: IAddressTagPair[] }` | Delete (POST because the operation carries a body) |
 
 Validation failures return 400 with the service's message; other failures 500.
+
+## Where Tags Surface
+
+Every address on the site renders through the canonical `TronAddress` chip
+(`src/frontend/components/ui/TronAddress/`), so that chip is the module's primary
+consumer: it appends an address's tags to its hover tooltip — `T…abcd (exchange,
+hot-wallet)` — and offers "Edit tags" in its wrench menu, which opens
+`AddressTagsEditor` in the core modal. Reads go through `useAddressTags`, one
+process-wide cache that coalesces a page's chips into a single request; tags are
+treated as an absent enhancement when the visitor is anonymous (reads are
+`requireLogin`) or the lookup fails. The edit item is gated on `admin` group
+membership because every mutation route is `requireAdmin` — widening it would
+only surface a 403 after the operator typed.
 
 ## Source Map
 

--- a/src/frontend/app/(core)/system/address-tags/AddressTagsManager.tsx
+++ b/src/frontend/app/(core)/system/address-tags/AddressTagsManager.tsx
@@ -33,6 +33,7 @@ import { useModal } from '../../../../components/ui/ModalProvider';
 import {
     createTags,
     deleteTags,
+    invalidateAddressTags,
     searchTags,
     updateTags,
     type IAddressTagView
@@ -144,6 +145,10 @@ export function AddressTagsManager() {
         setCreating(true);
         try {
             await createTags(tags.map((tag) => ({ address, tag })));
+            // Every address chip on the page reads its tooltip tags from the
+            // shared module cache, which only re-reads on invalidation — without
+            // this, they keep their pre-mutation list for the rest of the session.
+            invalidateAddressTags(address);
             notify('success', `Added ${tags.length} tag${tags.length > 1 ? 's' : ''}`);
             setNewAddress('');
             setNewTags('');
@@ -169,6 +174,7 @@ export function AddressTagsManager() {
         setBusyKey(rowKey(item));
         try {
             await updateTags([{ address: item.address, oldTag: item.tag, newTag }]);
+            invalidateAddressTags(item.address);
             notify('success', `Renamed '${item.tag}' to '${newTag}'`);
             setEditKey(null);
             await load(committedSearch, 0, false);
@@ -196,6 +202,7 @@ export function AddressTagsManager() {
                     onConfirm={async () => {
                         try {
                             await deleteTags([{ address: item.address, tag: item.tag }]);
+                            invalidateAddressTags(item.address);
                             notify('success', `Removed '${item.tag}'`);
                             setItems((current) => current.filter((row) => rowKey(row) !== rowKey(item)));
                         } catch (error) {

--- a/src/frontend/components/ui/TronAddress/TronAddress.module.scss
+++ b/src/frontend/components/ui/TronAddress/TronAddress.module.scss
@@ -2,17 +2,23 @@
  * TronAddress chip styling.
  *
  * Layout and affordance treatment for the canonical address chip. Structure is
- * a single inline row (address + slim icon actions); the tools popover is an
- * absolutely-positioned menu anchored to its trigger. All values reference
+ * a single inline row (address + slim icon actions); the tools popover is a
+ * viewport-fixed menu rendered in a body portal so no scroll container clips
+ * it, positioned from its trigger by the component. All values reference
  * semantic (Layer 2) tokens so the chip themes with the rest of the app — the
  * address uses the shared monospace face (`--font-mono`), and affordance icons
  * follow the muted -> primary hover convention used by the bare IconButton.
  */
 
+/*
+ * No row gap: the icon controls carry their own padding, so a gap on top of it
+ * spread the three affordances further apart than they read as one cluster. The
+ * address/label instead pays for its own separation from the icons below.
+ */
 .root {
     display: inline-flex;
     align-items: center;
-    gap: var(--gap-2xs);
+    gap: 0;
     max-width: 100%;
 }
 
@@ -23,6 +29,7 @@
     color: var(--color-text);
     white-space: nowrap;
     cursor: default;
+    margin-right: var(--gap-2xs);
 }
 
 /* Label-first display: a resolved human name reads as prose, not code. */
@@ -31,6 +38,7 @@
     color: var(--color-text);
     white-space: nowrap;
     cursor: default;
+    margin-right: var(--gap-2xs);
 }
 
 /* Trim the wrapped TrCopyIcon/IconButton so the icons sit slim in the row. */
@@ -38,7 +46,8 @@
     flex: 0 0 auto;
 }
 
-/* Anchor establishes the positioning context for the tools popover. */
+/* Trigger wrapper for the tools popover. The menu itself is portaled and
+   viewport-fixed, so this only keeps the wrench inline with the chip's row. */
 .menu_anchor {
     position: relative;
     display: inline-flex;
@@ -50,7 +59,9 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: var(--padding-2xs);
+    /* Matches the bare IconButton's xs padding beside it, so the explorer link
+       and the copy/wrench buttons sit on the same rhythm. */
+    padding: var(--icon-button-bare-padding-xs);
     color: var(--color-text-muted);
     border-radius: var(--radius-xs);
     transition: color var(--transition-fast);
@@ -65,13 +76,19 @@
     }
 }
 
-/* Popover surface floating below the tools trigger. */
+/*
+ * Popover surface for the tools menu. Fixed rather than absolute because the
+ * menu renders in a `<body>` portal so it escapes whatever scroll container
+ * hosts the chip — most often the shared Table wrapper, whose `overflow-x: auto`
+ * also clips vertically and used to cut the menu off at the table's edge. Its
+ * top/left come from the component, which measures the trigger and flips the
+ * menu above it when the viewport has no room below. `--z-index-fixed` (not
+ * `--z-index-dropdown`) because a body-level popover must clear sticky table
+ * headers and the nav shell while staying under modals and toasts.
+ */
 .menu {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    z-index: var(--z-index-dropdown);
-    margin-top: var(--gap-2xs);
+    position: fixed;
+    z-index: var(--z-index-fixed);
     display: flex;
     flex-direction: column;
     padding: var(--padding-2xs);
@@ -81,27 +98,21 @@
     box-shadow: var(--shadow-md);
 }
 
-/*
- * Flip variant: open the menu above the trigger instead of below. Applied when
- * the trigger sits near the bottom of the viewport so the menu opens into
- * visible space rather than a scroll container's clipped overflow.
- */
-.menu_top {
-    top: auto;
-    bottom: 100%;
-    margin-top: 0;
-    margin-bottom: var(--gap-2xs);
-}
-
-/* Individual forward target link. */
+/* One menu row — a tool-forward link, or the tag-editor button, which resets the
+   native button chrome so both render identically. */
 .menu_item {
     display: block;
+    width: 100%;
     padding: var(--padding-xs) var(--padding-sm);
+    font-family: inherit;
     font-size: var(--font-size-body-sm);
     color: var(--color-text);
+    background: none;
+    border: none;
     border-radius: var(--radius-xs);
     white-space: nowrap;
     text-align: left;
+    cursor: pointer;
     transition: background var(--transition-fast);
 
     &:hover {

--- a/src/frontend/components/ui/TronAddress/TronAddress.tsx
+++ b/src/frontend/components/ui/TronAddress/TronAddress.tsx
@@ -16,16 +16,40 @@
  * more visual weight than the wrench and out-link beside it. It is a
  * `'use client'` component purely because those affordances need event handlers
  * and a click-outside listener.
+ *
+ * The tools menu renders in a `<body>` portal with viewport-fixed coordinates.
+ * An earlier revision anchored it absolutely and only flipped it upward near the
+ * viewport bottom, which left it clipped inside any scrolling ancestor — the
+ * shared `Table` wrapper sets `overflow-x: auto`, and CSS turns the other axis
+ * into `auto` too, so a menu opening below a row was cut at the table's edge
+ * regardless of the space beyond it.
  */
 'use client';
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { ExternalLink, Wrench } from 'lucide-react';
 import { TrCopyIcon } from '../TrCopyIcon';
 import { IconButton } from '../IconButton';
 import { Tooltip } from '../Tooltip';
+import { useModal } from '../ModalProvider';
+// Deep imports rather than the module barrels: the address-tags barrel re-exports
+// its editor, which imports core UI primitives, so pulling the barrel in here
+// would close an import cycle through this file. The user barrel is skipped for
+// the established reason that it drags component CSS into every bundle.
+import { useAddressTags } from '../../../modules/address-tags/hooks/useAddressTags';
+import { AddressTagsEditor } from '../../../modules/address-tags/components/AddressTagsEditor/AddressTagsEditor';
+import { useAuthSession } from '../../../modules/user/components/SessionProvider';
 import { FORWARDABLE_TOOLS, buildToolForwardUrl } from './forwardableTools';
 import styles from './TronAddress.module.scss';
+
+/**
+ * Group whose members may change tags. Address-tag reads are open to any
+ * logged-in visitor, but every mutation route is `requireAdmin`, so the edit
+ * affordance is gated on the same membership the backend enforces — offering it
+ * more widely would only produce a 403 after the operator typed.
+ */
+const TAG_EDIT_GROUP = 'admin';
 
 /**
  * Base58 explorer deep-link root. Tronscan is hardcoded because the codebase
@@ -45,13 +69,22 @@ const HEAD_CHARS = 4;
 const TAIL_CHARS = 4;
 
 /**
- * Minimum gap (px) to keep between the open tools menu and the viewport edge
- * when deciding which way it opens. The menu flips above its trigger only when
- * the space below cannot fit the menu plus this breathing room, so a menu near
- * the bottom of a scroll-clipped container (the shared `Table` wrapper sets
- * `overflow: auto`) opens upward into visible space instead of being clipped.
+ * Minimum gap (px) to keep between the open tools menu and both its trigger and
+ * the viewport edge. The menu flips above its trigger only when the space below
+ * cannot fit the menu plus this breathing room.
  */
 const MENU_VIEWPORT_GAP_PX = 8;
+
+/**
+ * Viewport-fixed coordinates for the portaled tools menu, resolved from the
+ * trigger's live bounding rect. Held in state (rather than derived in render)
+ * because measuring requires the DOM, and `null` marks "not yet measured" so
+ * the menu stays invisible instead of flashing at the origin.
+ */
+interface IMenuPosition {
+    top: number;
+    left: number;
+}
 
 /**
  * Props for {@link TronAddress}.
@@ -112,22 +145,31 @@ export function TronAddress({
     className
 }: ITronAddressProps) {
     const [menuOpen, setMenuOpen] = useState(false);
-    const [menuPlacement, setMenuPlacement] = useState<'bottom' | 'top'>('bottom');
+    const [menuPosition, setMenuPosition] = useState<IMenuPosition | null>(null);
     const menuRef = useRef<HTMLDivElement | null>(null);
     const menuListRef = useRef<HTMLDivElement | null>(null);
+    const tags = useAddressTags(address);
+    const { session } = useAuthSession();
+    const modal = useModal();
+    const canEditTags = session?.user?.groups?.includes(TAG_EDIT_GROUP) ?? false;
 
     /**
      * Close the tools popover on any click outside it and on Escape, why: an
      * anchored menu that only dismisses via its own toggle is a well-known
      * usability trap. The listeners attach only while the menu is open, so
      * they are a no-op in the common closed state. Mirrors the Tooltip
-     * primitive's outside-pointer handling.
+     * primitive's outside-pointer handling. The menu itself is portaled to
+     * `<body>`, so it is not a descendant of the anchor — both nodes are
+     * checked or clicking a tool link would dismiss before it navigates.
      */
     useEffect(() => {
         if (!menuOpen) return undefined;
         function handlePointerDown(event: globalThis.PointerEvent): void {
-            const menu = menuRef.current;
-            if (menu && !menu.contains(event.target as Node)) {
+            const anchor = menuRef.current;
+            const menu = menuListRef.current;
+            const target = event.target as Node;
+            const inside = Boolean(anchor?.contains(target)) || Boolean(menu?.contains(target));
+            if (!inside) {
                 setMenuOpen(false);
             }
         }
@@ -151,44 +193,88 @@ export function TronAddress({
     }, []);
 
     /**
-     * Choose whether the open menu drops below its trigger or flips above it,
-     * why: the menu is absolutely positioned and cannot escape an ancestor's
-     * overflow box (a portal would, but that is heavier machinery than this
-     * primitive warrants — see the flip precedent in the sibling Tooltip). When
-     * the trigger sits near the bottom of the viewport (the common clipped case
-     * inside a scrolling table), opening downward would render the menu into
-     * clipped space; flipping it upward keeps it visible. Runs in a layout
-     * effect so the corrected side is set before paint (no downward flash), and
-     * re-measures on resize so a menu left open through a viewport change stays
-     * placed. Measuring needs the menu in the DOM, so this depends on menuOpen.
+     * Resolve the open menu's viewport-fixed coordinates from its trigger, why:
+     * an absolutely-positioned menu cannot escape an ancestor's overflow box, and
+     * the chip's most common home is a scroll container — the shared `Table`
+     * wrapper sets `overflow-x: auto`, which per CSS also clips vertically, so a
+     * menu opening below a row was cut off at the table's edge no matter how much
+     * viewport space remained. The menu therefore renders in a `<body>` portal and
+     * is placed here: below the trigger when the viewport has room, flipped above
+     * it when not, and clamped so it never runs off the right edge.
+     *
+     * Runs in a layout effect so the position is set before paint (no flash at the
+     * origin), and re-measures on scroll and resize because a fixed menu does not
+     * follow its trigger the way an anchored one does. Scroll is captured so
+     * scrolling the *table* — not just the window — repositions too. Measuring
+     * needs the menu mounted, so this depends on `menuOpen`.
      */
     useLayoutEffect(() => {
         if (!menuOpen) {
-            setMenuPlacement('bottom');
+            setMenuPosition(null);
             return undefined;
         }
-        function updatePlacement(): void {
+        function updatePosition(): void {
             const anchor = menuRef.current;
             const menu = menuListRef.current;
             if (!anchor || !menu) return;
             const anchorRect = anchor.getBoundingClientRect();
-            const menuHeight = menu.getBoundingClientRect().height;
+            const menuRect = menu.getBoundingClientRect();
             const viewportHeight = document.documentElement.clientHeight;
+            const viewportWidth = document.documentElement.clientWidth;
             const spaceBelow = viewportHeight - anchorRect.bottom;
             const spaceAbove = anchorRect.top;
-            const fitsBelow = spaceBelow >= menuHeight + MENU_VIEWPORT_GAP_PX;
-            setMenuPlacement(!fitsBelow && spaceAbove > spaceBelow ? 'top' : 'bottom');
+            const fitsBelow = spaceBelow >= menuRect.height + MENU_VIEWPORT_GAP_PX;
+            const openAbove = !fitsBelow && spaceAbove > spaceBelow;
+            const top = openAbove
+                ? anchorRect.top - menuRect.height - MENU_VIEWPORT_GAP_PX
+                : anchorRect.bottom + MENU_VIEWPORT_GAP_PX;
+            const maxLeft = viewportWidth - menuRect.width - MENU_VIEWPORT_GAP_PX;
+            const left = Math.max(MENU_VIEWPORT_GAP_PX, Math.min(anchorRect.left, maxLeft));
+            setMenuPosition({ top, left });
         }
-        updatePlacement();
-        window.addEventListener('resize', updatePlacement);
-        return () => window.removeEventListener('resize', updatePlacement);
+        updatePosition();
+        window.addEventListener('resize', updatePosition);
+        window.addEventListener('scroll', updatePosition, true);
+        return () => {
+            window.removeEventListener('resize', updatePosition);
+            window.removeEventListener('scroll', updatePosition, true);
+        };
     }, [menuOpen]);
 
+    /**
+     * Open the freeform tag editor for this address in the shared core modal.
+     *
+     * The editor lives in the address-tags module and is handed the tags already
+     * resolved for the chip, so it opens seeded rather than fetching again. The
+     * modal is closed by id from inside the editor, which also invalidates the
+     * shared read cache so every chip on the page picks the change up.
+     */
+    const openTagEditor = useCallback((): void => {
+        setMenuOpen(false);
+        const id = `address-tags:${address}`;
+        modal.open({
+            id,
+            title: 'Edit tags',
+            size: 'sm',
+            content: (
+                <AddressTagsEditor
+                    address={address}
+                    initialTags={tags}
+                    onClose={() => modal.close(id)}
+                />
+            )
+        });
+    }, [address, modal, tags]);
+
     const display = label ?? truncateAddress(address);
+    // Tags ride in the tooltip rather than beside the chip: they are context for
+    // "which wallet is this", and a chip that grew inline chips would reflow
+    // every dense table it sits in.
+    const tooltip = tags.length > 0 ? `${address} (${tags.join(', ')})` : address;
 
     return (
         <span className={[styles.root, className].filter(Boolean).join(' ')}>
-            <Tooltip content={address}>
+            <Tooltip content={tooltip}>
                 <span
                     className={label ? styles.label : styles.address}
                     data-testid="tron-address-display"
@@ -211,12 +297,14 @@ export function TronAddress({
             )}
 
             {tools && (
-                // Stop tool clicks (the wrench toggle and the menu-item links,
-                // both descendants of this wrapper) from bubbling to an enclosing
-                // clickable row (`<Tr onClick>`), which would navigate or unmount
-                // the chip before the menu is usable. Mirrors CopyButton, which
-                // stops propagation for the same reason. preventDefault is not
-                // called, so the tool links still navigate.
+                // Stop tool clicks from bubbling to an enclosing clickable row
+                // (`<Tr onClick>`), which would navigate or unmount the chip
+                // before the menu is usable. Mirrors CopyButton, which stops
+                // propagation for the same reason. preventDefault is not called,
+                // so the tool links still navigate. The portaled menu is not a
+                // descendant of this wrapper, so it stops propagation itself —
+                // its own DOM position is under `<body>`, but React still
+                // bubbles its events through this tree.
                 <div
                     className={styles.menu_anchor}
                     ref={menuRef}
@@ -233,13 +321,19 @@ export function TronAddress({
                     >
                         <Wrench size={14} />
                     </IconButton>
-                    {menuOpen && (
+                    {menuOpen && createPortal(
                         <div
                             ref={menuListRef}
-                            className={[styles.menu, menuPlacement === 'top' ? styles.menu_top : '']
-                                .filter(Boolean)
-                                .join(' ')}
+                            className={styles.menu}
                             role="menu"
+                            // Hidden until measured so the first paint never
+                            // shows the menu parked at the viewport origin.
+                            style={
+                                menuPosition
+                                    ? { top: menuPosition.top, left: menuPosition.left }
+                                    : { top: 0, left: 0, visibility: 'hidden' }
+                            }
+                            onClick={event => event.stopPropagation()}
                         >
                             {FORWARDABLE_TOOLS.map(tool => (
                                 <a
@@ -252,7 +346,21 @@ export function TronAddress({
                                     {tool.label}
                                 </a>
                             ))}
-                        </div>
+                            {canEditTags && (
+                                // A button, not a link: it opens a modal in place
+                                // rather than navigating, so the tool-forward
+                                // links above stay the only anchors here.
+                                <button
+                                    type="button"
+                                    role="menuitem"
+                                    className={styles.menu_item}
+                                    onClick={openTagEditor}
+                                >
+                                    Edit tags
+                                </button>
+                            )}
+                        </div>,
+                        document.body
                     )}
                 </div>
             )}

--- a/src/frontend/modules/address-tags/api/client.ts
+++ b/src/frontend/modules/address-tags/api/client.ts
@@ -1,16 +1,22 @@
 /**
- * @fileoverview Admin API client for the address-tags module.
+ * @fileoverview API client for the address-tags module.
  *
- * Thin fetch wrappers over `/api/admin/system/address-tags/*`. Same-origin
- * calls carry the Better Auth session cookie automatically, which the
- * backend's `requireAdmin` middleware consults — no token plumbing here.
- * Every function throws on a non-2xx response so callers surface the failure
- * in the UI.
+ * Thin fetch wrappers over the module's two HTTP surfaces: the read-only user
+ * routes (`/api/address-tags/*`, `requireLogin`) and the mutation routes
+ * (`/api/admin/system/address-tags/*`, `requireAdmin`). Same-origin calls carry
+ * the Better Auth session cookie automatically, which those gates consult — no
+ * token plumbing here. Every function throws on a non-2xx response so callers
+ * surface the failure in the UI.
+ *
+ * The split matters to callers: any logged-in visitor may *read* an address's
+ * tags, but only an admin may change them, so a UI offering an edit affordance
+ * gates it on admin group membership rather than on login.
  */
 
 import type { IAddressTagPair, IAddressTagRename } from '@/types';
 
 const BASE = '/api/admin/system/address-tags';
+const USER_BASE = '/api/address-tags';
 
 export type { IAddressTagPair, IAddressTagRename } from '@/types';
 
@@ -38,6 +44,27 @@ async function parse<T>(response: Response, what: string): Promise<T> {
         throw new Error(body.error || `Failed to ${what} (HTTP ${response.status})`);
     }
     return response.json() as Promise<T>;
+}
+
+/**
+ * Read every tag assigned to the given addresses.
+ *
+ * Batched by design: the caller passes as many addresses as it needs rendered,
+ * so a table of a hundred chips costs one request instead of a hundred. Reads
+ * are gated on `requireLogin`, so an anonymous visitor gets a 401 here — treat
+ * tags as an absent enhancement in that case rather than an error to surface.
+ *
+ * @param addresses - Base58 addresses to look up; a single address is a
+ *        one-element array.
+ * @returns Every stored `(address, tag)` assignment across those addresses.
+ */
+export async function getTagsByAddresses(addresses: string[]): Promise<IAddressTagView[]> {
+    const query = new URLSearchParams({ addresses: addresses.join(',') });
+    const data = await parse<{ tags: IAddressTagView[] }>(
+        await fetch(`${USER_BASE}/by-address?${query.toString()}`),
+        'load address tags'
+    );
+    return data.tags;
 }
 
 /**

--- a/src/frontend/modules/address-tags/components/AddressTagsEditor/AddressTagsEditor.module.scss
+++ b/src/frontend/modules/address-tags/components/AddressTagsEditor/AddressTagsEditor.module.scss
@@ -1,0 +1,58 @@
+/*
+ * AddressTagsEditor styling.
+ *
+ * A single-field form inside the shared modal dialog: the address it edits at
+ * the top, the freeform field, then the action row. The modal owns the surface
+ * and padding, so this module only sets the internal rhythm and the field's
+ * supporting text.
+ */
+
+.editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+}
+
+/* The address being edited, restated so the modal stands on its own once it
+   covers the row the operator clicked from. Monospace and wrapping: the whole
+   34-character value is shown on purpose, so it must break rather than widen
+   the dialog. */
+.address {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text-muted);
+    word-break: break-all;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+}
+
+.label {
+    font-size: var(--font-size-body-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text);
+}
+
+/* States the destructive case plainly: an emptied field is a delete, which is
+   not obvious from a text input that accepts anything. */
+.hint {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+    line-height: var(--line-height-relaxed);
+}
+
+.error {
+    margin: 0;
+    font-size: var(--font-size-body-sm);
+    color: var(--color-danger-text);
+}
+
+.actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--gap-sm);
+}

--- a/src/frontend/modules/address-tags/components/AddressTagsEditor/AddressTagsEditor.tsx
+++ b/src/frontend/modules/address-tags/components/AddressTagsEditor/AddressTagsEditor.tsx
@@ -1,0 +1,143 @@
+/**
+ * @fileoverview Freeform tag editor for one address, rendered as a modal body.
+ *
+ * Tagging an address is a two-second correction an operator makes while reading
+ * a table, so the editor is deliberately one text field rather than a chip
+ * builder: type a comma-separated list, save, done. The field is seeded with the
+ * address's current tags, and saving diffs the submitted list against them so
+ * the component issues only the creates and deletes that actually changed —
+ * cheaper than a delete-all/recreate, and it leaves untouched assignments' own
+ * `createdAt` intact.
+ *
+ * Writes are admin-gated by the backend (`/api/admin/system/address-tags/*`), so
+ * callers must only offer this editor to admins; a non-admin would meet a 403
+ * here rather than a validation message.
+ */
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { Button } from '../../../../components/ui/Button';
+import { Input } from '../../../../components/ui/Input';
+import { createTags, deleteTags } from '../../api/client';
+import { invalidateAddressTags } from '../../hooks/useAddressTags';
+import styles from './AddressTagsEditor.module.scss';
+
+/**
+ * Props accepted by {@link AddressTagsEditor}.
+ */
+export interface IAddressTagsEditorProps {
+    /** Address whose tags are being edited. */
+    address: string;
+    /** The address's current tags, used to seed the field and diff the save. */
+    initialTags: string[];
+    /** Closes the hosting modal; called after a successful save and on cancel. */
+    onClose: () => void;
+}
+
+/**
+ * Split a submitted list into clean tag values.
+ *
+ * Commas are the delimiter the backend itself uses in `?tags=x,y` and are
+ * rejected inside a stored tag, so they are the only separator honoured here.
+ * Blank entries are dropped and duplicates collapse, which makes trailing commas
+ * and double spaces harmless instead of validation errors.
+ *
+ * @param value - Raw field contents as typed.
+ * @returns Distinct, trimmed tag values in the order entered.
+ */
+function parseTags(value: string): string[] {
+    const seen = new Set<string>();
+    value.split(',').forEach(part => {
+        const tag = part.trim();
+        if (tag.length > 0) {
+            seen.add(tag);
+        }
+    });
+    return [...seen];
+}
+
+/**
+ * Modal body letting an admin rewrite one address's tag list.
+ *
+ * @param props - {@link IAddressTagsEditorProps}.
+ * @returns The editor form.
+ */
+export function AddressTagsEditor({ address, initialTags, onClose }: IAddressTagsEditorProps) {
+    const [value, setValue] = useState(() => initialTags.join(', '));
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    // Sorted copy so the diff below is order-insensitive: retyping the same tags
+    // in a different order must not delete and recreate every assignment.
+    const existing = useMemo(() => new Set(initialTags), [initialTags]);
+
+    /**
+     * Apply the field's contents as the address's complete tag list.
+     *
+     * Diffs against the seeded tags and issues at most one create batch and one
+     * delete batch, then invalidates the shared read cache so every chip showing
+     * this address updates without a reload.
+     */
+    const handleSave = useCallback(async (): Promise<void> => {
+        const next = parseTags(value);
+        const added = next.filter(tag => !existing.has(tag));
+        const removed = [...existing].filter(tag => !next.includes(tag));
+        setSaving(true);
+        setError(null);
+        try {
+            if (added.length > 0) {
+                await createTags(added.map(tag => ({ address, tag })));
+            }
+            if (removed.length > 0) {
+                await deleteTags(removed.map(tag => ({ address, tag })));
+            }
+            invalidateAddressTags(address);
+            onClose();
+        } catch (caught) {
+            setError(caught instanceof Error ? caught.message : 'Failed to save tags');
+        } finally {
+            setSaving(false);
+        }
+    }, [address, existing, onClose, value]);
+
+    return (
+        <div className={styles.editor}>
+            {/* The full address, untruncated: the modal covers the row it was
+                opened from, and an operator about to relabel a wallet needs to
+                confirm which one. Deliberately plain text rather than the
+                TronAddress chip — the chip opens this editor, so consuming it
+                here would make the two modules import each other. */}
+            <p className={styles.address}>{address}</p>
+
+            <label className={styles.field}>
+                <span className={styles.label}>Tags</span>
+                <Input
+                    value={value}
+                    onChange={event => setValue(event.target.value)}
+                    placeholder="exchange, hot-wallet, market-payment"
+                    autoFocus
+                    disabled={saving}
+                />
+                <span className={styles.hint}>
+                    Comma-separated. Clearing the field removes every tag from this address.
+                </span>
+            </label>
+
+            {error && <p className={styles.error}>{error}</p>}
+
+            <div className={styles.actions}>
+                <Button variant="ghost" size="sm" onClick={onClose} disabled={saving}>
+                    Cancel
+                </Button>
+                <Button
+                    variant="primary"
+                    size="sm"
+                    loading={saving}
+                    onClick={() => { void handleSave(); }}
+                >
+                    Save tags
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/frontend/modules/address-tags/components/AddressTagsEditor/AddressTagsEditor.tsx
+++ b/src/frontend/modules/address-tags/components/AddressTagsEditor/AddressTagsEditor.tsx
@@ -3,11 +3,19 @@
  *
  * Tagging an address is a two-second correction an operator makes while reading
  * a table, so the editor is deliberately one text field rather than a chip
- * builder: type a comma-separated list, save, done. The field is seeded with the
- * address's current tags, and saving diffs the submitted list against them so
- * the component issues only the creates and deletes that actually changed —
- * cheaper than a delete-all/recreate, and it leaves untouched assignments' own
- * `createdAt` intact.
+ * builder: type a comma-separated list, save, done. Saving diffs the submitted
+ * list against the address's stored tags so the component issues only the
+ * creates and deletes that actually changed — cheaper than a
+ * delete-all/recreate, and it leaves untouched assignments' `createdAt` intact.
+ *
+ * **The editor reads its own authoritative tag list on mount** and keeps the
+ * field disabled until it lands. It cannot trust a caller-supplied snapshot:
+ * callers get their tags from `useAddressTags`, which reports an unresolved
+ * lookup and a genuinely untagged address identically (both `[]`), so a snapshot
+ * taken before that lookup resolved — or after it failed — would present a
+ * tagged address as empty, and the save diff would then add without removing the
+ * tags the operator never saw. `initialTags` survives only as an optimistic seed
+ * for the pre-load render.
  *
  * Writes are admin-gated by the backend (`/api/admin/system/address-tags/*`), so
  * callers must only offer this editor to admins; a non-admin would meet a 403
@@ -15,10 +23,10 @@
  */
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Button } from '../../../../components/ui/Button';
 import { Input } from '../../../../components/ui/Input';
-import { createTags, deleteTags } from '../../api/client';
+import { createTags, deleteTags, getTagsByAddresses } from '../../api/client';
 import { invalidateAddressTags } from '../../hooks/useAddressTags';
 import styles from './AddressTagsEditor.module.scss';
 
@@ -28,8 +36,12 @@ import styles from './AddressTagsEditor.module.scss';
 export interface IAddressTagsEditorProps {
     /** Address whose tags are being edited. */
     address: string;
-    /** The address's current tags, used to seed the field and diff the save. */
-    initialTags: string[];
+    /**
+     * Optimistic seed for the field while the editor loads its own list. Purely
+     * cosmetic — the save diff always uses the tags this component fetched, so a
+     * stale or empty seed cannot cause a wrong write.
+     */
+    initialTags?: string[];
     /** Closes the hosting modal; called after a successful save and on cancel. */
     onClose: () => void;
 }
@@ -63,22 +75,48 @@ function parseTags(value: string): string[] {
  * @returns The editor form.
  */
 export function AddressTagsEditor({ address, initialTags, onClose }: IAddressTagsEditorProps) {
-    const [value, setValue] = useState(() => initialTags.join(', '));
+    const [value, setValue] = useState(() => (initialTags ?? []).join(', '));
     const [saving, setSaving] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    /**
+     * The address's stored tags as this editor read them, and the sole basis for
+     * the save diff. `null` until the read resolves, which is what keeps the form
+     * disabled — an editor that cannot state the current tags must not let an
+     * operator submit a replacement for them.
+     */
+    const [loaded, setLoaded] = useState<string[] | null>(null);
 
-    // Sorted copy so the diff below is order-insensitive: retyping the same tags
-    // in a different order must not delete and recreate every assignment.
-    const existing = useMemo(() => new Set(initialTags), [initialTags]);
+    // Read the authoritative list on mount. A failure is surfaced and leaves the
+    // form disabled rather than falling back to "no tags", because an empty list
+    // is indistinguishable from a wiped one at save time.
+    useEffect(() => {
+        let active = true;
+        getTagsByAddresses([address])
+            .then(rows => {
+                if (!active) return;
+                const tags = rows.filter(row => row.address === address).map(row => row.tag);
+                setLoaded(tags);
+                setValue(tags.join(', '));
+            })
+            .catch(caught => {
+                if (!active) return;
+                setError(caught instanceof Error ? caught.message : 'Failed to load tags');
+            });
+        return () => { active = false; };
+    }, [address]);
 
     /**
      * Apply the field's contents as the address's complete tag list.
      *
-     * Diffs against the seeded tags and issues at most one create batch and one
-     * delete batch, then invalidates the shared read cache so every chip showing
-     * this address updates without a reload.
+     * Diffs against the tags this editor loaded and issues at most one create
+     * batch and one delete batch, then invalidates the shared read cache so every
+     * chip showing this address updates without a reload.
      */
     const handleSave = useCallback(async (): Promise<void> => {
+        if (loaded === null) {
+            return;
+        }
+        const existing = new Set(loaded);
         const next = parseTags(value);
         const added = next.filter(tag => !existing.has(tag));
         const removed = [...existing].filter(tag => !next.includes(tag));
@@ -98,7 +136,7 @@ export function AddressTagsEditor({ address, initialTags, onClose }: IAddressTag
         } finally {
             setSaving(false);
         }
-    }, [address, existing, onClose, value]);
+    }, [address, loaded, onClose, value]);
 
     return (
         <div className={styles.editor}>
@@ -116,10 +154,12 @@ export function AddressTagsEditor({ address, initialTags, onClose }: IAddressTag
                     onChange={event => setValue(event.target.value)}
                     placeholder="exchange, hot-wallet, market-payment"
                     autoFocus
-                    disabled={saving}
+                    disabled={saving || loaded === null}
                 />
                 <span className={styles.hint}>
-                    Comma-separated. Clearing the field removes every tag from this address.
+                    {loaded === null && !error
+                        ? 'Loading this address’s current tags…'
+                        : 'Comma-separated. Clearing the field removes every tag from this address.'}
                 </span>
             </label>
 
@@ -133,6 +173,7 @@ export function AddressTagsEditor({ address, initialTags, onClose }: IAddressTag
                     variant="primary"
                     size="sm"
                     loading={saving}
+                    disabled={loaded === null}
                     onClick={() => { void handleSave(); }}
                 >
                     Save tags

--- a/src/frontend/modules/address-tags/hooks/useAddressTags.ts
+++ b/src/frontend/modules/address-tags/hooks/useAddressTags.ts
@@ -1,0 +1,157 @@
+/**
+ * @fileoverview Client-side read cache for address tags, shared by every chip.
+ *
+ * The canonical `TronAddress` chip renders anywhere addresses appear — often
+ * dozens of times in one table — and each instance wants the tags for its own
+ * address. Fetching per chip would issue a request per row, so this module holds
+ * one process-wide cache and coalesces every address requested inside the same
+ * tick into a single `/api/address-tags/by-address` call. Chips subscribe, so a
+ * later save invalidates one address and every chip showing it re-reads.
+ *
+ * Tags are an enhancement, never load-bearing: reads require a login, so an
+ * anonymous visitor resolves to no tags and the chip renders exactly as before.
+ * Failures are swallowed for the same reason — a tag lookup must never break the
+ * address it decorates.
+ */
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getTagsByAddresses } from '../api/client';
+import { useAuthSession } from '../../user/components/SessionProvider';
+
+/**
+ * Addresses per outbound request. The backend caps a batch at 1000 items; this
+ * lower bound keeps the query string well inside proxy URL limits while still
+ * collapsing any realistic page's worth of chips into one or two calls.
+ */
+const MAX_BATCH = 100;
+
+/** Resolved tags by address. An empty array is a cached "no tags" answer. */
+const cache = new Map<string, string[]>();
+
+/** Addresses queued for the next flush, not yet requested. */
+let queued = new Set<string>();
+
+/** Addresses currently in flight, so a re-render does not re-request them. */
+const inFlight = new Set<string>();
+
+/** Per-address subscribers, notified when that address's tags change. */
+const subscribers = new Map<string, Set<() => void>>();
+
+/** Pending flush handle; non-null means a batch is already scheduled. */
+let flushHandle: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Notify every chip watching an address that its tags changed.
+ *
+ * @param address - The address whose subscribers should re-read the cache.
+ */
+function notify(address: string): void {
+    subscribers.get(address)?.forEach(listener => listener());
+}
+
+/**
+ * Fetch the queued addresses and publish the answers.
+ *
+ * Every requested address is written to the cache — including the ones the
+ * response carried no rows for — so an untagged address is answered from cache
+ * next time instead of being re-requested by every chip that renders it.
+ */
+async function flush(): Promise<void> {
+    flushHandle = null;
+    const batch = [...queued].slice(0, MAX_BATCH);
+    // Anything over the cap stays queued and goes out on the next flush.
+    queued = new Set([...queued].slice(MAX_BATCH));
+    if (queued.size > 0) {
+        schedule();
+    }
+    if (batch.length === 0) {
+        return;
+    }
+    batch.forEach(address => inFlight.add(address));
+    try {
+        const rows = await getTagsByAddresses(batch);
+        const byAddress = new Map<string, string[]>();
+        rows.forEach(row => {
+            const tags = byAddress.get(row.address) ?? [];
+            tags.push(row.tag);
+            byAddress.set(row.address, tags);
+        });
+        batch.forEach(address => cache.set(address, byAddress.get(address) ?? []));
+    } catch {
+        // Anonymous visitor (401) or a transient failure: cache the empty
+        // answer so the page does not retry per chip, and let an explicit
+        // invalidation be the only thing that asks again.
+        batch.forEach(address => cache.set(address, cache.get(address) ?? []));
+    } finally {
+        batch.forEach(address => {
+            inFlight.delete(address);
+            notify(address);
+        });
+    }
+}
+
+/**
+ * Schedule a flush on the next macrotask, why: chips mount in one render pass,
+ * so deferring by a tick lets the whole page's addresses land in one request.
+ */
+function schedule(): void {
+    if (flushHandle === null) {
+        flushHandle = setTimeout(() => { void flush(); }, 0);
+    }
+}
+
+/**
+ * Drop an address's cached tags and re-read it, so every chip showing that
+ * address reflects an edit immediately rather than on the next full page load.
+ *
+ * @param address - The address whose assignments were just changed.
+ */
+export function invalidateAddressTags(address: string): void {
+    cache.delete(address);
+    queued.add(address);
+    schedule();
+}
+
+/**
+ * Subscribe one component to the tags of one address.
+ *
+ * @param address - Base58 address to read tags for. Falsy values are ignored so
+ *        a caller need not branch before calling the hook.
+ * @returns The address's tags, empty until they resolve (or if the visitor is
+ *          not logged in, in which case they never do).
+ */
+export function useAddressTags(address: string | undefined): string[] {
+    const { isLoggedIn } = useAuthSession();
+    const [tags, setTags] = useState<string[]>(() => (address ? cache.get(address) ?? [] : []));
+
+    useEffect(() => {
+        if (!address || !isLoggedIn) {
+            setTags([]);
+            return undefined;
+        }
+        // Bound to a local so the closures below carry the narrowed type rather
+        // than re-narrowing the possibly-undefined prop on every call.
+        const key = address;
+        /** Re-read this address from the shared cache after a batch resolves. */
+        function readCache(): void {
+            setTags(cache.get(key) ?? []);
+        }
+        const listeners = subscribers.get(key) ?? new Set<() => void>();
+        listeners.add(readCache);
+        subscribers.set(key, listeners);
+        readCache();
+        if (!cache.has(key) && !inFlight.has(key)) {
+            queued.add(key);
+            schedule();
+        }
+        return () => {
+            listeners.delete(readCache);
+            if (listeners.size === 0) {
+                subscribers.delete(key);
+            }
+        };
+    }, [address, isLoggedIn]);
+
+    return tags;
+}

--- a/src/frontend/modules/address-tags/hooks/useAddressTags.ts
+++ b/src/frontend/modules/address-tags/hooks/useAddressTags.ts
@@ -42,6 +42,23 @@ const subscribers = new Map<string, Set<() => void>>();
 let flushHandle: ReturnType<typeof setTimeout> | null = null;
 
 /**
+ * Consecutive failed lookups per address. The client cannot tell a transient 5xx
+ * from a standing refusal — the API client throws a plain `Error` — so an attempt
+ * count is what bounds retries rather than the status code.
+ */
+const failures = new Map<string, number>();
+
+/**
+ * Attempts before a failing address falls back to the cached empty answer. Small
+ * on purpose: a persistent refusal (a session that expired mid-visit) should
+ * settle in a few requests rather than re-ask for the page's lifetime.
+ */
+const MAX_ATTEMPTS = 3;
+
+/** Backoff before a failed batch is retried, so a flapping backend gets air. */
+const RETRY_DELAY_MS = 2000;
+
+/**
  * Notify every chip watching an address that its tags changed.
  *
  * @param address - The address whose subscribers should re-read the cache.
@@ -53,9 +70,13 @@ function notify(address: string): void {
 /**
  * Fetch the queued addresses and publish the answers.
  *
- * Every requested address is written to the cache — including the ones the
- * response carried no rows for — so an untagged address is answered from cache
- * next time instead of being re-requested by every chip that renders it.
+ * Every successfully requested address is written to the cache — including the
+ * ones the response carried no rows for — so an untagged address is answered from
+ * cache next time instead of being re-requested by every chip that renders it.
+ * A failed address is deliberately left uncached for a bounded number of
+ * attempts: an empty cache entry is indistinguishable from "no tags", so caching
+ * one transient failure would suppress those tags until an explicit invalidation
+ * or a full reload.
  */
 async function flush(): Promise<void> {
     flushHandle = null;
@@ -77,12 +98,29 @@ async function flush(): Promise<void> {
             tags.push(row.tag);
             byAddress.set(row.address, tags);
         });
-        batch.forEach(address => cache.set(address, byAddress.get(address) ?? []));
+        batch.forEach(address => {
+            cache.set(address, byAddress.get(address) ?? []);
+            failures.delete(address);
+        });
     } catch {
-        // Anonymous visitor (401) or a transient failure: cache the empty
-        // answer so the page does not retry per chip, and let an explicit
-        // invalidation be the only thing that asks again.
-        batch.forEach(address => cache.set(address, cache.get(address) ?? []));
+        // Retry a transient failure a bounded number of times, then fall back to
+        // the empty answer. Leaving the earlier attempts uncached is what lets a
+        // 5xx or dropped request heal; the eventual fallback is what stops a
+        // standing refusal (an expired session's 401) from asking forever.
+        // Retries go back through `queued`, so they stay coalesced into one
+        // batch rather than one request per chip.
+        batch.forEach(address => {
+            const attempts = (failures.get(address) ?? 0) + 1;
+            failures.set(address, attempts);
+            if (attempts >= MAX_ATTEMPTS) {
+                cache.set(address, cache.get(address) ?? []);
+                return;
+            }
+            queued.add(address);
+        });
+        if (queued.size > 0 && flushHandle === null) {
+            flushHandle = setTimeout(() => { void flush(); }, RETRY_DELAY_MS);
+        }
     } finally {
         batch.forEach(address => {
             inFlight.delete(address);
@@ -109,6 +147,10 @@ function schedule(): void {
  */
 export function invalidateAddressTags(address: string): void {
     cache.delete(address);
+    // Clear the attempt count too: an address that exhausted its retries earlier
+    // must get a fresh budget now, or a mutation confirmed against the backend
+    // would still be unable to re-read its own result.
+    failures.delete(address);
     queued.add(address);
     schedule();
 }

--- a/src/frontend/modules/address-tags/index.ts
+++ b/src/frontend/modules/address-tags/index.ts
@@ -1,7 +1,11 @@
 /**
- * @fileoverview Public surface of the frontend address-tags module — the
- * admin API client for the tag management surface. Consumers import from the
- * module root.
+ * @fileoverview Public surface of the frontend address-tags module — the API
+ * client for both HTTP surfaces, the shared read cache every address chip
+ * consumes, and the freeform tag editor rendered inside the core modal.
+ * Consumers import from the module root.
  */
 
 export * from './api/client';
+export { useAddressTags, invalidateAddressTags } from './hooks/useAddressTags';
+export { AddressTagsEditor } from './components/AddressTagsEditor/AddressTagsEditor';
+export type { IAddressTagsEditorProps } from './components/AddressTagsEditor/AddressTagsEditor';


### PR DESCRIPTION
Integrates the address-tags module into the canonical `TronAddress` chip, so tags reach every surface that renders an address rather than only the `/system/address-tags` manager.

## Tooltip

An address's tags append to its hover tooltip — `T4Hf…9kQm (exchange, hot-wallet)` — and the tooltip is unchanged when there are none. Reads go through a new `useAddressTags` hook: one process-wide cache that coalesces every chip rendered in a tick into a single `/api/address-tags/by-address` call, so a hundred-row table costs one request instead of a hundred. Tags are treated as an absent enhancement — an anonymous visitor (reads are `requireLogin`) or a failed lookup leaves the chip rendering exactly as before.

## Edit tags

The wrench menu gains an "Edit tags" item that opens the new `AddressTagsEditor` in the core modal: a single comma-separated field seeded with the current tags, diffed on save so only the actual creates and deletes are issued, then invalidating the shared cache so every chip showing that address updates without a reload.

The item is gated on `admin` group membership because every tag mutation route is `requireAdmin` while reads are only `requireLogin` — offering it more widely would surface a 403 after the operator had typed.

## Popover clipping fix

The tools popover was absolutely positioned inside the shared `Table` wrapper, whose `overflow-x: auto` also clips vertically, so the menu was cut at the table's edge regardless of remaining viewport space; the previous mitigation only flipped it near the viewport bottom. It now renders in a `<body>` portal with viewport-fixed coordinates, flipping and clamping from its trigger and re-measuring on resize and captured scroll.

## Spacing

The chip's row gap is zero with the address carrying its own right margin, and the explorer link's padding matches the bare IconButton step, so the three icon affordances read as one cluster.