### PR TITLE
refactor(admin): adopt StatTile across the core admin surfaces

### DIFF
--- a/src/frontend/app/(core)/system/pages/tabs/PagesTab.module.css
+++ b/src/frontend/app/(core)/system/pages/tabs/PagesTab.module.css
@@ -4,30 +4,6 @@
     gap: var(--spacing-7);
 }
 
-.stats {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: var(--spacing-10);
-}
-
-.stat {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-2);
-}
-
-.stat_label {
-    font-size: var(--font-size-sm);
-    color: var(--color-text-muted);
-    font-weight: var(--font-weight-medium);
-}
-
-.stat_value {
-    font-size: var(--font-size-2xl);
-    font-weight: var(--font-weight-bold);
-    color: var(--color-text);
-}
-
 .error {
     color: var(--color-danger);
     margin: 0;

--- a/src/frontend/app/(core)/system/pages/tabs/PagesTab.tsx
+++ b/src/frontend/app/(core)/system/pages/tabs/PagesTab.tsx
@@ -7,6 +7,7 @@ import { Button } from '../../../../../components/ui/Button';
 import { Card } from '../../../../../components/ui/Card';
 import { Input } from '../../../../../components/ui/Input';
 import { Select } from '../../../../../components/ui/Select';
+import { StatTile, StatGrid } from '../../../../../components/ui/StatTile';
 import { Plus, Edit, Trash2, Eye, EyeOff, Search } from 'lucide-react';
 import type { IPage } from '@/types';
 import styles from './PagesTab.module.css';
@@ -153,20 +154,16 @@ export function PagesTab() {
         <div className={styles.container}>
             {/* Stats Summary */}
             <Card padding="md">
-                <div className={styles.stats}>
-                    <div className={styles.stat}>
-                        <span className={styles.stat_label}>Total Pages</span>
-                        <span className={styles.stat_value}>{stats.total}</span>
-                    </div>
-                    <div className={styles.stat}>
-                        <span className={styles.stat_label}>Published</span>
-                        <span className={styles.stat_value}>{stats.published}</span>
-                    </div>
-                    <div className={styles.stat}>
-                        <span className={styles.stat_label}>Drafts</span>
-                        <span className={styles.stat_value}>{stats.drafts}</span>
-                    </div>
-                </div>
+                {/*
+                  * Tiles sit inside this card, so they draw no surface of
+                  * their own — nested boxes would read as a grid of cards
+                  * inside a card.
+                  */}
+                <StatGrid size="sm">
+                    <StatTile size="sm" surface={false} label="Total Pages" value={stats.total} />
+                    <StatTile size="sm" surface={false} label="Published" value={stats.published} />
+                    <StatTile size="sm" surface={false} label="Drafts" value={stats.drafts} />
+                </StatGrid>
             </Card>
 
             {/* Error Display */}

--- a/src/frontend/app/(core)/system/price-history/PriceHistoryAdminClient.tsx
+++ b/src/frontend/app/(core)/system/price-history/PriceHistoryAdminClient.tsx
@@ -16,10 +16,11 @@ import { useEffect, useState, useCallback } from 'react';
 import { RefreshCw, ArrowUpToLine, Save } from 'lucide-react';
 import type { MenuNodeSerialized } from '@/shared';
 import type { IPriceHistoryStats, IPriceHistorySettings, IPriceCoverageDiagnostics } from '@/types';
-import { Page, PageHeader, Stack, Grid } from '../../../../components/layout';
+import { Page, PageHeader, Stack } from '../../../../components/layout';
 import { Card } from '../../../../components/ui/Card';
 import { Button } from '../../../../components/ui/Button';
 import { Badge } from '../../../../components/ui/Badge';
+import { StatTile, StatGrid } from '../../../../components/ui/StatTile';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../components/ui/Table';
 import { useToast } from '../../../../components/ui/ToastProvider';
 import { MenuNavClient } from '../../../../components/layout/MenuNav/MenuNavClient';
@@ -183,36 +184,32 @@ export function PriceHistoryAdminClient({ submenuTree, submenuGeneratedAt, initi
 
             {activeTab === 'coverage' && (
                 <Stack gap="md">
-                    <Grid columns="responsive" gap="md">
-                        <Card padding="md">
-                            <div className="stat-card__label">Tracked assets</div>
-                            <div className="stat-card__value">{stats?.totals.assetCount ?? '—'}</div>
-                        </Card>
-                        <Card padding="md">
-                            <div className="stat-card__label">Oldest day</div>
-                            <div className="stat-card__value">{stats?.totals.oldestDay ?? '—'}</div>
-                        </Card>
-                        <Card padding="md">
-                            <div className="stat-card__label">Newest day</div>
-                            <div className="stat-card__value">{stats?.totals.newestDay ?? '—'}</div>
-                        </Card>
-                        <Card padding="md">
-                            <div className="stat-card__label">Stale assets</div>
-                            <div className="stat-card__value">
-                                {!stats ? '—' : stats.totals.staleAssets > 0 ? <Badge tone="warning">{stats.totals.staleAssets}</Badge> : 0}
-                            </div>
-                        </Card>
-                        <Card padding="md">
-                            <div className="stat-card__label">Provider errors</div>
-                            <div className="stat-card__value">
-                                {!stats
+                    <StatGrid>
+                        <StatTile
+                            label="Tracked assets"
+                            value={stats?.totals.assetCount ?? '—'}
+                        />
+                        <StatTile
+                            label="Oldest day"
+                            value={stats?.totals.oldestDay ?? '—'}
+                        />
+                        <StatTile
+                            label="Newest day"
+                            value={stats?.totals.newestDay ?? '—'}
+                        />
+                        <StatTile
+                            label="Stale assets"
+                            value={!stats ? '—' : stats.totals.staleAssets > 0 ? <Badge tone="warning">{stats.totals.staleAssets}</Badge> : 0}
+                        />
+                        <StatTile
+                            label="Provider errors"
+                            value={!stats
                                     ? '—'
                                     : stats.totals.providerErrors > 0
                                         ? <Badge tone="danger">{stats.totals.providerErrors} / {stats.totals.providerCalls} calls</Badge>
                                         : `0 / ${stats.totals.providerCalls} calls`}
-                            </div>
-                        </Card>
-                    </Grid>
+                        />
+                    </StatGrid>
 
                     <Stack direction="horizontal" gap="sm">
                         <Button variant="secondary" size="sm" icon={<RefreshCw size={18} aria-hidden />} loading={busy === 'backfill'} disabled={!!busy} onClick={() => runAction('backfill', runBackfill)}>
@@ -270,22 +267,20 @@ export function PriceHistoryAdminClient({ submenuTree, submenuGeneratedAt, initi
 
             {activeTab === 'diagnostics' && (
                 <Stack gap="md">
-                    <Grid columns="responsive" gap="md">
-                        <Card padding="md">
-                            <div className="stat-card__label">Held tokens</div>
-                            <div className="stat-card__value">{diagnostics?.heldTokenCount ?? '—'}</div>
-                        </Card>
-                        <Card padding="md">
-                            <div className="stat-card__label">Priced</div>
-                            <div className="stat-card__value">{diagnostics?.pricedTokenCount ?? '—'}</div>
-                        </Card>
-                        <Card padding="md">
-                            <div className="stat-card__label">Unpriced</div>
-                            <div className="stat-card__value">
-                                {!diagnostics ? '—' : diagnostics.unpricedTokens.length > 0 ? <Badge tone="warning">{diagnostics.unpricedTokens.length}</Badge> : 0}
-                            </div>
-                        </Card>
-                    </Grid>
+                    <StatGrid>
+                        <StatTile
+                            label="Held tokens"
+                            value={diagnostics?.heldTokenCount ?? '—'}
+                        />
+                        <StatTile
+                            label="Priced"
+                            value={diagnostics?.pricedTokenCount ?? '—'}
+                        />
+                        <StatTile
+                            label="Unpriced"
+                            value={!diagnostics ? '—' : diagnostics.unpricedTokens.length > 0 ? <Badge tone="warning">{diagnostics.unpricedTokens.length}</Badge> : 0}
+                        />
+                    </StatGrid>
                     <Card padding="md">
                         {!diagnostics ? (
                             <span className="text-muted">Loading…</span>

--- a/src/frontend/app/(core)/system/system/components/StatStrip.module.scss
+++ b/src/frontend/app/(core)/system/system/components/StatStrip.module.scss
@@ -1,15 +1,21 @@
 /**
  * StatStrip styles.
  *
- * Mission-control telemetry layout: dense auto-fit grid with hairline
- * dividers between cells. Tone is communicated via a 2px left rule so the
- * stripe consumes no horizontal real estate, keeping the value column
- * monospace-aligned across the strip.
+ * Mission-control telemetry layout: dense auto-fit grid of cells with a
+ * hairline gap between them. The cells are core `<StatTile>`s, so the
+ * label/value/detail typography lives with that primitive and this module
+ * carries only what makes a strip — the enclosing chrome, the mono figure,
+ * and the tone treatment.
+ *
+ * Tone is communicated via a 2px left rule so the stripe consumes no
+ * horizontal real estate, keeping the value column monospace-aligned across
+ * the strip. Both the rule and the tinted figure are applied by
+ * scope-overriding the tile's own tokens rather than restyling its internals.
  */
 
 .strip {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(var(--stat-col-min, 140px), 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(var(--stat-col-min, 140px), 100%), 1fr));
     gap: var(--gap-2xs);
     background: var(--color-surface-base);
     border: var(--border-width-thin) solid var(--color-border);
@@ -17,10 +23,23 @@
     padding: var(--gap-2xs);
 }
 
+/*
+ * The cell's own surface. The tile renders with `surface={false}` and this
+ * rule supplies the box, so the strip keeps its tighter padding and the
+ * left-rule slot the tile has no concept of.
+ */
 .cell {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-2xs);
+    /*
+     * Console density: a mono figure one step below the tile's own compact
+     * value, at semibold rather than bold. A telemetry strip is read by
+     * scanning a column of numbers, not by landing on one — the weight the
+     * tile uses to make a KPI the focal point works against that here.
+     */
+    --stat-tile-value-font-family: var(--font-mono);
+    --stat-tile-value-font-size-sm: var(--font-size-body);
+    --stat-tile-value-font-weight: var(--font-weight-semibold);
+    --stat-tile-note-color: var(--color-text-subtle);
+
     padding: var(--padding-xs) var(--padding-sm);
     border-radius: var(--radius-xs);
     border-left: var(--border-width-medium) solid transparent;
@@ -29,57 +48,22 @@
 }
 
 .cell_success {
+    --stat-tile-value-color: var(--color-success-text);
+
     border-left-color: var(--color-success-alpha-45);
     background: var(--color-success-alpha-18);
 }
 
 .cell_warning {
+    --stat-tile-value-color: var(--color-warning-text);
+
     border-left-color: var(--color-warning-alpha-40);
     background: var(--color-warning-alpha-15);
 }
 
 .cell_danger {
+    --stat-tile-value-color: var(--color-danger-text);
+
     border-left-color: var(--color-danger-alpha-50);
     background: var(--color-danger-alpha-18);
-}
-
-.label {
-    font-size: var(--font-size-caption);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-wide);
-    color: var(--color-text-muted);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.value {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-body);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text);
-    line-height: var(--line-height-tight);
-    word-break: break-word;
-    display: inline-flex;
-    align-items: center;
-    gap: var(--gap-xs);
-    flex-wrap: wrap;
-}
-
-.cell_success .value {
-    color: var(--color-success-text);
-}
-
-.cell_danger .value {
-    color: var(--color-danger-text);
-}
-
-.cell_warning .value {
-    color: var(--color-warning-text);
-}
-
-.detail {
-    font-size: var(--font-size-caption);
-    color: var(--color-text-subtle);
-    line-height: var(--line-height-tight);
 }

--- a/src/frontend/app/(core)/system/system/components/StatStrip.tsx
+++ b/src/frontend/app/(core)/system/system/components/StatStrip.tsx
@@ -2,6 +2,7 @@
 
 import type { CSSProperties, ReactNode } from 'react';
 import { cn } from '../../../../../lib/cn';
+import { StatTile } from '../../../../../components/ui/StatTile';
 import styles from './StatStrip.module.scss';
 
 type Tone = 'neutral' | 'success' | 'warning' | 'danger';
@@ -26,30 +27,40 @@ interface StatStripProps {
 /**
  * Compact horizontal stat readout used by the system console.
  *
- * Replaces the older HealthMetric tile pattern. Each cell renders a tiny
- * uppercase label, a monospace numeric value, and an optional detail line —
- * roughly half the vertical footprint of the iconed tile it supersedes. The
- * grid uses CSS auto-fit + a container query so the strip can flow from
- * six columns on a wide console to two on a narrow modal context.
+ * Mission-control telemetry: a dense grid of cells, each a tiny uppercase
+ * label over a monospace figure with an optional detail line — roughly half
+ * the vertical footprint of the iconed tile it superseded. The grid auto-fits
+ * so the strip flows from six columns on a wide console to two in a modal.
+ *
+ * The cells are the core `<StatTile>` at compact density, not a parallel
+ * implementation: the label/value/detail typography comes from the shared
+ * primitive, and this component contributes only what makes a *strip* — the
+ * enclosing chrome, the mono figure, and the tone treatment, all applied by
+ * scope-overriding the tile's own tokens. Tone is a 2px left rule rather than
+ * the tile's coloured value, so the figures stay optically aligned down the
+ * strip while the cell still reads as healthy or degraded at a glance.
  */
 export function StatStrip({ items, minColWidth = '140px', className }: StatStripProps) {
     const style = { '--stat-col-min': minColWidth } as CSSProperties;
     return (
         <div className={cn(styles.strip, className)} style={style}>
             {items.map((item, index) => (
-                <div
+                <StatTile
                     key={`${item.label}-${index}`}
+                    size="sm"
+                    // The strip draws the cell's surface itself, so the tile
+                    // must not draw a second one inside it.
+                    surface={false}
                     className={cn(
                         styles.cell,
                         item.tone === 'success' && styles.cell_success,
                         item.tone === 'warning' && styles.cell_warning,
                         item.tone === 'danger' && styles.cell_danger
                     )}
-                >
-                    <span className={styles.label}>{item.label}</span>
-                    <span className={styles.value}>{item.value}</span>
-                    {item.detail && <span className={styles.detail}>{item.detail}</span>}
-                </div>
+                    label={item.label}
+                    value={item.value}
+                    note={item.detail}
+                />
             ))}
         </div>
     );

--- a/src/frontend/app/semantic-tokens.scss
+++ b/src/frontend/app/semantic-tokens.scss
@@ -345,6 +345,9 @@
     --stat-tile-value-font-size-sm: var(--font-size-heading-sm); /* 1.05rem */
     --stat-tile-value-font-weight: var(--font-weight-bold);
     --stat-tile-value-color: var(--color-text);
+    /* Overridable so a telemetry surface can set its figures in mono (the
+       system console's StatStrip does) without forking the tile. */
+    --stat-tile-value-font-family: var(--font-body);
 
     /* Value tone variants. The -text steps are calibrated for coloured text on
        a dark surface; the solid status colours are not, and fail contrast here. */

--- a/src/frontend/components/ui/StatTile/StatTile.module.scss
+++ b/src/frontend/components/ui/StatTile/StatTile.module.scss
@@ -61,6 +61,7 @@
 
 .value {
     color: var(--stat-tile-value-color);
+    font-family: var(--stat-tile-value-font-family);
     font-weight: var(--stat-tile-value-font-weight);
     line-height: var(--line-height-tight);
 }

--- a/src/frontend/features/system/components/MarketMonitor/MarketMonitor.module.css
+++ b/src/frontend/features/system/components/MarketMonitor/MarketMonitor.module.css
@@ -47,33 +47,6 @@
    Freshness Metrics Grid
    ======================================== */
 
-.metrics_grid {
-    /* Narrower auto-fit floor than the <Grid> default: metric cards hold a short
-       label and a single number, so they tile well below 280px. */
-    --grid-responsive-min: 200px;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(var(--grid-responsive-min), 1fr));
-    gap: var(--gap-md);
-}
-
-.metric_card {
-    padding: var(--card-padding-sm);
-    background: var(--color-surface-elevated);
-    border: var(--border-width-thin) solid var(--color-border-strong);
-    border-radius: var(--radius-md);
-}
-
-.metric_card__label {
-    font-size: var(--font-size-body-sm);
-    opacity: var(--opacity-70);
-    margin-bottom: var(--gap-sm);
-}
-
-.metric_card__value {
-    font-size: var(--font-size-heading-lg);
-    font-weight: var(--font-weight-bold);
-}
-
 /* ========================================
    Warning Alert
    ======================================== */

--- a/src/frontend/features/system/components/MarketMonitor/MarketMonitor.tsx
+++ b/src/frontend/features/system/components/MarketMonitor/MarketMonitor.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Badge, type BadgeTone } from '../../../../components/ui/Badge';
 import { Button } from '../../../../components/ui/Button';
+import { StatTile, StatGrid } from '../../../../components/ui/StatTile';
 import styles from './MarketMonitor.module.css';
 
 interface MarketPlatform {
@@ -188,24 +189,22 @@ export function MarketMonitor() {
                 </header>
 
                 {freshness && (
-                    <div className={styles.metrics_grid}>
-                        <div className={styles.metric_card}>
-                            <div className={styles.metric_card__label}>Stale Platforms</div>
-                            <div className={styles.metric_card__value}>{freshness.stalePlatformCount}</div>
-                        </div>
-
-                        <div className={styles.metric_card}>
-                            <div className={styles.metric_card__label}>Average Data Age</div>
-                            <div className={styles.metric_card__value}>{freshness.averageDataAge.toFixed(1)} min</div>
-                        </div>
-
+                    <StatGrid minColWidth="200px">
+                        <StatTile
+                            label="Stale Platforms"
+                            value={freshness.stalePlatformCount}
+                        />
+                        <StatTile
+                            label="Average Data Age"
+                            value={`${freshness.averageDataAge.toFixed(1)} min`}
+                        />
                         {freshness.oldestDataAge !== null && (
-                            <div className={styles.metric_card}>
-                                <div className={styles.metric_card__label}>Oldest Data</div>
-                                <div className={styles.metric_card__value}>{freshness.oldestDataAge.toFixed(1)} min</div>
-                            </div>
+                            <StatTile
+                                label="Oldest Data"
+                                value={`${freshness.oldestDataAge.toFixed(1)} min`}
+                            />
                         )}
-                    </div>
+                    </StatGrid>
                 )}
 
                 {freshness && freshness.platformsWithOldData.length > 0 && (

--- a/src/frontend/modules/logs/components/SystemLogsMonitor/SystemLogsMonitor.module.scss
+++ b/src/frontend/modules/logs/components/SystemLogsMonitor/SystemLogsMonitor.module.scss
@@ -18,32 +18,6 @@
 }
 
 /* Statistics */
-.stats {
-    display: grid;
-    grid-template-columns: repeat(7, 1fr);
-    gap: var(--spacing-7);
-}
-
-.stat_card {
-    background: var(--color-surface);
-    border: var(--border-width-thin) solid var(--color-border);
-    border-radius: var(--radius-md);
-    padding: var(--spacing-7);
-    text-align: center;
-}
-
-.stat_label {
-    font-size: var(--font-size-sm);
-    color: var(--color-text-muted);
-    margin-bottom: var(--spacing-4);
-}
-
-.stat_value {
-    font-size: var(--font-size-xl);
-    font-weight: var(--font-weight-bold);
-    color: var(--color-text);
-}
-
 /* Filters */
 .filters {
     display: flex;

--- a/src/frontend/modules/logs/components/SystemLogsMonitor/SystemLogsMonitor.tsx
+++ b/src/frontend/modules/logs/components/SystemLogsMonitor/SystemLogsMonitor.tsx
@@ -5,6 +5,7 @@ import { Trash2, ChevronDown, ChevronUp } from 'lucide-react';
 import type { LogLevel } from '@/types';
 import { Button } from '../../../../components/ui/Button';
 import { Select } from '../../../../components/ui/Select';
+import { StatTile, StatGrid } from '../../../../components/ui/StatTile';
 import { useToast } from '../../../../components/ui/ToastProvider';
 import { useModal } from '../../../../components/ui/ModalProvider';
 import { Stack } from '../../../../components/layout';
@@ -348,37 +349,21 @@ export function SystemLogsMonitor() {
     return (
         <div className={styles.container}>
             {/* Statistics */}
+            {/*
+              * Dense seven-up level breakdown, so the compact tile density.
+              * The grid auto-fits rather than forcing seven fixed columns,
+              * which squeezed the counts on a narrow console.
+              */}
             {stats && (
-                <div className={styles.stats}>
-                    <div className={styles.stat_card}>
-                        <div className={styles.stat_label}>Total Logs</div>
-                        <div className={styles.stat_value}>{stats.total.toLocaleString()}</div>
-                    </div>
-                    <div className={styles.stat_card}>
-                        <div className={styles.stat_label}>Fatal</div>
-                        <div className={styles.stat_value}>{stats.byLevel.fatal?.toLocaleString() ?? '0'}</div>
-                    </div>
-                    <div className={styles.stat_card}>
-                        <div className={styles.stat_label}>Errors</div>
-                        <div className={styles.stat_value}>{stats.byLevel.error.toLocaleString()}</div>
-                    </div>
-                    <div className={styles.stat_card}>
-                        <div className={styles.stat_label}>Warnings</div>
-                        <div className={styles.stat_value}>{stats.byLevel.warn.toLocaleString()}</div>
-                    </div>
-                    <div className={styles.stat_card}>
-                        <div className={styles.stat_label}>Info</div>
-                        <div className={styles.stat_value}>{stats.byLevel.info.toLocaleString()}</div>
-                    </div>
-                    <div className={styles.stat_card}>
-                        <div className={styles.stat_label}>Debug</div>
-                        <div className={styles.stat_value}>{stats.byLevel.debug.toLocaleString()}</div>
-                    </div>
-                    <div className={styles.stat_card}>
-                        <div className={styles.stat_label}>Trace</div>
-                        <div className={styles.stat_value}>{stats.byLevel.trace?.toLocaleString() ?? '0'}</div>
-                    </div>
-                </div>
+                <StatGrid size="sm">
+                    <StatTile size="sm" label="Total Logs" value={stats.total.toLocaleString()} />
+                    <StatTile size="sm" label="Fatal" value={stats.byLevel.fatal?.toLocaleString() ?? '0'} />
+                    <StatTile size="sm" label="Errors" value={stats.byLevel.error.toLocaleString()} />
+                    <StatTile size="sm" label="Warnings" value={stats.byLevel.warn.toLocaleString()} />
+                    <StatTile size="sm" label="Info" value={stats.byLevel.info.toLocaleString()} />
+                    <StatTile size="sm" label="Debug" value={stats.byLevel.debug.toLocaleString()} />
+                    <StatTile size="sm" label="Trace" value={stats.byLevel.trace?.toLocaleString() ?? '0'} />
+                </StatGrid>
             )}
 
             {/* Filters */}

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.module.scss
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.module.scss
@@ -28,40 +28,6 @@
 }
 
 /* Engagement summary cards */
-.metrics_grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: var(--grid-gap-sm);
-    container-type: inline-size;
-    container-name: metrics-grid;
-}
-
-@container metrics-grid (min-width: #{$breakpoint-mobile-lg}) {
-    .metrics_grid {
-        grid-template-columns: repeat(4, 1fr);
-    }
-}
-
-.metric_card {
-    text-align: center;
-    padding: var(--card-padding-sm);
-    background: color-mix(in srgb, var(--color-surface-elevated) 50%, transparent);
-    border-radius: var(--radius-md);
-}
-
-.metric_card__value {
-    font-size: var(--font-size-heading-md);
-    font-weight: var(--font-weight-bold);
-    color: var(--color-primary);
-    line-height: var(--line-height-tight);
-}
-
-.metric_card__label {
-    font-size: var(--font-size-caption);
-    color: var(--color-text-muted);
-    margin-top: var(--gap-xs);
-}
-
 /* Funnel visualization */
 .funnel {
     display: flex;

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
@@ -34,6 +34,7 @@ import type { ChartSeries } from '../../../../../features/charts/components/Line
 import { Card } from '../../../../../components/ui/Card';
 import { Badge, type BadgeTone } from '../../../../../components/ui/Badge';
 import { Table, Thead, Tbody, Tr, Th, Td } from '../../../../../components/ui/Table';
+import { StatTile, StatGrid } from '../../../../../components/ui/StatTile';
 import { Grid, Stack } from '../../../../../components/layout';
 import { OverviewTrend } from '../OverviewTrend';
 import {
@@ -806,26 +807,26 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
                                 <Users size={16} className={styles.section_title__icon} />
                                 Accounts
                             </h3>
-                            <div className={styles.metrics_grid}>
-                                <div className={styles.metric_card}>
-                                    <div className={styles.metric_card__value}>
-                                        {overview.totalAccounts.toLocaleString()}
-                                    </div>
-                                    <div className={styles.metric_card__label}>Total Accounts</div>
-                                </div>
-                                <div className={styles.metric_card}>
-                                    <div className={styles.metric_card__value}>
-                                        {overview.accountsWithWallets.toLocaleString()}
-                                    </div>
-                                    <div className={styles.metric_card__label}>With Wallet</div>
-                                </div>
-                                <div className={styles.metric_card}>
-                                    <div className={styles.metric_card__value}>
-                                        {Math.round(overview.walletAdoptionRate * 100)}%
-                                    </div>
-                                    <div className={styles.metric_card__label}>Wallet Adoption</div>
-                                </div>
-                            </div>
+                            <StatGrid size="sm">
+                                <StatTile
+                                    size="sm"
+                                    tone="primary"
+                                    label="Total Accounts"
+                                    value={overview.totalAccounts.toLocaleString()}
+                                />
+                                <StatTile
+                                    size="sm"
+                                    tone="primary"
+                                    label="With Wallet"
+                                    value={overview.accountsWithWallets.toLocaleString()}
+                                />
+                                <StatTile
+                                    size="sm"
+                                    tone="primary"
+                                    label="Wallet Adoption"
+                                    value={`${Math.round(overview.walletAdoptionRate * 100)}%`}
+                                />
+                            </StatGrid>
                         </Card>
                     )}
                 </>


### PR DESCRIPTION
Follow-up to #473, which added the primitive without migrating anyone. This moves the core admin surfaces onto it.

## Migrated

| Surface | Was |
|---|---|
| `/system/price-history` | eight `Card` + legacy `.stat-card__*` globals |
| `/system/pages` PagesTab | local `.stat_label` / `.stat_value` (now `surface={false}`, they sit inside a card) |
| `SystemLogsMonitor` | local `.stat_card` seven-up level breakdown |
| traffic `AnalyticsDashboard` | local `.metric_card` accounts block (`tone="primary"`, matching its old primary-coloured values) |
| `MarketMonitor` | local `.metric_card` freshness metrics (`minColWidth="200px"`, preserving its narrower floor) |

Each site's now-dead grid and label/value CSS is deleted with it.

## StatStrip is rebuilt on the tile, not replaced

Its twelve system-console call sites keep their look — mono figures, tone as a 2px left rule, dense padding — but the label/value/detail typography now comes from the primitive, and the strip contributes only what makes it a *strip*, applied by scope-overriding the tile's own tokens rather than restyling its internals.

That needs one new token, `--stat-tile-value-font-family`, so a telemetry surface can set mono without forking the component. Leaving StatStrip untouched would have kept a parallel standard alive, which is the thing #473 set out to end.

## Behaviour notes

- The logs strip auto-fits instead of forcing seven fixed columns that squeezed on a narrow console; its values drop to the compact 1.05rem and align left rather than centre. **Worth an eye before merge** — it is a real visual change, not just a refactor.
- `/system/plugins` and `SchedulerMonitor` stats bars are deliberately untouched: they are inline baseline pairs with vertical dividers ("12 Total │ 8 Enabled"), not stacked tiles, so converting them would restructure the design rather than standardise it. They duplicate each other exactly and want their own small primitive.
- `TransactionDetails` (`Metric`/`StatBlock`) and the `WalletManager` `StatTile` are user-facing, not admin, so they are out of this PR's scope.