### PR TITLE
feat(traffic): responsive Visitors table, full visitor detail, dashboard layout

### DIFF
--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.module.scss
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.module.scss
@@ -93,11 +93,19 @@ th.table__number {
 
 /*
  * Truncate an overflowing cell to one ellipsized line instead of wrapping.
- * `max-width: 0` lets the auto table layout hand this column only the space
- * left after the fixed numeric and bar columns, then clip the overflow — used
- * by the landing-pages path column, whose URLs would otherwise wrap.
+ * Used by the landing-pages path column, whose URLs would otherwise wrap.
+ *
+ * The two width declarations do opposite jobs and both are required.
+ * `max-width: 0` keeps the cell's content out of the table's intrinsic width
+ * calculation, so a long path can neither widen the row nor make the wrapper
+ * scroll horizontally. On its own, though, it also collapses the column toward
+ * its minimum — which clipped paths after ~20 characters while the row had
+ * space to spare. `width: 100%` claims whatever is left once the numeric and
+ * bar columns take what they need, so the text ellipsizes at the real
+ * available width instead of an arbitrarily narrow one.
  */
 .table__truncate {
+    width: 100%;
     max-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
+++ b/src/frontend/modules/traffic/components/admin/AnalyticsDashboard/AnalyticsDashboard.tsx
@@ -330,37 +330,52 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
                 <div className={styles.loading}>Loading analytics data...</div>
             ) : (
                 <>
-                    {/* Conversion Funnel + Traffic Sources side by side */}
+                    {/* Top Landing Pages + Traffic Sources side by side */}
                     <Grid columns="responsive">
-                        {/* Conversion Funnel */}
-                        {funnel.length > 0 && (
-                            <Card>
-                                <h3 className={styles.section_title}>
-                                    <Target size={16} className={styles.section_title__icon} />
-                                    Conversion Funnel
-                                </h3>
-                                <div className={styles.funnel}>
-                                    {funnel.map(stage => (
-                                        <div
-                                            key={stage.stage}
-                                            className={styles.funnel_stage}
-                                            title="Counts are unique visitors (browser identities / tids), not accounts. One person logged in from two browsers or devices counts as two logged-in visitors but one account, so these stages nest under Visitors and never exceed it."
-                                        >
-                                            <span className={styles.funnel_stage__label}>{stage.stage}</span>
-                                            <div className={styles.funnel_stage__bar_wrapper}>
-                                                <div
-                                                    className={styles.funnel_stage__bar}
-                                                    style={{ width: `${stage.percentage}%` }}
-                                                />
-                                            </div>
-                                            <span className={styles.funnel_stage__stats}>
-                                                {stage.count.toLocaleString()} ({stage.percentage}%)
-                                            </span>
-                                        </div>
-                                    ))}
-                                </div>
-                            </Card>
-                        )}
+                        {/* Top Landing Pages */}
+                        <Card>
+                            <h3
+                                className={styles.section_title}
+                                title="Session-scoped attribution: the entry page of every session starting in this window, so a returning visitor's re-entry page now appears here — not the most-viewed pages. The figure shown stays distinct visitors, so re-entering on the same page does not count twice. Sessions resumed after the 30-minute idle gap are excluded; nobody landed on them."
+                            >
+                                <MousePointerClick size={16} className={styles.section_title__icon} />
+                                Top Landing Pages
+                                <span className={`text-muted ${styles.section_title__subtitle}`}>
+                                    (by session)
+                                </span>
+                            </h3>
+                            <div>
+                                {landingPages.length === 0 ? (
+                                    <div className={styles.empty_state}>No landing page data for this period</div>
+                                ) : (
+                                    <div className={styles.table_wrapper}>
+                                        <Table>
+                                            <Thead>
+                                                <Tr>
+                                                    <Th scope="col">Page</Th>
+                                                    <Th scope="col" className={styles.table__number}>Visitors</Th>
+                                                    <Th scope="col" className={styles.table__bar_cell}></Th>
+                                                </Tr>
+                                            </Thead>
+                                            <Tbody>
+                                                {landingPages.map(p => (
+                                                    <Tr key={p.path}>
+                                                        <Td className={styles.table__truncate} title={p.path}>{p.path}</Td>
+                                                        <Td className={styles.table__number}>{p.visitors.toLocaleString()}</Td>
+                                                        <Td className={styles.table__bar_cell}>
+                                                            <div
+                                                                className={styles.table__bar}
+                                                                style={{ width: `${(p.visitors / maxPageVisitors) * 100}%` }}
+                                                            />
+                                                        </Td>
+                                                    </Tr>
+                                                ))}
+                                            </Tbody>
+                                        </Table>
+                                    </div>
+                                )}
+                            </div>
+                        </Card>
 
                         {/* Traffic Sources */}
                         <Card>
@@ -609,52 +624,37 @@ export function AnalyticsDashboard({ period, customRange, includeBots, refreshSi
                         </Card>
                     </Grid>
 
-                    {/* Top Landing Pages + Geographic Distribution side by side */}
+                    {/* Conversion Funnel + Geographic Distribution side by side */}
                     <Grid columns="responsive">
-                        {/* Top Landing Pages */}
-                        <Card>
-                            <h3
-                                className={styles.section_title}
-                                title="Session-scoped attribution: the entry page of every session starting in this window, so a returning visitor's re-entry page now appears here — not the most-viewed pages. The figure shown stays distinct visitors, so re-entering on the same page does not count twice. Sessions resumed after the 30-minute idle gap are excluded; nobody landed on them."
-                            >
-                                <MousePointerClick size={16} className={styles.section_title__icon} />
-                                Top Landing Pages
-                                <span className={`text-muted ${styles.section_title__subtitle}`}>
-                                    (by session)
-                                </span>
-                            </h3>
-                            <div>
-                                {landingPages.length === 0 ? (
-                                    <div className={styles.empty_state}>No landing page data for this period</div>
-                                ) : (
-                                    <div className={styles.table_wrapper}>
-                                        <Table>
-                                            <Thead>
-                                                <Tr>
-                                                    <Th scope="col">Page</Th>
-                                                    <Th scope="col" className={styles.table__number}>Visitors</Th>
-                                                    <Th scope="col" className={styles.table__bar_cell}></Th>
-                                                </Tr>
-                                            </Thead>
-                                            <Tbody>
-                                                {landingPages.map(p => (
-                                                    <Tr key={p.path}>
-                                                        <Td className={styles.table__truncate} title={p.path}>{p.path}</Td>
-                                                        <Td className={styles.table__number}>{p.visitors.toLocaleString()}</Td>
-                                                        <Td className={styles.table__bar_cell}>
-                                                            <div
-                                                                className={styles.table__bar}
-                                                                style={{ width: `${(p.visitors / maxPageVisitors) * 100}%` }}
-                                                            />
-                                                        </Td>
-                                                    </Tr>
-                                                ))}
-                                            </Tbody>
-                                        </Table>
-                                    </div>
-                                )}
-                            </div>
-                        </Card>
+                        {/* Conversion Funnel */}
+                        {funnel.length > 0 && (
+                            <Card>
+                                <h3 className={styles.section_title}>
+                                    <Target size={16} className={styles.section_title__icon} />
+                                    Conversion Funnel
+                                </h3>
+                                <div className={styles.funnel}>
+                                    {funnel.map(stage => (
+                                        <div
+                                            key={stage.stage}
+                                            className={styles.funnel_stage}
+                                            title="Counts are unique visitors (browser identities / tids), not accounts. One person logged in from two browsers or devices counts as two logged-in visitors but one account, so these stages nest under Visitors and never exceed it."
+                                        >
+                                            <span className={styles.funnel_stage__label}>{stage.stage}</span>
+                                            <div className={styles.funnel_stage__bar_wrapper}>
+                                                <div
+                                                    className={styles.funnel_stage__bar}
+                                                    style={{ width: `${stage.percentage}%` }}
+                                                />
+                                            </div>
+                                            <span className={styles.funnel_stage__stats}>
+                                                {stage.count.toLocaleString()} ({stage.percentage}%)
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </Card>
+                        )}
 
                         {/* Geographic Distribution */}
                         <Card>

--- a/src/frontend/modules/traffic/components/admin/VisitorsExplorer/VisitorsExplorer.module.scss
+++ b/src/frontend/modules/traffic/components/admin/VisitorsExplorer/VisitorsExplorer.module.scss
@@ -206,10 +206,94 @@
     color: var(--color-text-subtle);
 }
 
-/* Expanded per-row page-hit clickstream */
+/*
+ * Columns dropped at tablet width and below (First Seen, Channel, Device).
+ *
+ * Chosen because each is either recoverable from another column or the least
+ * load-bearing of its kind: Last Seen answers recency, Source carries
+ * acquisition more specifically than Channel, and device is rarely the reason
+ * an operator opens this table. Nothing is lost — the expanded row publishes
+ * every attribute at every width, so hiding a column narrows the summary rather
+ * than the record.
+ *
+ * Marked with an explicit class rather than :nth-child so reordering a column
+ * cannot silently hide the wrong one.
+ */
+.col_optional {
+    display: table-cell;
+}
+
+/* Expanded per-row detail: full attribute set, then the page-hit clickstream */
 .detail_row td {
     background: var(--color-surface);
     padding: var(--card-padding-sm);
+}
+
+.detail {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+}
+
+.detail_section_title {
+    margin: 0 0 var(--gap-sm);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: var(--letter-spacing-wide);
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+}
+
+/*
+ * Attribute grid. `auto-fit` with a floor rather than a fixed column count so
+ * the panel reflows on its own — it renders inside a cell spanning the whole
+ * table, so its width tracks the table, not the container query above.
+ */
+.detail_grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(var(--max-width-xs), 1fr));
+    gap: var(--gap-sm) var(--gap-md);
+    margin: 0;
+}
+
+.detail_field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-2xs);
+    min-width: 0;
+}
+
+.detail_label {
+    font-size: var(--font-size-caption);
+    color: var(--color-text-subtle);
+}
+
+/* dd carries a default indent that would misalign every value from its label. */
+.detail_value {
+    margin: 0;
+    font-size: var(--font-size-body-sm);
+    color: var(--color-text);
+    overflow-wrap: anywhere;
+}
+
+.detail_mono {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-caption);
+}
+
+.detail_device {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-2xs);
+}
+
+.detail_flag {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-2xs);
+    margin-left: var(--gap-sm);
+    font-size: var(--font-size-caption);
+    color: var(--color-warning-text);
 }
 
 .hits {
@@ -269,6 +353,14 @@
 }
 
 /* Container query responsive overrides */
+
+/* iPad and below: drop the three optional columns — see .col_optional. */
+@container visitors-explorer (max-width: #{$breakpoint-tablet}) {
+    .col_optional {
+        display: none;
+    }
+}
+
 @container visitors-explorer (max-width: #{$breakpoint-mobile-lg}) {
     .section_header {
         flex-direction: column;

--- a/src/frontend/modules/traffic/components/admin/VisitorsExplorer/VisitorsExplorer.tsx
+++ b/src/frontend/modules/traffic/components/admin/VisitorsExplorer/VisitorsExplorer.tsx
@@ -22,7 +22,13 @@
  * an account id filters the table to that account's tids, which is the
  * replacement for the per-account rollup the old Registered view provided.
  *
- * Clicking anywhere on a row expands that visitor's clickstream. The row stays
+ * Expanding a row publishes that visitor's *complete* record — every stored
+ * attribute for the tid and its account, then the clickstream. That is what
+ * makes the responsive rule safe: at tablet width and below the table drops
+ * First Seen, Channel, and Device (see `.col_optional`), and none of it becomes
+ * unreachable because the panel already carries all of it at every width.
+ *
+ * Clicking anywhere on a row expands that visitor's detail. The row stays
  * a real `<tr>`: giving it `role="button"` would make every `<td>` descendant
  * presentational, orphaning the cell/header relationships so a screen reader
  * hears only the row's label instead of its ten columns — and it would nest the
@@ -58,7 +64,15 @@ const PAGE_LIMIT = 25;
 /** Max page hits fetched for a drill-down. */
 const HITS_LIMIT = 200;
 
-/** Column count, so the expanded drill-down row spans the full table. */
+/**
+ * Column count, so the expanded drill-down row spans the full table.
+ *
+ * Counts every column the header declares, including the three the container
+ * query hides at tablet width and below. Those columns still exist in the table
+ * model, so a smaller colSpan would leave the detail cell short of the right
+ * edge at wide widths; the hidden columns carry no content, so spanning them at
+ * narrow widths costs nothing.
+ */
 const COLUMN_COUNT = 10;
 
 /**
@@ -86,21 +100,56 @@ function formatUtm(utm: IVisitorRow['utm']): string | null {
     return parts.length > 0 ? parts.join(' / ') : null;
 }
 
-interface IPageHitsRowProps {
-    id: string;
+interface IDetailFieldProps {
+    label: string;
+    children: React.ReactNode;
+}
+
+/**
+ * One label/value pair in the expanded row's attribute grid.
+ *
+ * A `<dt>`/`<dd>` pair rather than two `<div>`s: the panel is a set of
+ * name-value pairs about one subject, which is exactly what a definition list
+ * conveys to a screen reader — a grid of anonymous divs would read as a wall of
+ * unassociated text.
+ *
+ * @param props - The field's label and its already-formatted value node.
+ * @returns The paired term and description.
+ */
+function DetailField({ label, children }: IDetailFieldProps) {
+    return (
+        <div className={styles.detail_field}>
+            <dt className={styles.detail_label}>{label}</dt>
+            <dd className={styles.detail_value}>{children}</dd>
+        </div>
+    );
+}
+
+interface IVisitorDetailRowProps {
+    row: IVisitorRow;
+    isFlagged: boolean;
     window: IVisitorsWindow;
 }
 
 /**
- * Expanded clickstream row for a single visitor. Self-contained so each open
- * drill-down owns its fetch — mounting on expand and unmounting on collapse —
- * which eliminates the shared-state race where a late response from a
- * previously-open row could render under the currently-open one.
+ * Expanded detail row for a single visitor: every stored attribute for the tid
+ * (and its account, when it has one) followed by the page-hit clickstream.
  *
- * @param props - The tid to fetch hits for and the active window.
- * @returns A table row spanning the parent's columns with the page-hit list.
+ * Carrying the full attribute set here is what lets the table hide its three
+ * lowest-value columns on narrow viewports without the data becoming
+ * unreachable — the panel is the canonical place a visitor's complete record is
+ * readable, at every width, so nothing is only visible on a wide screen.
+ *
+ * Self-contained fetch so each open drill-down owns its request — mounting on
+ * expand and unmounting on collapse — which eliminates the shared-state race
+ * where a late response from a previously-open row could render under the
+ * currently-open one.
+ *
+ * @param props - The visitor row to describe, whether its source network was
+ *   flagged high-volume, and the active window scoping the clickstream.
+ * @returns A table row spanning the parent's columns with attributes and hits.
  */
-function PageHitsRow({ id, window }: IPageHitsRowProps) {
+function VisitorDetailRow({ row, isFlagged, window }: IVisitorDetailRowProps) {
     const [hits, setHits] = useState<IPageHit[]>([]);
     const [loading, setLoading] = useState(true);
 
@@ -113,7 +162,7 @@ function PageHitsRow({ id, window }: IPageHitsRowProps) {
         const fetchHits = async (): Promise<void> => {
             setLoading(true);
             try {
-                const result = await adminGetPageHits('tid', id, { ...window, limit: HITS_LIMIT });
+                const result = await adminGetPageHits('tid', row.id, { ...window, limit: HITS_LIMIT });
                 if (active) {
                     setHits(result);
                 }
@@ -130,39 +179,112 @@ function PageHitsRow({ id, window }: IPageHitsRowProps) {
         };
         fetchHits();
         return () => { active = false; };
-    }, [id, window]);
+    }, [row.id, window]);
+
+    const utm = formatUtm(row.utm);
+    /** Placeholder for an attribute the visitor has no value for. */
+    const none = <span className={styles.muted}>—</span>;
 
     return (
         <Tr className={styles.detail_row}>
             <Td colSpan={COLUMN_COUNT}>
-                {loading ? (
-                    <div className={styles.loading}>Loading pages…</div>
-                ) : hits.length === 0 ? (
-                    <div className={styles.empty}>No page hits in this window.</div>
-                ) : (
-                    <>
-                        <ol className={styles.hits}>
-                            {hits.map((hit, index) => (
-                                <li key={`${hit.timestamp}_${index}`} className={styles.hit}>
-                                    <span className={styles.hit_time}>
-                                        <ClientTime date={hit.timestamp} format="datetime" />
+                <div className={styles.detail}>
+                    <section>
+                        <h3 className={styles.detail_section_title}>Visitor detail</h3>
+                        <dl className={styles.detail_grid}>
+                            <DetailField label="Traffic id">
+                                <code className={styles.detail_mono}>{row.id}</code>
+                            </DetailField>
+                            <DetailField label="Account">
+                                {row.accountId
+                                    ? <code className={styles.detail_mono}>{row.accountId}</code>
+                                    : <span className={styles.muted}>anonymous</span>}
+                            </DetailField>
+                            <DetailField label="Visitor type">
+                                {row.isNew ? 'New in this window' : 'Returning'}
+                            </DetailField>
+                            <DetailField label="Classification">
+                                {row.botClass
+                                    ? (row.botClass === 'human'
+                                        ? 'human'
+                                        : <span className={styles.bot_tag}>{row.botClass}</span>)
+                                    : <span className={styles.muted}>unclassified</span>}
+                            </DetailField>
+                            <DetailField label="First seen">
+                                <ClientTime date={row.firstSeen} format="datetime" />
+                            </DetailField>
+                            <DetailField label="Last seen">
+                                <ClientTime date={row.lastSeen} format="datetime" />
+                            </DetailField>
+                            <DetailField label="Page views">{row.pageViews.toLocaleString()}</DetailField>
+                            <DetailField label="Distinct paths">{row.distinctPaths.toLocaleString()}</DetailField>
+                            <DetailField label="Channel">{row.channel || none}</DetailField>
+                            <DetailField label="Source">
+                                {row.referrerDomain || 'direct'}
+                                {isFlagged && (
+                                    <span className={styles.detail_flag}>
+                                        <AlertTriangle size={14} aria-hidden="true" />
+                                        high-volume network
                                     </span>
-                                    <code className={styles.hit_path}>{hit.path}</code>
-                                    {hit.referer && (
-                                        <span className={styles.hit_referer} title={hit.referer}>
-                                            ← {hit.referer}
-                                        </span>
-                                    )}
-                                </li>
-                            ))}
-                        </ol>
-                        {hits.length >= HITS_LIMIT && (
-                            <p className="text-muted">
-                                Showing the newest {HITS_LIMIT} page hits — more exist in this window.
-                            </p>
+                                )}
+                            </DetailField>
+                            <DetailField label="Campaign (UTM)">{utm || none}</DetailField>
+                            <DetailField label="Landing page">
+                                {row.landingPage
+                                    ? <code className={styles.detail_mono}>{row.landingPage}</code>
+                                    : none}
+                            </DetailField>
+                            <DetailField label="Last path">
+                                {row.lastPath
+                                    ? <code className={styles.detail_mono}>{row.lastPath}</code>
+                                    : none}
+                            </DetailField>
+                            <DetailField label="Country">{row.country || none}</DetailField>
+                            <DetailField label="Device">
+                                <span className={styles.detail_device}>
+                                    {getDeviceIcon(row.device)} {row.device}
+                                </span>
+                            </DetailField>
+                            <DetailField label="Source network">
+                                {row.subnetHash
+                                    ? <code className={styles.detail_mono}>{row.subnetHash}</code>
+                                    : none}
+                            </DetailField>
+                        </dl>
+                    </section>
+
+                    <section>
+                        <h3 className={styles.detail_section_title}>Pages hit</h3>
+                        {loading ? (
+                            <div className={styles.loading}>Loading pages…</div>
+                        ) : hits.length === 0 ? (
+                            <div className={styles.empty}>No page hits in this window.</div>
+                        ) : (
+                            <>
+                                <ol className={styles.hits}>
+                                    {hits.map((hit, index) => (
+                                        <li key={`${hit.timestamp}_${index}`} className={styles.hit}>
+                                            <span className={styles.hit_time}>
+                                                <ClientTime date={hit.timestamp} format="datetime" />
+                                            </span>
+                                            <code className={styles.hit_path}>{hit.path}</code>
+                                            {hit.referer && (
+                                                <span className={styles.hit_referer} title={hit.referer}>
+                                                    ← {hit.referer}
+                                                </span>
+                                            )}
+                                        </li>
+                                    ))}
+                                </ol>
+                                {hits.length >= HITS_LIMIT && (
+                                    <p className="text-muted">
+                                        Showing the newest {HITS_LIMIT} page hits — more exist in this window.
+                                    </p>
+                                )}
+                            </>
                         )}
-                    </>
-                )}
+                    </section>
+                </div>
             </Td>
         </Tr>
     );
@@ -269,7 +391,7 @@ export function VisitorsExplorer({ period, customRange, includeBots }: IVisitors
 
     /**
      * Toggle a row's page-hit drill-down open or closed. The expanded row owns
-     * its own fetch (see {@link PageHitsRow}), so this only flips which row is
+     * its own fetch (see {@link VisitorDetailRow}), so this only flips which row is
      * open — there is no shared hit state to race.
      *
      * @param id - The tid of the row to expand or collapse.
@@ -291,7 +413,8 @@ export function VisitorsExplorer({ period, customRange, includeBots }: IVisitors
                     otherwise the traffic id; an asterisk marks a visitor whose first-ever contact
                     falls inside this window. Acquisition columns read the visitor&apos;s first
                     server-recorded hit, whenever that was — so a returning visitor still shows where
-                    they originally came from. Select a row to see every page that visitor hit.{' '}
+                    they originally came from. Select a row to see that visitor&apos;s full record and
+                    every page they hit — on narrower screens some columns move there instead.{' '}
                     {includeBots
                         ? 'JavaScript-running bots the classifier caught are included; referrers are client-supplied and often spoofed.'
                         : 'Known bots are excluded — unclassified visitors are kept, so this is not "humans only".'}
@@ -330,15 +453,15 @@ export function VisitorsExplorer({ period, customRange, includeBots }: IVisitors
                                 <Thead>
                                     <Tr>
                                         <Th scope="col">Visitor</Th>
-                                        <Th scope="col">First Seen</Th>
+                                        <Th scope="col" className={styles.col_optional}>First Seen</Th>
                                         <Th scope="col">Last Seen</Th>
                                         <Th scope="col">Views</Th>
                                         <Th scope="col">Paths</Th>
-                                        <Th scope="col">Channel</Th>
+                                        <Th scope="col" className={styles.col_optional}>Channel</Th>
                                         <Th scope="col">Source</Th>
                                         <Th scope="col">Landing</Th>
                                         <Th scope="col">Country</Th>
-                                        <Th scope="col">Device</Th>
+                                        <Th scope="col" className={styles.col_optional}>Device</Th>
                                     </Tr>
                                 </Thead>
                                 <Tbody>
@@ -412,11 +535,13 @@ export function VisitorsExplorer({ period, customRange, includeBots }: IVisitors
                                                             )}
                                                         </span>
                                                     </Td>
-                                                    <Td><ClientTime date={row.firstSeen} format="relative" /></Td>
+                                                    <Td className={styles.col_optional}>
+                                                        <ClientTime date={row.firstSeen} format="relative" />
+                                                    </Td>
                                                     <Td><ClientTime date={row.lastSeen} format="relative" /></Td>
                                                     <Td>{row.pageViews.toLocaleString()}</Td>
                                                     <Td>{row.distinctPaths.toLocaleString()}</Td>
-                                                    <Td className={styles.channel_cell}>
+                                                    <Td className={`${styles.channel_cell} ${styles.col_optional}`}>
                                                         {row.channel || <span className={styles.muted}>—</span>}
                                                     </Td>
                                                     <Td className={styles.source_cell}>
@@ -440,10 +565,16 @@ export function VisitorsExplorer({ period, customRange, includeBots }: IVisitors
                                                     <Td className={styles.country_cell}>
                                                         {row.country || <span className={styles.muted}>—</span>}
                                                     </Td>
-                                                    <Td className={styles.device_cell}>{getDeviceIcon(row.device)}</Td>
+                                                    <Td className={`${styles.device_cell} ${styles.col_optional}`}>
+                                                        {getDeviceIcon(row.device)}
+                                                    </Td>
                                                 </Tr>
                                                 {expandedId === row.id && (
-                                                    <PageHitsRow id={row.id} window={window} />
+                                                    <VisitorDetailRow
+                                                        row={row}
+                                                        isFlagged={isFlagged}
+                                                        window={window}
+                                                    />
                                                 )}
                                             </React.Fragment>
                                         );

--- a/src/frontend/modules/traffic/components/admin/VisitorsExplorer/VisitorsExplorer.tsx
+++ b/src/frontend/modules/traffic/components/admin/VisitorsExplorer/VisitorsExplorer.tsx
@@ -100,6 +100,39 @@ function formatUtm(utm: IVisitorRow['utm']): string | null {
     return parts.length > 0 ? parts.join(' / ') : null;
 }
 
+/**
+ * Format every stored UTM field for the expanded detail panel.
+ *
+ * The detail panel claims to publish the complete stored record, so it cannot
+ * use {@link formatUtm} — that summary deliberately drops `term` and `content`
+ * to keep the table's Source column narrow, which would hide keyword/creative
+ * attribution and render a term-or-content-only first touch as untagged. Fields
+ * are labelled because the positional `a / b / c` form becomes ambiguous once
+ * nulls are filtered out of a five-part list.
+ *
+ * @param utm - UTM parameters object from the visitors read, or null when the
+ *   first-touch row carried no campaign tags at all.
+ * @returns Labelled string like "source=google, medium=cpc, term=trx", or null
+ *   when no field holds a value so the caller can render its placeholder.
+ */
+function formatUtmDetail(utm: IVisitorRow['utm']): string | null {
+    if (!utm) {
+        return null;
+    }
+
+    const parts = ([
+        ['source', utm.source],
+        ['medium', utm.medium],
+        ['campaign', utm.campaign],
+        ['term', utm.term],
+        ['content', utm.content]
+    ] as const)
+        .filter(([, value]) => Boolean(value))
+        .map(([label, value]) => `${label}=${value}`);
+
+    return parts.length > 0 ? parts.join(', ') : null;
+}
+
 interface IDetailFieldProps {
     label: string;
     children: React.ReactNode;
@@ -181,7 +214,7 @@ function VisitorDetailRow({ row, isFlagged, window }: IVisitorDetailRowProps) {
         return () => { active = false; };
     }, [row.id, window]);
 
-    const utm = formatUtm(row.utm);
+    const utm = formatUtmDetail(row.utm);
     /** Placeholder for an attribute the visitor has no value for. */
     const none = <span className={styles.muted}>—</span>;
 


### PR DESCRIPTION
Three changes to the `/system/traffic` admin UI.

## Visitors table — responsive columns

At tablet width and below (1024px) the **First Seen**, **Channel**, and **Device** columns are dropped via a `@container visitors-explorer` query. Those three were chosen because each is either recoverable elsewhere or the least load-bearing of its kind: Last Seen already answers recency, Source carries acquisition more specifically than Channel, and device is rarely why an operator opens this table.

The cells carry an explicit `.col_optional` class rather than a `:nth-child` selector, so reordering a column later cannot silently hide the wrong one.

`COLUMN_COUNT` deliberately stays at 10. A colSpan wider than the rendered column count leaves the hidden columns in the table model with no content, so they collapse to zero width; deriving the count from a `matchMedia` listener would add resize state to reach the same pixels.

## Visitors table — full detail on expand

Expanding a row now publishes the visitor's complete record rather than only the clickstream: traffic id, account, new/returning, bot classification, absolute first and last seen, page views, distinct paths, channel, source (with the high-volume-network flag), UTM campaign, landing page, last path, country, device, and source-network hash — followed by the page hits as before.

This is what makes hiding columns safe: the panel renders at every width, so a hidden column narrows the summary, never the record. Rendered as a `<dl>` so each label/value pair is actually associated for assistive technology.

## Dashboard layout

Conversion Funnel and Top Landing Pages swap places. The two acquisition panels (Traffic Sources, Top Landing Pages) now sit together, and the funnel pairs with Geographic Distribution.

## Top Landing Pages truncation fix

The Page column set `max-width: 0` with nothing claiming the leftover space, so the auto table layout collapsed it toward its minimum and clipped paths at roughly 20 characters while the row had room to spare. Adding `width: 100%` lets the column absorb whatever the numeric and bar columns don't need. `max-width: 0` still keeps the content out of the table's intrinsic width, so a long path can neither widen the row nor make the wrapper scroll.